### PR TITLE
Derive TypeScript SDK version from release tag

### DIFF
--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -30,19 +30,19 @@ jobs:
           package-manager-cache: false
       - name: Install npm with trusted publishing support
         run: npm install --global npm@11.19.0
-      - name: Verify release version
+      - name: Resolve release version
         id: release
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          package_version="$(node -p "require('./package.json').version")"
-          expected_tag="sdk-typescript/v${package_version}"
-          if [[ "${RELEASE_TAG}" != "${expected_tag}" ]]; then
-            echo "Release tag ${RELEASE_TAG} does not match package version ${package_version}" >&2
+          release_version="${RELEASE_TAG#sdk-typescript/v}"
+          npm version "${release_version}" --no-git-tag-version --allow-same-version
+          if [[ "$(node -p "require('./package.json').version")" != "${release_version}" ]]; then
+            echo "npm did not resolve release version ${release_version}" >&2
             exit 1
           fi
-          if [[ "${package_version}" == *-* ]]; then
+          if [[ "${release_version}" == *-* ]]; then
             echo "dist_tag=next" >> "${GITHUB_OUTPUT}"
           else
             echo "dist_tag=latest" >> "${GITHUB_OUTPUT}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,12 +145,12 @@ Each component has its own version and tag prefix. Create a GitHub Release for t
 | Python SDK | `sdk-python/vX.Y.Z` | `sdk-python/v0.0.2` | PyPI [`dex-python-sdk`](https://pypi.org/project/dex-python-sdk/) (version from `sdk-python/pyproject.toml`) |
 | Java SDK | `sdk-java/vX.Y.Z` | `sdk-java/v0.0.3` | Maven Central `io.superdurable:dex-sdk` via [`.github/workflows/sdk-java-publish.yml`](.github/workflows/sdk-java-publish.yml) (version from the tag) |
 | Go SDK | `sdk-go/vX.Y.Z` | `sdk-go/v1.2.3` | Go module tag for `github.com/superdurable/dex/sdk-go` |
-| TypeScript SDK | `sdk-typescript/vX.Y.Z` | `sdk-typescript/v0.1.0` | npm [`@superdurable/dex`](https://www.npmjs.com/package/@superdurable/dex) via [`.github/workflows/sdk-typescript-publish.yml`](.github/workflows/sdk-typescript-publish.yml) |
+| TypeScript SDK | `sdk-typescript/vX.Y.Z` | `sdk-typescript/v0.1.0` | npm [`@superdurable/dex`](https://www.npmjs.com/package/@superdurable/dex) via [`.github/workflows/sdk-typescript-publish.yml`](.github/workflows/sdk-typescript-publish.yml) (version from the tag) |
 | Dex CLI | `cli-vX.Y.Z` | `cli-v0.1.0` | macOS/Linux archives and Homebrew formula input |
 
 Notes:
 
-- Bump the component’s own version file before tagging (`pyproject.toml`, `build.gradle`, etc.).
+- Bump a component's version file when its release workflow uses it; Java and TypeScript derive versions from tags.
 - Go uses a path-style tag (`sdk-go/v…`) so `go get` resolves the subdirectory module.
 - Python, Java, and Docker release workflows also support **workflow_dispatch** for manual runs. Python manual runs build without publishing unless `publish` is selected.
 - TypeScript publishing requires a GitHub Release after its one-time npm bootstrap publish.

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -118,11 +118,12 @@ suite's workflow behavior and its 58 assertions run against a real Dex server.
 ## Releases
 
 The npm package is published as [`@superdurable/dex`](https://www.npmjs.com/package/@superdurable/dex).
-Update `package.json` and `package-lock.json` to the same version, merge the
-change, then publish a GitHub Release tagged `sdk-typescript/vX.Y.Z`. The
-release workflow verifies that the tag matches `package.json`, runs type checks
-and tests, inspects the tarball, and publishes through npm Trusted Publishing.
-Prerelease versions use the `next` npm dist-tag; stable versions use `latest`.
+After the initial bootstrap, publish a GitHub Release tagged
+`sdk-typescript/vX.Y.Z`. The tag is the release version source of truth; CI
+temporarily writes it to `package.json` and `package-lock.json` without
+committing either file. The release workflow then runs type checks and tests,
+inspects the tarball, and publishes through npm Trusted Publishing. Prerelease
+versions use the `next` npm dist-tag; stable versions use `latest`.
 
 Trusted Publishing can only be configured after the package exists. Bootstrap
 the first version from a maintainer workstation with 2FA:


### PR DESCRIPTION
## Summary

- derive the npm package version from `sdk-typescript/vX.Y.Z` release tags
- update `package.json` and `package-lock.json` only inside the release runner
- preserve `latest` for stable releases and `next` for prereleases
- document the tag-driven TypeScript release process

## Rationale

The release tag should be the version source of truth, matching the Java SDK release model. Maintainers no longer need a version-only repository commit before each TypeScript SDK release.

## User impact

Creating `sdk-typescript/v0.1.1` publishes npm version `0.1.1`. Malformed versions are rejected by `npm version` before tests or publication.

## Validation

- `actionlint .github/workflows/sdk-typescript-publish.yml .github/workflows/sdk-typescript-ci.yml`
- simulated `npm version 1.2.3-beta.4 --no-git-tag-version --allow-same-version` and verified both manifests
- `npm run typecheck`
- `npm test` (7/7)
- `make copyright-check`
