### PR TITLE
Add TypeScript SDK npm release workflow

### DIFF
--- a/.github/workflows/sdk-typescript-ci.yml
+++ b/.github/workflows/sdk-typescript-ci.yml
@@ -10,6 +10,7 @@ on:
       - "protos/**"
       - "web/**"
       - ".github/workflows/sdk-typescript-ci.yml"
+      - ".github/workflows/sdk-typescript-publish.yml"
   pull_request:
     paths:
       - "sdk-typescript/**"
@@ -18,6 +19,7 @@ on:
       - "protos/**"
       - "web/**"
       - ".github/workflows/sdk-typescript-ci.yml"
+      - ".github/workflows/sdk-typescript-publish.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -1,0 +1,59 @@
+name: Publish TypeScript SDK to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: sdk-typescript-publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish @superdurable/dex
+    if: startsWith(github.event.release.tag_name, 'sdk-typescript/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: sdk-typescript
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@11.19.0
+      - name: Verify release version
+        id: release
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          expected_tag="sdk-typescript/v${package_version}"
+          if [[ "${RELEASE_TAG}" != "${expected_tag}" ]]; then
+            echo "Release tag ${RELEASE_TAG} does not match package version ${package_version}" >&2
+            exit 1
+          fi
+          if [[ "${package_version}" == *-* ]]; then
+            echo "dist_tag=next" >> "${GITHUB_OUTPUT}"
+          else
+            echo "dist_tag=latest" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Install dependencies
+        run: npm ci
+      - name: Check static types
+        run: npm run typecheck
+      - name: Test package
+        run: npm test
+      - name: Inspect package contents
+        run: npm pack --dry-run
+      - name: Publish package
+        run: npm publish --access public --tag '${{ steps.release.outputs.dist_tag }}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,7 @@ Each component has its own version and tag prefix. Create a GitHub Release for t
 | Python SDK | `sdk-python/vX.Y.Z` | `sdk-python/v0.0.2` | PyPI [`dex-python-sdk`](https://pypi.org/project/dex-python-sdk/) (version from `sdk-python/pyproject.toml`) |
 | Java SDK | `sdk-java/vX.Y.Z` | `sdk-java/v0.0.3` | Maven Central `io.superdurable:dex-sdk` via [`.github/workflows/sdk-java-publish.yml`](.github/workflows/sdk-java-publish.yml) (version from the tag) |
 | Go SDK | `sdk-go/vX.Y.Z` | `sdk-go/v1.2.3` | Go module tag for `github.com/superdurable/dex/sdk-go` |
+| TypeScript SDK | `sdk-typescript/vX.Y.Z` | `sdk-typescript/v0.1.0` | npm [`@superdurable/dex`](https://www.npmjs.com/package/@superdurable/dex) via [`.github/workflows/sdk-typescript-publish.yml`](.github/workflows/sdk-typescript-publish.yml) |
 | Dex CLI | `cli-vX.Y.Z` | `cli-v0.1.0` | macOS/Linux archives and Homebrew formula input |
 
 Notes:
@@ -152,6 +153,7 @@ Notes:
 - Bump the component’s own version file before tagging (`pyproject.toml`, `build.gradle`, etc.).
 - Go uses a path-style tag (`sdk-go/v…`) so `go get` resolves the subdirectory module.
 - Python, Java, and Docker release workflows also support **workflow_dispatch** for manual runs. Python manual runs build without publishing unless `publish` is selected.
+- TypeScript publishing requires a GitHub Release after its one-time npm bootstrap publish.
 
 ## Package-specific guides
 
@@ -159,3 +161,4 @@ Notes:
 - [sdk-go/CONTRIBUTION.md](sdk-go/CONTRIBUTION.md)
 - [sdk-java/README.md](sdk-java/README.md)
 - [sdk-python/README.md](sdk-python/README.md)
+- [sdk-typescript/README.md](sdk-typescript/README.md)

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -114,3 +114,32 @@ The Actions run also publishes the complete HTML report as
 The complete legacy IWF integration inventory lives under
 [`test/integ`](test/integ/README.md). Its Flow fixtures retain the Java
 suite's workflow behavior and its 58 assertions run against a real Dex server.
+
+## Releases
+
+The npm package is published as [`@superdurable/dex`](https://www.npmjs.com/package/@superdurable/dex).
+Update `package.json` and `package-lock.json` to the same version, merge the
+change, then publish a GitHub Release tagged `sdk-typescript/vX.Y.Z`. The
+release workflow verifies that the tag matches `package.json`, runs type checks
+and tests, inspects the tarball, and publishes through npm Trusted Publishing.
+Prerelease versions use the `next` npm dist-tag; stable versions use `latest`.
+
+Trusted Publishing can only be configured after the package exists. Bootstrap
+the first version from a maintainer workstation with 2FA:
+
+```shell
+cd sdk-typescript
+npm ci
+npm run typecheck
+npm test
+npm pack --dry-run
+npm login
+npm publish --access public
+```
+
+Then open the package settings on npmjs.com and add a GitHub Actions trusted
+publisher with organization `superdurable`, repository `dex`, workflow
+`sdk-typescript-publish.yml`, no environment, and `npm publish` permission.
+Future releases use short-lived OIDC credentials and require no `NPM_TOKEN`.
+After verifying the first OIDC release, configure npm publishing access to
+require 2FA and disallow token-based publication.

--- a/sdk-typescript/package.json
+++ b/sdk-typescript/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@superdurable/dex",
   "version": "0.1.0",
-  "description": "TypeScript SDK contracts for Dex",
+  "description": "TypeScript SDK for the Dex durable workflow engine",
   "license": "LicenseRef-Super-Durable-1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/superdurable/dex.git",
+    "directory": "sdk-typescript"
+  },
+  "homepage": "https://github.com/superdurable/dex/tree/main/sdk-typescript#readme",
+  "bugs": {
+    "url": "https://github.com/superdurable/dex/issues"
+  },
   "type": "module",
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
@@ -17,10 +26,15 @@
       "import": "./dist/src/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "coverage:integration": "./run-integration-tests.sh --coverage",
     "generate:proto": "node scripts/generate-proto.mjs",
+    "prepack": "npm run build",
     "test:integration": "npm run build && node --test --test-concurrency=1 dist/test/integ/*.integration.test.js",
     "test:integration:coverage": "npm run build && c8 node --test --test-concurrency=1 dist/test/integ/*.integration.test.js && node scripts/report-uncovered.mjs coverage/lcov.info",
     "typecheck": "tsc -p tsconfig.json --noEmit",


### PR DESCRIPTION
## Summary

- publish `@superdurable/dex` from `sdk-typescript/vX.Y.Z` GitHub Releases
- authenticate npm publishing with GitHub OIDC trusted publishing
- validate package version, types, tests, and tarball contents before publishing
- document the one-time npm bootstrap and future release process

## Rationale

The TypeScript SDK had build and integration CI but no npm release workflow. This adds a tokenless release path with automatic npm provenance after the package's initial manual bootstrap publication.

## User impact

Stable releases publish to the npm `latest` dist-tag. Prerelease versions publish to `next`. Release tags must exactly match the version in `sdk-typescript/package.json`.

## Validation

- `actionlint .github/workflows/sdk-typescript-publish.yml .github/workflows/sdk-typescript-ci.yml`
- `npm run typecheck`
- `npm test` (7/7)
- `npm pack --dry-run --json`
- `make copyright-check`
