### PR TITLE
Improve Overview Live Flow State and section expand controls

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,7 +1,7 @@
 # Dex Web
 
 Dex Web searches flows and displays Dex semantic history, step topology,
-current interpreter state, and reset points.
+live flow state, and reset points.
 
 The production Web server is Go. It serves an embedded React SPA and translates
 same-origin HTTP/JSON requests under `/api/` to Dex `FlowService` gRPC calls.
@@ -65,8 +65,10 @@ The Flows page provides Basic and Advanced visibility queries, pagination,
 saved queries, configurable columns, custom search attributes, and timezone
 preferences.
 
-The Run page provides Overview, Step graph, Timeline, active/waiting state,
-attributes, timers, queued steps, channels, completed outputs, and reset.
+The Run page provides Overview (Live Flow State beside Selected event, then
+Run input beside Identity), Step graph, Timeline, attributes, timers, queued
+steps, channels, completed outputs, and reset. Timeline and Step graph keep
+Selected event in the sidebar.
 Continued runs link to their previous run from Timeline and Step graph.
 Step graph nodes separate WaitFor and Execute with distinct colors, channel names, condition icons, and individual event details.
 Timeline and Step graph share structured event details for flow, step method, RPC,

--- a/web/app/components/JsonView.tsx
+++ b/web/app/components/JsonView.tsx
@@ -8,7 +8,7 @@
 
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { storedValueJSONReplacer } from '@/lib/blobs';
 import { StructuredValue } from './StructuredValue';
 
@@ -20,11 +20,15 @@ export function JsonView({
   label = 'Details',
   initiallyOpen = false,
   persistKey,
+  forceOpen,
+  collapseNonce = 0,
 }: {
   value: unknown;
   label?: string;
   initiallyOpen?: boolean;
   persistKey?: string;
+  forceOpen?: boolean;
+  collapseNonce?: number;
 }) {
   const storageKey = persistKey ?? label;
   const [open, setOpen] = useState(() => openByKey.get(storageKey) ?? initiallyOpen);
@@ -32,11 +36,26 @@ export function JsonView({
     () => viewByKey.get(storageKey) ?? 'details',
   );
 
+  useEffect(() => {
+    if (!forceOpen) return;
+    setOpen(true);
+    openByKey.set(storageKey, true);
+  }, [forceOpen, storageKey]);
+
+  useEffect(() => {
+    if (collapseNonce <= 0) return;
+    setOpen(false);
+    openByKey.set(storageKey, false);
+  }, [collapseNonce, storageKey]);
+
+  const effectiveOpen = forceOpen || open;
+
   return (
     <div className="json-view">
       <button
         type="button"
         className="json-toggle"
+        disabled={forceOpen}
         onClick={() => {
           setOpen((current) => {
             const next = !current;
@@ -45,10 +64,10 @@ export function JsonView({
           });
         }}
       >
-        <span>{open ? '−' : '+'}</span>
+        <span>{effectiveOpen ? '−' : '+'}</span>
         {label}
       </button>
-      {open && (
+      {effectiveOpen && (
         <div className="json-view-body">
           <div className="event-detail-tabs" role="tablist" aria-label={`${label} view`}>
             <button

--- a/web/app/components/JsonView.tsx
+++ b/web/app/components/JsonView.tsx
@@ -10,24 +10,81 @@
 
 import { useState } from 'react';
 import { storedValueJSONReplacer } from '@/lib/blobs';
+import { StructuredValue } from './StructuredValue';
+
+const openByKey = new Map<string, boolean>();
+const viewByKey = new Map<string, 'details' | 'raw'>();
 
 export function JsonView({
   value,
   label = 'Details',
   initiallyOpen = false,
+  persistKey,
 }: {
   value: unknown;
   label?: string;
   initiallyOpen?: boolean;
+  persistKey?: string;
 }) {
-  const [open, setOpen] = useState(initiallyOpen);
+  const storageKey = persistKey ?? label;
+  const [open, setOpen] = useState(() => openByKey.get(storageKey) ?? initiallyOpen);
+  const [view, setView] = useState<'details' | 'raw'>(
+    () => viewByKey.get(storageKey) ?? 'details',
+  );
+
   return (
     <div className="json-view">
-      <button type="button" className="json-toggle" onClick={() => setOpen(!open)}>
+      <button
+        type="button"
+        className="json-toggle"
+        onClick={() => {
+          setOpen((current) => {
+            const next = !current;
+            openByKey.set(storageKey, next);
+            return next;
+          });
+        }}
+      >
         <span>{open ? '−' : '+'}</span>
         {label}
       </button>
-      {open && <pre>{JSON.stringify(value, storedValueJSONReplacer, 2)}</pre>}
+      {open && (
+        <div className="json-view-body">
+          <div className="event-detail-tabs" role="tablist" aria-label={`${label} view`}>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === 'details'}
+              className={view === 'details' ? 'active' : ''}
+              onClick={() => {
+                setView('details');
+                viewByKey.set(storageKey, 'details');
+              }}
+            >
+              Details
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === 'raw'}
+              className={view === 'raw' ? 'active' : ''}
+              onClick={() => {
+                setView('raw');
+                viewByKey.set(storageKey, 'raw');
+              }}
+            >
+              Raw JSON
+            </button>
+          </div>
+          {view === 'details'
+            ? <StructuredValue value={value} />
+            : (
+              <pre className="json-view-raw">
+                {JSON.stringify(value, storedValueJSONReplacer, 2)}
+              </pre>
+            )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/app/components/StructuredValue.tsx
+++ b/web/app/components/StructuredValue.tsx
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+'use client';
+
+import {
+  isBlobReferenceValue,
+  isStoredValueUnavailable,
+  storedValueJSONReplacer,
+} from '@/lib/blobs';
+import { formatDate, type TimezonePreference } from '@/lib/format';
+import {
+  conditionStatusLabel,
+  durabilityLabel,
+  waitingConditionTypeLabel,
+} from '@/lib/semantic';
+import { VALUE_BLOB_UNAVAILABLE } from '@/lib/unavailable';
+import { usePreferences } from '@/app/providers';
+
+type Data = Record<string, unknown>;
+
+function asData(value: unknown): Data {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Data : {};
+}
+
+function asDataArray(value: unknown): Data[] {
+  return Array.isArray(value) ? value.map(asData) : [];
+}
+
+function isPresent(value: unknown): boolean {
+  return value !== undefined && value !== null && value !== '';
+}
+
+function displayScalar(value: unknown): string {
+  if (value === undefined || value === null || value === '') return '—';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  return JSON.stringify(value);
+}
+
+function decodedValue(value: unknown): unknown {
+  if (isBlobReferenceValue(value)) return 'Loading stored value…';
+  if (isStoredValueUnavailable(value)) return VALUE_BLOB_UNAVAILABLE;
+  const message = asData(value);
+  if ('stringValue' in message) return message.stringValue;
+  if ('intValue' in message) return message.intValue;
+  if ('doubleValue' in message) return message.doubleValue;
+  if ('boolValue' in message) return message.boolValue;
+  if ('nullValue' in message) return null;
+  const object = asData(message.objValue);
+  if (typeof object.payload !== 'string') return value;
+  try {
+    const bytes = Uint8Array.from(atob(object.payload), (character) => character.charCodeAt(0));
+    const decoded = new TextDecoder().decode(bytes);
+    if (object.encoding === 'json') {
+      try {
+        return JSON.parse(decoded) as unknown;
+      } catch {
+        return decoded;
+      }
+    }
+    return decoded;
+  } catch {
+    return value;
+  }
+}
+
+function Fields({ values }: { values: Array<[string, unknown]> }) {
+  const visible = values.filter(([, value]) => isPresent(value));
+  if (visible.length === 0) return null;
+  return (
+    <dl className="semantic-fields semantic-fields-compact">
+      {visible.map(([label, value]) => (
+        <div key={label}>
+          <dt>{label}</dt>
+          <dd>{displayScalar(value)}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function ValueChip({ value }: { value: unknown }) {
+  const decoded = decodedValue(value);
+  if (decoded && typeof decoded === 'object') {
+    return <pre>{JSON.stringify(decoded, storedValueJSONReplacer, 2)}</pre>;
+  }
+  return <code>{displayScalar(decoded)}</code>;
+}
+
+function unixTime(value: unknown, timezone: TimezonePreference): string | undefined {
+  if (!isPresent(value)) return undefined;
+  const timestamp = Number(value);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return undefined;
+  return formatDate(new Date(timestamp * 1000).toISOString(), timezone);
+}
+
+function isWaitingCondition(value: unknown): boolean {
+  const data = asData(value);
+  return 'waitingConditionType' in data
+    || 'channelConditions' in data
+    || 'timerConditions' in data;
+}
+
+function isKeyValueList(value: unknown): boolean {
+  const entries = asDataArray(value);
+  return entries.length > 0 && entries.every((entry) => 'key' in entry);
+}
+
+function isTimerList(value: unknown): boolean {
+  const entries = asDataArray(value);
+  return entries.length > 0 && entries.every((entry) => (
+    'firingUnixTimestampSeconds' in entry || 'durationSeconds' in entry
+  ));
+}
+
+function WaitingConditionStructured({ value }: { value: unknown }) {
+  const { timezone } = usePreferences();
+  const condition = asData(value);
+  const channels = asDataArray(condition.channelConditions);
+  const timers = asDataArray(condition.timerConditions);
+  return (
+    <div className="structured-value">
+      <Fields values={[[
+        'Completion rule',
+        waitingConditionTypeLabel(condition.waitingConditionType),
+      ]]} />
+      {channels.map((channel, index) => (
+        <div className="semantic-record channel-record" key={`${String(channel.channelName)}-${index}`}>
+          <strong>{displayScalar(channel.channelName)}</strong>
+          <Fields values={[
+            ['Condition ID', channel.conditionId],
+            ['At least', channel.atLeast],
+            ['At most', channel.atMost],
+          ]} />
+        </div>
+      ))}
+      {timers.map((timer, index) => (
+        <div className="semantic-record" key={`${String(timer.conditionId)}-${index}`}>
+          <strong>Timer {index + 1}</strong>
+          <Fields values={[
+            ['Condition ID', timer.conditionId],
+            ['Fires at', unixTime(timer.firingUnixTimestampSeconds, timezone)],
+            ['Delay', isPresent(timer.durationSeconds) ? `${timer.durationSeconds}s` : undefined],
+          ]} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function KeyValueListStructured({ value }: { value: unknown }) {
+  return (
+    <div className="structured-value semantic-records">
+      {asDataArray(value).map((entry, index) => (
+        <div className="semantic-record" key={`${String(entry.key)}-${index}`}>
+          <strong>{displayScalar(entry.key)}</strong>
+          <div className="semantic-value">
+            <ValueChip value={entry.value} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TimerListStructured({ value }: { value: unknown }) {
+  const { timezone } = usePreferences();
+  return (
+    <div className="structured-value semantic-records">
+      {asDataArray(value).map((timer, index) => (
+        <div className="semantic-record" key={`${String(timer.conditionId)}-${index}`}>
+          <strong>Timer {index + 1}</strong>
+          <Fields values={[
+            ['Condition ID', timer.conditionId],
+            ['Status', conditionStatusLabel(timer.status)],
+            ['Fires at', unixTime(timer.firingUnixTimestampSeconds, timezone)],
+            ['Delay', isPresent(timer.durationSeconds) ? `${timer.durationSeconds}s` : undefined],
+          ]} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ObjectStructured({ value }: { value: Data }) {
+  const entries = Object.entries(value);
+  if (entries.length === 0) return <p className="muted">Empty object</p>;
+  return (
+    <div className="structured-value">
+      <dl className="semantic-fields semantic-fields-compact">
+        {entries.map(([key, entry]) => {
+          const decoded = decodedValue(entry);
+          const labeled = key === 'stepDurability' || key === 'waitForDurability'
+            ? durabilityLabel(entry)
+            : null;
+          return (
+            <div className="semantic-field-wide" key={key}>
+              <dt>{key}</dt>
+              <dd>
+                {labeled !== null
+                  ? labeled
+                  : decoded && typeof decoded === 'object'
+                    ? <pre>{JSON.stringify(decoded, storedValueJSONReplacer, 2)}</pre>
+                    : displayScalar(decoded)}
+              </dd>
+            </div>
+          );
+        })}
+      </dl>
+    </div>
+  );
+}
+
+function ArrayStructured({ value }: { value: unknown[] }) {
+  if (value.length === 0) return <p className="muted">Empty list</p>;
+  return (
+    <div className="structured-value semantic-records">
+      {value.map((entry, index) => (
+        <div className="semantic-record" key={index}>
+          <strong>Item {index + 1}</strong>
+          {entry && typeof entry === 'object'
+            ? <ObjectStructured value={asData(entry)} />
+            : <code>{displayScalar(entry)}</code>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function StructuredValue({ value }: { value: unknown }) {
+  if (value === undefined || value === null) {
+    return <p className="muted">No value</p>;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <p className="muted">Empty list</p>;
+    if (isKeyValueList(value)) return <KeyValueListStructured value={value} />;
+    if (isTimerList(value)) return <TimerListStructured value={value} />;
+    return <ArrayStructured value={value} />;
+  }
+  if (typeof value === 'object') {
+    if (Object.keys(value).length === 0) return <p className="muted">Empty object</p>;
+    if (isWaitingCondition(value)) return <WaitingConditionStructured value={value} />;
+    return <ObjectStructured value={asData(value)} />;
+  }
+  return <code>{displayScalar(value)}</code>;
+}

--- a/web/app/flows/RunDetailsPage.tsx
+++ b/web/app/flows/RunDetailsPage.tsx
@@ -453,7 +453,11 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
       </div>
 
       <div
-        className={`run-content ${resizingSidebar ? 'is-resizing-sidebar' : ''}`}
+        className={[
+          'run-content',
+          tab === 'overview' ? 'run-content--overview' : '',
+          resizingSidebar ? 'is-resizing-sidebar' : '',
+        ].filter(Boolean).join(' ')}
         ref={runContent}
         style={{ '--run-sidebar-width': `${sidebarWidth}px` } as CSSProperties}
       >
@@ -470,7 +474,12 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
         )}
         <section className="run-primary">
           {tab === 'overview' && summary && (
-            <FlowOverview summary={summary} events={displayedHistory} state={state} />
+            <FlowOverview
+              summary={summary}
+              events={displayedHistory}
+              state={state}
+              selectedEvent={selected}
+            />
           )}
           {tab === 'steps' && (
             <StepGraph
@@ -507,27 +516,27 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
             </div>
           )}
         </section>
-        <aside className="run-sidebar">
-          <button
-            type="button"
-            className="run-sidebar-resizer"
-            role="separator"
-            aria-label="Resize selected event panel"
-            aria-orientation="vertical"
-            aria-valuemin={minimumSidebarWidth}
-            aria-valuemax={maximumSidebarWidth}
-            aria-valuenow={sidebarWidth}
-            onDoubleClick={() => persistSidebarWidth(updateSidebarWidth(defaultSidebarWidth))}
-            onKeyDown={resizeSidebarWithKeyboard}
-            onPointerDown={startSidebarResize}
-          />
-          <FlowStatePanel
-            state={state}
-            selectedEvent={selected}
-            summary={summary}
-            history={displayedHistory}
-          />
-        </aside>
+        {tab !== 'overview' && (
+          <aside className="run-sidebar">
+            <button
+              type="button"
+              className="run-sidebar-resizer"
+              role="separator"
+              aria-label="Resize selected event panel"
+              aria-orientation="vertical"
+              aria-valuemin={minimumSidebarWidth}
+              aria-valuemax={maximumSidebarWidth}
+              aria-valuenow={sidebarWidth}
+              onDoubleClick={() => persistSidebarWidth(updateSidebarWidth(defaultSidebarWidth))}
+              onKeyDown={resizeSidebarWithKeyboard}
+              onPointerDown={startSidebarResize}
+            />
+            <FlowStatePanel
+              selectedEvent={selected}
+              history={displayedHistory}
+            />
+          </aside>
+        )}
       </div>
 
       {summary && (

--- a/web/app/flows/details/FlowOverview.tsx
+++ b/web/app/flows/details/FlowOverview.tsx
@@ -8,65 +8,177 @@
 
 import type { FlowHistoryEvent, FlowState, FlowSummary } from '@/lib/types';
 import { JsonView } from '../../components/JsonView';
-import { SemanticEventDetails } from './EventDetails';
+import { EventDetails, eventTitle, SemanticEventDetails } from './EventDetails';
 
 export function FlowOverview({
   summary,
   events,
   state,
+  selectedEvent,
 }: {
   summary: FlowSummary;
   events: FlowHistoryEvent[];
   state: FlowState | null;
+  selectedEvent: FlowHistoryEvent | null;
 }) {
   const started = events.find((event) => event.type === 'FlowStartedOrContinued');
   const closed = events.findLast((event) => event.type === 'FlowClosed');
   const startKind = started?.payload.initialStart ? 'Initial start' : 'Continued run';
   return (
     <div className="overview-grid">
-      <section className="card overview-card">
-        <div className="section-heading">
-          <div><p className="eyebrow">Identity</p><h2>Execution</h2></div>
-        </div>
-        <dl className="definition-list">
-          <div><dt>Flow ID</dt><dd className="mono">{summary.flowId}</dd></div>
-          <div><dt>Run ID</dt><dd className="mono">{summary.runId}</dd></div>
-          <div><dt>First run ID</dt><dd className="mono">{summary.firstRunId || '—'}</dd></div>
-          <div><dt>Request ID</dt><dd className="mono">{summary.requestId || '—'}</dd></div>
-          <div><dt>Flow type</dt><dd>{summary.flowType || '—'}</dd></div>
-        </dl>
-      </section>
-
-      <section className="card overview-card">
-        <div className="section-heading">
-          <div><p className="eyebrow">Run input</p><h2>{startKind}</h2></div>
-        </div>
-        {started ? (
-          <div className="semantic-event">
-            <SemanticEventDetails event={started} showStartHeading={false} />
+      <div className="overview-column">
+        <section className="card overview-card overview-live-state">
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">{state ? 'Current' : summary.flowStatus || 'Unavailable'}</p>
+              <h2>Live Flow State</h2>
+            </div>
           </div>
-        ) : (
-          <p className="muted">The start event is not in the loaded history page.</p>
-        )}
-      </section>
+          {!state && <p className="muted">Live state is queried only while this run is active.</p>}
+          {state && (
+            <>
+              <div className="metric-grid">
+                <div><span>Attributes</span><b>{state.attributes.length}</b></div>
+                <div><span>Active steps</span><b>{state.activeStepExecutions.length}</b></div>
+                <div><span>Queued steps</span><b>{state.queuedSteps.length}</b></div>
+                <div><span>Completed outputs</span><b>{state.completedSteps.length}</b></div>
+                <div>
+                  <span>Pending channels</span>
+                  <b>{Object.keys(state.pendingChannelMessages).length}</b>
+                </div>
+              </div>
 
-      <section className="card overview-card wide">
-        <div className="section-heading">
-          <div><p className="eyebrow">Interpreter</p><h2>Flow state</h2></div>
-        </div>
-        <div className="metric-grid">
-          <div><span>Attributes</span><b>{state?.attributes.length ?? 0}</b></div>
-          <div><span>Active steps</span><b>{state?.activeStepExecutions.length ?? 0}</b></div>
-          <div><span>Queued steps</span><b>{state?.queuedSteps.length ?? 0}</b></div>
-          <div><span>Completed outputs</span><b>{state?.completedSteps.length ?? 0}</b></div>
-          <div>
-            <span>Pending channels</span>
-            <b>{Object.keys(state?.pendingChannelMessages ?? {}).length}</b>
+              <div className="live-state-block">
+                <p className="eyebrow">Active steps</p>
+                {state.activeStepExecutions.map((step) => (
+                  <div className="active-step-card" key={step.stepExecutionId}>
+                    <div>
+                      <b>{step.stepType}</b>
+                      <span className={`phase phase-${step.phase.toLowerCase()}`}>{step.phase}</span>
+                    </div>
+                    <code>{step.stepExecutionId}</code>
+                    <span>From {step.fromStepExecutionId || '—'}</span>
+                    {step.waitingCondition && Object.keys(step.waitingCondition).length > 0 && (
+                      <JsonView
+                        value={step.waitingCondition}
+                        label="Waiting condition"
+                        persistKey={`overview:active-step:${step.stepExecutionId}:waiting-condition`}
+                      />
+                    )}
+                    {step.timers.length > 0 && (
+                      <JsonView
+                        value={step.timers}
+                        label={`${step.timers.length} timers`}
+                        persistKey={`overview:active-step:${step.stepExecutionId}:timers`}
+                      />
+                    )}
+                  </div>
+                ))}
+                {state.activeStepExecutions.length === 0 && (
+                  <p className="muted">No active step executions.</p>
+                )}
+              </div>
+
+              <div className="live-state-block">
+                <p className="eyebrow">Attributes</p>
+                <h3>{state.attributes.length} values</h3>
+                <JsonView
+                  value={state.attributes}
+                  label="Attributes"
+                  persistKey="overview:attributes"
+                />
+              </div>
+
+              <div className="live-state-block">
+                <p className="eyebrow">Queues & channels</p>
+                <JsonView
+                  value={state.queuedSteps}
+                  label={`${state.queuedSteps.length} queued steps`}
+                  persistKey="overview:queued-steps"
+                />
+                <JsonView
+                  value={state.pendingChannelMessages}
+                  label="Pending channel messages"
+                  persistKey="overview:pending-channels"
+                />
+                <JsonView
+                  value={state.completedSteps}
+                  label="Completed outputs"
+                  persistKey="overview:completed-outputs"
+                />
+              </div>
+
+              {state.flowConfig && (
+                <JsonView
+                  value={state.flowConfig}
+                  label="Flow config"
+                  persistKey="overview:flow-config"
+                />
+              )}
+            </>
+          )}
+          {closed && (
+            <JsonView
+              value={closed.payload.results ?? []}
+              label="Close result"
+              persistKey="overview:close-result"
+            />
+          )}
+        </section>
+
+        <section className="card overview-card">
+          <div className="section-heading">
+            <div><p className="eyebrow">Run input</p><h2>{startKind}</h2></div>
           </div>
-        </div>
-        {state?.flowConfig && <JsonView value={state.flowConfig} label="Flow config" />}
-        {closed && <JsonView value={closed.payload.results ?? []} label="Close result" />}
-      </section>
+          {started ? (
+            <div className="semantic-event">
+              <SemanticEventDetails event={started} showStartHeading={false} />
+            </div>
+          ) : (
+            <p className="muted">The start event is not in the loaded history page.</p>
+          )}
+        </section>
+      </div>
+
+      <div className="overview-column">
+        <section className="card overview-card overview-selected-event">
+          {selectedEvent ? (
+            <>
+              <header className="overview-selected-event-header" data-selected-event-target>
+                <p className="eyebrow">Selected event</p>
+                <h2>{eventTitle(selectedEvent)}</h2>
+                <div className="event-meta">
+                  <span>Event {selectedEvent.eventId}</span>
+                  <span>{selectedEvent.eventTime || 'No timestamp'}</span>
+                </div>
+              </header>
+              <div className="overview-selected-event-body">
+                <EventDetails event={selectedEvent} history={events} />
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="section-heading">
+                <div><p className="eyebrow">Selected event</p><h2>None</h2></div>
+              </div>
+              <p className="muted">Select an event from Timeline or Step graph.</p>
+            </>
+          )}
+        </section>
+
+        <section className="card overview-card">
+          <div className="section-heading">
+            <div><p className="eyebrow">Identity</p><h2>Execution</h2></div>
+          </div>
+          <dl className="definition-list">
+            <div><dt>Flow ID</dt><dd className="mono">{summary.flowId}</dd></div>
+            <div><dt>Run ID</dt><dd className="mono">{summary.runId}</dd></div>
+            <div><dt>First run ID</dt><dd className="mono">{summary.firstRunId || '—'}</dd></div>
+            <div><dt>Request ID</dt><dd className="mono">{summary.requestId || '—'}</dd></div>
+            <div><dt>Flow type</dt><dd>{summary.flowType || '—'}</dd></div>
+          </dl>
+        </section>
+      </div>
     </div>
   );
 }

--- a/web/app/flows/details/FlowOverview.tsx
+++ b/web/app/flows/details/FlowOverview.tsx
@@ -6,9 +6,48 @@
 //
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
+import { useState } from 'react';
 import type { FlowHistoryEvent, FlowState, FlowSummary } from '@/lib/types';
 import { JsonView } from '../../components/JsonView';
 import { EventDetails, eventTitle, SemanticEventDetails } from './EventDetails';
+
+const sectionExpandByKey = new Map<string, boolean>();
+
+function useSectionExpand(persistKey: string) {
+  const [expanded, setExpanded] = useState(() => sectionExpandByKey.get(persistKey) ?? false);
+  const [collapseNonce, setCollapseNonce] = useState(0);
+  return {
+    expanded,
+    collapseNonce,
+    setExpanded: (next: boolean) => {
+      sectionExpandByKey.set(persistKey, next);
+      setExpanded(next);
+      if (!next) setCollapseNonce((current) => current + 1);
+    },
+  };
+}
+
+function SectionExpandToggle({
+  expanded,
+  onChange,
+  label,
+}: {
+  expanded: boolean;
+  onChange: (next: boolean) => void;
+  label: string;
+}) {
+  return (
+    <label className="section-expand-toggle">
+      <input
+        type="checkbox"
+        checked={expanded}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      {expanded ? 'Collapse all' : 'Expand all'}
+      <span className="sr-only">{label}</span>
+    </label>
+  );
+}
 
 export function FlowOverview({
   summary,
@@ -24,6 +63,10 @@ export function FlowOverview({
   const started = events.find((event) => event.type === 'FlowStartedOrContinued');
   const closed = events.findLast((event) => event.type === 'FlowClosed');
   const startKind = started?.payload.initialStart ? 'Initial start' : 'Continued run';
+  const activeStepsExpand = useSectionExpand('overview:expand:active-steps');
+  const attributesExpand = useSectionExpand('overview:expand:attributes');
+  const channelsExpand = useSectionExpand('overview:expand:channels');
+
   return (
     <div className="overview-grid">
       <div className="overview-column">
@@ -49,10 +92,17 @@ export function FlowOverview({
               </div>
 
               <div className="live-state-block">
-                <p className="eyebrow">Active steps</p>
+                <div className="live-state-block-heading">
+                  <p className="eyebrow">Active steps</p>
+                  <SectionExpandToggle
+                    expanded={activeStepsExpand.expanded}
+                    onChange={activeStepsExpand.setExpanded}
+                    label="active steps"
+                  />
+                </div>
                 {state.activeStepExecutions.map((step) => (
                   <div className="active-step-card" key={step.stepExecutionId}>
-                    <div>
+                    <div className="active-step-heading">
                       <b>{step.stepType}</b>
                       <span className={`phase phase-${step.phase.toLowerCase()}`}>{step.phase}</span>
                     </div>
@@ -62,14 +112,18 @@ export function FlowOverview({
                       <JsonView
                         value={step.waitingCondition}
                         label="Waiting condition"
-                        persistKey={`overview:active-step:${step.stepExecutionId}:waiting-condition`}
+                        persistKey={`overview:active-step:${step.stepType}:waiting-condition`}
+                        forceOpen={activeStepsExpand.expanded || undefined}
+                        collapseNonce={activeStepsExpand.collapseNonce}
                       />
                     )}
                     {step.timers.length > 0 && (
                       <JsonView
                         value={step.timers}
                         label={`${step.timers.length} timers`}
-                        persistKey={`overview:active-step:${step.stepExecutionId}:timers`}
+                        persistKey={`overview:active-step:${step.stepType}:timers`}
+                        forceOpen={activeStepsExpand.expanded || undefined}
+                        collapseNonce={activeStepsExpand.collapseNonce}
                       />
                     )}
                   </div>
@@ -80,31 +134,55 @@ export function FlowOverview({
               </div>
 
               <div className="live-state-block">
-                <p className="eyebrow">Attributes</p>
-                <h3>{state.attributes.length} values</h3>
+                <div className="live-state-block-heading">
+                  <div>
+                    <p className="eyebrow">Attributes</p>
+                    <h3>{state.attributes.length} values</h3>
+                  </div>
+                  <SectionExpandToggle
+                    expanded={attributesExpand.expanded}
+                    onChange={attributesExpand.setExpanded}
+                    label="attributes"
+                  />
+                </div>
                 <JsonView
                   value={state.attributes}
                   label="Attributes"
                   persistKey="overview:attributes"
+                  forceOpen={attributesExpand.expanded || undefined}
+                  collapseNonce={attributesExpand.collapseNonce}
                 />
               </div>
 
               <div className="live-state-block">
-                <p className="eyebrow">Queues & channels</p>
+                <div className="live-state-block-heading">
+                  <p className="eyebrow">Channels & Others Internals</p>
+                  <SectionExpandToggle
+                    expanded={channelsExpand.expanded}
+                    onChange={channelsExpand.setExpanded}
+                    label="channels and other internals"
+                  />
+                </div>
                 <JsonView
                   value={state.queuedSteps}
                   label={`${state.queuedSteps.length} queued steps`}
                   persistKey="overview:queued-steps"
+                  forceOpen={channelsExpand.expanded || undefined}
+                  collapseNonce={channelsExpand.collapseNonce}
                 />
                 <JsonView
                   value={state.pendingChannelMessages}
                   label="Pending channel messages"
                   persistKey="overview:pending-channels"
+                  forceOpen={channelsExpand.expanded || undefined}
+                  collapseNonce={channelsExpand.collapseNonce}
                 />
                 <JsonView
                   value={state.completedSteps}
                   label="Completed outputs"
                   persistKey="overview:completed-outputs"
+                  forceOpen={channelsExpand.expanded || undefined}
+                  collapseNonce={channelsExpand.collapseNonce}
                 />
               </div>
 

--- a/web/app/flows/details/FlowStatePanel.tsx
+++ b/web/app/flows/details/FlowStatePanel.tsx
@@ -7,24 +7,8 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import { useEffect, useRef } from 'react';
-import type { FlowHistoryEvent, FlowState, FlowSummary } from '@/lib/types';
-import { waitingConditionTypeLabel } from '@/lib/semantic';
-import { JsonView } from '../../components/JsonView';
+import type { FlowHistoryEvent } from '@/lib/types';
 import { EventDetails, eventTitle } from './EventDetails';
-
-type Data = Record<string, unknown>;
-
-function data(value: unknown): Data {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as Data : {};
-}
-
-function normalizeWaitingCondition(value: unknown): Data {
-  const condition = data(value);
-  return {
-    ...condition,
-    waitingConditionType: waitingConditionTypeLabel(condition.waitingConditionType),
-  };
-}
 
 function canScroll(element: HTMLElement, deltaY: number): boolean {
   if (deltaY < 0) return element.scrollTop > 0;
@@ -36,7 +20,7 @@ function containSidebarWheel(event: WheelEvent) {
   const sidebar = event.currentTarget;
   if (!(sidebar instanceof HTMLElement) || sidebar.scrollHeight <= sidebar.clientHeight) return;
   const nested = event.target instanceof Element
-    ? event.target.closest<HTMLElement>('.raw-event-json, .semantic-value pre, .semantic-alert pre, .json-view pre')
+    ? event.target.closest<HTMLElement>('.raw-event-json, .semantic-value pre, .semantic-alert pre, .json-view pre, .json-view-raw')
     : null;
   if (nested && nested !== sidebar && canScroll(nested, event.deltaY)) return;
   if (Math.abs(event.deltaX) > Math.abs(event.deltaY)) return;
@@ -51,14 +35,10 @@ function containSidebarWheel(event: WheelEvent) {
 }
 
 export function FlowStatePanel({
-  state,
   selectedEvent,
-  summary,
   history,
 }: {
-  state: FlowState | null;
   selectedEvent: FlowHistoryEvent | null;
-  summary: FlowSummary | null;
   history: FlowHistoryEvent[];
 }) {
   const sidebar = useRef<HTMLDivElement>(null);
@@ -72,7 +52,7 @@ export function FlowStatePanel({
 
   return (
     <div className="sidebar-stack" ref={sidebar}>
-      {selectedEvent && (
+      {selectedEvent ? (
         <>
           <header className="selected-event-anchor" data-selected-event-target>
             <p className="eyebrow">Selected event</p>
@@ -86,45 +66,12 @@ export function FlowStatePanel({
             <EventDetails event={selectedEvent} history={history} />
           </section>
         </>
-      )}
-
-      <section className="sidebar-section">
-        <p className="eyebrow">Live state</p>
-        <h3>{state ? 'Interpreter snapshot' : `${summary?.flowStatus || 'Unavailable'}`}</h3>
-        {!state && <p className="muted">Live state is queried only while this run is active.</p>}
-        {state?.activeStepExecutions.map((step) => (
-          <div className="active-step-card" key={step.stepExecutionId}>
-            <div>
-              <b>{step.stepType}</b>
-              <span className={`phase phase-${step.phase.toLowerCase()}`}>{step.phase}</span>
-            </div>
-            <code>{step.stepExecutionId}</code>
-            <span>From {step.fromStepExecutionId || '—'}</span>
-            {step.waitingCondition && Object.keys(step.waitingCondition).length > 0 && (
-              <JsonView value={normalizeWaitingCondition(step.waitingCondition)} label="Waiting condition" />
-            )}
-            {step.timers.length > 0 && <JsonView value={step.timers} label={`${step.timers.length} timers`} />}
-          </div>
-        ))}
-        {state && state.activeStepExecutions.length === 0 && (
-          <p className="muted">No active step executions.</p>
-        )}
-      </section>
-
-      {state && (
-        <>
-          <section className="sidebar-section">
-            <p className="eyebrow">Attributes</p>
-            <h3>{state.attributes.length} values</h3>
-            <JsonView value={state.attributes} label="Attributes" />
-          </section>
-          <section className="sidebar-section">
-            <p className="eyebrow">Queues & channels</p>
-            <JsonView value={state.queuedSteps} label={`${state.queuedSteps.length} queued steps`} />
-            <JsonView value={state.pendingChannelMessages} label="Pending channel messages" />
-            <JsonView value={state.completedSteps} label="Completed outputs" />
-          </section>
-        </>
+      ) : (
+        <section className="sidebar-section">
+          <p className="eyebrow">Selected event</p>
+          <h3>None</h3>
+          <p className="muted">Select an event from Timeline or Step graph.</p>
+        </section>
       )}
     </div>
   );

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1244,18 +1244,57 @@ pre {
   font-size: 16px;
 }
 
+.json-view-body {
+  display: flex;
+  padding: 10px;
+  flex-direction: column;
+  gap: 9px;
+  border-top: 1px solid var(--line);
+  background: #fbfcfc;
+}
+
+.json-view-body .event-detail-tabs {
+  background: #f1f4f3;
+}
+
+.json-view-raw,
 .json-view pre {
   max-height: 420px;
   margin: 0;
   padding: 11px;
   overflow: auto;
-  border-top: 1px solid var(--line);
+  border: 1px solid var(--line);
+  border-radius: 8px;
   color: #33413e;
-  background: #fbfcfc;
+  background: white;
   font-size: 10px;
   line-height: 1.55;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.structured-value {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.structured-value .semantic-record {
+  background: white;
+}
+
+.structured-value .semantic-fields {
+  margin: 0;
+}
+
+.structured-value .semantic-value {
+  margin-top: 4px;
+}
+
+.structured-value .semantic-value pre,
+.structured-value dd pre {
+  max-height: 220px;
 }
 
 .active-step-card {
@@ -1307,18 +1346,51 @@ pre {
   font-size: 12px;
 }
 
+.run-content--overview {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .overview-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.overview-column {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
   gap: 16px;
 }
 
 .overview-card {
   padding: 18px;
+  min-width: 0;
 }
 
 .overview-card.wide {
   grid-column: 1 / -1;
+}
+
+.overview-live-state .metric-grid {
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+}
+
+.overview-selected-event-header > h2 {
+  margin-bottom: 10px;
+}
+
+.overview-selected-event-header .event-meta {
+  margin-bottom: 0;
+}
+
+.overview-selected-event-body {
+  margin-top: 14px;
+}
+
+.overview-selected-event-body .event-details {
+  margin-top: 0;
 }
 
 .definition-list {
@@ -1369,6 +1441,17 @@ pre {
 
 .metric-grid b {
   font-size: 22px;
+}
+
+.live-state-block {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid #edf1ef;
+}
+
+.live-state-block > h3 {
+  margin: 4px 0 8px;
+  font-size: 14px;
 }
 
 .view-toolbar {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1220,7 +1220,10 @@ pre {
 }
 
 .json-view {
+  display: flex;
+  width: 100%;
   margin-top: 8px;
+  flex-direction: column;
   overflow: hidden;
   border: 1px solid var(--line);
   border-radius: 9px;
@@ -1309,7 +1312,7 @@ pre {
   font-size: 11px;
 }
 
-.active-step-card > div {
+.active-step-card > .active-step-heading {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1449,9 +1452,56 @@ pre {
   border-top: 1px solid #edf1ef;
 }
 
-.live-state-block > h3 {
+.live-state-block-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.live-state-block-heading > .eyebrow {
+  margin-bottom: 0;
+}
+
+.live-state-block-heading > div > .eyebrow {
+  margin-bottom: 0;
+}
+
+.live-state-block > h3,
+.live-state-block-heading h3 {
   margin: 4px 0 8px;
   font-size: 14px;
+}
+
+.section-expand-toggle {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 650;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+
+.section-expand-toggle input {
+  margin: 0;
+  accent-color: var(--brand);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .view-toolbar {


### PR DESCRIPTION
## Summary
- Move Live Flow State onto the Overview page (beside Selected event), with structured Details/Raw JsonView panels.
- Add Expand all / Collapse all toggles for Active steps, Attributes, and Channels & Others Internals.
- Persist active-step expand state by `stepType` so Reminder panels survive `stepExecutionId` churn; rename Queues & channels → Channels & Others Internals; fix JsonView layout width inside active-step cards.

## Rationale
Overview is the right place for live run state. Reminder steps were losing expand state because persist keys used unstable execution IDs. Section-level expand makes bulk inspection explicit.

## User impact
Run Overview shows Live Flow State without using the sidebar; operators can expand whole sections at once and keep Reminder details open across refreshes.

## Test plan
- [ ] Open a run with ProcessTimeout + Reminder active steps on Overview
- [ ] Expand Reminder Waiting condition / timers, wait for live refresh — panels stay open
- [ ] Toggle Expand all on Active steps, Attributes, and Channels & Others Internals; Collapse all restores closed state
- [ ] Confirm section title reads **Channels & Others Internals**
- [ ] Confirm Details panels fill card width (no large middle gap)
- [ ] `cd web && npm run typecheck`

## Validation
```bash
cd web && npm run typecheck
# verified against Dex at http://127.0.0.1:8812 → gRPC 8801
```
