### PR TITLE
Add searchFlows to TypeScript SDK Client

### DIFF
--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -24,6 +24,8 @@ import {
   type GetFlowSummaryResponse,
   type InvokeRPCResponse,
   type ResetFlowResponse,
+  type SearchFlowsResponse,
+  type SearchFlowsResponseEntry,
   type StartFlowResponse,
   StartFlowRequest,
   StepDurability as ProtoStepDurability,
@@ -63,6 +65,8 @@ import {
   type FlowInfo,
   type FlowStatus,
   type ResetFlowOptions,
+  type SearchFlowEntry,
+  type SearchFlowsPage,
   type StartFlowOptions,
   type StepExecutionId,
   type StopFlowOptions,
@@ -72,7 +76,7 @@ import { AttributeMap, IndexType, type Attribute } from "./persistence.js";
 import type { RPCResult } from "./rpc.js";
 import type { RetryPolicy, StepOptions } from "./step.js";
 import { requireName } from "./validation.js";
-import { decodeValue, encodeValue, ValueHydrator } from "./value-mapper.js";
+import { decodeUnknown, decodeValue, encodeValue, ValueHydrator } from "./value-mapper.js";
 import { ChannelMap, type Channel } from "./wait.js";
 
 const defaultServerAddress = "localhost:8801";
@@ -398,6 +402,42 @@ export class Client {
       flowType: response.flowType,
       status: mapFlowStatus(response.flowStatus),
       startedAt: response.startTime,
+    };
+  }
+
+  public async searchFlows(
+    query: string,
+    pageSize: number,
+    nextPageToken = "",
+  ): Promise<SearchFlowsPage> {
+    if (pageSize < 0) {
+      throw new RangeError("search page size must not be negative");
+    }
+    const response = await unary<SearchFlowsResponse>((callback) =>
+      this.service.searchFlows({ query, pageSize, nextPageToken }, callback),
+    );
+    const flows = await Promise.all(
+      response.flowRuns.map((entry) => this.mapSearchEntry(entry)),
+    );
+    return { flows, nextPageToken: response.nextPageToken };
+  }
+
+  private async mapSearchEntry(entry: SearchFlowsResponseEntry): Promise<SearchFlowEntry> {
+    if (entry.startTime === undefined) {
+      throw new TypeError(`Dex returned a search entry without a start time for Flow ${entry.flowId}`);
+    }
+    const searchAttributes = new Map<string, unknown>();
+    for (const attribute of entry.searchAttributes) {
+      searchAttributes.set(attribute.key, decodeUnknown(await this.hydrator.hydrate(attribute.value)));
+    }
+    return {
+      flowId: entry.flowId,
+      runId: entry.runId,
+      flowType: entry.flowType,
+      status: mapFlowStatus(entry.flowStatus),
+      startedAt: entry.startTime,
+      closedAt: entry.closeTime,
+      searchAttributes,
     };
   }
 

--- a/sdk-typescript/src/options.ts
+++ b/sdk-typescript/src/options.ts
@@ -90,6 +90,21 @@ export interface FlowInfo {
   readonly startedAt: Date;
 }
 
+export interface SearchFlowEntry {
+  readonly flowId: string;
+  readonly runId: string;
+  readonly flowType: string;
+  readonly status: FlowStatus;
+  readonly startedAt: Date;
+  readonly closedAt: Date | undefined;
+  readonly searchAttributes: ReadonlyMap<string, unknown>;
+}
+
+export interface SearchFlowsPage {
+  readonly flows: readonly SearchFlowEntry[];
+  readonly nextPageToken: string;
+}
+
 export interface StepExecutionId {
   readonly stepType: string;
   readonly number?: number;

--- a/sdk-typescript/src/value-mapper.ts
+++ b/sdk-typescript/src/value-mapper.ts
@@ -79,6 +79,38 @@ export function decodeValue<T>(codec: Codec<T>, value: ProtoValue): T {
   return codec.decode(toCodecValue(value));
 }
 
+export function decodeUnknown(value: ProtoValue): unknown {
+  const kind = value.kind;
+  if (kind === undefined) {
+    throw new TypeError("Value has no concrete kind");
+  }
+  switch (kind.$case) {
+    case "stringValue":
+      return kind.value;
+    case "boolValue":
+      return kind.value;
+    case "intValue":
+      return kind.value;
+    case "doubleValue":
+      return kind.value;
+    case "objValue": {
+      const object = kind.value;
+      if (object.encoding === "rawbytes") {
+        return object.payload;
+      }
+      if (object.encoding === "json") {
+        return JSON.parse(textDecoder.decode(object.payload));
+      }
+      throw new TypeError(`unsupported object encoding ${object.encoding}`);
+    }
+    case "internalBlobIdForStringValue":
+    case "internalBlobIdForObjValue":
+      throw new TypeError("blob-backed Value was not hydrated");
+    case "nullValue":
+      return undefined;
+  }
+}
+
 export function deletionValue(): ProtoValue {
   return ProtoValue.create({
     kind: { $case: "nullValue", value: NullValue.NULL_VALUE },

--- a/sdk-typescript/test/integ/search-flows.integration.test.ts
+++ b/sdk-typescript/test/integ/search-flows.integration.test.ts
@@ -1,0 +1,65 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
+import test from "node:test";
+
+import { stringCodec, type Client, type SearchFlowEntry } from "../../src/index.js";
+import { flowId, withEnvironment } from "./environment.js";
+import { KEYWORD_KEY, SearchFlowsFlow } from "./search_flows_flow.js";
+
+test("searchFlows finds an indexed flow", async () => {
+  const flow = new SearchFlowsFlow();
+  await withEnvironment([flow], async ({ client }) => {
+    const keywordValue = `sf-${randomUUID()}`;
+    const id = flowId("search-flows");
+    await client.startFlow(flow, id, keywordValue);
+    assert.equal(await client.waitForFlow(id, stringCodec, 30_000), keywordValue);
+
+    const query = `${KEYWORD_KEY} = '${keywordValue}'`;
+    const entry = await pollForFlow(client, query, id);
+    assert.equal(entry.flowId, id);
+    assert.ok(entry.runId.length > 0);
+    assert.equal(entry.status, "completed");
+    assert.ok(entry.startedAt instanceof Date);
+    assert.equal(entry.searchAttributes.get(KEYWORD_KEY), keywordValue);
+  });
+});
+
+test("searchFlows rejects a negative page size", async () => {
+  const flow = new SearchFlowsFlow();
+  await withEnvironment([flow], async ({ client }) => {
+    await assert.rejects(client.searchFlows("CustomKeywordField = 'x'", -1), RangeError);
+  });
+});
+
+async function pollForFlow(
+  client: Client,
+  query: string,
+  id: string,
+): Promise<SearchFlowEntry> {
+  const deadline = Date.now() + 30_000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const page = await client.searchFlows(query, 100);
+      const found = page.flows.find((entry) => entry.flowId === id);
+      if (found !== undefined) {
+        return found;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(200);
+  }
+  throw new Error(`flow ${id} not found via searchFlows: ${String(lastError)}`);
+}

--- a/sdk-typescript/test/integ/search_flows_flow.ts
+++ b/sdk-typescript/test/integ/search_flows_flow.ts
@@ -1,0 +1,63 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+import {
+  Attribute,
+  IndexType,
+  StepList,
+  Wait,
+  gracefulComplete,
+  stringCodec,
+  type Context,
+  type Flow,
+  type PersistenceSchema,
+  type Step,
+  type StepDecision,
+} from "../../src/index.js";
+
+export const KEYWORD_KEY = "CustomKeywordField";
+
+class IndexStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public constructor(private readonly flow: SearchFlowsFlow) {}
+
+  public getStepType(): string {
+    return "IndexStep";
+  }
+
+  public waitFor(): Wait {
+    return Wait.skipImmediately();
+  }
+
+  public execute(context: Context, input: string): StepDecision {
+    this.flow.keyword.set(context, input);
+    return gracefulComplete(input);
+  }
+}
+
+export class SearchFlowsFlow implements Flow<string> {
+  public readonly keyword = new Attribute(KEYWORD_KEY, stringCodec, {
+    type: IndexType.KEYWORD,
+  });
+  private readonly start = new IndexStep(this);
+
+  public getFlowType(): string {
+    return "SearchFlowsFlow";
+  }
+
+  public getSteps() {
+    return StepList.startStep(this.start);
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return { attributes: [this.keyword] };
+  }
+}


### PR DESCRIPTION
## Summary
- Add `searchFlows` to the TypeScript SDK `Client`, mirroring the Go SDK's `SearchFlows(ctx, query, pageSize, nextPageToken)` surface (Go/Java/Python cover the same).
- Add `SearchFlowsPage` / `SearchFlowEntry` result interfaces.
- Integration coverage verifying an indexed KEYWORD attribute is searchable end-to-end.

## Rationale
The TypeScript `Client` had describeFlow/resetFlow/stopFlow/skipTimer/waitForStepCompletion but no `searchFlows`, so TypeScript could not exercise indexed search attributes the way `examples/go` does. The gRPC client and message types were already generated — this only adds the client wrapper.

## Changes
- `Client.searchFlows(query, pageSize, nextPageToken = "")` — validates non-negative page size, hydrates blob-backed search-attribute values via the blob cache, and maps `SearchFlowsResponse` into public types.
- `SearchFlowEntry` (`flowId`, `runId`, `flowType`, `status: FlowStatus`, `startedAt`, `closedAt`, `searchAttributes: ReadonlyMap<string, unknown>`) and `SearchFlowsPage` (`flows`, `nextPageToken`), exported via `options.ts`.
- `decodeUnknown(value)` in `value-mapper.ts` — decodes a hydrated proto `Value` into a plain JS value (string / boolean / bigint / number / parsed JSON / bytes), since a search attribute's static type is unknown at query time.

## Tests
- `search_flows_flow.ts` indexes a `CustomKeywordField` KEYWORD attribute; `search-flows.integration.test.ts`:
  1. starts a flow, waits for completion, polls `searchFlows("CustomKeywordField = '<uuid>'", 100)` until the flow is found, and asserts `flowId` / `runId` / `status === "completed"` / `startedAt` / decoded attribute value.
  2. asserts the negative-page-size guard rejects with `RangeError`.
- Verified locally: `npm run typecheck`, `npm test`, and the integration test against `dexcli dev` (**2 passed**); `make copyright-check`.

## Documentation
- N/A: no per-method client API list in `sdk-typescript/README.md`.

## UI/UX
- N/A: no in-repo web UI.