### PR TITLE
Improve timeline event relationship navigation

### DIFF
--- a/web/app/flows/RunDetailsPage.tsx
+++ b/web/app/flows/RunDetailsPage.tsx
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import { Link } from 'react-router-dom';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type {
   CSSProperties,
   KeyboardEvent as ReactKeyboardEvent,
@@ -34,6 +34,13 @@ import { StepGraph } from './details/StepGraph';
 import { Timeline } from './details/Timeline';
 
 type RunTab = 'overview' | 'steps' | 'timeline';
+
+interface SelectedEventConnector {
+  height: number;
+  path: string;
+  tone: 'default' | 'execute' | 'wait-for';
+  width: number;
+}
 
 const terminalStatuses = new Set([2, 3, 4, 5, 6, 7]);
 const sidebarWidthStorageKey = 'dex.run.selected-event-width';
@@ -64,6 +71,12 @@ function persistSidebarWidth(width: number) {
   }
 }
 
+function selectedEventConnectorTone(event: FlowHistoryEvent): SelectedEventConnector['tone'] {
+  if (event.type.startsWith('StepWaitFor')) return 'wait-for';
+  if (event.type.startsWith('StepExecute')) return 'execute';
+  return 'default';
+}
+
 async function responseJSON<T>(response: Response): Promise<T> {
   const data = await response.json() as T & { error?: string };
   if (!response.ok) throw new Error(data.error || `Request failed (${response.status})`);
@@ -89,12 +102,14 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
   const [dataWarnings, setDataWarnings] = useState<string[]>([]);
   const [sidebarWidth, setSidebarWidth] = useState(storedSidebarWidth);
   const [resizingSidebar, setResizingSidebar] = useState(false);
+  const [selectedEventConnector, setSelectedEventConnector] = useState<SelectedEventConnector | null>(null);
   const waitGeneration = useRef(0);
   const blobCache = useRef(new Map<string, unknown>());
   const hydratingEventIDs = useRef(new Set<number>());
   const hydratedEventIDs = useRef(new Set<number>());
   const sidebarWidthRef = useRef(sidebarWidth);
   const sidebarResizeStart = useRef({ pointerX: 0, width: sidebarWidth });
+  const runContent = useRef<HTMLDivElement>(null);
 
   const summaryURL = `/api/flows/summary?flowId=${encodeURIComponent(flowId)}&runId=${encodeURIComponent(runId)}`;
   const stateURL = `/api/flows/state?flowId=${encodeURIComponent(flowId)}&runId=${encodeURIComponent(runId)}`;
@@ -322,6 +337,60 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
     const startEvent = history.find((event) => event.type === 'FlowStartedOrContinued');
     if (startEvent) void hydrateEvent(startEvent);
   }, [hydrateEvent, history, tab]);
+
+  useLayoutEffect(() => {
+    const content = runContent.current;
+    const selectedEventID = selectedEvent?.eventId;
+    if (!content || tab !== 'timeline' || !selectedEventID) {
+      setSelectedEventConnector(null);
+      return;
+    }
+    const source = content.querySelector<HTMLElement>(`[data-event-id="${selectedEventID}"] .event-card`);
+    const target = content.querySelector<HTMLElement>('[data-selected-event-target]');
+    if (!source || !target) {
+      setSelectedEventConnector(null);
+      return;
+    }
+    let animationFrame = 0;
+    const update = () => {
+      animationFrame = 0;
+      if (window.innerWidth <= 1100) {
+        setSelectedEventConnector(null);
+        return;
+      }
+      const contentRect = content.getBoundingClientRect();
+      const sourceRect = source.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      const startX = sourceRect.right - contentRect.left + 4;
+      const startY = sourceRect.top + sourceRect.height / 2 - contentRect.top;
+      const endX = targetRect.left - contentRect.left - 4;
+      const endY = targetRect.top + Math.min(48, targetRect.height / 2) - contentRect.top;
+      const bendX = startX + (endX - startX) / 2;
+      setSelectedEventConnector({
+        height: content.scrollHeight,
+        path: `M ${startX} ${startY} H ${bendX} V ${endY} H ${endX}`,
+        tone: selectedEventConnectorTone(selectedEvent),
+        width: content.scrollWidth,
+      });
+    };
+    const scheduleUpdate = () => {
+      if (!animationFrame) animationFrame = window.requestAnimationFrame(update);
+    };
+    const observer = new ResizeObserver(scheduleUpdate);
+    observer.observe(content);
+    observer.observe(source);
+    observer.observe(target);
+    window.addEventListener('resize', scheduleUpdate);
+    window.addEventListener('scroll', scheduleUpdate, true);
+    scheduleUpdate();
+    return () => {
+      if (animationFrame) window.cancelAnimationFrame(animationFrame);
+      observer.disconnect();
+      window.removeEventListener('resize', scheduleUpdate);
+      window.removeEventListener('scroll', scheduleUpdate, true);
+    };
+  }, [selectedEvent, sidebarWidth, tab]);
+
   const runChain = useMemo(() => {
     if (!summary) return [];
     return [...new Set([summary.firstRunId, summary.runId].filter(Boolean))];
@@ -385,8 +454,20 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
 
       <div
         className={`run-content ${resizingSidebar ? 'is-resizing-sidebar' : ''}`}
+        ref={runContent}
         style={{ '--run-sidebar-width': `${sidebarWidth}px` } as CSSProperties}
       >
+        {selectedEventConnector && (
+          <svg
+            aria-hidden="true"
+            className={`selected-event-connector tone-${selectedEventConnector.tone}`}
+            height={selectedEventConnector.height}
+            viewBox={`0 0 ${selectedEventConnector.width} ${selectedEventConnector.height}`}
+            width={selectedEventConnector.width}
+          >
+            <path d={selectedEventConnector.path} />
+          </svg>
+        )}
         <section className="run-primary">
           {tab === 'overview' && summary && (
             <FlowOverview summary={summary} events={displayedHistory} state={state} />

--- a/web/app/flows/details/FlowStatePanel.tsx
+++ b/web/app/flows/details/FlowStatePanel.tsx
@@ -73,15 +73,19 @@ export function FlowStatePanel({
   return (
     <div className="sidebar-stack" ref={sidebar}>
       {selectedEvent && (
-        <section className="sidebar-section">
-          <p className="eyebrow">Selected event</p>
-          <h3>{eventTitle(selectedEvent)}</h3>
-          <div className="event-meta">
-            <span>Event {selectedEvent.eventId}</span>
-            <span>{selectedEvent.eventTime || 'No timestamp'}</span>
-          </div>
-          <EventDetails event={selectedEvent} history={history} />
-        </section>
+        <>
+          <header className="selected-event-anchor" data-selected-event-target>
+            <p className="eyebrow">Selected event</p>
+            <h3>{eventTitle(selectedEvent)}</h3>
+            <div className="event-meta">
+              <span>Event {selectedEvent.eventId}</span>
+              <span>{selectedEvent.eventTime || 'No timestamp'}</span>
+            </div>
+          </header>
+          <section className="sidebar-section selected-event-body">
+            <EventDetails event={selectedEvent} history={history} />
+          </section>
+        </>
       )}
 
       <section className="sidebar-section">

--- a/web/app/flows/details/Timeline.tsx
+++ b/web/app/flows/details/Timeline.tsx
@@ -21,9 +21,12 @@ interface StepLinkPath {
   label: string;
   lane: number;
   path: string;
+  waitForEventId: number;
+  executeEventId: number;
   duration: string;
   durationX: number;
   durationY: number;
+  durationWidth: number;
 }
 
 interface StepLinkLayout {
@@ -38,6 +41,12 @@ function eventTone(event: FlowHistoryEvent) {
   if (event.type.endsWith('Completed')) return 'completed';
   if (event.type === 'FlowClosed') return 'closed';
   return 'neutral';
+}
+
+function stepMethodClass(event: FlowHistoryEvent) {
+  if (event.type.startsWith('StepWaitFor')) return ' step-method-wait-for';
+  if (event.type.startsWith('StepExecute')) return ' step-method-execute';
+  return '';
 }
 
 function executionSummary(event: FlowHistoryEvent): string {
@@ -76,6 +85,8 @@ export function Timeline({
     '--timeline-link-rail-width': `${88 + (linkLaneCount - 1) * 48}px`,
   } as CSSProperties;
   const [stepLinkLayout, setStepLinkLayout] = useState<StepLinkLayout>({ width: 0, height: 0, paths: [] });
+  const [interactionStepLinkID, setInteractionStepLinkID] = useState<string | null>(null);
+  const [pinnedStepLinkID, setPinnedStepLinkID] = useState<string | null>(null);
   const updateStepLinks = useCallback(() => {
     const timeline = timelineRef.current;
     if (!timeline) return;
@@ -97,9 +108,12 @@ export function Timeline({
         label: `${link.stepExecutionId}: WaitForCondition started to Execute`,
         lane: link.lane,
         path: `M ${waitForX} ${waitForY} H ${linkX} V ${executeY} H ${executeX}`,
+        waitForEventId: link.waitForEventId,
+        executeEventId: link.executeEventId,
         duration,
         durationX: linkX + 6,
         durationY: (waitForY + executeY) / 2,
+        durationWidth: Math.max(28, duration.length * 7 + 10),
       }];
     });
     setStepLinkLayout({ width: timelineRect.width, height: timelineRect.height, paths });
@@ -126,6 +140,12 @@ export function Timeline({
     if (!eventMs) return earliest;
     return earliest ? Math.min(earliest, eventMs) : eventMs;
   }, 0);
+  const selectedStepLink = stepLinkLayout.paths.find((link) => (
+    link.waitForEventId === selectedEvent?.eventId || link.executeEventId === selectedEvent?.eventId
+  ));
+  const pinnedStepLink = stepLinkLayout.paths.find((link) => link.id === pinnedStepLinkID);
+  const activeStepLinkID = interactionStepLinkID ?? pinnedStepLink?.id ?? selectedStepLink?.id ?? null;
+  const activeStepLink = stepLinkLayout.paths.find((link) => link.id === activeStepLinkID);
   return (
     <div className="timeline-wrap">
       <div className="view-toolbar">
@@ -136,9 +156,10 @@ export function Timeline({
       <div className="timeline" ref={timelineRef} style={timelineStyle}>
         {stepLinkLayout.paths.length > 0 && (
           <svg
-            aria-hidden="true"
+            aria-label="WaitForCondition to Execute links"
             className="timeline-step-links"
             height={stepLinkLayout.height}
+            role="group"
             viewBox={`0 0 ${stepLinkLayout.width} ${stepLinkLayout.height}`}
             width={stepLinkLayout.width}
           >
@@ -146,36 +167,89 @@ export function Timeline({
               <marker id="timeline-step-arrow" markerHeight="7" markerWidth="7" orient="auto" refX="5" refY="3.5">
                 <path d="M 0 0 L 6 3.5 L 0 7 z" />
               </marker>
+              <marker id="timeline-step-arrow-active" markerHeight="9" markerWidth="9" orient="auto" refX="7" refY="4.5">
+                <path d="M 0 0 L 8 4.5 L 0 9 z" />
+              </marker>
             </defs>
-            {stepLinkLayout.paths.map((link) => (
-              <g data-step-execution-id={link.id} data-timeline-lane={link.lane} key={link.id}>
-                <path className="timeline-step-link" d={link.path} markerEnd="url(#timeline-step-arrow)">
-                  <title>{link.label}</title>
-                </path>
-                {link.duration && (
-                  <text
-                    className="timeline-step-duration"
-                    dominantBaseline="middle"
-                    x={link.durationX}
-                    y={link.durationY}
-                  >
-                    {link.duration}
-                  </text>
-                )}
-              </g>
-            ))}
+            {stepLinkLayout.paths.map((link) => {
+              const active = activeStepLinkID === link.id;
+              const pinned = pinnedStepLinkID === link.id;
+              const accessibleLabel = link.duration ? `${link.label}, ${link.duration}` : link.label;
+              return (
+                <g
+                  aria-label={accessibleLabel}
+                  aria-pressed={pinned}
+                  className={`timeline-step-link-group${active ? ' is-active' : ''}`}
+                  data-step-execution-id={link.id}
+                  data-timeline-lane={link.lane}
+                  key={link.id}
+                  onBlur={() => setInteractionStepLinkID(null)}
+                  onClick={() => setPinnedStepLinkID((current) => current === link.id ? null : link.id)}
+                  onFocus={() => setInteractionStepLinkID(link.id)}
+                  onKeyDown={(event) => {
+                    if (event.key !== 'Enter' && event.key !== ' ') return;
+                    event.preventDefault();
+                    setPinnedStepLinkID((current) => current === link.id ? null : link.id);
+                  }}
+                  onMouseEnter={() => setInteractionStepLinkID(link.id)}
+                  onMouseLeave={(event) => {
+                    if (document.activeElement !== event.currentTarget) setInteractionStepLinkID(null);
+                  }}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <title>{accessibleLabel}</title>
+                  <path aria-hidden="true" className="timeline-step-link-hitarea" d={link.path} />
+                  <path
+                    aria-hidden="true"
+                    className="timeline-step-link"
+                    d={link.path}
+                    markerEnd={active ? 'url(#timeline-step-arrow-active)' : 'url(#timeline-step-arrow)'}
+                  />
+                  {link.duration && (
+                    <>
+                      <rect
+                        aria-hidden="true"
+                        className="timeline-step-duration-background"
+                        height="20"
+                        rx="7"
+                        width={link.durationWidth}
+                        x={link.durationX - 5}
+                        y={link.durationY - 10}
+                      />
+                      <text
+                        aria-hidden="true"
+                        className="timeline-step-duration"
+                        dominantBaseline="middle"
+                        x={link.durationX}
+                        y={link.durationY}
+                      >
+                        {link.duration}
+                      </text>
+                    </>
+                  )}
+                </g>
+              );
+            })}
           </svg>
         )}
         {orderedEvents.map((event) => {
           const eventMs = event.eventTime ? Date.parse(event.eventTime) : 0;
           const relative = startMs && eventMs ? Math.max(0, Math.round((eventMs - startMs) / 1000)) : null;
           const selected = selectedEvent?.eventId === event.eventId;
+          const linked = activeStepLink?.waitForEventId === event.eventId || activeStepLink?.executeEventId === event.eventId;
+          const counterpart = activeStepLink?.id === selectedStepLink?.id && linked && !selected;
           const previousRunId = previousRunID(event);
           return (
             <article
-              className={`timeline-row ${selected ? 'selected' : ''}`}
+              className={`timeline-row${stepMethodClass(event)}${selected ? ' selected' : ''}${linked ? ' link-highlighted' : ''}${counterpart ? ' link-counterpart' : ''}`}
+              data-event-id={event.eventId}
               key={event.eventId}
-              onClick={() => onSelectEvent(event)}
+              onClick={() => {
+                setInteractionStepLinkID(null);
+                setPinnedStepLinkID(null);
+                onSelectEvent(event);
+              }}
             >
               <div className="timeline-time">
                 <b>{formatDate(event.eventTime, timezone)}</b>
@@ -183,7 +257,7 @@ export function Timeline({
               </div>
               <div className="timeline-rail">
                 <span
-                  className={`timeline-dot tone-${eventTone(event)}`}
+                  className={`timeline-dot tone-${eventTone(event)}${linked ? ' link-highlighted' : ''}`}
                   ref={(node) => {
                     if (node) eventDots.current.set(event.eventId, node);
                     else eventDots.current.delete(event.eventId);

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -826,10 +826,36 @@ pre {
 }
 
 .run-content {
+  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) var(--run-sidebar-width, 340px);
   gap: 18px;
   padding-top: 18px;
+}
+
+.selected-event-connector {
+  position: absolute;
+  z-index: 4;
+  inset: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.selected-event-connector path {
+  fill: none;
+  stroke: var(--brand);
+  stroke-dasharray: 5 5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2px;
+}
+
+.selected-event-connector.tone-wait-for path {
+  stroke: #d39732;
+}
+
+.selected-event-connector.tone-execute path {
+  stroke: var(--brand);
 }
 
 .run-content.is-resizing-sidebar,
@@ -922,6 +948,29 @@ pre {
 .sidebar-section {
   padding: 15px;
   border-bottom: 1px solid var(--line);
+}
+
+.selected-event-anchor {
+  position: sticky;
+  z-index: 5;
+  top: 0;
+  padding: 15px 15px 10px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.97);
+  box-shadow: 0 8px 18px rgba(45, 79, 42, 0.06);
+  backdrop-filter: blur(10px);
+}
+
+.selected-event-anchor > h3 {
+  margin-bottom: 10px;
+}
+
+.selected-event-anchor .event-meta {
+  margin-bottom: 0;
+}
+
+.selected-event-body .event-details {
+  margin-top: 0;
 }
 
 .sidebar-section:last-child {
@@ -1363,16 +1412,56 @@ pre {
   pointer-events: none;
 }
 
+.timeline-step-link-group {
+  cursor: pointer;
+  outline: none;
+}
+
+.timeline-step-link-hitarea {
+  fill: none;
+  pointer-events: stroke;
+  stroke: transparent;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 16px;
+}
+
 .timeline-step-link {
   fill: none;
+  pointer-events: none;
   stroke: #4f87a3;
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke-width: 2px;
+  transition: filter 140ms ease, stroke 140ms ease, stroke-width 140ms ease;
 }
 
 #timeline-step-arrow path {
   fill: #4f87a3;
+}
+
+#timeline-step-arrow-active path {
+  fill: var(--brand-bright);
+  filter: drop-shadow(0 0 2px rgba(79, 129, 39, 0.45));
+}
+
+.timeline-step-link-group:hover .timeline-step-link,
+.timeline-step-link-group:focus .timeline-step-link,
+.timeline-step-link-group.is-active .timeline-step-link {
+  animation: timeline-step-link-flow 650ms linear infinite;
+  filter: drop-shadow(0 0 3px rgba(79, 129, 39, 0.38));
+  marker-end: url("#timeline-step-arrow-active");
+  stroke: var(--brand-bright);
+  stroke-dasharray: 8 5;
+  stroke-width: 3px;
+}
+
+.timeline-step-duration-background {
+  fill: white;
+  opacity: 0;
+  pointer-events: painted;
+  stroke: transparent;
+  transition: fill 140ms ease, opacity 140ms ease, stroke 140ms ease;
 }
 
 .timeline-step-duration {
@@ -1380,15 +1469,43 @@ pre {
   font-size: 10px;
   font-weight: 700;
   paint-order: stroke;
+  pointer-events: painted;
   stroke: white;
   stroke-linejoin: round;
   stroke-width: 5px;
+  transition: fill 140ms ease, font-weight 140ms ease;
+}
+
+.timeline-step-link-group:hover .timeline-step-duration-background,
+.timeline-step-link-group:focus .timeline-step-duration-background,
+.timeline-step-link-group.is-active .timeline-step-duration-background {
+  fill: var(--brand-soft);
+  opacity: 1;
+  stroke: var(--brand-bright);
+}
+
+.timeline-step-link-group:hover .timeline-step-duration,
+.timeline-step-link-group:focus .timeline-step-duration,
+.timeline-step-link-group.is-active .timeline-step-duration {
+  fill: var(--brand-dark);
+  font-weight: 850;
+  stroke: var(--brand-soft);
+}
+
+@keyframes timeline-step-link-flow {
+  to {
+    stroke-dashoffset: -13;
+  }
 }
 
 .timeline-row.selected .event-card {
+  position: relative;
+  border-width: 2px;
   border-color: var(--brand);
-  box-shadow: 0 0 0 3px rgba(111, 160, 54, 0.11);
+  box-shadow: inset 5px 0 0 var(--brand), 0 0 0 4px rgba(111, 160, 54, 0.16), 0 12px 28px rgba(79, 129, 39, 0.13);
+  transform: translateY(-1px);
 }
+
 
 .timeline-time {
   display: flex;
@@ -1517,9 +1634,108 @@ pre {
   box-shadow: 0 0 0 1px #d39732;
 }
 
+.timeline-dot,
+.timeline-row .event-card {
+  transition: border-color 140ms ease, box-shadow 140ms ease, transform 140ms ease;
+}
+
+.timeline-dot.link-highlighted {
+  box-shadow: 0 0 0 3px rgba(143, 201, 61, 0.32);
+  transform: scale(1.35);
+}
+
+.timeline-row.link-highlighted .event-card {
+  border-color: rgba(121, 174, 53, 0.65);
+  box-shadow: 0 8px 22px rgba(79, 129, 39, 0.09);
+}
+
+.timeline-row.step-method-wait-for.link-highlighted .event-card {
+  border-color: rgba(211, 151, 50, 0.72);
+  background: linear-gradient(90deg, rgba(255, 247, 224, 0.82), #fff 38%);
+  box-shadow: 0 8px 22px rgba(128, 88, 23, 0.1);
+}
+
+.timeline-row.step-method-execute.link-highlighted .event-card {
+  border-color: rgba(111, 160, 54, 0.72);
+  background: linear-gradient(90deg, rgba(239, 247, 229, 0.88), #fff 38%);
+  box-shadow: 0 8px 22px rgba(79, 129, 39, 0.1);
+}
+
+.timeline-row.link-counterpart .event-card {
+  position: relative;
+}
+
+.timeline-row.link-counterpart .event-card::before {
+  position: absolute;
+  z-index: 1;
+  top: -10px;
+  right: 12px;
+  padding: 3px 7px;
+  border: 1px solid rgba(79, 135, 163, 0.55);
+  border-radius: 999px;
+  color: #315e74;
+  content: "Paired event";
+  background: #edf7fa;
+  font-size: 8px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.timeline-row.step-method-wait-for.link-counterpart .event-card {
+  border-color: #d39732;
+  box-shadow: 0 0 0 3px rgba(211, 151, 50, 0.2), 0 10px 25px rgba(128, 88, 23, 0.12);
+}
+
+.timeline-row.step-method-wait-for.link-counterpart .event-card::before {
+  border-color: rgba(211, 151, 50, 0.58);
+  color: #76500f;
+  background: #fff4d8;
+}
+
+.timeline-row.step-method-execute.link-counterpart .event-card {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(111, 160, 54, 0.2), 0 10px 25px rgba(79, 129, 39, 0.12);
+}
+
+.timeline-row.step-method-execute.link-counterpart .event-card::before {
+  border-color: rgba(111, 160, 54, 0.58);
+  color: var(--brand-dark);
+  background: var(--brand-soft);
+}
+
+.timeline-row.step-method-wait-for.selected .event-card {
+  border-color: #d39732;
+  background: linear-gradient(90deg, #fff3cf, #fff 46%);
+  box-shadow: inset 5px 0 0 #d39732, 0 0 0 4px rgba(211, 151, 50, 0.24), 0 13px 30px rgba(128, 88, 23, 0.16);
+}
+
+.timeline-row.step-method-execute.selected .event-card {
+  border-color: var(--brand);
+  background: linear-gradient(90deg, #e8f4da, #fff 46%);
+  box-shadow: inset 5px 0 0 var(--brand-bright), 0 0 0 4px rgba(111, 160, 54, 0.24), 0 13px 30px rgba(79, 129, 39, 0.16);
+}
+
+
+.timeline-row.step-method-wait-for.selected .timeline-dot {
+  box-shadow: 0 0 0 4px rgba(211, 151, 50, 0.28);
+}
+
+.timeline-row.step-method-execute.selected .timeline-dot {
+  box-shadow: 0 0 0 4px rgba(111, 160, 54, 0.28);
+}
+
 .event-type.tone-waiting {
   color: #805817;
   background: #f7eacd;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .timeline-step-link-group:hover .timeline-step-link,
+  .timeline-step-link-group:focus .timeline-step-link,
+  .timeline-step-link-group.is-active .timeline-step-link {
+    animation: none;
+  }
 }
 
 .event-highlights {


### PR DESCRIPTION
## Summary

- make WaitFor-to-Execute timeline relationships interactive and keyboard accessible
- highlight both events when either endpoint or the connecting path is selected
- distinguish WaitFor and Execute selections with warm yellow and green treatments
- keep a dynamic dashed connector between the selected timeline event and the sticky Selected Event header while either pane scrolls

## Why

Long flow histories make paired WaitFor and Execute events difficult to correlate and make the selected event easy to lose while inspecting its details. These changes preserve that visual context across long distances and independent scrolling.

## User impact

- hovering or focusing a relationship emphasizes its path, arrow, duration, and endpoints
- clicking a relationship pins the highlight
- selecting either endpoint marks the paired event for quick discovery
- the Selected Event header remains visible and connected to its source event during scrolling

## Validation

- `make -C cli build`
- `make copyright-check`
- `git diff --cached --check`
- browser verification against the local Dex/Temporal stack on port 18802, including page scrolling, sidebar scrolling, endpoint selection, relationship pinning, and paired-event highlighting
