### PR TITLE
Add Go SDK integration coverage and Codecov reporting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ sdk-typescript/dist/
 sdk-java/publication-smoke-test/target/
 sdk-typescript/coverage/
 sdk-python/coverage/
+sdk-go/coverage/

--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -11,6 +11,7 @@ on:
       - "web/**"
       - "go.work"
       - "go.work.sum"
+      - "codecov.yml"
       - ".github/workflows/sdk-go-ci.yml"
   pull_request:
     paths:
@@ -21,8 +22,16 @@ on:
       - "web/**"
       - "go.work"
       - "go.work.sum"
+      - "codecov.yml"
       - ".github/workflows/sdk-go-ci.yml"
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-go-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   unit:
@@ -94,8 +103,12 @@ jobs:
         run: make clientIntegTests
 
   e2e:
-    name: End-to-end tests
+    name: Integration coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: sdk-go
@@ -106,6 +119,8 @@ jobs:
           go-version-file: sdk-go/go.mod
           cache-dependency-path: |
             sdk-go/go.sum
+            cli/go.sum
+            server/go.sum
             go.work.sum
       - uses: actions/setup-node@v6
         with:
@@ -114,8 +129,24 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - name: Install Temporal CLI runtime for dexcli dev
         uses: temporalio/setup-temporal@v0
-      - name: End-to-end tests
-        run: make e2eTests
+      - name: Run integration coverage with dexcli dev
+        run: ./run-e2e-tests.sh --coverage
+      - name: Upload Go coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          disable_search: true
+          fail_ci_if_error: true
+          files: ./sdk-go/coverage/coverage.out
+          flags: sdk-go-integration
+          name: sdk-go-integration
+          use_oidc: true
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdk-go-integration-coverage
+          path: sdk-go/coverage/
+          if-no-files-found: ignore
       - name: Upload service logs
         if: always()
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.test
 *.out
 coverage.out
+sdk-go/coverage/
 dex-server
 examples/go/dex-samples
 cli/dexcli

--- a/sdk-go/CONTRIBUTION.md
+++ b/sdk-go/CONTRIBUTION.md
@@ -36,6 +36,8 @@ make copyright-check 2>&1 | tee /tmp/test-go-sdk-phase5-copyright.log
 `clientIntegTests` and `workerIntegTests` use real in-process gRPC with the race
 detector. `e2eTests` builds `dexcli`, starts its local Dex and Temporal
 environment, migrates the former iWF SDK scenarios, and owns cleanup.
+`integrationCoverage` runs the Client/Worker suites plus `e2eTests` with
+coverage limited to `./dex/...`, writing reports under `coverage/`.
 
 ## How to update IDL and the generated code
 1. Edit [`protos/dex.proto`](../protos/dex.proto)

--- a/sdk-go/Makefile
+++ b/sdk-go/Makefile
@@ -145,6 +145,9 @@ integTests:
 e2eTests:
 	$Q ./run-e2e-tests.sh
 
+integrationCoverage:
+	$Q ./run-e2e-tests.sh --coverage
+
 blobCacheTests:
 	$Q go test -race ./dex/blobcache
 

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -293,5 +293,26 @@ make copyright-check
 `e2eTests` uses the current checkout's `dexcli dev` environment. It
 runs the migrated iWF Go SDK scenarios through the public Dex SDK.
 
+### Measure integration coverage
+
+Run the local Client and Worker integration suites plus all `dexcli dev`
+E2E scenarios with Go coverage:
+
+```shell
+make integrationCoverage
+```
+
+The report measures only production packages under `./dex/...`. Unit
+tests, BlobCache package tests, examples, generated protobuf stubs under
+`gen/`, and `*_test.go` files are excluded. Open `coverage/index.html` for
+annotated source, or inspect `coverage/coverage.txt` for per-function
+totals. `coverage/coverage.out` is the profile uploaded by CI.
+
+CI uploads the profile to Codecov with GitHub OIDC, so no upload secret is
+stored in this repository. The report uses the `sdk-go-integration` flag
+and contributes to the Go SDK component defined in the root `codecov.yml`.
+The Actions run also publishes the report directory as
+`sdk-go-integration-coverage`.
+
 The detailed design and later phase boundaries are in the
 [Go SDK rewrite plan](../docs/design/plan/go-sdk-rewrite.md).

--- a/sdk-go/run-e2e-tests.sh
+++ b/sdk-go/run-e2e-tests.sh
@@ -16,27 +16,73 @@
 
 set -euo pipefail
 
-dex_port="${DEX_INTEG_DEX_PORT:-18801}"
-web_port="${DEX_INTEG_WEB_PORT:-18901}"
-temporal_port="${DEX_INTEG_TEMPORAL_PORT:-17233}"
-temporal_ui_port="${DEX_INTEG_TEMPORAL_UI_PORT:-18233}"
+coverage=false
+if [[ "${1:-}" == "--coverage" ]]; then
+  coverage=true
+  shift
+fi
+if [[ "$#" -ne 0 ]]; then
+  echo "usage: $0 [--coverage]" >&2
+  exit 2
+fi
+
+available_port() {
+  python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'
+}
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$script_dir"
+
+dex_port="${DEX_INTEG_DEX_PORT:-$(available_port)}"
+web_port="${DEX_INTEG_WEB_PORT:-$(available_port)}"
+temporal_port="${DEX_INTEG_TEMPORAL_PORT:-$(available_port)}"
+temporal_ui_port="${DEX_INTEG_TEMPORAL_UI_PORT:-$(available_port)}"
 dex_address="127.0.0.1:${dex_port}"
 temporal_address="127.0.0.1:${temporal_port}"
 log_file="/tmp/test-go-sdk-phase5-e2e-services.log"
 test_dir=$(mktemp -d)
 dexcli_pid=""
+cover_dir=""
+coverpkg="./dex/..."
+: >"$log_file"
 
 cleanup() {
+  status=$?
   if [[ -n "$dexcli_pid" ]] && kill -0 "$dexcli_pid" 2>/dev/null; then
     kill -TERM "$dexcli_pid"
     wait "$dexcli_pid" || true
   fi
+  if [[ "$status" -ne 0 ]]; then
+    cat "$log_file" >&2
+  fi
   rm -r "$test_dir"
+  if [[ -n "$cover_dir" ]]; then
+    rm -rf "$cover_dir"
+  fi
 }
 trap cleanup EXIT
 
+run_go_test() {
+  if $coverage; then
+    go test \
+      -covermode=atomic \
+      -coverpkg="$coverpkg" \
+      "$@" \
+      -args \
+      -test.gocoverdir="$cover_dir"
+  else
+    go test "$@"
+  fi
+}
+
+if $coverage; then
+  rm -rf coverage
+  cover_dir=$(mktemp -d "$script_dir/coverage-raw.XXXXXX")
+  run_go_test -count=1 -race -v ./dex -run '^TestClient'
+  run_go_test -count=1 -race -v ./dex -run '^TestWorker'
+fi
+
 make -C ../cli build
-: >"$log_file"
 ../cli/dexcli dev \
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
@@ -54,14 +100,12 @@ for _ in {1..240}; do
     break
   fi
   if ! kill -0 "$dexcli_pid" 2>/dev/null; then
-    cat "$log_file" >&2
     echo "dexcli exited before Temporal became ready" >&2
     exit 1
   fi
   sleep 0.25
 done
 if ! $temporal_ready; then
-  cat "$log_file" >&2
   echo "Temporal did not become ready" >&2
   exit 1
 fi
@@ -73,6 +117,30 @@ temporal --address "$temporal_address" operator search-attribute create --name C
 temporal --address "$temporal_address" operator search-attribute create --name CustomIntField --type Int
 temporal --address "$temporal_address" operator search-attribute create --name CustomDoubleField --type Double
 
+dex_ready=false
+for _ in {1..240}; do
+  if grep -q "Dex development environment is ready" "$log_file"; then
+    dex_ready=true
+    break
+  fi
+  if ! kill -0 "$dexcli_pid" 2>/dev/null; then
+    echo "dexcli exited before Dex became ready" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+if ! $dex_ready; then
+  echo "Dex did not become ready" >&2
+  exit 1
+fi
+
 DEX_FLOW_SERVICE_ADDRESS="$dex_address" \
 DEX_WORKER_HOST=127.0.0.1 \
-  go test -count=1 -race -v ./integ
+  run_go_test -count=1 -race -v ./integ
+
+if $coverage; then
+  mkdir -p coverage
+  go tool covdata textfmt -i="$cover_dir" -o=coverage/coverage.out
+  go tool cover -func=coverage/coverage.out | tee coverage/coverage.txt
+  go tool cover -html=coverage/coverage.out -o=coverage/index.html
+fi


### PR DESCRIPTION
## Summary

- measure Go SDK Client/Worker integration suites and `dexcli dev` E2E scenarios with `go test` coverage
- restrict coverage to production packages under `./dex/...`, excluding unit tests, examples, and generated protobuf stubs
- upload `coverage/coverage.out` to Codecov from CI with GitHub OIDC and retain the HTML report as an Actions artifact
- use ephemeral ports and wait for Dex readiness so local runs do not collide with other `dexcli` processes

## Rationale

Other SDKs already publish integration-only Codecov baselines. Go needs the same scoped report so the Go SDK component in the root `codecov.yml` reflects real Client/Worker/`integ` paths rather than unit or contract coverage.

Current Go SDK integration coverage:

- statements: 65.2%

## User impact

Run `make integrationCoverage` from `sdk-go` to start `dexcli dev`, execute the integration suites, and write `coverage/coverage.out`, `coverage/coverage.txt`, and `coverage/index.html`. CI uploads the same profile under the `sdk-go-integration` Codecov flag.

## Validation

- `./run-e2e-tests.sh --coverage` from `sdk-go`
- `bash -n sdk-go/run-e2e-tests.sh`
- `shellcheck sdk-go/run-e2e-tests.sh`
- `actionlint .github/workflows/sdk-go-ci.yml`
- `make copyright-check`
- `git diff --check`
