### PR TITLE
Add Java SDK integration coverage and Codecov reporting

### DIFF
--- a/.github/workflows/sdk-java-ci.yml
+++ b/.github/workflows/sdk-java-ci.yml
@@ -12,6 +12,7 @@ on:
       - "cli/**"
       - "server/**"
       - "protos/**"
+      - "codecov.yml"
       - ".github/workflows/sdk-java-ci.yml"
       - ".github/workflows/sdk-java-publish.yml"
   pull_request:
@@ -24,6 +25,7 @@ on:
       - "cli/**"
       - "server/**"
       - "protos/**"
+      - "codecov.yml"
       - ".github/workflows/sdk-java-ci.yml"
       - ".github/workflows/sdk-java-publish.yml"
   workflow_dispatch:
@@ -87,6 +89,9 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: read
+      id-token: write
     env:
       RUSTUP_TOOLCHAIN: "1.88.0"
     defaults:
@@ -116,8 +121,24 @@ jobs:
           java-version: "8"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-      - name: Run JVM and dexcli dev integration tests
-        run: ./run-integration-tests.sh
+      - name: Run JVM and dexcli dev integration coverage
+        run: ./run-integration-tests.sh --coverage
+      - name: Upload Java integration coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          disable_search: true
+          fail_ci_if_error: true
+          files: ./sdk-java/build/reports/jacoco/integration/jacoco.xml
+          flags: sdk-java-integration
+          name: sdk-java-integration
+          use_oidc: true
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdk-java-integration-coverage
+          path: sdk-java/build/reports/jacoco/integration/
+          if-no-files-found: ignore
       - name: Upload service logs
         if: always()
         uses: actions/upload-artifact@v7

--- a/codecov.yml
+++ b/codecov.yml
@@ -56,6 +56,7 @@ component_management:
 ignore:
   - "server/gen/**/*"
   - "sdk-go/gen/**/*"
+  - "sdk-java/src/main/java/io/superdurable/gen/**/*"
   - "sdk-typescript/src/gen/**/*"
   - "**/*_test.go"
   - "**/mock*.go"

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -223,6 +223,21 @@ the Rust BlobCache JNI library and starts a fresh Java Worker for each E2E case
 with a unique worker port and flow ID. A clean checkout also requires Go 1.24+,
 Node.js 22+, Rust 1.88+, and Temporal CLI.
 
+### Measure integration coverage
+
+Run the same integration suite with JaCoCo coverage:
+
+```shell
+./run-integration-tests.sh --coverage
+```
+
+The report combines the local JNI and WorkerService integration tests with all
+`dexcli dev` E2E scenarios. It measures only production classes under
+`io.superdurable.dex`; contract tests, other unit tests, test fixtures, and
+generated protobuf classes are excluded. The XML report is written to
+`build/reports/jacoco/integration/jacoco.xml`, and the browser report starts at
+`build/reports/jacoco/integration/html/index.html`.
+
 ### Validate the publication
 
 The validation command builds a Maven repository, verifies its JAR and POM,

--- a/sdk-java/build.gradle
+++ b/sdk-java/build.gradle
@@ -141,6 +141,19 @@ tasks.named('test') {
     }
 }
 
+tasks.register('localIntegrationTest', Test) {
+    group = 'verification'
+    description = 'Runs Java SDK integration tests that do not require dexcli dev.'
+    outputs.upToDateWhen { false }
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    filter {
+        includeTestsMatching 'io.superdurable.dex.NativeBlobCacheIntegrationTest'
+        includeTestsMatching 'io.superdurable.dex.WorkerServiceIntegrationTest'
+    }
+    useJUnitPlatform()
+}
+
 tasks.register('dexDevTest', Test) {
     group = 'verification'
     description = 'Runs Java SDK integration tests against dexcli dev.'
@@ -189,6 +202,34 @@ jacocoTestReport {
 }
 
 check.dependsOn jacocoTestReport
+
+tasks.register('integrationCoverageReport', JacocoReport) {
+    group = 'verification'
+    description = 'Reports coverage from only Java SDK integration tests.'
+    executionData.setFrom(files(
+            layout.buildDirectory.file('jacoco/localIntegrationTest.exec'),
+            layout.buildDirectory.file('jacoco/dexDevTest.exec')))
+    sourceDirectories.setFrom(sourceSets.main.allJava.srcDirs)
+    classDirectories.setFrom(sourceSets.main.output.classesDirs.asFileTree.matching {
+        include 'io/superdurable/dex/**'
+    })
+    reports {
+        xml.required = true
+        xml.outputLocation = layout.buildDirectory.file(
+                'reports/jacoco/integration/jacoco.xml')
+        html.required = true
+        html.outputLocation = layout.buildDirectory.dir(
+                'reports/jacoco/integration/html')
+        csv.required = false
+    }
+    doFirst {
+        def missingExecutionData = executionData.files.findAll { !it.isFile() }
+        if (!missingExecutionData.isEmpty()) {
+            throw new GradleException(
+                    "integration coverage data is missing: ${missingExecutionData*.name.join(', ')}")
+        }
+    }
+}
 
 // Custom task to unpublish from local Maven repository
 // Usage: ./gradlew unpublishFromMavenLocal

--- a/sdk-java/run-integration-tests.sh
+++ b/sdk-java/run-integration-tests.sh
@@ -10,6 +10,16 @@
 
 set -euo pipefail
 
+coverage=false
+if [[ "${1:-}" == "--coverage" ]]; then
+  coverage=true
+  shift
+fi
+if [[ "$#" -ne 0 ]]; then
+  echo "usage: $0 [--coverage]" >&2
+  exit 2
+fi
+
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$script_dir/.." && pwd)
 dex_port="${DEX_INTEG_DEX_PORT:-18801}"
@@ -103,8 +113,8 @@ if ! $dex_ready; then
 fi
 
 cd "$script_dir"
-./gradlew test \
-  --tests io.superdurable.dex.NativeBlobCacheIntegrationTest \
-  --tests io.superdurable.dex.WorkerServiceIntegrationTest \
-  --no-daemon
+./gradlew localIntegrationTest --no-daemon
 DEX_SERVER_ADDRESS="$dex_address" ./gradlew dexDevTest --no-daemon
+if $coverage; then
+  ./gradlew integrationCoverageReport --no-daemon
+fi


### PR DESCRIPTION
## Summary

- measure the complete Java SDK integration suite with JaCoCo
- combine local JNI and WorkerService integration execution data with all `dexcli dev` E2E scenarios
- restrict coverage to production classes under `io.superdurable.dex`, excluding contracts, unit tests, fixtures, and generated protobuf code
- upload JaCoCo XML to Codecov with GitHub OIDC and retain the HTML report as an Actions artifact
- document the local integration coverage command and report paths

## Rationale

Java SDK coverage should reflect the real integration paths exercised against Dex rather than contract or unit tests. A dedicated report keeps generated protobuf code and non-integration execution data out of the uploaded baseline.

Current Java SDK integration coverage:

- lines: 80.35% (1836/2285)
- branches: 59.13% (515/871)

## User impact

Run `./run-integration-tests.sh --coverage` from `sdk-java` to start `dexcli dev`, execute the complete integration suite, and generate XML and HTML coverage reports. CI uploads the same scoped report under the `sdk-java-integration` Codecov flag.

## Validation

- `JAVA_HOME=... ./run-integration-tests.sh --coverage`
- `./gradlew test --tests io.superdurable.dex.contracts.UserContractsTest --no-daemon`
- `actionlint .github/workflows/sdk-java-ci.yml`
- `shellcheck sdk-java/run-integration-tests.sh`
- `bash -n sdk-java/run-integration-tests.sh`
- `make copyright-check`
- `git diff --check`
