### PR TITLE
Add search_flows to Python SDK Client

### DIFF
--- a/sdk-python/dex/__init__.py
+++ b/sdk-python/dex/__init__.py
@@ -35,7 +35,13 @@ from dex.condition import ConditionCombination
 from dex.context import Context
 from dex.flow import Flow, PersistenceSchema, Registry, RPCResult, rpc
 from dex.flow_config import ActiveStepSearchMode, FlowConfig
-from dex.flow_info import FlowInfo, FlowStatus, HealthInfo, SearchFlowEntry
+from dex.flow_info import (
+    FlowInfo,
+    FlowStatus,
+    HealthInfo,
+    SearchFlowEntry,
+    SearchFlowsPage,
+)
 from dex.flow_options import (
     IdReusePolicy,
     ResetFlowOptions,
@@ -115,6 +121,7 @@ __all__ = [
     "ResetType",
     "RetryPolicy",
     "SearchFlowEntry",
+    "SearchFlowsPage",
     "StartFlowOptions",
     "StepExecutionId",
     "StepDecision",

--- a/sdk-python/dex/_value_mapper.py
+++ b/sdk-python/dex/_value_mapper.py
@@ -112,6 +112,29 @@ class ValueMapper:
             raise ValueError("attribute deletion marker cannot be decoded")
         raise TypeError(f"cannot decode {kind or 'empty Value'} as {codec.type_name}")
 
+    def to_value(self, value: pb.Value) -> Value:
+        kind = value.WhichOneof("kind")
+        if kind == "string_value":
+            return Value(WireKind.STRING, value.string_value)
+        if kind == "bool_value":
+            return Value(WireKind.BOOL, value.bool_value)
+        if kind == "int_value":
+            return Value(WireKind.INT64, value.int_value)
+        if kind == "double_value":
+            return Value(WireKind.DOUBLE, value.double_value)
+        if kind == "obj_value":
+            if value.obj_value.encoding == _RAW_BYTES_ENCODING:
+                return Value(WireKind.BYTES, value.obj_value.payload)
+            if value.obj_value.encoding == _JSON_ENCODING:
+                return Value(WireKind.JSON, value.obj_value.payload.decode("utf-8"))
+            raise ValueError(f"unsupported object encoding {value.obj_value.encoding}")
+        if kind in (
+            "internal_blob_id_for_string_value",
+            "internal_blob_id_for_obj_value",
+        ):
+            raise ValueError("blob-backed Value was not hydrated")
+        raise TypeError(f"cannot wrap {kind or 'empty Value'} as Value")
+
     @staticmethod
     def deletion() -> pb.Value:
         return pb.Value(null_value=cast(struct_pb2.NullValue, struct_pb2.NULL_VALUE))

--- a/sdk-python/dex/client.py
+++ b/sdk-python/dex/client.py
@@ -31,7 +31,7 @@ from dex.dexpb import dex_pb2 as pb
 from dex.dexpb import dex_pb2_grpc
 from dex.flow import Flow, Registry, RPCResult
 from dex.flow_config import ActiveStepSearchMode, FlowConfig
-from dex.flow_info import FlowInfo, FlowStatus
+from dex.flow_info import FlowInfo, FlowStatus, SearchFlowEntry, SearchFlowsPage
 from dex.flow_options import (
     IdReusePolicy,
     ResetFlowOptions,
@@ -416,6 +416,48 @@ class Client:
             response.flow_type,
             self._map_flow_status(response.flow_status),
             response.start_time.ToDatetime(tzinfo=timezone.utc),
+        )
+
+    def search_flows(
+        self,
+        query: str,
+        page_size: int,
+        next_page_token: str = "",
+    ) -> SearchFlowsPage:
+        if page_size < 0:
+            raise ValueError("search page size must not be negative")
+        response = cast(
+            pb.SearchFlowsResponse,
+            self._call(
+                self._service.SearchFlows,
+                pb.SearchFlowsRequest(
+                    query=query,
+                    page_size=page_size,
+                    next_page_token=next_page_token,
+                ),
+            ),
+        )
+        flows = [self._map_search_entry(entry) for entry in response.flow_runs]
+        return SearchFlowsPage(flows, response.next_page_token)
+
+    def _map_search_entry(self, entry: pb.SearchFlowsResponseEntry) -> SearchFlowEntry:
+        attributes = {
+            kv.key: self._values.to_value(self._hydrator.hydrate(kv.value))
+            for kv in entry.search_attributes
+        }
+        closed_at = (
+            entry.close_time.ToDatetime(tzinfo=timezone.utc)
+            if entry.HasField("close_time")
+            else None
+        )
+        return SearchFlowEntry(
+            entry.flow_id,
+            entry.run_id,
+            entry.flow_type,
+            self._map_flow_status(entry.flow_status),
+            entry.start_time.ToDatetime(tzinfo=timezone.utc),
+            closed_at,
+            attributes,
         )
 
     def reset_flow(self, flow_id: str, options: ResetFlowOptions) -> str:

--- a/sdk-python/dex/flow_info.py
+++ b/sdk-python/dex/flow_info.py
@@ -9,7 +9,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Mapping
+from typing import Mapping, Sequence
 
 from dex.codec import Value
 
@@ -45,7 +45,13 @@ class SearchFlowEntry:
     flow_id: str
     run_id: str
     flow_type: str
-    status: str
+    status: FlowStatus
     started_at: datetime
     closed_at: datetime | None
     attributes: Mapping[str, Value]
+
+
+@dataclass(frozen=True)
+class SearchFlowsPage:
+    flows: Sequence[SearchFlowEntry]
+    next_page_token: str

--- a/sdk-python/tests/integ/search_flows_flow.py
+++ b/sdk-python/tests/integ/search_flows_flow.py
@@ -1,0 +1,49 @@
+# Portions of this file are derived from indeedeng/iwf-java-sdk.
+# Those portions are licensed under the Apache License, Version 2.0.
+# See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+#
+# Modifications Copyright (c) 2026 Super Durable, Inc.
+#
+# Modifications are licensed under the Super Durable Source License 1.0.
+# Third-Party Materials remain under the Apache License, Version 2.0.
+# See LICENSE and LEGACY_NOTICES.md.
+
+from dex import (
+    Attribute,
+    AttributeIndex,
+    Context,
+    Flow,
+    IndexType,
+    PersistenceSchema,
+    Step,
+    StepDecision,
+    StepList,
+    graceful_complete,
+)
+
+KEYWORD_KEY = "CustomKeywordField"
+
+
+class IndexStep(Step[str]):
+    def __init__(self, flow: "SearchFlowsFlow") -> None:
+        self.flow = flow
+
+    def execute(self, context: Context, input: str) -> StepDecision:
+        self.flow.keyword.set(context, input)
+        return graceful_complete(input)
+
+
+class SearchFlowsFlow(Flow[str]):
+    def __init__(self) -> None:
+        self.keyword = Attribute(
+            KEYWORD_KEY,
+            str,
+            AttributeIndex(IndexType.KEYWORD),
+        )
+        self.index = IndexStep(self)
+
+    def get_steps(self) -> StepList[str]:
+        return StepList.start_step(self.index)
+
+    def get_persistence_schema(self) -> PersistenceSchema:
+        return PersistenceSchema.of(self.keyword)

--- a/sdk-python/tests/integ/test_search_flows_runtime.py
+++ b/sdk-python/tests/integ/test_search_flows_runtime.py
@@ -1,0 +1,67 @@
+# Portions of this file are derived from indeedeng/iwf-java-sdk.
+# Those portions are licensed under the Apache License, Version 2.0.
+# See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+#
+# Modifications Copyright (c) 2026 Super Durable, Inc.
+#
+# Modifications are licensed under the Super Durable Source License 1.0.
+# Third-Party Materials remain under the Apache License, Version 2.0.
+# See LICENSE and LEGACY_NOTICES.md.
+
+from __future__ import annotations
+
+import time
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+
+from dex import Client, FlowStatus
+from dex.flow_info import SearchFlowEntry
+
+from .environment import DexDevTestEnvironment
+from .search_flows_flow import KEYWORD_KEY, SearchFlowsFlow
+from .test_basic_runtime import unique_id
+
+WAIT_TIMEOUT = timedelta(seconds=30)
+
+
+def test_search_flows_finds_indexed_flow() -> None:
+    flow = SearchFlowsFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        keyword_value = f"sf-{uuid4().hex}"
+        flow_id = unique_id("search-flows")
+        environment.client.start_flow(flow, flow_id, keyword_value)
+        assert (
+            environment.client.wait_for_flow(flow_id, str, WAIT_TIMEOUT)
+            == keyword_value
+        )
+        query = f"{KEYWORD_KEY} = '{keyword_value}'"
+        entry = _poll_for_flow(environment.client, query, flow_id)
+        assert entry.flow_id == flow_id
+        assert entry.run_id
+        assert entry.status == FlowStatus.COMPLETED
+        assert entry.started_at is not None
+        assert entry.attributes[KEYWORD_KEY].data == keyword_value
+
+
+def test_search_flows_rejects_negative_page_size() -> None:
+    flow = SearchFlowsFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        with pytest.raises(ValueError):
+            environment.client.search_flows("CustomKeywordField = 'x'", -1)
+
+
+def _poll_for_flow(client: Client, query: str, flow_id: str) -> SearchFlowEntry:
+    deadline = time.monotonic() + 30
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            page = client.search_flows(query, 100)
+            for entry in page.flows:
+                if entry.flow_id == flow_id:
+                    return entry
+        except Exception as error:  # noqa: BLE001
+            last_error = error
+        time.sleep(0.2)
+    raise AssertionError(f"flow {flow_id} not found via search_flows") from last_error


### PR DESCRIPTION
## Summary
- Add `search_flows` to the Python SDK `Client`, mirroring the Go SDK's `SearchFlows(ctx, query, pageSize, nextPageToken)` surface (Java got the same in a parallel PR).
- Add the `SearchFlowsPage` result type and complete the pre-existing `SearchFlowEntry` (its `status` is now typed `FlowStatus` instead of a bare `str`); both are exported.
- Integration coverage verifying an indexed KEYWORD attribute is searchable end-to-end.

## Rationale
The Python `Client` had describe/reset/stop/wait/get/set/publish/skip_timer but no `search_flows`, so Python could not exercise indexed search attributes the way `examples/go` does. The gRPC stub and message types were already generated — this only adds the client wrapper.

## Changes
- `Client.search_flows(query, page_size, next_page_token="")` — validates non-negative page size, hydrates blob-backed search-attribute values via the blob cache, and maps `SearchFlowsResponse` into public types.
- `SearchFlowsPage(flows, next_page_token)`; `SearchFlowEntry.status: FlowStatus`.
- `ValueMapper.to_value(pb.Value) -> codec.Value` — wraps a hydrated proto value into a decode-ready `codec.Value`, so callers decode search attributes with the codec of their choice (matches Go's `map[string]Value`).

## Tests
- `search_flows_flow.py` indexes a `CustomKeywordField` KEYWORD attribute; `test_search_flows_runtime.py`:
  1. starts a flow, waits for completion, polls `search_flows("CustomKeywordField = '<uuid>'", 100)` until the flow is found, and asserts `flow_id` / `run_id` / `status == FlowStatus.COMPLETED` / `started_at` / decoded attribute value.
  2. asserts the negative-page-size guard raises `ValueError`.
- Verified locally against `dexcli dev`: **2 passed**; plus `mypy --strict`, `pyright`, `ruff`, `black`, contract tests, and `make copyright-check`.

## Documentation
- N/A: no per-method client API list in `sdk-python/README.md`.

## UI/UX
- N/A: no in-repo web UI.