### PR TITLE
Add TypeScript SDK Node-API BlobCache bridge

### DIFF
--- a/.github/workflows/sdk-typescript-ci.yml
+++ b/.github/workflows/sdk-typescript-ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - "sdk-typescript/**"
+      - "sdk-rust/Cargo.lock"
+      - "sdk-rust/Cargo.toml"
+      - "sdk-rust/crates/dex-blob-cache/**"
+      - "sdk-rust/crates/dex-blob-cache-node/**"
       - "cli/**"
       - "server/**"
       - "protos/**"
@@ -14,6 +18,10 @@ on:
   pull_request:
     paths:
       - "sdk-typescript/**"
+      - "sdk-rust/Cargo.lock"
+      - "sdk-rust/Cargo.toml"
+      - "sdk-rust/crates/dex-blob-cache/**"
+      - "sdk-rust/crates/dex-blob-cache-node/**"
       - "cli/**"
       - "server/**"
       - "protos/**"
@@ -37,11 +45,15 @@ jobs:
       fail-fast: false
       matrix:
         node-version: ["22", "24"]
+    env:
+      RUSTUP_TOOLCHAIN: "1.88.0"
     defaults:
       run:
         working-directory: sdk-typescript
     steps:
       - uses: actions/checkout@v7
+      - name: Install Rust
+        run: rustup toolchain install 1.88.0 --profile minimal
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
@@ -61,11 +73,15 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      RUSTUP_TOOLCHAIN: "1.88.0"
     defaults:
       run:
         working-directory: sdk-typescript
     steps:
       - uses: actions/checkout@v7
+      - name: Install Rust
+        run: rustup toolchain install 1.88.0 --profile minimal
       - uses: actions/setup-node@v6
         with:
           node-version: "22"

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -13,16 +13,68 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  native:
+    name: Native ${{ matrix.platform }}
+    if: startsWith(github.event.release.tag_name, 'sdk-typescript/v')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-latest
+            library: libdex_blob_cache_node.so
+          - platform: linux-aarch64
+            runner: ubuntu-24.04-arm
+            library: libdex_blob_cache_node.so
+          - platform: macos-x86_64
+            runner: macos-15-intel
+            library: libdex_blob_cache_node.dylib
+          - platform: macos-aarch64
+            runner: macos-latest
+            library: libdex_blob_cache_node.dylib
+          - platform: windows-x86_64
+            runner: windows-latest
+            library: dex_blob_cache_node.dll
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    env:
+      RUSTUP_TOOLCHAIN: "1.88.0"
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust
+        run: rustup toolchain install 1.88.0 --profile minimal
+      - name: Build BlobCache Node binding
+        working-directory: sdk-rust
+        run: cargo build --release -p dex-blob-cache-node --locked
+      - name: Stage native library
+        shell: bash
+        run: |
+          destination="sdk-typescript/native/${{ matrix.platform }}"
+          mkdir -p "${destination}"
+          cp "sdk-rust/target/release/${{ matrix.library }}" \
+            "${destination}/dex_blob_cache_node.node"
+      - name: Upload native library
+        uses: actions/upload-artifact@v7
+        with:
+          name: dex-typescript-native-${{ matrix.platform }}
+          path: sdk-typescript/native
+          if-no-files-found: error
+
   publish:
     name: Publish @superdurable/dex
+    needs: native
     if: startsWith(github.event.release.tag_name, 'sdk-typescript/v')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
+    env:
+      RUSTUP_TOOLCHAIN: "1.88.0"
     defaults:
       run:
         working-directory: sdk-typescript
     steps:
       - uses: actions/checkout@v7
+      - name: Install Rust
+        run: rustup toolchain install 1.88.0 --profile minimal
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
@@ -47,12 +99,20 @@ jobs:
           else
             echo "dist_tag=latest" >> "${GITHUB_OUTPUT}"
           fi
+      - name: Download native libraries
+        uses: actions/download-artifact@v7
+        with:
+          pattern: dex-typescript-native-*
+          path: sdk-typescript/native
+          merge-multiple: true
       - name: Install dependencies
         run: npm ci
       - name: Check static types
         run: npm run typecheck
+      - name: Build TypeScript
+        run: npm run build
       - name: Test package
-        run: npm test
+        run: node --test dist/test/*.test.js
       - name: Inspect package contents
         run: npm pack --dry-run
       - name: Publish package

--- a/sdk-rust/Cargo.lock
+++ b/sdk-rust/Cargo.lock
@@ -165,6 +165,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
+
+[[package]]
 name = "dex-blob-cache"
 version = "0.1.0"
 dependencies = [
@@ -232,6 +247,16 @@ version = "0.1.0"
 dependencies = [
  "dex-blob-cache",
  "jni",
+]
+
+[[package]]
+name = "dex-blob-cache-node"
+version = "0.1.0"
+dependencies = [
+ "dex-blob-cache",
+ "napi",
+ "napi-build",
+ "napi-derive",
 ]
 
 [[package]]
@@ -323,12 +348,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -336,6 +377,34 @@ name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "futures-sink"
@@ -355,8 +424,13 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -620,6 +694,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +767,69 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "napi"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f71d6bc097c4a6eb853c3f24991ab8c9f50f57d1f719e305175541482217e36"
+dependencies = [
+ "bitflags",
+ "ctor",
+ "futures",
+ "napi-build",
+ "napi-sys",
+ "nohash-hasher",
+ "rustc-hash",
+]
+
+[[package]]
+name = "napi-build"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5282704fbe8d49b0cf8b08e3f33233416a528658f205c7e5ace63b582de0b11c"
+
+[[package]]
+name = "napi-derive"
+version = "3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9002b2940f0184444754546e0fcd15182f56948e6f381968b019d549387c42"
+dependencies = [
+ "convert_case",
+ "ctor",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60b5d773ad46c698c8cc2cd9fde0b283d39cbb7f71c04bee633c7bdba4423bd"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "napi-sys"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fbf1fa9f1babfe396d74bbbf52b3643770243e8f5b0b46715d4caf7f0dfc9a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "once_cell"
@@ -1065,6 +1212,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1509,6 +1662,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unindent"

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/dex-blob-cache",
     "crates/dex-blob-cache-jni",
+    "crates/dex-blob-cache-node",
     "crates/dex-blob-cache-python",
     "crates/dex-protocol",
 ]
@@ -17,6 +18,9 @@ rust-version = "1.88"
 [workspace.dependencies]
 crc32c = "0.6"
 jni = "0.21"
+napi = { version = "3.12.0", default-features = false }
+napi-build = "2.4.0"
+napi-derive = "3.6.2"
 pyo3 = "0.23"
 prost = "0.14"
 prost-types = "0.14"

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -9,6 +9,8 @@ The crates are:
 
 - `dex-blob-cache`: transport-neutral, Go-compatible disk cache.
 - `dex-blob-cache-jni`: Java 8-compatible binding containing only cache APIs.
+- `dex-blob-cache-python`: PyO3 binding for the Python SDK.
+- `dex-blob-cache-node`: Node-API binding for the TypeScript SDK.
 - `dex-protocol`: generated Rust protobuf and gRPC protocol.
 
 The architecture is defined in
@@ -43,6 +45,14 @@ Build the Java cache binding as an optimized native library:
 
 ```bash
 cargo build --release -p dex-blob-cache-jni --locked
+```
+
+Build the Node cache binding and stage it into the TypeScript package:
+
+```bash
+cargo build --release -p dex-blob-cache-node --locked
+# or from sdk-typescript:
+npm run build:native
 ```
 
 ## Development

--- a/sdk-rust/crates/dex-blob-cache-node/Cargo.toml
+++ b/sdk-rust/crates/dex-blob-cache-node/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "dex-blob-cache-node"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Node-API binding for the shared Dex DXBC blob cache"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+dex-blob-cache = { path = "../dex-blob-cache" }
+napi = { workspace = true, features = ["napi6"] }
+napi-derive.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true

--- a/sdk-rust/crates/dex-blob-cache-node/build.rs
+++ b/sdk-rust/crates/dex-blob-cache-node/build.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+fn main() {
+    napi_build::setup();
+}

--- a/sdk-rust/crates/dex-blob-cache-node/src/lib.rs
+++ b/sdk-rust/crates/dex-blob-cache-node/src/lib.rs
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+use dex_blob_cache::{BlobCache, BlobCacheConfig};
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+#[napi]
+pub struct NativeBlobCache {
+    cache: BlobCache,
+}
+
+#[napi]
+impl NativeBlobCache {
+    #[napi(constructor)]
+    pub fn new(directory: String, max_bytes: i64, frequency_counters: i64) -> Result<Self> {
+        let config = BlobCacheConfig::new(directory, max_bytes, frequency_counters)
+            .map_err(|error| Error::from_reason(error.to_string()))?;
+        let cache =
+            BlobCache::open(config).map_err(|error| Error::from_reason(error.to_string()))?;
+        Ok(Self { cache })
+    }
+
+    #[napi]
+    pub fn get(&self, blob_id: String) -> Result<Option<Buffer>> {
+        match self
+            .cache
+            .get(&blob_id)
+            .map_err(|error| Error::from_reason(error.to_string()))?
+        {
+            Some(payload) => Ok(Some(Buffer::from(payload))),
+            None => Ok(None),
+        }
+    }
+
+    #[napi]
+    pub fn put(&self, blob_id: String, payload: Buffer) -> Result<bool> {
+        self.cache
+            .put(&blob_id, payload.as_ref())
+            .map_err(|error| Error::from_reason(error.to_string()))
+    }
+
+    #[napi]
+    pub fn delete(&self, blob_id: String) -> Result<()> {
+        self.cache
+            .delete(&blob_id)
+            .map_err(|error| Error::from_reason(error.to_string()))
+    }
+
+    #[napi]
+    pub fn delete_all(&self) -> Result<()> {
+        self.cache
+            .delete_all()
+            .map_err(|error| Error::from_reason(error.to_string()))
+    }
+
+    #[napi]
+    pub fn close(&self) -> Result<()> {
+        self.cache
+            .close()
+            .map_err(|error| Error::from_reason(error.to_string()))
+    }
+}

--- a/sdk-typescript/.gitignore
+++ b/sdk-typescript/.gitignore
@@ -1,0 +1,5 @@
+/dist/
+/native/
+/coverage/
+/node_modules/
+*.tgz

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -2,7 +2,8 @@
 
 This package targets Node.js 22 and 24. It provides strongly typed workflow
 contracts and a Promise-based gRPC Client. The Client and Worker runtime use
-`@grpc/grpc-js`. The native BlobCache binding remains a separate runtime phase.
+`@grpc/grpc-js`. Blob caching uses the shared Rust DXBC implementation through
+a Node-API addon.
 
 Application values use `Codec<T>`. Flow, Step, RPC, Attribute, and Channel
 definitions retain their input and output types. Client methods return Promise
@@ -81,12 +82,13 @@ continue importing only from `@superdurable/dex`.
 - `worker.ts`: Worker gRPC service and lifecycle
 - `worker-dispatcher.ts`: typed callback dispatch and response mapping
 - `invocation-context.ts`: invocation-scoped persistence and condition state
-- `blob-cache.ts`: injectable cache contract and future N-API binding
+- `blob-cache.ts`: DXBC BlobCache contract and Node-API binding loader
 - `gen/`: checked-in protobuf and grpc-js bindings
 
-Run `npm test` for runtime contracts and `npm run typecheck` for strict static
-contracts. Run `./run-integration-tests.sh` for all 58 IWF compatibility
-scenarios against an isolated `dexcli dev` environment. Run
+Run `npm run build:native` once to stage the DXBC Node addon for the current
+platform, then `npm test` for runtime contracts and `npm run typecheck` for
+strict static contracts. Run `./run-integration-tests.sh` for all 58 IWF
+compatibility scenarios against an isolated `dexcli dev` environment. Run
 `npm run generate:proto` after changing `protos/dex.proto`; `protoc` and its
 standard protobuf includes must be installed.
 

--- a/sdk-typescript/package.json
+++ b/sdk-typescript/package.json
@@ -18,6 +18,7 @@
   },
   "files": [
     "dist/src",
+    "native",
     "LICENSE"
   ],
   "exports": {
@@ -32,13 +33,14 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "build:native": "node scripts/build-native.mjs",
     "coverage:integration": "./run-integration-tests.sh --coverage",
     "generate:proto": "node scripts/generate-proto.mjs",
-    "prepack": "npm run build",
-    "test:integration": "npm run build && node --test --test-concurrency=1 dist/test/integ/*.integration.test.js",
-    "test:integration:coverage": "npm run build && c8 node --test --test-concurrency=1 dist/test/integ/*.integration.test.js && node scripts/report-uncovered.mjs coverage/lcov.info",
+    "prepack": "npm run build:native && npm run build",
+    "test:integration": "npm run build:native && npm run build && node --test --test-concurrency=1 dist/test/integ/*.integration.test.js",
+    "test:integration:coverage": "npm run build:native && npm run build && c8 node --test --test-concurrency=1 dist/test/integ/*.integration.test.js && node scripts/report-uncovered.mjs coverage/lcov.info",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "npm run build && node --test dist/test/*.test.js"
+    "test": "npm run build:native && npm run build && node --test dist/test/*.test.js"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/sdk-typescript/scripts/build-native.mjs
+++ b/sdk-typescript/scripts/build-native.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+import { copyFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(scriptDirectory, "..");
+const repositoryRoot = join(packageRoot, "..");
+const rustRoot = join(repositoryRoot, "sdk-rust");
+
+const platform = nativePlatform();
+const libraryName = nativeLibraryName();
+const stagedName = "dex_blob_cache_node.node";
+const cargoTarget = process.env.DEX_BLOB_CACHE_CARGO_TARGET ?? "release";
+const builtLibrary = join(rustRoot, "target", cargoTarget, libraryName);
+const destinationDirectory = join(packageRoot, "native", platform);
+const destination = join(destinationDirectory, stagedName);
+
+const cargoArguments = ["build", "-p", "dex-blob-cache-node", "--locked"];
+if (cargoTarget === "release") {
+  cargoArguments.push("--release");
+}
+
+const build = spawnSync("cargo", cargoArguments, {
+  cwd: rustRoot,
+  stdio: "inherit",
+  env: process.env,
+});
+if (build.status !== 0) {
+  process.exit(build.status === null ? 1 : build.status);
+}
+
+mkdirSync(destinationDirectory, { recursive: true });
+copyFileSync(builtLibrary, destination);
+console.log(`staged ${destination}`);
+
+function nativePlatform() {
+  return `${operatingSystem()}-${architecture()}`;
+}
+
+function operatingSystem() {
+  switch (process.platform) {
+    case "darwin":
+      return "macos";
+    case "linux":
+      return "linux";
+    case "win32":
+      return "windows";
+    default:
+      throw new Error(`unsupported operating system: ${process.platform}`);
+  }
+}
+
+function architecture() {
+  switch (process.arch) {
+    case "x64":
+      return "x86_64";
+    case "arm64":
+      return "aarch64";
+    default:
+      throw new Error(`unsupported architecture: ${process.arch}`);
+  }
+}
+
+function nativeLibraryName() {
+  switch (process.platform) {
+    case "darwin":
+      return "libdex_blob_cache_node.dylib";
+    case "win32":
+      return "dex_blob_cache_node.dll";
+    default:
+      return "libdex_blob_cache_node.so";
+  }
+}

--- a/sdk-typescript/src/blob-cache.ts
+++ b/sdk-typescript/src/blob-cache.ts
@@ -6,7 +6,9 @@
 //
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
-import { laterPhase } from "./errors.js";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export interface BlobCacheConfig {
   readonly directory: string;
@@ -23,6 +25,29 @@ export interface BlobCache {
   close(): void;
 }
 
+interface NativeBlobCacheBinding {
+  get(blobId: string): Buffer | null;
+  put(blobId: string, payload: Buffer): boolean;
+  delete(blobId: string): void;
+  deleteAll(): void;
+  close(): void;
+}
+
+interface NativeBlobCacheConstructor {
+  new (
+    directory: string,
+    maxBytes: number,
+    frequencyCounters: number,
+  ): NativeBlobCacheBinding;
+}
+
+interface NativeModule {
+  NativeBlobCache: NativeBlobCacheConstructor;
+}
+
+const require = createRequire(import.meta.url);
+let nativeModule: NativeModule | undefined;
+
 export function openBlobCache(config: BlobCacheConfig): BlobCache {
   if (config.directory.length === 0) {
     throw new TypeError("blob cache directory is required");
@@ -36,5 +61,100 @@ export function openBlobCache(config: BlobCacheConfig): BlobCache {
   ) {
     throw new RangeError("blob cache frequencyCounters must be a non-negative safe integer");
   }
-  throw laterPhase("BlobCache bridge");
+  return new RustBlobCache(config, loadNativeModule());
+}
+
+class RustBlobCache implements BlobCache {
+  public readonly config: BlobCacheConfig;
+  private readonly native: NativeBlobCacheBinding;
+
+  public constructor(config: BlobCacheConfig, binding: NativeModule) {
+    this.config = config;
+    this.native = new binding.NativeBlobCache(
+      config.directory,
+      config.maxBytes,
+      config.frequencyCounters ?? 0,
+    );
+  }
+
+  public get(blobId: string): Uint8Array | undefined {
+    const payload = this.native.get(blobId);
+    return payload === null ? undefined : new Uint8Array(payload);
+  }
+
+  public put(blobId: string, payload: Uint8Array): boolean {
+    return this.native.put(blobId, Buffer.from(payload));
+  }
+
+  public delete(blobId: string): void {
+    this.native.delete(blobId);
+  }
+
+  public deleteAll(): void {
+    this.native.deleteAll();
+  }
+
+  public close(): void {
+    this.native.close();
+  }
+}
+
+function loadNativeModule(): NativeModule {
+  if (nativeModule !== undefined) {
+    return nativeModule;
+  }
+  const candidates = nativeCandidates();
+  const failures: string[] = [];
+  for (const candidate of candidates) {
+    try {
+      nativeModule = require(candidate) as NativeModule;
+      return nativeModule;
+    } catch (failure) {
+      failures.push(`${candidate}: ${failure instanceof Error ? failure.message : String(failure)}`);
+    }
+  }
+  throw new Error(
+    `cannot load the Dex BlobCache native module for ${process.platform}/${process.arch}; ` +
+      `set DEX_BLOB_CACHE_NATIVE to an absolute .node path to override packaged natives. ` +
+      `Tried:\n${failures.join("\n")}`,
+  );
+}
+
+function nativeCandidates(): string[] {
+  const override = process.env.DEX_BLOB_CACHE_NATIVE;
+  if (override !== undefined && override.length > 0) {
+    return [override];
+  }
+  const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+  const packaged = join(
+    packageRoot,
+    "native",
+    `${operatingSystem()}-${architecture()}`,
+    "dex_blob_cache_node.node",
+  );
+  return [packaged];
+}
+
+function operatingSystem(): string {
+  switch (process.platform) {
+    case "darwin":
+      return "macos";
+    case "linux":
+      return "linux";
+    case "win32":
+      return "windows";
+    default:
+      throw new Error(`unsupported operating system: ${process.platform}`);
+  }
+}
+
+function architecture(): string {
+  switch (process.arch) {
+    case "x64":
+      return "x86_64";
+    case "arm64":
+      return "aarch64";
+    default:
+      throw new Error(`unsupported architecture: ${process.arch}`);
+  }
 }

--- a/sdk-typescript/test/contracts.test.ts
+++ b/sdk-typescript/test/contracts.test.ts
@@ -7,13 +7,15 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import {
   Attribute,
   Channel,
   Client,
-  PhaseNotImplementedError,
   Registry,
   StepList,
   Timer,
@@ -169,11 +171,18 @@ test("registry rejects duplicate definitions", () => {
   assert.throws(() => new Registry([orders, orders]), /duplicate Flow Orders/);
 });
 
-test("blob cache contract validates config before the native phase", () => {
-  assert.throws(
-    () => openBlobCache({ directory: "contract-cache", maxBytes: 1024 }),
-    PhaseNotImplementedError,
-  );
+test("blob cache contract opens the native DXBC cache", () => {
+  const directory = mkdtempSync(join(tmpdir(), "dex-typescript-blob-cache-"));
+  const cache = openBlobCache({ directory, maxBytes: 1024, frequencyCounters: 0 });
+  try {
+    assert.equal(cache.put("blob", Buffer.from("payload")), true);
+    assert.deepEqual(cache.get("blob"), new Uint8Array(Buffer.from("payload")));
+    cache.delete("blob");
+    assert.equal(cache.get("blob"), undefined);
+  } finally {
+    cache.close();
+    rmSync(directory, { recursive: true, force: true });
+  }
   assert.throws(() => openBlobCache({ directory: "", maxBytes: 1024 }), TypeError);
 });
 

--- a/sdk-typescript/test/integ/environment.ts
+++ b/sdk-typescript/test/integ/environment.ts
@@ -10,13 +10,16 @@
 
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   Client,
   Registry,
   Worker,
-  type BlobCache,
+  openBlobCache,
   type Flow,
 } from "../../src/index.js";
 
@@ -30,7 +33,11 @@ export async function startEnvironment(...flows: readonly Flow<any>[]): Promise<
   const serverAddress = process.env.DEX_SERVER_ADDRESS ?? "127.0.0.1:8801";
   const workerAddress = `127.0.0.1:${await availablePort()}`;
   const registry = new Registry(flows);
-  const blobCache = new MemoryBlobCache();
+  const cacheDirectory = mkdtempSync(join(tmpdir(), "dex-typescript-integration-cache-"));
+  const blobCache = openBlobCache({
+    directory: cacheDirectory,
+    maxBytes: 64 * 1_024 * 1_024,
+  });
   const worker = new Worker(registry, blobCache, {
     bindAddress: workerAddress,
     serverAddress,
@@ -47,6 +54,7 @@ export async function startEnvironment(...flows: readonly Flow<any>[]): Promise<
       await client.close();
       await worker.close();
       blobCache.close();
+      rmSync(cacheDirectory, { recursive: true, force: true });
     },
   };
 }
@@ -78,32 +86,6 @@ export async function expectError<Failure extends Error>(
     return failure;
   }
   assert.fail(`expected ${errorType.name}`);
-}
-
-class MemoryBlobCache implements BlobCache {
-  public readonly config = { directory: "memory", maxBytes: 64 * 1_024 * 1_024 };
-  private readonly values = new Map<string, Uint8Array>();
-
-  public get(blobId: string): Uint8Array | undefined {
-    return this.values.get(blobId)?.slice();
-  }
-
-  public put(blobId: string, payload: Uint8Array): boolean {
-    this.values.set(blobId, payload.slice());
-    return true;
-  }
-
-  public delete(blobId: string): void {
-    this.values.delete(blobId);
-  }
-
-  public deleteAll(): void {
-    this.values.clear();
-  }
-
-  public close(): void {
-    this.values.clear();
-  }
 }
 
 function availablePort(): Promise<number> {


### PR DESCRIPTION
## Summary
- Add `dex-blob-cache-node` Node-API binding over the shared Rust DXBC BlobCache.
- Wire TypeScript `openBlobCache()` to the staged native addon instead of `laterPhase`.
- Update TS contract/integ coverage and CI/publish workflows to build and ship platform natives.

## Rationale
Python and Java already use the Rust disk cache. TS had only the interface stub, so workers could not share the DXBC on-disk contract.

## User impact
`openBlobCache({ directory, maxBytes })` now opens a real disk cache. Run `npm run build:native` locally; published packages include prebuilt `native/<os>-<arch>/dex_blob_cache_node.node`.

## Test plan
- [x] `cargo +1.88.0 build --release -p dex-blob-cache-node --locked`
- [x] `cargo clippy -p dex-blob-cache-node --locked -- -D warnings`
- [x] `cd sdk-typescript && npm test && npm run typecheck`
- [ ] CI TypeScript contracts + integration on this PR

