### PR TITLE
Add Python SDK integration coverage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ sdk-rust/target/
 sdk-typescript/dist/
 sdk-java/publication-smoke-test/target/
 sdk-typescript/coverage/
+sdk-python/coverage/

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -13,6 +13,7 @@ on:
     - "server/**"
     - "web/**"
     - "protos/**"
+    - "codecov.yml"
     - ".github/workflows/sdk-python-ci.yml"
   pull_request:
     paths:
@@ -25,6 +26,7 @@ on:
     - "server/**"
     - "web/**"
     - "protos/**"
+    - "codecov.yml"
     - ".github/workflows/sdk-python-ci.yml"
   workflow_dispatch:
 
@@ -131,6 +133,9 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: sdk-python
@@ -161,8 +166,24 @@ jobs:
         enable-cache: true
     - name: Install dependencies
       run: uv sync --locked
-    - name: Run Python and dexcli dev integration tests
-      run: ./run-integration-tests.sh
+    - name: Run Python and dexcli dev integration coverage
+      run: ./run-integration-tests.sh --coverage
+    - name: Upload Python integration coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        disable_search: true
+        fail_ci_if_error: true
+        files: ./sdk-python/coverage/lcov.info
+        flags: sdk-python-integration
+        name: sdk-python-integration
+        use_oidc: true
+    - name: Upload coverage report
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: sdk-python-integration-coverage
+        path: sdk-python/coverage/
+        if-no-files-found: ignore
     - name: Upload service logs
       if: always()
       uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ venv/
 .ruff_cache/
 .coverage
 htmlcov/
+sdk-python/coverage/
 dist/
 *.egg-info/
 .tox/

--- a/codecov.yml
+++ b/codecov.yml
@@ -57,6 +57,8 @@ ignore:
   - "server/gen/**/*"
   - "sdk-go/gen/**/*"
   - "sdk-java/src/main/java/io/superdurable/gen/**/*"
+  - "sdk-python/dex/dexpb/**/*"
+  - "sdk-python/dex/tests/**/*"
   - "sdk-typescript/src/gen/**/*"
   - "**/*_test.go"
   - "**/mock*.go"

--- a/sdk-python/.gitignore
+++ b/sdk-python/.gitignore
@@ -50,6 +50,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage/
 *.cover
 *.py,cover
 .hypothesis/

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -145,6 +145,25 @@ environment:
 ./run-integration-tests.sh
 ```
 
+### Measure integration coverage
+
+Run the same integration suite with Python source coverage:
+
+```bash
+./run-integration-tests.sh --coverage
+```
+
+Only the integration scenarios contribute execution data, and only production
+Python modules under `dex` are measured. Generated protobuf modules under
+`dex/dexpb` and packaged legacy tests under `dex/tests` are excluded. The
+terminal report lists uncovered line ranges. The browser report starts at
+`coverage/html/index.html`; `coverage/coverage.xml` and `coverage/lcov.info`
+are also generated.
+
+CI uploads LCOV to Codecov with GitHub OIDC under the
+`sdk-python-integration` flag and retains the full report as the
+`sdk-python-integration-coverage` Actions artifact.
+
 #### Update IDL
 
 Edit [`protos/dex.proto`](../protos/dex.proto). Rename catalog: [`docs/design/idl-renames.md`](../docs/design/idl-renames.md).

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -62,6 +62,17 @@ warn_unused_ignores = false
 warn_return_any = false
 namespace_packages = true
 
+[tool.coverage.run]
+branch = true
+source = ["dex"]
+omit = [
+    "dex/dexpb/*",
+    "dex/tests/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+
 [build-system]
 requires = ["maturin>=1.9,<2"]
 build-backend = "maturin"

--- a/sdk-python/run-integration-tests.sh
+++ b/sdk-python/run-integration-tests.sh
@@ -10,6 +10,24 @@
 
 set -euo pipefail
 
+pytest_args=(-q)
+if [[ "${1:-}" == "--coverage" ]]; then
+  pytest_args+=(
+    --cov=dex
+    --cov-branch
+    --cov-config=pyproject.toml
+    --cov-report=term-missing
+    --cov-report=html:coverage/html
+    --cov-report=xml:coverage/coverage.xml
+    --cov-report=lcov:coverage/lcov.info
+  )
+  shift
+fi
+if [[ "$#" -ne 0 ]]; then
+  echo "usage: $0 [--coverage]" >&2
+  exit 2
+fi
+
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$script_dir/.." && pwd)
 dex_port="${DEX_INTEG_DEX_PORT:-18802}"
@@ -104,4 +122,4 @@ fi
 
 cd "$script_dir"
 DEX_SERVER_ADDRESS="$dex_address" \
-  uv run --frozen pytest -q tests/integ/test_*_runtime.py
+  uv run --frozen pytest "${pytest_args[@]}" tests/integ/test_*_runtime.py


### PR DESCRIPTION
## Summary

- collect branch coverage from the Python SDK integration runtime suite
- upload LCOV to Codecov with GitHub OIDC under `sdk-python-integration`
- retain HTML, XML, and LCOV reports as a GitHub Actions artifact
- document the local integration coverage workflow

## Rationale

This gives the Python SDK the same integration-focused coverage reporting already used by the TypeScript and Java SDKs. Coverage execution is limited to integration tests, while measurement is limited to production modules under `sdk-python/dex`; generated protobuf modules and packaged legacy tests are excluded.

## User impact

Contributors can run `./run-integration-tests.sh --coverage` to reproduce CI coverage locally. Normal integration test behavior is unchanged when the flag is omitted.

## Validation

- `./run-integration-tests.sh --coverage` — 58 passed
- `uv run --frozen pytest -q tests/test_contracts.py` — 15 passed
- `uv run --frozen mypy --strict tests/typecheck_contracts.py tests/integ`
- `uv run --frozen pyright tests/typecheck_contracts.py tests/integ`
- `actionlint .github/workflows/sdk-python-ci.yml`
- `make copyright-check`
