### PR TITLE
Simplify Go SDK handler results and attribute reads

### DIFF
--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -44,7 +44,7 @@ adding aliases.
 - WaitFor may carry one server-supported transient step movement. The Go SDK
   uses this internally and does not expose it to applications.
 - `StepDecision` has normal next steps and a separate `CloseDecision`.
-- A normal Execute must return a non-empty decision. Only conditional
+- A normal Execute must return a non-nil, non-empty decision. Only conditional
   force-complete may combine a close decision with fallback next steps.
 - `Context.from_step_execution_id` exposes step-execution lineage.
 - WaitFor, Execute, and RPC may write attributes, record events, and publish
@@ -275,8 +275,8 @@ type StepDef interface {
 	stepValue() any
 	isStarting() bool
 	skipWaitFor() bool
-	waitFor(Context, any) (Wait, error)
-	execute(Context, any) (StepDecision, error)
+	waitFor(Context, any) (*Wait, error)
+	execute(Context, any) (*StepDecision, error)
 }
 ```
 
@@ -727,9 +727,9 @@ Map operations derive the physical key with the Phase 2 escaping rule. Get
 first observes the invocation's latest buffered write:
 
 - a buffered Set decodes that value;
-- a buffered Delete returns `found=false`;
+- a buffered Delete returns `*AttributeNotFoundError`;
 - otherwise Get reads the hydrated request snapshot; and
-- a missing key returns the typed zero value with `found=false`.
+- a missing key returns the typed zero value plus `*AttributeNotFoundError`.
 
 Set and Delete encode immediately. A failed encode leaves the previous buffer
 unchanged. Multiple writes to one physical key use last-write-wins and emit one
@@ -803,7 +803,7 @@ transient Execute to return only `DeadEnd()`.
 ### Execute response
 
 Execute receives condition results and source-step locals, calls the registered
-typed handler, and requires a non-empty `StepDecision`.
+typed handler, and requires a non-nil, non-empty `StepDecision`.
 
 Every movement is resolved through `registeredFlow.resolveMovement`. Mapping
 uses the registered target's immutable defaults plus the explicit movement
@@ -913,10 +913,11 @@ Cover these scenarios:
    order, including static and map channels.
 6. RPC reflection dispatch preserves typed input/output, movement validation,
    attributes, events, publishes, and channel sizes including local publishes.
-7. Set-then-Get and Delete-then-Get observe buffered state; duplicate events
-   and malformed incoming keys fail.
-8. Returned errors, gRPC status errors, panics, cancellation, and mapping
-   failures return WorkerError details and commit no buffered mutations.
+7. Set-then-Get observes buffered state; Delete-then-Get returns
+   `*AttributeNotFoundError`; duplicate events and malformed keys fail.
+8. Nil Wait/StepDecision results, returned errors, gRPC status errors, panics,
+   cancellation, and mapping failures return WorkerError details and commit no
+   buffered mutations.
 9. Unknown flow/step/RPC, a WaitFor request for `NoWaitFor`, undeclared schema
    handles, and lookalike movement targets return the planned status codes.
 10. A fake FlowService plus real disk cache covers cache hit, miss, corrupt
@@ -1602,8 +1603,8 @@ Every application step implements the same `Step[IN]` interface:
 type Step[IN any] interface {
 	GetStepType() string
 	GetStepOptions() *StepOptions
-	WaitFor(ctx Context, input IN) (Wait, error)
-	Execute(ctx Context, input IN) (StepDecision, error)
+	WaitFor(ctx Context, input IN) (*Wait, error)
+	Execute(ctx Context, input IN) (*StepDecision, error)
 }
 
 type none struct{}
@@ -1633,7 +1634,7 @@ type StepDefaultsNoWaitFor[IN any] struct {
 	NoWaitFor[IN]
 }
 
-func (NoWaitFor[IN]) WaitFor(Context, IN) (Wait, error) {
+func (NoWaitFor[IN]) WaitFor(Context, IN) (*Wait, error) {
 	panic("NoWaitFor: framework must skip WaitFor")
 }
 
@@ -1683,7 +1684,7 @@ type ApproveOrderStep struct {
 func (ApproveOrderStep) WaitFor(
 	ctx dex.Context,
 	input ApproveOrderInput,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AnyOf(
 		ApprovalChannel.ForOne(),
 		dex.Timer(
@@ -1696,13 +1697,13 @@ func (ApproveOrderStep) WaitFor(
 func (ApproveOrderStep) Execute(
 	ctx dex.Context,
 	input ApproveOrderInput,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if ctx.HasTimerFired() {
 		return dex.ForceFail("approval timed out"), nil
 	}
 	approvals, err := ApprovalChannel.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	_ = approvals
 	return dex.GoTo(ShipOrder, ShipOrderInput{
@@ -1720,7 +1721,7 @@ type ShipOrderStep struct {
 func (ShipOrderStep) Execute(
 	ctx dex.Context,
 	input ShipOrderInput,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.DeadEnd(), nil
 }
 
@@ -1776,13 +1777,13 @@ Step-execution locals deliberately do not carry a Go type:
 
 ```go
 if err := ctx.SetStepExecutionLocal("snapshot", snapshot); err != nil {
-	return dex.Wait{}, err
+	return nil, err
 }
 
 var snapshot OrderSnapshot
 found, err := ctx.GetStepExecutionLocal("snapshot", &snapshot)
 if err != nil {
-	return dex.StepDecision{}, err
+	return nil, err
 }
 ```
 
@@ -1855,14 +1856,14 @@ key. Physical keys and their escaping are internal SDK details.
 Invocation operations take `Context` explicitly:
 
 ```go
-func (a Attribute[T]) Get(ctx Context) (value T, found bool, err error)
+func (a Attribute[T]) Get(ctx Context) (value T, err error)
 func (a Attribute[T]) Set(ctx Context, value T) error
 func (a Attribute[T]) Delete(ctx Context) error
 
 func (a AttributeMap[T]) Get(
 	ctx Context,
 	instance string,
-) (value T, found bool, err error)
+) (value T, err error)
 func (a AttributeMap[T]) Set(
 	ctx Context,
 	instance string,
@@ -1871,9 +1872,10 @@ func (a AttributeMap[T]) Set(
 func (a AttributeMap[T]) Delete(ctx Context, instance string) error
 ```
 
-`found` distinguishes a missing attribute from the zero value. `Delete` maps to
-the proto null arm. A delete retains the definition's index configuration so an
-indexed value is also removed from visibility.
+A missing invocation attribute returns its typed zero value plus
+`*AttributeNotFoundError`; callers use `errors.As` when absence is expected.
+`Delete` maps to the proto null arm. A delete retains the definition's index
+configuration so an indexed value is also removed from visibility.
 
 Indexing is opt-in:
 
@@ -2027,11 +2029,11 @@ type ConditionOption interface {
 	applyCondition(*conditionValue)
 }
 
-func SkipWaitImmediately() Wait
-func AllOf(conditions ...Condition) Wait
-func AnyOf(conditions ...Condition) Wait
+func SkipWaitImmediately() *Wait
+func AllOf(conditions ...Condition) *Wait
+func AnyOf(conditions ...Condition) *Wait
 func Combo(conditions ...Condition) ConditionCombination
-func AnyComboOf(combinations ...ConditionCombination) Wait
+func AnyComboOf(combinations ...ConditionCombination) *Wait
 func Timer(
 	duration time.Duration,
 	options ...ConditionOption,
@@ -2080,7 +2082,7 @@ func GoTo[IN any](
 	step Step[IN],
 	input IN,
 	options ...StepMoveOption,
-) StepDecision
+) *StepDecision
 
 func MovementOf[IN any](
 	step Step[IN],
@@ -2088,17 +2090,17 @@ func MovementOf[IN any](
 	options ...StepMoveOption,
 ) StepMovement
 
-func GoToMulti(movements ...StepMovement) StepDecision
-func GracefulComplete(output any) StepDecision
-func ForceComplete(output any) StepDecision
-func ForceFail(reason string) StepDecision
-func DeadEnd() StepDecision
+func GoToMulti(movements ...StepMovement) *StepDecision
+func GracefulComplete(output any) *StepDecision
+func ForceComplete(output any) *StepDecision
+func ForceFail(reason string) *StepDecision
+func DeadEnd() *StepDecision
 
 func ForceCompleteOnChannelsEmpty(
 	output any,
 	channels []ChannelDef,
 	otherwise ...StepMovement,
-) StepDecision
+) *StepDecision
 ```
 
 Rules enforced by construction or Phase 3 validation:
@@ -2114,7 +2116,7 @@ Rules enforced by construction or Phase 3 validation:
 - normal movements never expose the server-owned lineage field.
 
 An RPC may return optional next-step movements but cannot close the flow.
-Execute must return a valid, non-empty `StepDecision`.
+Execute must return a valid, non-nil, non-empty `StepDecision`.
 
 ### Step options
 
@@ -2607,6 +2609,18 @@ No old reset, memo, loading-policy, or worker-URL fields are retained.
 
 ### Public errors
 
+Invocation attribute misses return a typed local error:
+
+```go
+type AttributeNotFoundError struct {
+	AttributeName string
+	Instance      string
+}
+```
+
+`Instance` is populated for `AttributeMap` reads. The error supports
+`errors.As` and is never converted to a gRPC status.
+
 All FlowService failures are returned as an SDK error that preserves both gRPC
 status and Dex details:
 
@@ -2657,19 +2671,19 @@ type WaitForCommandStep struct {
 func (WaitForCommandStep) WaitFor(
 	ctx dex.Context,
 	input OrderInput,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	if err := OrderStatus.Set(ctx, "waiting"); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 
 	if err := ctx.SetStepExecutionLocal(
 		"snapshot",
 		OrderSnapshot{OrderID: input.OrderID},
 	); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	if err := ctx.RecordEvent("waiting-for-command", input); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 
 	return dex.AnyOf(
@@ -2684,24 +2698,24 @@ func (WaitForCommandStep) WaitFor(
 func (WaitForCommandStep) Execute(
 	ctx dex.Context,
 	input OrderInput,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if ctx.HasTimerFired() {
 		return dex.ForceFail("command timed out"), nil
 	}
 
 	commands, err := Commands.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	_ = commands
 
 	var snapshot OrderSnapshot
 	found, err := ctx.GetStepExecutionLocal("snapshot", &snapshot)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if !found {
-		return dex.StepDecision{}, fmt.Errorf("snapshot is missing")
+		return nil, fmt.Errorf("snapshot is missing")
 	}
 	return dex.GracefulComplete(snapshot), nil
 }
@@ -2730,8 +2744,8 @@ var Orders = OrderFlow{}
 var _ dex.Flow = Orders
 ```
 
-The exact zero values returned on an error are not part of normal application
-style; they only satisfy Go's return rules.
+Step handlers return nil with an error. Other exact zero values only satisfy
+Go's return rules.
 
 ## Phase 1 deliverables
 
@@ -2763,7 +2777,8 @@ Add SDK external-package tests (`package dex_test`) for these scenarios:
 5. A Flow method matching `RPC[IN, OUT]` preserves typed worker handlers, while
    `Client.InvokeRPC` accepts `any` and a caller-provided output pointer.
 6. Static and map attributes expose typed Get/Set/Delete methods that take
-   `Context`, while physical keys remain internal behind sealed lock values.
+   `Context`; missing reads return `*AttributeNotFoundError`, while physical
+   keys remain internal behind sealed lock values.
 7. Static and map channels expose Publish, all five count forms, and the
    `myCh.Size(ctx)` / `myChMap.Size(ctx, key)` RPC shape.
 8. A Wait combines timers and channel conditions through All, Any, and

--- a/docs/wiki/Basic-concepts-overview.md
+++ b/docs/wiki/Basic-concepts-overview.md
@@ -180,7 +180,7 @@ func (*OrchestrationFlow) Swap(
 	ctx dex.Context,
 	newData string,
 ) (dex.RPCResult[string], error) {
-	oldData, _, err := Data.Get(ctx)
+	oldData, err := Data.Get(ctx)
 	if err != nil {
 		return dex.RPCResult[string]{}, err
 	}

--- a/docs/wiki/Persistence.md
+++ b/docs/wiki/Persistence.md
@@ -190,13 +190,13 @@ And example to read/write the persistence:
 func (step callAPI1Step) Execute(
 	ctx dex.Context,
 	input string,
-) (dex.StepDecision, error) {
-	oldData, _, err := Data.Get(ctx)
+) (*dex.StepDecision, error) {
+	oldData, err := Data.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if err := Data.Set(ctx, input); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.GracefulComplete(oldData), nil
 }

--- a/examples/go/workflows/engagement/workflow.go
+++ b/examples/go/workflows/engagement/workflow.go
@@ -89,11 +89,11 @@ func (*EngagementFlow) Decline(
 	ctx dex.Context,
 	note string,
 ) (dex.RPCResult[Status], error) {
-	status, found, err := EngagementStatus.Get(ctx)
+	status, err := EngagementStatus.Get(ctx)
 	if err != nil {
 		return dex.RPCResult[Status]{}, err
 	}
-	if !found || status != StatusInitiated {
+	if status != StatusInitiated {
 		return dex.RPCResult[Status]{}, fmt.Errorf(
 			"can only decline an initiated engagement; current status is %q",
 			status,
@@ -114,11 +114,11 @@ func (*EngagementFlow) Accept(
 	ctx dex.Context,
 	note string,
 ) (dex.RPCResult[Status], error) {
-	status, found, err := EngagementStatus.Get(ctx)
+	status, err := EngagementStatus.Get(ctx)
 	if err != nil {
 		return dex.RPCResult[Status]{}, err
 	}
-	if !found || (status != StatusInitiated && status != StatusDeclined) {
+	if status != StatusInitiated && status != StatusDeclined {
 		return dex.RPCResult[Status]{}, fmt.Errorf(
 			"can only accept an initiated or declined engagement; current status is %q",
 			status,
@@ -139,19 +139,19 @@ func (*EngagementFlow) Accept(
 }
 
 func describe(ctx dex.Context) (EngagementDescription, error) {
-	status, _, err := EngagementStatus.Get(ctx)
+	status, err := EngagementStatus.Get(ctx)
 	if err != nil {
 		return EngagementDescription{}, err
 	}
-	employerID, _, err := EmployerID.Get(ctx)
+	employerID, err := EmployerID.Get(ctx)
 	if err != nil {
 		return EngagementDescription{}, err
 	}
-	jobSeekerID, _, err := JobSeekerID.Get(ctx)
+	jobSeekerID, err := JobSeekerID.Get(ctx)
 	if err != nil {
 		return EngagementDescription{}, err
 	}
-	notes, _, err := Notes.Get(ctx)
+	notes, err := Notes.Get(ctx)
 	if err != nil {
 		return EngagementDescription{}, err
 	}
@@ -170,7 +170,7 @@ func updateStatus(ctx dex.Context, status Status, note string) error {
 	if err := LastUpdateTimestamp.Set(ctx, time.Now().UnixMilli()); err != nil {
 		return err
 	}
-	currentNotes, _, err := Notes.Get(ctx)
+	currentNotes, err := Notes.Get(ctx)
 	if err != nil {
 		return err
 	}
@@ -187,21 +187,21 @@ type initializeStep struct {
 func (initializeStep) Execute(
 	ctx dex.Context,
 	input EngagementInput,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if err := EmployerID.Set(ctx, input.EmployerID); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if err := JobSeekerID.Set(ctx, input.JobSeekerID); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if err := EngagementStatus.Set(ctx, StatusInitiated); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if err := LastUpdateTimestamp.Set(ctx, time.Now().UnixMilli()); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if err := Notes.Set(ctx, input.Notes); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.GoToMulti(
 		dex.MovementOf(processTimeoutStep{}, nil),
@@ -218,7 +218,7 @@ type processTimeoutStep struct {
 func (processTimeoutStep) WaitFor(
 	dex.Context,
 	dex.None,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AnyOf(
 		dex.Timer(60*24*time.Hour),
 		CompleteProcess.ForOne(),
@@ -228,10 +228,10 @@ func (processTimeoutStep) WaitFor(
 func (step processTimeoutStep) Execute(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	description, err := describe(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	result := "timeout"
 	if description.CurrentStatus == StatusAccepted {
@@ -254,7 +254,7 @@ type reminderStep struct {
 func (reminderStep) WaitFor(
 	dex.Context,
 	dex.None,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AnyOf(
 		dex.Timer(5*time.Second),
 		OptOutReminder.ForOne(),
@@ -264,27 +264,27 @@ func (reminderStep) WaitFor(
 func (step reminderStep) Execute(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.StepDecision, error) {
-	status, _, err := EngagementStatus.Get(ctx)
+) (*dex.StepDecision, error) {
+	status, err := EngagementStatus.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if status != StatusInitiated {
 		return dex.DeadEnd(), nil
 	}
 	optOuts, err := OptOutReminder.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if len(optOuts) > 0 {
 		if err := updateStatus(ctx, status, "user opted out of reminders"); err != nil {
-			return dex.StepDecision{}, err
+			return nil, err
 		}
 		return dex.DeadEnd(), nil
 	}
-	jobSeekerID, _, err := JobSeekerID.Get(ctx)
+	jobSeekerID, err := JobSeekerID.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	step.service.SendEmail(jobSeekerID, "Reminder: please respond", "Please respond to the engagement.")
 	return dex.GoTo(reminderStep{}, nil), nil
@@ -298,14 +298,14 @@ type notifyExternalSystemStep struct {
 func (step notifyExternalSystemStep) Execute(
 	ctx dex.Context,
 	status Status,
-) (dex.StepDecision, error) {
-	employerID, _, err := EmployerID.Get(ctx)
+) (*dex.StepDecision, error) {
+	employerID, err := EmployerID.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
-	jobSeekerID, _, err := JobSeekerID.Get(ctx)
+	jobSeekerID, err := JobSeekerID.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	step.service.UpdateExternalSystem(fmt.Sprintf(
 		"notify engagement from employer %s to job seeker %s for status %s",

--- a/examples/go/workflows/microservices/workflow.go
+++ b/examples/go/workflows/microservices/workflow.go
@@ -61,7 +61,7 @@ func (*OrchestrationFlow) Swap(
 	ctx dex.Context,
 	newData string,
 ) (dex.RPCResult[string], error) {
-	oldData, _, err := Data.Get(ctx)
+	oldData, err := Data.Get(ctx)
 	if err != nil {
 		return dex.RPCResult[string]{}, err
 	}
@@ -79,10 +79,10 @@ type callAPI1Step struct {
 func (step callAPI1Step) Execute(
 	ctx dex.Context,
 	input string,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	step.service.CallAPI1(input)
 	if err := Data.Set(ctx, input); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.GoToMulti(
 		dex.MovementOf(callAPI2Step{}, nil),
@@ -98,10 +98,10 @@ type callAPI2Step struct {
 func (step callAPI2Step) Execute(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.StepDecision, error) {
-	data, _, err := Data.Get(ctx)
+) (*dex.StepDecision, error) {
+	data, err := Data.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	step.service.CallAPI2(data)
 	return dex.DeadEnd(), nil
@@ -115,7 +115,7 @@ type callAPI3Step struct {
 func (callAPI3Step) WaitFor(
 	dex.Context,
 	dex.None,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AnyOf(
 		dex.Timer(24*time.Hour),
 		Ready.ForOne(),
@@ -125,10 +125,10 @@ func (callAPI3Step) WaitFor(
 func (step callAPI3Step) Execute(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.StepDecision, error) {
-	data, _, err := Data.Get(ctx)
+) (*dex.StepDecision, error) {
+	data, err := Data.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	step.service.CallAPI3(data)
 	if ctx.HasTimerFired() {
@@ -145,10 +145,10 @@ type callAPI4Step struct {
 func (step callAPI4Step) Execute(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.StepDecision, error) {
-	data, _, err := Data.Get(ctx)
+) (*dex.StepDecision, error) {
+	data, err := Data.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	step.service.CallAPI4(data)
 	return dex.GracefulComplete(data), nil

--- a/examples/go/workflows/moneytransfer/workflow.go
+++ b/examples/go/workflows/moneytransfer/workflow.go
@@ -67,7 +67,7 @@ type checkBalanceStep struct {
 func (step checkBalanceStep) Execute(
 	_ dex.Context,
 	request TransferRequest,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if !step.service.CheckBalance(request.FromAccount, request.Amount) {
 		return dex.ForceFail("insufficient funds"), nil
 	}
@@ -87,13 +87,13 @@ func (createDebitMemoStep) GetStepOptions() *dex.StepOptions {
 func (step createDebitMemoStep) Execute(
 	_ dex.Context,
 	request TransferRequest,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if err := step.service.CreateDebitMemo(
 		request.FromAccount,
 		request.Amount,
 		request.Notes,
 	); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.GoTo(debitStep{}, request), nil
 }
@@ -111,9 +111,9 @@ func (debitStep) GetStepOptions() *dex.StepOptions {
 func (step debitStep) Execute(
 	_ dex.Context,
 	request TransferRequest,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if err := step.service.Debit(request.FromAccount, request.Amount); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.GoTo(createCreditMemoStep{}, request), nil
 }
@@ -131,13 +131,13 @@ func (createCreditMemoStep) GetStepOptions() *dex.StepOptions {
 func (step createCreditMemoStep) Execute(
 	_ dex.Context,
 	request TransferRequest,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if err := step.service.CreateCreditMemo(
 		request.ToAccount,
 		request.Amount,
 		request.Notes,
 	); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.GoTo(creditStep{}, request), nil
 }
@@ -155,9 +155,9 @@ func (creditStep) GetStepOptions() *dex.StepOptions {
 func (step creditStep) Execute(
 	_ dex.Context,
 	request TransferRequest,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if err := step.service.Credit(request.ToAccount, request.Amount); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.GracefulComplete(fmt.Sprintf(
 		"transfer is done from %s to %s for amount %d",
@@ -182,28 +182,28 @@ func (compensateStep) GetStepOptions() *dex.StepOptions {
 func (step compensateStep) Execute(
 	_ dex.Context,
 	request TransferRequest,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	// NOTE: to improve, we can use Dex data attributes to track whether each step has been attempted to execute
 	// and check a flag to see if we should undo it or not
 	if err := step.service.UndoCredit(request.ToAccount, request.Amount); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if err := step.service.UndoCreateCreditMemo(
 		request.ToAccount,
 		request.Amount,
 		request.Notes,
 	); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if err := step.service.UndoCreateDebitMemo(
 		request.FromAccount,
 		request.Amount,
 		request.Notes,
 	); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if err := step.service.UndoDebit(request.FromAccount, request.Amount); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.ForceFail(fmt.Sprintf(
 		"transfer has failed from %s to %s for amount %d",

--- a/examples/go/workflows/polling/workflow.go
+++ b/examples/go/workflows/polling/workflow.go
@@ -67,9 +67,12 @@ type initializeStep struct {
 }
 
 func (initializeStep) Execute(
-	_ dex.Context,
+	ctx dex.Context,
 	maximumPolls int,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
+	if err := CurrentPolls.Set(ctx, 0); err != nil {
+		return nil, err
+	}
 	return dex.GoToMulti(
 		dex.MovementOf(pollStep{}, maximumPolls),
 		dex.MovementOf(waitForTasksStep{}, nil),
@@ -83,7 +86,7 @@ type waitForTasksStep struct {
 func (waitForTasksStep) WaitFor(
 	dex.Context,
 	dex.None,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AllOf(
 		TaskACompleted.ForOne(),
 		TaskBCompleted.ForOne(),
@@ -94,7 +97,7 @@ func (waitForTasksStep) WaitFor(
 func (waitForTasksStep) Execute(
 	dex.Context,
 	dex.None,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.GracefulComplete("all tasks completed"), nil
 }
 
@@ -106,30 +109,27 @@ type pollStep struct {
 func (pollStep) WaitFor(
 	dex.Context,
 	int,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AnyOf(dex.Timer(time.Second)), nil
 }
 
 func (step pollStep) Execute(
 	ctx dex.Context,
 	maximumPolls int,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	step.service.CallAPI1("calling API1 for polling service C")
-	currentPolls, found, err := CurrentPolls.Get(ctx)
+	currentPolls, err := CurrentPolls.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
-	}
-	if !found {
-		currentPolls = 0
+		return nil, err
 	}
 	if currentPolls >= maximumPolls {
 		if err := TaskCCompleted.Publish(ctx, nil); err != nil {
-			return dex.StepDecision{}, err
+			return nil, err
 		}
 		return dex.DeadEnd(), nil
 	}
 	if err := CurrentPolls.Set(ctx, currentPolls+1); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.GoTo(pollStep{}, maximumPolls), nil
 }

--- a/examples/go/workflows/subscription/workflow.go
+++ b/examples/go/workflows/subscription/workflow.go
@@ -80,7 +80,7 @@ func (*SubscriptionFlow) Describe(
 	ctx dex.Context,
 	_ dex.None,
 ) (dex.RPCResult[Subscription], error) {
-	customer, _, err := CustomerDetails.Get(ctx)
+	customer, err := CustomerDetails.Get(ctx)
 	if err != nil {
 		return dex.RPCResult[Subscription]{}, err
 	}
@@ -94,9 +94,9 @@ type initializeStep struct {
 func (initializeStep) Execute(
 	ctx dex.Context,
 	customer Customer,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if err := CustomerDetails.Set(ctx, customer); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return initializeSubscription(), nil
 }
@@ -109,10 +109,10 @@ type trialStep struct {
 func (step trialStep) WaitFor(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.Wait, error) {
-	customer, _, err := CustomerDetails.Get(ctx)
+) (*dex.Wait, error) {
+	customer, err := CustomerDetails.Get(ctx)
 	if err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	return waitForTrial(customer, step.service), nil
 }
@@ -120,9 +120,9 @@ func (step trialStep) WaitFor(
 func (trialStep) Execute(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if err := BillingPeriodNumber.Set(ctx, 0); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return executeTrial(), nil
 }
@@ -137,27 +137,24 @@ type chargeCurrentBillStep struct {
 func (chargeCurrentBillStep) WaitFor(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.Wait, error) {
-	customer, _, err := CustomerDetails.Get(ctx)
+) (*dex.Wait, error) {
+	customer, err := CustomerDetails.Get(ctx)
 	if err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
-	periodNumber, found, err := BillingPeriodNumber.Get(ctx)
+	periodNumber, err := BillingPeriodNumber.Get(ctx)
 	if err != nil {
-		return dex.Wait{}, err
-	}
-	if !found {
-		periodNumber = 0
+		return nil, err
 	}
 	wait, subscriptionOver := waitForCharge(customer, periodNumber)
 	if subscriptionOver {
 		if err := ctx.SetStepExecutionLocal(subscriptionOverKey, true); err != nil {
-			return dex.Wait{}, err
+			return nil, err
 		}
 		return wait, nil
 	}
 	if err := BillingPeriodNumber.Set(ctx, periodNumber+1); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	return wait, nil
 }
@@ -165,15 +162,15 @@ func (chargeCurrentBillStep) WaitFor(
 func (step chargeCurrentBillStep) Execute(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.StepDecision, error) {
-	customer, _, err := CustomerDetails.Get(ctx)
+) (*dex.StepDecision, error) {
+	customer, err := CustomerDetails.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	var subscriptionOver bool
 	found, err := ctx.GetStepExecutionLocal(subscriptionOverKey, &subscriptionOver)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return executeCharge(customer, found && subscriptionOver, step.service), nil
 }
@@ -186,17 +183,17 @@ type cancelStep struct {
 func (cancelStep) WaitFor(
 	dex.Context,
 	dex.None,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AllOf(CancelSubscription.ForOne()), nil
 }
 
 func (step cancelStep) Execute(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.StepDecision, error) {
-	customer, _, err := CustomerDetails.Get(ctx)
+) (*dex.StepDecision, error) {
+	customer, err := CustomerDetails.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return executeCancel(customer, step.service), nil
 }
@@ -208,33 +205,33 @@ type updateChargeAmountStep struct {
 func (updateChargeAmountStep) WaitFor(
 	dex.Context,
 	dex.None,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AllOf(UpdateChargeAmount.ForOne()), nil
 }
 
 func (updateChargeAmountStep) Execute(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	amounts, err := UpdateChargeAmount.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
-	customer, _, err := CustomerDetails.Get(ctx)
+	customer, err := CustomerDetails.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	updatedCustomer, decision, err := executeUpdateChargeAmount(customer, amounts)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if err := CustomerDetails.Set(ctx, updatedCustomer); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return decision, nil
 }
 
-func initializeSubscription() dex.StepDecision {
+func initializeSubscription() *dex.StepDecision {
 	return dex.GoToMulti(
 		dex.MovementOf(trialStep{}, nil),
 		dex.MovementOf(cancelStep{}, nil),
@@ -245,17 +242,17 @@ func initializeSubscription() dex.StepDecision {
 func waitForTrial(
 	customer Customer,
 	applicationService subscriptionService,
-) dex.Wait {
+) *dex.Wait {
 	// send welcome email
 	applicationService.SendEmail(customer.Email, "welcome email", "hello content")
 	return dex.AllOf(dex.Timer(customer.Subscription.TrialPeriod))
 }
 
-func executeTrial() dex.StepDecision {
+func executeTrial() *dex.StepDecision {
 	return dex.GoTo(chargeCurrentBillStep{}, nil)
 }
 
-func waitForCharge(customer Customer, periodNumber int) (dex.Wait, bool) {
+func waitForCharge(customer Customer, periodNumber int) (*dex.Wait, bool) {
 	if periodNumber >= customer.Subscription.MaxBillingPeriods {
 		return dex.SkipWaitImmediately(), true
 	}
@@ -266,7 +263,7 @@ func executeCharge(
 	customer Customer,
 	subscriptionOver bool,
 	applicationService subscriptionService,
-) dex.StepDecision {
+) *dex.StepDecision {
 	if subscriptionOver {
 		applicationService.SendEmail(customer.Email, "subscription over", "hello content")
 		// use force completing because the cancel state is still waiting for signal
@@ -283,7 +280,7 @@ func executeCharge(
 func executeCancel(
 	customer Customer,
 	applicationService subscriptionService,
-) dex.StepDecision {
+) *dex.StepDecision {
 	applicationService.SendEmail(customer.Email, "subscription canceled", "hello content")
 	return dex.ForceComplete("subscription canceled")
 }
@@ -291,9 +288,9 @@ func executeCancel(
 func executeUpdateChargeAmount(
 	customer Customer,
 	amounts []int,
-) (Customer, dex.StepDecision, error) {
+) (Customer, *dex.StepDecision, error) {
 	if len(amounts) != 1 {
-		return Customer{}, dex.StepDecision{}, fmt.Errorf(
+		return Customer{}, nil, fmt.Errorf(
 			"expected one charge amount, got %d",
 			len(amounts),
 		)

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -31,9 +31,9 @@ type WaitForCommandStep struct {
 func (WaitForCommandStep) WaitFor(
 	ctx dex.Context,
 	input OrderInput,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	if err := OrderStatus.Set(ctx, "waiting"); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	return dex.AnyOf(
 		Commands.ForOne(dex.WithConditionID("command")),
@@ -47,13 +47,13 @@ func (WaitForCommandStep) WaitFor(
 func (WaitForCommandStep) Execute(
 	ctx dex.Context,
 	input OrderInput,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if ctx.HasTimerFired() {
 		return dex.ForceFail("command timed out"), nil
 	}
 	commands, err := Commands.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.GracefulComplete(commands), nil
 }
@@ -91,6 +91,10 @@ the absence of a payload explicit.
 Flow RPCs are methods matching `dex.RPC[IN, OUT]`. Attributes and channels stay
 strongly typed inside handlers. Step-execution locals and recorded events accept
 arbitrary values through `dex.Context`.
+
+Invocation attribute reads return `(value, error)`. A missing static or map
+attribute returns `*dex.AttributeNotFoundError`, which callers can inspect with
+`errors.As` when absence is expected.
 
 ## Registration
 

--- a/sdk-go/dex/attribute.go
+++ b/sdk-go/dex/attribute.go
@@ -32,13 +32,20 @@ type AttributeDef interface {
 	attributeIsMap() bool
 }
 
-func (a Attribute[T]) Get(ctx Context) (value T, found bool, err error) {
+// Get returns the current value. Missing values return AttributeNotFoundError.
+func (a Attribute[T]) Get(ctx Context) (value T, err error) {
 	invocation, ok := ctx.(attributeInvocation)
 	if !ok {
-		return value, false, errInvalidInvocationContext
+		return value, errInvalidInvocationContext
 	}
-	found, err = invocation.getAttribute(a.name, &value)
-	return value, found, err
+	found, err := invocation.getAttribute(a.name, &value)
+	if err != nil {
+		return value, err
+	}
+	if !found {
+		return value, &AttributeNotFoundError{AttributeName: a.name}
+	}
+	return value, nil
 }
 
 func (a Attribute[T]) Set(ctx Context, value T) error {
@@ -85,16 +92,26 @@ func DefineAttributeMap[T any](name string, options ...AttributeOption) Attribut
 	return AttributeMap[T]{name: name, index: config.index}
 }
 
+// Get returns the current map value. Missing instances return AttributeNotFoundError.
 func (a AttributeMap[T]) Get(
 	ctx Context,
 	instance string,
-) (value T, found bool, err error) {
+) (value T, err error) {
 	invocation, ok := ctx.(attributeInvocation)
 	if !ok {
-		return value, false, errInvalidInvocationContext
+		return value, errInvalidInvocationContext
 	}
-	found, err = invocation.getAttributeMap(a.name, instance, &value)
-	return value, found, err
+	found, err := invocation.getAttributeMap(a.name, instance, &value)
+	if err != nil {
+		return value, err
+	}
+	if !found {
+		return value, &AttributeNotFoundError{
+			AttributeName: a.name,
+			Instance:      instance,
+		}
+	}
+	return value, nil
 }
 
 func (a AttributeMap[T]) Set(ctx Context, instance string, value T) error {

--- a/sdk-go/dex/client_integration_test.go
+++ b/sdk-go/dex/client_integration_test.go
@@ -65,7 +65,7 @@ type clientTestRPCOutput struct {
 	Status string
 }
 
-func (clientTestStep) Execute(Context, clientTestInput) (StepDecision, error) {
+func (clientTestStep) Execute(Context, clientTestInput) (*StepDecision, error) {
 	return DeadEnd(), nil
 }
 

--- a/sdk-go/dex/condition.go
+++ b/sdk-go/dex/condition.go
@@ -22,23 +22,23 @@ type Wait struct {
 	transient    *StepMovement
 }
 
-func SkipWaitImmediately() Wait {
-	return Wait{kind: skipWaitImmediately}
+func SkipWaitImmediately() *Wait {
+	return &Wait{kind: skipWaitImmediately}
 }
 
-func AllOf(conditions ...Condition) Wait {
-	return Wait{kind: waitAllOf, conditions: conditions}
+func AllOf(conditions ...Condition) *Wait {
+	return &Wait{kind: waitAllOf, conditions: conditions}
 }
 
-func AnyOf(conditions ...Condition) Wait {
-	return Wait{kind: waitAnyOf, conditions: conditions}
+func AnyOf(conditions ...Condition) *Wait {
+	return &Wait{kind: waitAnyOf, conditions: conditions}
 }
 
-func AnyComboOf(combinations ...ConditionCombination) Wait {
-	return Wait{kind: waitAnyComboOf, combinations: combinations}
+func AnyComboOf(combinations ...ConditionCombination) *Wait {
+	return &Wait{kind: waitAnyComboOf, combinations: combinations}
 }
 
-func withTransientMovement(wait Wait, movement StepMovement) Wait {
+func withTransientMovement(wait *Wait, movement StepMovement) *Wait {
 	wait.transient = &movement
 	return wait
 }

--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -50,7 +50,7 @@ type noPayloadStep struct {
 func (noPayloadStep) Execute(
 	dex.Context,
 	dex.None,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.DeadEnd(), nil
 }
 
@@ -64,9 +64,9 @@ type waitingStep struct {
 func (waitingStep) WaitFor(
 	ctx dex.Context,
 	input stepInput,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	if err := statusAttribute.Set(ctx, input.OrderID); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	return dex.AnyComboOf(
 		dex.Combo(
@@ -82,13 +82,13 @@ func (waitingStep) WaitFor(
 func (waitingStep) Execute(
 	ctx dex.Context,
 	input stepInput,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if ctx.WaitForMethodFailed() || ctx.HasTimerFiredByIndex(0) {
 		return dex.ForceFail("wait failed"), nil
 	}
 	results, err := commandChannel.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if len(results) == 0 {
 		return dex.DeadEnd(), nil
@@ -106,7 +106,7 @@ type executeOnlyStep struct {
 func (executeOnlyStep) Execute(
 	ctx dex.Context,
 	input stepInput,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	first := dex.MovementOf(waitForCommand, input)
 	second := dex.MovementOf(executeOnly, input)
 	return dex.GoToMulti(first, second), nil
@@ -249,8 +249,22 @@ func TestErrorSupportsErrorsAs(t *testing.T) {
 	}
 }
 
+func TestAttributeNotFoundErrorSupportsErrorsAs(t *testing.T) {
+	missing := error(&dex.AttributeNotFoundError{
+		AttributeName: "items",
+		Instance:      "order-1",
+	})
+	var target *dex.AttributeNotFoundError
+	if !errors.As(missing, &target) {
+		t.Fatal("attribute not-found error does not support errors.As")
+	}
+	if target.AttributeName != "items" || target.Instance != "order-1" {
+		t.Fatalf("unexpected attribute identity: %#v", target)
+	}
+}
+
 func compileAttributeOperations(ctx dex.Context) error {
-	if _, _, err := statusAttribute.Get(ctx); err != nil {
+	if _, err := statusAttribute.Get(ctx); err != nil {
 		return err
 	}
 	if err := statusAttribute.Set(ctx, "ready"); err != nil {
@@ -259,7 +273,7 @@ func compileAttributeOperations(ctx dex.Context) error {
 	if err := statusAttribute.Delete(ctx); err != nil {
 		return err
 	}
-	if _, _, err := itemsAttribute.Get(ctx, "order-1"); err != nil {
+	if _, err := itemsAttribute.Get(ctx, "order-1"); err != nil {
 		return err
 	}
 	if err := itemsAttribute.Set(ctx, "order-1", 1); err != nil {

--- a/sdk-go/dex/decision.go
+++ b/sdk-go/dex/decision.go
@@ -20,7 +20,7 @@ func GoTo[IN any](
 	step Step[IN],
 	input IN,
 	options ...StepMoveOption,
-) StepDecision {
+) *StepDecision {
 	return GoToMulti(MovementOf(step, input, options...))
 }
 
@@ -39,15 +39,15 @@ func MovementOf[IN any](
 	return movement
 }
 
-func GoToMulti(movements ...StepMovement) StepDecision {
-	return StepDecision{
+func GoToMulti(movements ...StepMovement) *StepDecision {
+	return &StepDecision{
 		kind:      decisionNext,
 		movements: movements,
 	}
 }
 
-func GracefulComplete(output any) StepDecision {
-	return StepDecision{
+func GracefulComplete(output any) *StepDecision {
+	return &StepDecision{
 		kind: decisionClose,
 		close: CloseDecision{
 			kind:   closeGracefulComplete,
@@ -56,8 +56,8 @@ func GracefulComplete(output any) StepDecision {
 	}
 }
 
-func ForceComplete(output any) StepDecision {
-	return StepDecision{
+func ForceComplete(output any) *StepDecision {
+	return &StepDecision{
 		kind: decisionClose,
 		close: CloseDecision{
 			kind:   closeForceComplete,
@@ -66,8 +66,8 @@ func ForceComplete(output any) StepDecision {
 	}
 }
 
-func ForceFail(reason string) StepDecision {
-	return StepDecision{
+func ForceFail(reason string) *StepDecision {
+	return &StepDecision{
 		kind: decisionClose,
 		close: CloseDecision{
 			kind:   closeForceFail,
@@ -76,8 +76,8 @@ func ForceFail(reason string) StepDecision {
 	}
 }
 
-func DeadEnd() StepDecision {
-	return StepDecision{
+func DeadEnd() *StepDecision {
+	return &StepDecision{
 		kind:  decisionClose,
 		close: CloseDecision{kind: closeDeadEnd},
 	}
@@ -87,8 +87,8 @@ func ForceCompleteOnChannelsEmpty(
 	output any,
 	channels []ChannelDef,
 	otherwise ...StepMovement,
-) StepDecision {
-	return StepDecision{
+) *StepDecision {
+	return &StepDecision{
 		kind:      decisionConditionalClose,
 		movements: otherwise,
 		close: CloseDecision{

--- a/sdk-go/dex/errors.go
+++ b/sdk-go/dex/errors.go
@@ -23,6 +23,23 @@ var (
 	errInvalidInvocationContext = errors.New("dex: invalid invocation context")
 )
 
+// AttributeNotFoundError reports a missing invocation attribute.
+type AttributeNotFoundError struct {
+	AttributeName string
+	Instance      string
+}
+
+func (e *AttributeNotFoundError) Error() string {
+	if e.Instance == "" {
+		return fmt.Sprintf("dex: attribute %q not found", e.AttributeName)
+	}
+	return fmt.Sprintf(
+		"dex: attribute map %q instance %q not found",
+		e.AttributeName,
+		e.Instance,
+	)
+}
+
 type Error struct {
 	Code                codes.Code
 	SubStatus           ErrorSubStatus

--- a/sdk-go/dex/proto_mapper.go
+++ b/sdk-go/dex/proto_mapper.go
@@ -343,7 +343,10 @@ func mapWorkerTarget(target *WorkerTarget) *dexpb.WorkerTarget {
 	}
 }
 
-func mapWait(wait Wait) (*dexpb.WaitingCondition, error) {
+func mapWait(wait *Wait) (*dexpb.WaitingCondition, error) {
+	if wait == nil {
+		return nil, fmt.Errorf("dex: wait must not be nil")
+	}
 	switch wait.kind {
 	case skipWaitImmediately:
 		return nil, nil
@@ -517,7 +520,10 @@ func (mapper *conditionMapper) result(
 	}
 }
 
-func mapStepDecision(decision StepDecision) (*dexpb.StepDecision, error) {
+func mapStepDecision(decision *StepDecision) (*dexpb.StepDecision, error) {
+	if decision == nil {
+		return nil, fmt.Errorf("dex: step decision must not be nil")
+	}
 	switch decision.kind {
 	case decisionNext:
 		if len(decision.movements) == 0 {

--- a/sdk-go/dex/proto_mapper_test.go
+++ b/sdk-go/dex/proto_mapper_test.go
@@ -33,7 +33,7 @@ func (step mapperStep) GetStepOptions() *StepOptions {
 	return step.options
 }
 
-func (mapperStep) Execute(Context, int) (StepDecision, error) {
+func (mapperStep) Execute(Context, int) (*StepDecision, error) {
 	return DeadEnd(), nil
 }
 
@@ -82,7 +82,10 @@ func TestWaitMappingAssignsStableConditionIDs(t *testing.T) {
 
 func TestWaitMappingRejectsInvalidConditions(t *testing.T) {
 	channel := DefineChannel[string]("commands")
-	_, err := mapWait(AllOf())
+	_, err := mapWait(nil)
+	require.ErrorContains(t, err, "must not be nil")
+
+	_, err = mapWait(AllOf())
 	require.ErrorContains(t, err, "at least one")
 
 	_, err = mapWait(AllOf(
@@ -105,6 +108,9 @@ func TestWaitMappingRejectsInvalidConditions(t *testing.T) {
 }
 
 func TestStepDecisionAndOptionsMapping(t *testing.T) {
+	_, err := mapStepDecision(nil)
+	require.ErrorContains(t, err, "must not be nil")
+
 	status := DefineAttribute[string]("status")
 	defaults := &StepOptions{
 		ExecuteTimeout:    5 * time.Second,

--- a/sdk-go/dex/registration_test.go
+++ b/sdk-go/dex/registration_test.go
@@ -35,7 +35,7 @@ type automaticRegistrationStep struct {
 func (automaticRegistrationStep) Execute(
 	Context,
 	registrationInput,
-) (StepDecision, error) {
+) (*StepDecision, error) {
 	return DeadEnd(), nil
 }
 
@@ -46,7 +46,7 @@ type stepDefaultsWithoutWaitFor struct {
 func (stepDefaultsWithoutWaitFor) Execute(
 	Context,
 	registrationInput,
-) (StepDecision, error) {
+) (*StepDecision, error) {
 	return DeadEnd(), nil
 }
 
@@ -80,7 +80,7 @@ func (step *registrationStep) GetStepOptions() *StepOptions {
 func (step *registrationStep) WaitFor(
 	_ Context,
 	input registrationInput,
-) (Wait, error) {
+) (*Wait, error) {
 	step.waitForInput = input
 	return SkipWaitImmediately(), nil
 }
@@ -88,7 +88,7 @@ func (step *registrationStep) WaitFor(
 func (step *registrationStep) Execute(
 	_ Context,
 	input registrationInput,
-) (StepDecision, error) {
+) (*StepDecision, error) {
 	step.executeInput = input
 	return DeadEnd(), nil
 }
@@ -105,7 +105,7 @@ func (step *executeOnlyRegistrationStep) GetStepType() string {
 func (*executeOnlyRegistrationStep) Execute(
 	Context,
 	registrationInput,
-) (StepDecision, error) {
+) (*StepDecision, error) {
 	return DeadEnd(), nil
 }
 
@@ -121,7 +121,7 @@ func (step *stringRegistrationStep) GetStepType() string {
 func (*stringRegistrationStep) Execute(
 	Context,
 	string,
-) (StepDecision, error) {
+) (*StepDecision, error) {
 	return DeadEnd(), nil
 }
 

--- a/sdk-go/dex/step.go
+++ b/sdk-go/dex/step.go
@@ -36,7 +36,7 @@ type None = *none
 //	func (ApproveOrderStep) WaitFor(
 //		ctx dex.Context,
 //		input ApproveOrderInput,
-//	) (dex.Wait, error) {
+//	) (*dex.Wait, error) {
 //		return dex.AnyOf(
 //			ApprovalChannel.ForOne(),
 //			dex.Timer(input.Timeout, dex.WithConditionID("approval-timeout")),
@@ -46,7 +46,7 @@ type None = *none
 //	func (ApproveOrderStep) Execute(
 //		ctx dex.Context,
 //		input ApproveOrderInput,
-//	) (dex.StepDecision, error) {
+//	) (*dex.StepDecision, error) {
 //		if ctx.HasTimerFired() {
 //			return dex.ForceFail("approval timed out"), nil
 //		}
@@ -64,7 +64,7 @@ type None = *none
 //	func (ShipOrderStep) Execute(
 //		ctx dex.Context,
 //		input ShipOrderInput,
-//	) (dex.StepDecision, error) {
+//	) (*dex.StepDecision, error) {
 //		return dex.DeadEnd(), nil
 //	}
 //
@@ -84,7 +84,7 @@ type Step[IN any] interface {
 	//	ctx    invocation context (flow id, run id, step execution id, etc.)
 	//	input  typed step input for this execution
 	//
-	// Return a Wait built from Channel.ForOne / ForAll, Timer, AnyOf / AllOf, or
+	// Return a non-nil Wait built from Channel.ForOne / ForAll, Timer, AnyOf / AllOf, or
 	// SkipWaitImmediately. Attribute Set, RecordEvent, Publish, and
 	// SetStepExecutionLocal are allowed here; writes are accepted with the
 	// WaitFor response.
@@ -93,7 +93,7 @@ type Step[IN any] interface {
 	// StepDefaultsNoWaitFor[IN] instead of implementing a real WaitFor.
 	// Registration detects the marker and skips this method; the panic body must
 	// never run.
-	WaitFor(ctx Context, input IN) (Wait, error)
+	WaitFor(ctx Context, input IN) (*Wait, error)
 
 	// Execute decides what happens next after WaitFor conditions complete, or
 	// immediately when the step is execute-only (NoWaitFor / StepDefaultsNoWaitFor).
@@ -102,10 +102,10 @@ type Step[IN any] interface {
 	//	       step-execution locals set in WaitFor
 	//	input  the same typed step input passed to WaitFor
 	//
-	// Return a non-empty StepDecision (GoTo, GoToMulti, DeadEnd, GracefulComplete,
+	// Return a non-nil StepDecision (GoTo, GoToMulti, DeadEnd, GracefulComplete,
 	// ForceComplete, ForceFail, or a conditional close). Attribute / channel /
 	// event writes are allowed; they are accepted with the Execute response.
-	Execute(ctx Context, input IN) (StepDecision, error)
+	Execute(ctx Context, input IN) (*StepDecision, error)
 }
 
 // DefineStep wraps a non-starting Step for Flow.GetSteps.
@@ -133,8 +133,8 @@ type StepDef interface {
 	stepValue() any
 	isStarting() bool
 	skipWaitFor() bool
-	waitFor(Context, any) (Wait, error)
-	execute(Context, any) (StepDecision, error)
+	waitFor(Context, any) (*Wait, error)
+	execute(Context, any) (*StepDecision, error)
 }
 
 // NoWaitFor marks a Step as execute-only. Embed it (or StepDefaultsNoWaitFor) so
@@ -186,7 +186,7 @@ type StepDefaultsNoWaitFor[IN any] struct {
 	NoWaitFor[IN]
 }
 
-func (NoWaitFor[IN]) WaitFor(Context, IN) (Wait, error) {
+func (NoWaitFor[IN]) WaitFor(Context, IN) (*Wait, error) {
 	panic("NoWaitFor: framework must skip WaitFor")
 }
 
@@ -242,10 +242,10 @@ func (def typedStepDef[IN]) skipWaitFor() bool {
 func (def typedStepDef[IN]) waitFor(
 	ctx Context,
 	input any,
-) (Wait, error) {
+) (*Wait, error) {
 	typedInput, err := stepInput[IN](input)
 	if err != nil {
-		return Wait{}, err
+		return nil, err
 	}
 	return def.step.WaitFor(ctx, typedInput)
 }
@@ -253,10 +253,10 @@ func (def typedStepDef[IN]) waitFor(
 func (def typedStepDef[IN]) execute(
 	ctx Context,
 	input any,
-) (StepDecision, error) {
+) (*StepDecision, error) {
 	typedInput, err := stepInput[IN](input)
 	if err != nil {
-		return StepDecision{}, err
+		return nil, err
 	}
 	return def.step.Execute(ctx, typedInput)
 }

--- a/sdk-go/dex/worker_integration_test.go
+++ b/sdk-go/dex/worker_integration_test.go
@@ -75,22 +75,32 @@ type workerWaitingStep struct {
 func (workerWaitingStep) WaitFor(
 	ctx Context,
 	input workerTestInput,
-) (Wait, error) {
+) (*Wait, error) {
 	if err := workerTestStatus.Set(ctx, "waiting"); err != nil {
-		return Wait{}, err
+		return nil, err
 	}
-	statusValue, found, err := workerTestStatus.Get(ctx)
-	if err != nil || !found || statusValue != "waiting" {
-		return Wait{}, errors.New("buffered attribute write was not visible")
+	statusValue, err := workerTestStatus.Get(ctx)
+	if err != nil || statusValue != "waiting" {
+		return nil, errors.New("buffered attribute write was not visible")
+	}
+	_, err = workerTestItems.Get(ctx, "missing")
+	var missingItem *AttributeNotFoundError
+	if !errors.As(err, &missingItem) ||
+		missingItem.AttributeName != workerTestItems.AttributeName() ||
+		missingItem.Instance != "missing" {
+		return nil, errors.New("missing attribute map value returned the wrong error")
 	}
 	if err := ctx.SetStepExecutionLocal("input", input); err != nil {
-		return Wait{}, err
+		return nil, err
 	}
 	if err := ctx.RecordEvent("waiting", input); err != nil {
-		return Wait{}, err
+		return nil, err
 	}
 	if err := workerTestByOrder.Publish(ctx, input.OrderID, "published"); err != nil {
-		return Wait{}, err
+		return nil, err
+	}
+	if input.Mode == "nil-wait" {
+		return nil, nil
 	}
 	if input.Mode == "immediate" {
 		return SkipWaitImmediately(), nil
@@ -110,52 +120,55 @@ func (workerWaitingStep) WaitFor(
 func (workerWaitingStep) Execute(
 	ctx Context,
 	input workerTestInput,
-) (StepDecision, error) {
+) (*StepDecision, error) {
 	if input.Mode == "empty" {
-		return StepDecision{}, nil
+		return nil, nil
 	}
 	if input.Mode == "error" {
 		if err := workerTestStatus.Set(ctx, "discarded"); err != nil {
-			return StepDecision{}, err
+			return nil, err
 		}
-		return StepDecision{}, errors.New("execute failed")
+		return nil, errors.New("execute failed")
 	}
 	if input.Mode == "missing-local-target" {
 		found, err := ctx.GetStepExecutionLocal("missing", nil)
 		if err == nil || found {
-			return StepDecision{}, errors.New("missing local accepted a nil target")
+			return nil, errors.New("missing local accepted a nil target")
 		}
 		return DeadEnd(), nil
 	}
 	values, err := workerTestCommands.GetConditionResults(ctx)
 	if err != nil {
-		return StepDecision{}, err
+		return nil, err
 	}
 	if len(values) != 2 || values[0] != "first" || values[1] != "second" {
-		return StepDecision{}, errors.New("channel results are out of order")
+		return nil, errors.New("channel results are out of order")
 	}
 	mapValues, err := workerTestByOrder.GetConditionResults(ctx, input.OrderID)
 	if err != nil {
-		return StepDecision{}, err
+		return nil, err
 	}
 	if len(mapValues) != 1 || mapValues[0] != "mapped" {
-		return StepDecision{}, errors.New("map channel results are invalid")
+		return nil, errors.New("map channel results are invalid")
 	}
 	var local workerTestInput
 	found, err := ctx.GetStepExecutionLocal("input", &local)
 	if err != nil || !found || local != input {
-		return StepDecision{}, errors.New("step-execution local is invalid")
+		return nil, errors.New("step-execution local is invalid")
 	}
 	timerFired := input.Mode == "timer"
 	if !ctx.WaitForMethodFailed() || ctx.HasTimerFired() != timerFired ||
 		ctx.HasTimerFiredByIndex(0) != timerFired {
-		return StepDecision{}, errors.New("condition helpers are invalid")
+		return nil, errors.New("condition helpers are invalid")
 	}
 	if err := workerTestStatus.Delete(ctx); err != nil {
-		return StepDecision{}, err
+		return nil, err
 	}
-	if _, found, err := workerTestStatus.Get(ctx); err != nil || found {
-		return StepDecision{}, errors.New("buffered attribute delete was not visible")
+	_, err = workerTestStatus.Get(ctx)
+	var notFound *AttributeNotFoundError
+	if !errors.As(err, &notFound) ||
+		notFound.AttributeName != workerTestStatus.AttributeName() {
+		return nil, errors.New("buffered attribute delete was not visible")
 	}
 	return GoTo(workerTestFinish, input), nil
 }
@@ -169,7 +182,7 @@ type workerFinishStep struct {
 func (workerFinishStep) Execute(
 	Context,
 	workerTestInput,
-) (StepDecision, error) {
+) (*StepDecision, error) {
 	return DeadEnd(), nil
 }
 
@@ -359,9 +372,10 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 	defer closeService()
 
 	tests := []struct {
-		name string
-		call func() error
-		code codes.Code
+		name   string
+		call   func() error
+		code   codes.Code
+		detail string
 	}{
 		{
 			name: "unknown flow",
@@ -409,7 +423,27 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 			code: codes.NotFound,
 		},
 		{
-			name: "empty decision",
+			name: "nil wait",
+			call: func() error {
+				_, err := client.InvokeWaitForMethod(
+					context.Background(),
+					&dexpb.InvokeWaitForMethodRequest{
+						Context:  workerStepContext(),
+						FlowType: GetFinalFlowType(workerFlow),
+						StepType: GetFinalStepType(workerTestWait),
+						StepInput: mustEncodeWorkerTestValue(
+							t,
+							workerTestInput{OrderID: "order-1", Mode: "nil-wait"},
+						),
+					},
+				)
+				return err
+			},
+			code:   codes.InvalidArgument,
+			detail: "WaitFor returned nil",
+		},
+		{
+			name: "nil decision",
 			call: func() error {
 				_, err := client.InvokeExecuteMethod(
 					context.Background(),
@@ -417,7 +451,8 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 				)
 				return err
 			},
-			code: codes.InvalidArgument,
+			code:   codes.InvalidArgument,
+			detail: "Execute returned nil",
 		},
 		{
 			name: "application error",
@@ -457,6 +492,9 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 			require.Error(t, err)
 			rpcStatus := status.Convert(err)
 			require.Equal(t, testCase.code, rpcStatus.Code())
+			if testCase.detail != "" {
+				require.Contains(t, rpcStatus.Message(), testCase.detail)
+			}
 			requireWorkerErrorDetail(t, rpcStatus)
 		})
 	}
@@ -785,7 +823,7 @@ func TestWorkerRegisteredDecisionMapping(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		decision StepDecision
+		decision *StepDecision
 		close    dexpb.CloseDecisionType
 	}{
 		{name: "graceful", decision: GracefulComplete("done"), close: dexpb.CloseDecisionType_CLOSE_DECISION_TYPE_GRACEFUL_COMPLETE},

--- a/sdk-go/dex/worker_mapping.go
+++ b/sdk-go/dex/worker_mapping.go
@@ -18,8 +18,11 @@ import (
 
 func mapRegisteredWait(
 	flow *registeredFlow,
-	wait Wait,
+	wait *Wait,
 ) (*dexpb.WaitingCondition, *dexpb.StepMovement, error) {
+	if wait == nil {
+		return nil, nil, fmt.Errorf("dex: WaitFor returned nil")
+	}
 	if err := validateRegisteredWait(flow, wait); err != nil {
 		return nil, nil, err
 	}
@@ -37,7 +40,7 @@ func mapRegisteredWait(
 	return waiting, transient, nil
 }
 
-func validateRegisteredWait(flow *registeredFlow, wait Wait) error {
+func validateRegisteredWait(flow *registeredFlow, wait *Wait) error {
 	for _, condition := range wait.conditions {
 		if err := validateRegisteredCondition(flow, condition); err != nil {
 			return err
@@ -104,8 +107,11 @@ func mapTransientMovement(
 
 func mapRegisteredDecision(
 	flow *registeredFlow,
-	decision StepDecision,
+	decision *StepDecision,
 ) (*dexpb.StepDecision, error) {
+	if decision == nil {
+		return nil, fmt.Errorf("dex: Execute returned nil")
+	}
 	switch decision.kind {
 	case decisionNext:
 		if len(decision.movements) == 0 {

--- a/sdk-go/dex/worker_service.go
+++ b/sdk-go/dex/worker_service.go
@@ -309,7 +309,7 @@ func callWaitForHandler(
 	step *registeredStep,
 	invocation *invocationContext,
 	input any,
-) (Wait, error) {
+) (*Wait, error) {
 	defer invocation.finish()
 	return step.handler.waitFor(invocation, input)
 }
@@ -318,7 +318,7 @@ func callExecuteHandler(
 	step *registeredStep,
 	invocation *invocationContext,
 	input any,
-) (StepDecision, error) {
+) (*StepDecision, error) {
 	defer invocation.finish()
 	return step.handler.execute(invocation, input)
 }

--- a/sdk-go/examples/order/main.go
+++ b/sdk-go/examples/order/main.go
@@ -52,19 +52,19 @@ type WaitForCommandStep struct {
 func (WaitForCommandStep) WaitFor(
 	ctx dex.Context,
 	input OrderInput,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	if err := OrderStatus.Set(ctx, "waiting"); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 
 	if err := ctx.SetStepExecutionLocal(
 		"snapshot",
 		OrderSnapshot{OrderID: input.OrderID},
 	); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	if err := ctx.RecordEvent("waiting-for-command", input); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 
 	return dex.AnyOf(
@@ -79,26 +79,26 @@ func (WaitForCommandStep) WaitFor(
 func (WaitForCommandStep) Execute(
 	ctx dex.Context,
 	input OrderInput,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if ctx.HasTimerFired() {
 		return dex.ForceFail("command timed out"), nil
 	}
 
 	commands, err := Commands.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if len(commands) == 0 {
-		return dex.StepDecision{}, fmt.Errorf("command is missing")
+		return nil, fmt.Errorf("command is missing")
 	}
 
 	var snapshot OrderSnapshot
 	found, err := ctx.GetStepExecutionLocal("snapshot", &snapshot)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if !found {
-		return dex.StepDecision{}, fmt.Errorf("snapshot is missing")
+		return nil, fmt.Errorf("snapshot is missing")
 	}
 	return dex.GracefulComplete(snapshot), nil
 }

--- a/sdk-go/examples/transitions/main.go
+++ b/sdk-go/examples/transitions/main.go
@@ -38,7 +38,7 @@ type ApproveOrderStep struct {
 func (ApproveOrderStep) WaitFor(
 	ctx dex.Context,
 	input ApproveOrderInput,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AnyOf(
 		ApprovalChannel.ForOne(),
 		dex.Timer(
@@ -51,13 +51,13 @@ func (ApproveOrderStep) WaitFor(
 func (ApproveOrderStep) Execute(
 	ctx dex.Context,
 	input ApproveOrderInput,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if ctx.HasTimerFired() {
 		return dex.ForceFail("approval timed out"), nil
 	}
 	approvals, err := ApprovalChannel.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if len(approvals) == 0 || !approvals[0].Approved {
 		return dex.ForceFail("order rejected"), nil
@@ -77,7 +77,7 @@ type ShipOrderStep struct {
 func (ShipOrderStep) Execute(
 	ctx dex.Context,
 	input ShipOrderInput,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.DeadEnd(), nil
 }
 

--- a/sdk-go/integ/abnormal_exit_test.go
+++ b/sdk-go/integ/abnormal_exit_test.go
@@ -38,8 +38,8 @@ func (abnormalExitStep) GetStepOptions() *dex.StepOptions {
 	}
 }
 
-func (abnormalExitStep) Execute(dex.Context, struct{}) (dex.StepDecision, error) {
-	return dex.StepDecision{}, fmt.Errorf("abnormal exit step")
+func (abnormalExitStep) Execute(dex.Context, struct{}) (*dex.StepDecision, error) {
+	return nil, fmt.Errorf("abnormal exit step")
 }
 
 func TestAbnormalExitFlow(t *testing.T) {

--- a/sdk-go/integ/basic_test.go
+++ b/sdk-go/integ/basic_test.go
@@ -34,19 +34,19 @@ type basicFirstStep struct {
 	dex.StepDefaults
 }
 
-func (basicFirstStep) WaitFor(ctx dex.Context, input int) (dex.Wait, error) {
+func (basicFirstStep) WaitFor(ctx dex.Context, input int) (*dex.Wait, error) {
 	if ctx.Attempt() < 1 || ctx.FirstAttemptAt().IsZero() {
-		return dex.Wait{}, fmt.Errorf("invalid first-step attempt metadata")
+		return nil, fmt.Errorf("invalid first-step attempt metadata")
 	}
 	if input < 0 {
-		return dex.Wait{}, fmt.Errorf("input must not be negative")
+		return nil, fmt.Errorf("input must not be negative")
 	}
 	return dex.SkipWaitImmediately(), nil
 }
 
-func (basicFirstStep) Execute(ctx dex.Context, input int) (dex.StepDecision, error) {
+func (basicFirstStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, error) {
 	if ctx.Attempt() < 1 || ctx.FirstAttemptAt().IsZero() {
-		return dex.StepDecision{}, fmt.Errorf("invalid first-step attempt metadata")
+		return nil, fmt.Errorf("invalid first-step attempt metadata")
 	}
 	return dex.GoTo(basicSecondStep{}, input+1), nil
 }
@@ -55,7 +55,7 @@ type basicSecondStep struct {
 	dex.StepDefaultsNoWaitFor[int]
 }
 
-func (basicSecondStep) Execute(dex.Context, int) (dex.StepDecision, error) {
+func (basicSecondStep) Execute(dex.Context, int) (*dex.StepDecision, error) {
 	return dex.GracefulComplete(3), nil
 }
 
@@ -87,16 +87,16 @@ func (proceedOnWaitForFailureFirstStep) GetStepOptions() *dex.StepOptions {
 func (proceedOnWaitForFailureFirstStep) WaitFor(
 	dex.Context,
 	string,
-) (dex.Wait, error) {
-	return dex.Wait{}, fmt.Errorf("planned WaitFor failure")
+) (*dex.Wait, error) {
+	return nil, fmt.Errorf("planned WaitFor failure")
 }
 
 func (proceedOnWaitForFailureFirstStep) Execute(
 	ctx dex.Context,
 	input string,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if !ctx.WaitForMethodFailed() {
-		return dex.StepDecision{}, fmt.Errorf("WaitFor failure was not reported")
+		return nil, fmt.Errorf("WaitFor failure was not reported")
 	}
 	return dex.GoTo(
 		proceedOnWaitForFailureSecondStep{},
@@ -111,14 +111,14 @@ type proceedOnWaitForFailureSecondStep struct {
 func (proceedOnWaitForFailureSecondStep) WaitFor(
 	dex.Context,
 	string,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.SkipWaitImmediately(), nil
 }
 
 func (proceedOnWaitForFailureSecondStep) Execute(
 	_ dex.Context,
 	input string,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.GracefulComplete(input + "_step2_wait_for_step2_execute"), nil
 }
 

--- a/sdk-go/integ/interstate_test.go
+++ b/sdk-go/integ/interstate_test.go
@@ -49,7 +49,7 @@ type interStepStartStep struct {
 func (interStepStartStep) Execute(
 	dex.Context,
 	struct{},
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.GoToMulti(
 		dex.MovementOf(interStepWaitStep{}, struct{}{}),
 		dex.MovementOf(interStepPublishStep{}, 2),
@@ -63,7 +63,7 @@ type interStepWaitStep struct {
 func (interStepWaitStep) WaitFor(
 	dex.Context,
 	struct{},
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AnyOf(
 		interStepFirstChannel.ForOne(),
 		interStepSecondChannel.ForOne(),
@@ -73,17 +73,17 @@ func (interStepWaitStep) WaitFor(
 func (interStepWaitStep) Execute(
 	ctx dex.Context,
 	_ struct{},
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	first, err := interStepFirstChannel.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	second, err := interStepSecondChannel.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if len(first) != 0 || len(second) != 1 || second[0] != 2 {
-		return dex.StepDecision{}, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"unexpected channel results: first=%v second=%v",
 			first,
 			second,
@@ -99,9 +99,9 @@ type interStepPublishStep struct {
 func (interStepPublishStep) WaitFor(
 	ctx dex.Context,
 	input int,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	if err := interStepSecondChannel.Publish(ctx, input); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	return dex.SkipWaitImmediately(), nil
 }
@@ -109,7 +109,7 @@ func (interStepPublishStep) WaitFor(
 func (interStepPublishStep) Execute(
 	dex.Context,
 	int,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.DeadEnd(), nil
 }
 

--- a/sdk-go/integ/no_startstate_test.go
+++ b/sdk-go/integ/no_startstate_test.go
@@ -42,7 +42,7 @@ type noStartFinishStep struct {
 func (noStartFinishStep) Execute(
 	_ dex.Context,
 	input int,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.GracefulComplete(input + 1), nil
 }
 

--- a/sdk-go/integ/persistence_test.go
+++ b/sdk-go/integ/persistence_test.go
@@ -11,6 +11,7 @@
 package integ
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -96,46 +97,47 @@ type persistenceFirstStep struct {
 func (persistenceFirstStep) WaitFor(
 	ctx dex.Context,
 	input persistenceModel,
-) (dex.Wait, error) {
-	keyword, found, err := persistenceKeyword.Get(ctx)
+) (*dex.Wait, error) {
+	keyword, err := persistenceKeyword.Get(ctx)
 	if err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
-	if !found || keyword != "init-keyword" {
-		return dex.Wait{}, fmt.Errorf("unexpected initial keyword %q", keyword)
+	if keyword != "init-keyword" {
+		return nil, fmt.Errorf("unexpected initial keyword %q", keyword)
 	}
-	searchText, found, err := persistenceSearchText.Get(ctx)
+	searchText, err := persistenceSearchText.Get(ctx)
 	if err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
-	if !found || searchText != "init-text" {
-		return dex.Wait{}, fmt.Errorf("unexpected initial search text %q", searchText)
+	if searchText != "init-text" {
+		return nil, fmt.Errorf("unexpected initial search text %q", searchText)
 	}
-	_, found, err = persistenceData.Get(ctx)
+	_, err = persistenceData.Get(ctx)
+	if err == nil {
+		return nil, fmt.Errorf("data must not exist before its first write")
+	}
+	var notFound *dex.AttributeNotFoundError
+	if !errors.As(err, &notFound) {
+		return nil, err
+	}
+	item, err := persistenceMap.Get(ctx, "one")
 	if err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
-	if found {
-		return dex.Wait{}, fmt.Errorf("data must not exist before its first write")
-	}
-	item, found, err := persistenceMap.Get(ctx, "one")
-	if err != nil {
-		return dex.Wait{}, err
-	}
-	if !found || item != 10 {
-		return dex.Wait{}, fmt.Errorf("unexpected initial map value %d", item)
+	if item != 10 {
+		return nil, fmt.Errorf("unexpected initial map value %d", item)
 	}
 	if err := persistenceData.Set(ctx, input); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	if err := persistenceText.Set(ctx, "a string"); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	if err := persistenceMap.Set(ctx, "one", 11); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	if err := persistenceInt.Set(ctx, 1); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	return dex.SkipWaitImmediately(), nil
 }
@@ -143,26 +145,26 @@ func (persistenceFirstStep) WaitFor(
 func (persistenceFirstStep) Execute(
 	ctx dex.Context,
 	input persistenceModel,
-) (dex.StepDecision, error) {
-	integer, found, err := persistenceInt.Get(ctx)
+) (*dex.StepDecision, error) {
+	integer, err := persistenceInt.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
-	if !found || integer != 1 {
-		return dex.StepDecision{}, fmt.Errorf("WaitFor integer write was not visible")
+	if integer != 1 {
+		return nil, fmt.Errorf("WaitFor integer write was not visible")
 	}
-	data, found, err := persistenceData.Get(ctx)
+	data, err := persistenceData.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
-	if !found || data.Text != input.Text || data.Number != input.Number {
-		return dex.StepDecision{}, fmt.Errorf("WaitFor data write was not visible")
+	if data.Text != input.Text || data.Number != input.Number {
+		return nil, fmt.Errorf("WaitFor data write was not visible")
 	}
 	if err := persistenceDatetime.Set(ctx, data.Datetime); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if err := persistenceBool.Set(ctx, true); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.GoTo(persistenceSecondStep{}, struct{}{}), nil
 }
@@ -174,33 +176,30 @@ type persistenceSecondStep struct {
 func (persistenceSecondStep) WaitFor(
 	ctx dex.Context,
 	_ struct{},
-) (dex.Wait, error) {
-	data, found, err := persistenceData.Get(ctx)
+) (*dex.Wait, error) {
+	data, err := persistenceData.Get(ctx)
 	if err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
-	if !found {
-		return dex.Wait{}, fmt.Errorf("persisted data is missing")
-	}
-	dateTime, found, err := persistenceDatetime.Get(ctx)
+	dateTime, err := persistenceDatetime.Get(ctx)
 	if err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
-	if !found || !dateTime.Equal(data.Datetime) {
-		return dex.Wait{}, fmt.Errorf("persisted datetime does not round-trip")
+	if !dateTime.Equal(data.Datetime) {
+		return nil, fmt.Errorf("persisted datetime does not round-trip")
 	}
-	boolean, found, err := persistenceBool.Get(ctx)
+	boolean, err := persistenceBool.Get(ctx)
 	if err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
-	if !found || !boolean {
-		return dex.Wait{}, fmt.Errorf("persisted bool is false")
+	if !boolean {
+		return nil, fmt.Errorf("persisted bool is false")
 	}
 	if err := persistenceDouble.Set(ctx, 1); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	if err := persistenceSearchText.Set(ctx, "Hail Dex!"); err != nil {
-		return dex.Wait{}, err
+		return nil, err
 	}
 	return dex.SkipWaitImmediately(), nil
 }
@@ -208,16 +207,16 @@ func (persistenceSecondStep) WaitFor(
 func (persistenceSecondStep) Execute(
 	ctx dex.Context,
 	_ struct{},
-) (dex.StepDecision, error) {
-	text, found, err := persistenceSearchText.Get(ctx)
+) (*dex.StepDecision, error) {
+	text, err := persistenceSearchText.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
-	if !found || text != "Hail Dex!" {
-		return dex.StepDecision{}, fmt.Errorf("unexpected persisted text %q", text)
+	if text != "Hail Dex!" {
+		return nil, fmt.Errorf("unexpected persisted text %q", text)
 	}
 	if err := persistenceKeyword.Set(ctx, "Dex"); err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	return dex.GracefulComplete("done"), nil
 }

--- a/sdk-go/integ/rpc_test.go
+++ b/sdk-go/integ/rpc_test.go
@@ -11,6 +11,7 @@
 package integ
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -50,8 +51,12 @@ func (rpcFlow) Increment(
 	ctx dex.Context,
 	input int,
 ) (dex.RPCResult[rpcIncrementOutput], error) {
-	_, found, err := rpcFlowStatus.Get(ctx)
-	if err != nil {
+	_, err := rpcFlowStatus.Get(ctx)
+	statusFound := true
+	var notFound *dex.AttributeNotFoundError
+	if errors.As(err, &notFound) {
+		statusFound = false
+	} else if err != nil {
 		return dex.RPCResult[rpcIncrementOutput]{}, err
 	}
 	before := rpcFlowChannel.Size(ctx)
@@ -65,7 +70,7 @@ func (rpcFlow) Increment(
 		Value:       input + 1,
 		SizeBefore:  before,
 		SizeAfter:   rpcFlowChannel.Size(ctx),
-		StatusFound: found,
+		StatusFound: statusFound,
 	}}, nil
 }
 
@@ -83,27 +88,27 @@ type rpcFlowStep struct {
 func (rpcFlowStep) WaitFor(
 	dex.Context,
 	int,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AnyOf(rpcFlowChannel.ForOne()), nil
 }
 
 func (rpcFlowStep) Execute(
 	ctx dex.Context,
 	input int,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	values, err := rpcFlowChannel.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if len(values) != 1 || values[0] != input+1 {
-		return dex.StepDecision{}, fmt.Errorf("unexpected RPC channel values %v", values)
+		return nil, fmt.Errorf("unexpected RPC channel values %v", values)
 	}
-	status, found, err := rpcFlowStatus.Get(ctx)
+	status, err := rpcFlowStatus.Get(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
-	if !found || status != "invoked" {
-		return dex.StepDecision{}, fmt.Errorf("RPC attribute write was not committed")
+	if status != "invoked" {
+		return nil, fmt.Errorf("RPC attribute write was not committed")
 	}
 	return dex.GracefulComplete(values[0] + 1), nil
 }

--- a/sdk-go/integ/signal_test.go
+++ b/sdk-go/integ/signal_test.go
@@ -50,7 +50,7 @@ type channelFlowFirstStep struct {
 func (channelFlowFirstStep) WaitFor(
 	dex.Context,
 	struct{},
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AnyOf(
 		channelFlowFirst.ForOne(),
 		channelFlowSecond.ForOne(),
@@ -60,17 +60,17 @@ func (channelFlowFirstStep) WaitFor(
 func (channelFlowFirstStep) Execute(
 	ctx dex.Context,
 	_ struct{},
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	first, err := channelFlowFirst.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	second, err := channelFlowSecond.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if len(first) != 0 || len(second) != 1 || second[0] != 10 {
-		return dex.StepDecision{}, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"unexpected first-step channel results: first=%v second=%v",
 			first,
 			second,
@@ -86,7 +86,7 @@ type channelFlowSecondStep struct {
 func (channelFlowSecondStep) WaitFor(
 	dex.Context,
 	struct{},
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AnyComboOf(dex.Combo(
 		channelFlowFirst.ForOne(),
 		dex.Timer(24*time.Hour, dex.WithConditionID("finish-timer")),
@@ -96,20 +96,20 @@ func (channelFlowSecondStep) WaitFor(
 func (channelFlowSecondStep) Execute(
 	ctx dex.Context,
 	_ struct{},
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if !ctx.HasTimerFired() || !ctx.HasTimerFiredByIndex(0) {
-		return dex.StepDecision{}, fmt.Errorf("skipped timer was not reported as fired")
+		return nil, fmt.Errorf("skipped timer was not reported as fired")
 	}
 	first, err := channelFlowFirst.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	second, err := channelFlowSecond.GetConditionResults(ctx)
 	if err != nil {
-		return dex.StepDecision{}, err
+		return nil, err
 	}
 	if len(first) != 1 || first[0] != 100 || len(second) != 0 {
-		return dex.StepDecision{}, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"unexpected second-step channel results: first=%v second=%v",
 			first,
 			second,

--- a/sdk-go/integ/skip_wait_until_test.go
+++ b/sdk-go/integ/skip_wait_until_test.go
@@ -46,7 +46,7 @@ type executeOnlyFirstStep struct {
 func (executeOnlyFirstStep) Execute(
 	_ dex.Context,
 	input int,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.GoTo(executeOnlySecondStep{}, input+1), nil
 }
 
@@ -57,7 +57,7 @@ type executeOnlySecondStep struct {
 func (executeOnlySecondStep) Execute(
 	_ dex.Context,
 	input int,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.GracefulComplete(input + 1), nil
 }
 

--- a/sdk-go/integ/state_recovery_test.go
+++ b/sdk-go/integ/state_recovery_test.go
@@ -41,8 +41,8 @@ func (executeRecoveryFailStep) GetStepOptions() *dex.StepOptions {
 	}
 }
 
-func (executeRecoveryFailStep) Execute(dex.Context, string) (dex.StepDecision, error) {
-	return dex.StepDecision{}, fmt.Errorf("planned Execute failure")
+func (executeRecoveryFailStep) Execute(dex.Context, string) (*dex.StepDecision, error) {
+	return nil, fmt.Errorf("planned Execute failure")
 }
 
 type executeRecoveryFinishStep struct {
@@ -52,7 +52,7 @@ type executeRecoveryFinishStep struct {
 func (executeRecoveryFinishStep) Execute(
 	dex.Context,
 	string,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.GracefulComplete("this is flow step 2"), nil
 }
 

--- a/sdk-go/integ/timer_test.go
+++ b/sdk-go/integ/timer_test.go
@@ -34,16 +34,16 @@ type timerStep struct {
 func (timerStep) WaitFor(
 	_ dex.Context,
 	seconds int,
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	return dex.AllOf(dex.Timer(time.Duration(seconds) * time.Second)), nil
 }
 
 func (timerStep) Execute(
 	ctx dex.Context,
 	seconds int,
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	if !ctx.HasTimerFired() || !ctx.HasTimerFiredByIndex(0) {
-		return dex.StepDecision{}, fmt.Errorf("natural timer was not reported as fired")
+		return nil, fmt.Errorf("natural timer was not reported as fired")
 	}
 	return dex.GracefulComplete(seconds + 1), nil
 }

--- a/sdk-go/integ/workflow_uncompleted_test.go
+++ b/sdk-go/integ/workflow_uncompleted_test.go
@@ -35,7 +35,7 @@ type forceFailStep struct {
 func (forceFailStep) Execute(
 	dex.Context,
 	struct{},
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.ForceFail("a failing message"), nil
 }
 
@@ -58,14 +58,14 @@ func (waitForFailureStep) GetStepOptions() *dex.StepOptions {
 func (waitForFailureStep) WaitFor(
 	dex.Context,
 	struct{},
-) (dex.Wait, error) {
-	return dex.Wait{}, fmt.Errorf("test WaitFor failing")
+) (*dex.Wait, error) {
+	return nil, fmt.Errorf("test WaitFor failing")
 }
 
 func (waitForFailureStep) Execute(
 	dex.Context,
 	struct{},
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.ForceFail("must not execute"), nil
 }
 
@@ -91,15 +91,15 @@ func (waitForTimeoutStep) GetStepOptions() *dex.StepOptions {
 func (waitForTimeoutStep) WaitFor(
 	ctx dex.Context,
 	_ struct{},
-) (dex.Wait, error) {
+) (*dex.Wait, error) {
 	<-ctx.Done()
-	return dex.Wait{}, ctx.Err()
+	return nil, ctx.Err()
 }
 
 func (waitForTimeoutStep) Execute(
 	dex.Context,
 	struct{},
-) (dex.StepDecision, error) {
+) (*dex.StepDecision, error) {
 	return dex.ForceFail("must not execute"), nil
 }
 


### PR DESCRIPTION
## Summary

- simplify invocation `Attribute.Get` and `AttributeMap.Get` to return `(value, error)`
- return `*dex.AttributeNotFoundError` for missing attributes and map instances
- change Step `WaitFor` and `Execute` results, plus Wait/decision constructors, to pointers
- reject nil Wait and StepDecision handler results before committing Worker buffers
- migrate the Go SDK integration suite, SDK examples, existing Go samples, and documentation

## Rationale and user impact

This is a breaking API cleanup for the unreleased Go SDK. Attribute reads no longer require a separate `found` result, while callers that expect absence can use `errors.As`. Step handlers can return `nil, err` naturally instead of constructing meaningless zero-value Wait or StepDecision values.

The Dataset Deal example is intentionally excluded from this branch.

## Validation

- `make -C sdk-go unitTests`
- `make -C sdk-go clientIntegTests`
- `make -C sdk-go workerIntegTests`
- `make -C sdk-go blobCacheTests`
- `make -C sdk-go e2eTests`
- `make -C examples/go unitTests`
- `make -C examples/go e2eTests`
- `make copyright-check`
