### PR TITLE
Implement intercepted Java RPC stubs

### DIFF
--- a/.github/workflows/sdk-java-ci.yml
+++ b/.github/workflows/sdk-java-ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: ./gradlew test --tests io.superdurable.dex.contracts.UserContractsTest --no-daemon
 
   tests:
-    name: Integration tests (58 scenarios)
+    name: Integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -49,6 +49,7 @@ long value = client.invokeRPC(stub::increment, 1L);
 
 Flows exposing RPC methods and their annotated methods must not be `final`.
 RPC stubs intercept those methods without invoking Flow constructors.
+In Kotlin, declare the Flow class and its RPC methods with `open`.
 
 `Step<I>` declares `Class<I> getInputType()`; parameterized Step inputs are not
 supported. Steps, attributes, and channels declare Java classes, not codecs:

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -29,7 +29,7 @@ public final class IncrementStep implements Step<Long> {
     }
 }
 
-public final class CounterFlow implements Flow<Long> {
+public class CounterFlow implements Flow<Long> {
     private final IncrementStep start = new IncrementStep();
 
     @Override
@@ -46,6 +46,9 @@ public final class CounterFlow implements Flow<Long> {
 CounterFlow stub = client.newRpcStub(CounterFlow.class, flowId, runId);
 long value = client.invokeRPC(stub::increment, 1L);
 ```
+
+Flows exposing RPC methods and their annotated methods must not be `final`.
+RPC stubs intercept those methods without invoking Flow constructors.
 
 `Step<I>` declares `Class<I> getInputType()`; parameterized Step inputs are not
 supported. Steps, attributes, and channels declare Java classes, not codecs:

--- a/sdk-java/src/main/java/io/superdurable/dex/Client.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Client.java
@@ -55,7 +55,6 @@ import org.objenesis.ObjenesisStd;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.time.Duration;
@@ -168,7 +167,6 @@ public final class Client implements AutoCloseable {
             final String flowId,
             final String runId) {
         final Registry.RegisteredFlow flow = registry.getFlow(rpcClass);
-        validateRpcStubClass(rpcClass, flow);
         try {
             final Class<? extends T> stubClass = new ByteBuddy()
                     .subclass(rpcClass, ConstructorStrategy.Default.NO_CONSTRUCTORS)
@@ -182,21 +180,6 @@ public final class Client implements AutoCloseable {
         } catch (RuntimeException exception) {
             throw new IllegalArgumentException(
                     "RPC stub could not subclass " + rpcClass.getName(), exception);
-        }
-    }
-
-    private static void validateRpcStubClass(
-            final Class<?> rpcClass,
-            final Registry.RegisteredFlow flow) {
-        if (Modifier.isFinal(rpcClass.getModifiers())) {
-            throw new IllegalArgumentException(
-                    "RPC stub Flow class must not be final: " + rpcClass.getName());
-        }
-        for (Registry.RegisteredRpc rpc : flow.getRpcs().values()) {
-            if (Modifier.isFinal(rpc.getMethod().getModifiers())) {
-                throw new IllegalArgumentException(
-                        "RPC stub method must not be final: " + rpc.getMethod().getName());
-            }
         }
     }
 

--- a/sdk-java/src/main/java/io/superdurable/dex/Client.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Client.java
@@ -46,19 +46,23 @@ import io.superdurable.gen.UpdateFlowConfigRequest;
 import io.superdurable.gen.WaitForFlowRequest;
 import io.superdurable.gen.WaitForFlowResponse;
 import io.superdurable.gen.WaitForStepCompletionRequest;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy;
+import net.bytebuddy.implementation.InvocationHandlerAdapter;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.objenesis.ObjenesisStd;
 
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -71,8 +75,6 @@ public final class Client implements AutoCloseable {
     private final ValueMapper values;
     private final ValueHydrator hydrator;
     private final WorkerDispatcher mappings;
-    private final Map<Object, RpcTarget> rpcStubs =
-            Collections.synchronizedMap(new IdentityHashMap<Object, RpcTarget>());
 
     public Client(final Registry registry, final BlobCache blobCache) {
         this(registry, blobCache, new ClientOptions());
@@ -166,36 +168,56 @@ public final class Client implements AutoCloseable {
             final String flowId,
             final String runId) {
         final Registry.RegisteredFlow flow = registry.getFlow(rpcClass);
+        validateRpcStubClass(rpcClass, flow);
         try {
-            final Constructor<T> constructor = rpcClass.getDeclaredConstructor();
-            constructor.setAccessible(true);
-            final T stub = constructor.newInstance();
-            rpcStubs.put(stub, new RpcTarget(flow, flowId, runId));
-            return stub;
-        } catch (ReflectiveOperationException exception) {
+            final Class<? extends T> stubClass = new ByteBuddy()
+                    .subclass(rpcClass, ConstructorStrategy.Default.NO_CONSTRUCTORS)
+                    .method(ElementMatchers.isAnnotatedWith(RPC.class))
+                    .intercept(InvocationHandlerAdapter.of(
+                            new RpcInvocationHandler(new RpcTarget(flow, flowId, runId))))
+                    .make()
+                    .load(rpcClass.getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+                    .getLoaded();
+            return new ObjenesisStd().newInstance(stubClass);
+        } catch (RuntimeException exception) {
             throw new IllegalArgumentException(
-                    "RPC stub class requires a no-argument constructor", exception);
+                    "RPC stub could not subclass " + rpcClass.getName(), exception);
+        }
+    }
+
+    private static void validateRpcStubClass(
+            final Class<?> rpcClass,
+            final Registry.RegisteredFlow flow) {
+        if (Modifier.isFinal(rpcClass.getModifiers())) {
+            throw new IllegalArgumentException(
+                    "RPC stub Flow class must not be final: " + rpcClass.getName());
+        }
+        for (Registry.RegisteredRpc rpc : flow.getRpcs().values()) {
+            if (Modifier.isFinal(rpc.getMethod().getModifiers())) {
+                throw new IllegalArgumentException(
+                        "RPC stub method must not be final: " + rpc.getMethod().getName());
+            }
         }
     }
 
     public <I, O> O invokeRPC(
             final RpcDefinitions.RpcFunc1<I, O> rpcStubMethod,
             final I input) {
-        return invokeRpc(rpcStubMethod, input);
+        return rpcStubMethod.execute(null, input).getOutput();
     }
 
     public <O> O invokeRPC(final RpcDefinitions.RpcFunc0<O> rpcStubMethod) {
-        return invokeRpc(rpcStubMethod, null);
+        return rpcStubMethod.execute(null).getOutput();
     }
 
     public <I> void invokeRPC(
             final RpcDefinitions.RpcProc1<I> rpcStubMethod,
             final I input) {
-        invokeRpc(rpcStubMethod, input);
+        rpcStubMethod.execute(null, input);
     }
 
     public void invokeRPC(final RpcDefinitions.RpcProc0 rpcStubMethod) {
-        invokeRpc(rpcStubMethod, null);
+        rpcStubMethod.execute(null);
     }
 
     public <T> T getAttribute(
@@ -405,16 +427,11 @@ public final class Client implements AutoCloseable {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private <O> O invokeRpc(final Object lambda, final Object input) {
-        final SerializedLambda serialized = serializedLambda(lambda);
-        final Object receiver = serialized.getCapturedArg(0);
-        final RpcTarget target = rpcStubs.get(receiver);
-        if (target == null) {
-            throw new IllegalArgumentException("RPC method reference is not from this Client stub");
-        }
-        final Registry.RegisteredRpc rpc =
-                target.flow.getRpcByMethod(serialized.getImplMethodName());
+    private Object invokeRpc(
+            final RpcTarget target,
+            final Method method,
+            final Object input) {
+        final Registry.RegisteredRpc rpc = target.flow.getRpcByMethod(method.getName());
         final InvokeRPCRequest request = InvokeRPCRequest.newBuilder()
                 .setFlowId(target.flowId)
                 .setRunId(target.runId)
@@ -434,17 +451,7 @@ public final class Client implements AutoCloseable {
         if (!(outputType instanceof Class)) {
             throw new IllegalArgumentException("RPC output must be a concrete Class");
         }
-        return (O) values.decode(output, (Class<?>) outputType);
-    }
-
-    private static SerializedLambda serializedLambda(final Object lambda) {
-        try {
-            final Method replacement = lambda.getClass().getDeclaredMethod("writeReplace");
-            replacement.setAccessible(true);
-            return (SerializedLambda) replacement.invoke(lambda);
-        } catch (ReflectiveOperationException exception) {
-            throw new IllegalArgumentException("RPC must be a direct method reference", exception);
-        }
+        return values.decode(output, (Class<?>) outputType);
     }
 
     private <T> T getAttributeValue(
@@ -791,6 +798,24 @@ public final class Client implements AutoCloseable {
             return io.superdurable.gen.StepDurability.STEP_DURABILITY_ASYNC;
         }
         return io.superdurable.gen.StepDurability.STEP_DURABILITY_UNSPECIFIED;
+    }
+
+    private final class RpcInvocationHandler implements InvocationHandler {
+        private final RpcTarget target;
+
+        private RpcInvocationHandler(final RpcTarget target) {
+            this.target = target;
+        }
+
+        @Override
+        public Object invoke(
+                final Object stub,
+                final Method method,
+                final Object[] arguments) {
+            final Object input = arguments.length == 2 ? arguments[1] : null;
+            final Object output = invokeRpc(target, method, input);
+            return method.getReturnType() == Void.TYPE ? null : RPCResult.of(output);
+        }
     }
 
     private static final class RpcTarget {

--- a/sdk-java/src/main/java/io/superdurable/dex/Registry.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Registry.java
@@ -15,6 +15,7 @@
 package io.superdurable.dex;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -154,6 +155,7 @@ public final class Registry {
             if (annotation == null) {
                 continue;
             }
+            validateRpcInterceptability(flow.getClass(), method);
             if (annotation.timeoutSeconds() < 0) {
                 throw new IllegalArgumentException("RPC timeout must not be negative");
             }
@@ -169,6 +171,23 @@ public final class Registry {
             }
         }
         return rpcs;
+    }
+
+    private static void validateRpcInterceptability(
+            final Class<?> flowClass,
+            final Method method) {
+        if (Modifier.isFinal(flowClass.getModifiers())) {
+            throw new IllegalArgumentException(
+                    "RPC Flow class must not be final because RPC stubs subclass it. "
+                            + "In Kotlin, classes are final by default; declare the Flow class "
+                            + "with 'open': " + flowClass.getName());
+        }
+        if (Modifier.isFinal(method.getModifiers())) {
+            throw new IllegalArgumentException(
+                    "RPC method must not be final because RPC stubs override it. "
+                            + "In Kotlin, methods are final by default; declare the RPC method "
+                            + "with 'open': " + flowClass.getName() + "." + method.getName());
+        }
     }
 
     private static List<String> validateRpcLocks(

--- a/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
@@ -145,15 +145,20 @@ public class UserContractsTest {
     }
 
     @Test
-    public void rpcStubRejectsFinalFlowClasses() {
-        final FinalRpcFlow flow = new FinalRpcFlow();
-        final Registry registry = new Registry(Collections.<Flow<?>>singletonList(flow));
-        try (Client client = new Client(registry, BLOB_CACHE)) {
-            final IllegalArgumentException error = Assertions.assertThrows(
-                    IllegalArgumentException.class,
-                    () -> client.newRpcStub(FinalRpcFlow.class, "flow-id"));
-            Assertions.assertTrue(error.getMessage().contains("must not be final"));
-        }
+    public void registryRejectsNonInterceptableRpcDefinitions() {
+        final IllegalArgumentException finalFlowError = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new Registry(Collections.<Flow<?>>singletonList(new FinalRpcFlow())));
+        Assertions.assertTrue(finalFlowError.getMessage().contains("Flow class must not be final"));
+        Assertions.assertTrue(
+                finalFlowError.getMessage().contains("declare the Flow class with 'open'"));
+
+        final IllegalArgumentException finalMethodError = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new Registry(Collections.<Flow<?>>singletonList(new FinalRpcMethodFlow())));
+        Assertions.assertTrue(finalMethodError.getMessage().contains("method must not be final"));
+        Assertions.assertTrue(
+                finalMethodError.getMessage().contains("declare the RPC method with 'open'"));
     }
 
     @Test
@@ -317,6 +322,13 @@ public class UserContractsTest {
     public static final class FinalRpcFlow implements Flow<Void> {
         @RPC
         public RPCResult<String> read(final Context context) {
+            return RPCResult.of("local");
+        }
+    }
+
+    public static class FinalRpcMethodFlow implements Flow<Void> {
+        @RPC
+        public final RPCResult<String> read(final Context context) {
             return RPCResult.of("local");
         }
     }

--- a/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
@@ -132,6 +132,31 @@ public class UserContractsTest {
     }
 
     @Test
+    public void rpcStubBypassesFlowConstructors() {
+        ConstructorOnlyRpcFlow.constructorCalls = 0;
+        final ConstructorOnlyRpcFlow flow = new ConstructorOnlyRpcFlow("registered");
+        final Registry registry = new Registry(Collections.<Flow<?>>singletonList(flow));
+        try (Client client = new Client(registry, BLOB_CACHE)) {
+            final ConstructorOnlyRpcFlow stub =
+                    client.newRpcStub(ConstructorOnlyRpcFlow.class, "flow-id");
+            Assertions.assertEquals(1, ConstructorOnlyRpcFlow.constructorCalls);
+            Assertions.assertNotEquals(ConstructorOnlyRpcFlow.class, stub.getClass());
+        }
+    }
+
+    @Test
+    public void rpcStubRejectsFinalFlowClasses() {
+        final FinalRpcFlow flow = new FinalRpcFlow();
+        final Registry registry = new Registry(Collections.<Flow<?>>singletonList(flow));
+        try (Client client = new Client(registry, BLOB_CACHE)) {
+            final IllegalArgumentException error = Assertions.assertThrows(
+                    IllegalArgumentException.class,
+                    () -> client.newRpcStub(FinalRpcFlow.class, "flow-id"));
+            Assertions.assertTrue(error.getMessage().contains("must not be final"));
+        }
+    }
+
+    @Test
     public void blobCacheStoresAndReadsPayload() {
         final BlobCacheConfig config = new BlobCacheConfig(
                 cacheDirectory.toString(),
@@ -271,6 +296,29 @@ public class UserContractsTest {
 
     public static class OrderOutput {
         public boolean accepted;
+    }
+
+    public static class ConstructorOnlyRpcFlow implements Flow<Void> {
+        static int constructorCalls;
+
+        private ConstructorOnlyRpcFlow(final String dependency) {
+            constructorCalls++;
+            if (dependency == null) {
+                throw new IllegalArgumentException("dependency is required");
+            }
+        }
+
+        @RPC
+        public RPCResult<String> read(final Context context) {
+            throw new AssertionError("RPC stub must intercept the implementation");
+        }
+    }
+
+    public static final class FinalRpcFlow implements Flow<Void> {
+        @RPC
+        public RPCResult<String> read(final Context context) {
+            return RPCResult.of("local");
+        }
     }
 
     private static final class ContractBlobCache implements BlobCache {

--- a/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/ConditionalCompleteWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/ConditionalCompleteWorkflow.java
@@ -24,7 +24,7 @@ import io.superdurable.dex.StepDecision;
 import io.superdurable.dex.StepMovement;
 import io.superdurable.dex.Wait;
 
-final class ConditionalCompleteWorkflow implements Flow<Boolean> {
+class ConditionalCompleteWorkflow implements Flow<Boolean> {
     final Channel<Void> signal = Channel.define("test-signal-channel", Void.class);
     final Channel<Void> internal = Channel.define("test-internal-channel", Void.class);
     private final Attribute<Integer> counter = Attribute.define("counter", Integer.class);

--- a/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/NoStartStateDeadEndWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/NoStartStateDeadEndWorkflow.java
@@ -23,7 +23,7 @@ import io.superdurable.dex.StepList;
 import io.superdurable.dex.StepDecision;
 import io.superdurable.dex.StepMovement;
 
-final class NoStartStateDeadEndWorkflow implements Flow<Void> {
+class NoStartStateDeadEndWorkflow implements Flow<Void> {
     static final long RPC_OUTPUT = 100L;
     final Channel<Void> idleSignal = Channel.define("idle-signal", Void.class);
     final Channel<Void> idleInternal = Channel.define("idle-internal", Void.class);

--- a/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/NoStartStateWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/NoStartStateWorkflow.java
@@ -21,7 +21,7 @@ import io.superdurable.dex.StepList;
 import io.superdurable.dex.StepDecision;
 import io.superdurable.dex.StepMovement;
 
-final class NoStartStateWorkflow implements Flow<Void> {
+class NoStartStateWorkflow implements Flow<Void> {
     static final long RPC_OUTPUT = 100L;
     private final TriggeredStep triggered = new TriggeredStep();
 

--- a/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/ResetWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/ResetWorkflow.java
@@ -26,7 +26,7 @@ import io.superdurable.dex.StepList;
 import io.superdurable.dex.StepDecision;
 import io.superdurable.dex.Wait;
 
-final class ResetWorkflow implements Flow<Void> {
+class ResetWorkflow implements Flow<Void> {
     final Channel<Void> channel = Channel.define("rpc-channel", Void.class);
     final Attribute<String> data = Attribute.define("rpc-lock-data", String.class);
     final Attribute<String> keyword = Attribute.define(

--- a/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/RpcNoStateWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/RpcNoStateWorkflow.java
@@ -19,7 +19,7 @@ import io.superdurable.dex.PersistenceSchema;
 import io.superdurable.dex.RPC;
 import io.superdurable.dex.RPCResult;
 
-final class RpcNoStateWorkflow implements Flow<Void> {
+class RpcNoStateWorkflow implements Flow<Void> {
     static final long RPC_OUTPUT = 100L;
     private final Attribute<Integer> counter = Attribute.define("counter", Integer.class);
 

--- a/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/RpcWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/iwfcompat/RpcWorkflow.java
@@ -26,7 +26,7 @@ import io.superdurable.dex.StepDecision;
 import io.superdurable.dex.StepMovement;
 import io.superdurable.dex.Wait;
 
-final class RpcWorkflow implements Flow<Integer> {
+class RpcWorkflow implements Flow<Integer> {
     static final long RPC_OUTPUT = 100L;
     static final String HARDCODED_VALUE = "random-string";
     final Channel<Void> internal = Channel.define("rpc-internal", Void.class);


### PR DESCRIPTION
## Summary

- generate concrete Java Flow RPC stubs with ByteBuddy
- instantiate stubs with Objenesis without running user constructors
- intercept `@RPC` methods and route them through the Dex client transport
- reject final RPC Flow classes and methods during Registry construction
- explain Kotlin's required `open` modifier in validation errors and documentation
- remove the hard-coded integration scenario count from the Java CI job name

## Rationale

Java dynamic proxies only proxy interfaces, while Dex Flows are concrete classes. Runtime subclassing provides the strongly typed method-reference API without executing the user's RPC implementation.

## User impact

RPC Flow classes no longer need no-argument constructors. Classes and annotated methods must be non-final; Kotlin users must declare both with `open`.

## Validation

- `./gradlew test --tests io.superdurable.dex.contracts.UserContractsTest --no-daemon`
- `./run-integration-tests.sh`
- `git diff --check origin/main...HEAD`
