### PR TITLE
Add Stop flow action to Dex Web

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,7 +1,7 @@
 # Dex Web
 
 Dex Web searches flows and displays Dex semantic history, step topology,
-live flow state, and reset points.
+live flow state, reset points, and stop controls.
 
 The production Web server is Go. It serves an embedded React SPA and translates
 same-origin HTTP/JSON requests under `/api/` to Dex `FlowService` gRPC calls.
@@ -67,7 +67,7 @@ preferences.
 
 The Run page provides Overview (Live Flow State beside Selected event, then
 Run input beside Identity), Step graph, Timeline, attributes, timers, queued
-steps, channels, completed outputs, and reset. Timeline and Step graph keep
+steps, channels, completed outputs, stop, and reset. Timeline and Step graph keep
 Selected event in the sidebar.
 Continued runs link to their previous run from Timeline and Step graph.
 Step graph nodes separate WaitFor and Execute with distinct colors, channel names, condition icons, and individual event details.

--- a/web/api/handlers.go
+++ b/web/api/handlers.go
@@ -43,6 +43,7 @@ func RegisterHandlers(mux *http.ServeMux, client dexpb.FlowServiceClient) {
 	mux.HandleFunc("GET /api/flows/state", handler.getFlowState)
 	mux.HandleFunc("GET /api/flows/wait", handler.waitForHistoryEvent)
 	mux.HandleFunc("POST /api/flows/reset", handler.resetFlow)
+	mux.HandleFunc("POST /api/flows/stop", handler.stopFlow)
 	mux.HandleFunc("POST /api/blobs/load", handler.loadBlobs)
 	mux.HandleFunc("GET /healthz", health)
 }
@@ -232,6 +233,42 @@ func (h *handler) resetFlow(response http.ResponseWriter, request *http.Request)
 		return
 	}
 	writeJSON(response, http.StatusOK, resetFlowResponse{RunID: result.GetRunId()})
+}
+
+func (h *handler) stopFlow(response http.ResponseWriter, request *http.Request) {
+	var body stopFlowRequest
+	if err := decodeJSON(response, request, &body); err != nil {
+		WriteError(response, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+	if body.FlowID == "" || body.StopType == 0 {
+		WriteError(response, http.StatusBadRequest, "flowId and stopType are required", nil)
+		return
+	}
+	stopType := dexpb.StopType(body.StopType)
+	switch stopType {
+	case dexpb.StopType_STOP_TYPE_CANCEL,
+		dexpb.StopType_STOP_TYPE_TERMINATE,
+		dexpb.StopType_STOP_TYPE_FAIL:
+	default:
+		WriteError(response, http.StatusBadRequest, "stopType must be cancel, terminate, or fail", nil)
+		return
+	}
+	if stopType != dexpb.StopType_STOP_TYPE_CANCEL && strings.TrimSpace(body.Reason) == "" {
+		WriteError(response, http.StatusBadRequest, "reason is required for terminate and fail", nil)
+		return
+	}
+	_, err := h.client.StopFlow(request.Context(), &dexpb.StopFlowRequest{
+		FlowId:   body.FlowID,
+		RunId:    body.RunID,
+		Reason:   body.Reason,
+		StopType: stopType,
+	})
+	if err != nil {
+		writeGRPCError(response, err, "StopFlow")
+		return
+	}
+	writeJSON(response, http.StatusOK, map[string]struct{}{})
 }
 
 func (h *handler) loadBlobs(response http.ResponseWriter, request *http.Request) {

--- a/web/api/types.go
+++ b/web/api/types.go
@@ -113,3 +113,10 @@ type resetFlowRequest struct {
 type resetFlowResponse struct {
 	RunID string `json:"runId"`
 }
+
+type stopFlowRequest struct {
+	FlowID   string `json:"flowId"`
+	RunID    string `json:"runId"`
+	StopType int32  `json:"stopType"`
+	Reason   string `json:"reason"`
+}

--- a/web/app/flows/RunDetailsPage.tsx
+++ b/web/app/flows/RunDetailsPage.tsx
@@ -30,6 +30,7 @@ import { usePreferences } from '../providers';
 import { FlowOverview } from './details/FlowOverview';
 import { FlowStatePanel } from './details/FlowStatePanel';
 import { ResetFlowDialog } from './details/ResetFlowDialog';
+import { StopFlowDialog } from './details/StopFlowDialog';
 import { StepGraph } from './details/StepGraph';
 import { Timeline } from './details/Timeline';
 
@@ -97,6 +98,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
   const [error, setError] = useState('');
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [resetOpen, setResetOpen] = useState(false);
+  const [stopOpen, setStopOpen] = useState(false);
   const [waitCycle, setWaitCycle] = useState(0);
   const [hydratedEvents, setHydratedEvents] = useState<Record<number, FlowHistoryEvent>>({});
   const [dataWarnings, setDataWarnings] = useState<string[]>([]);
@@ -424,6 +426,13 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
               Copy link
             </button>
             <button className="button ghost" onClick={() => void refresh()}>Refresh</button>
+            <button
+              className="button danger"
+              disabled={!summary || terminalStatuses.has(summary.flowStatusCode)}
+              onClick={() => setStopOpen(true)}
+            >
+              Stop
+            </button>
             <button className="button danger" onClick={() => setResetOpen(true)}>Reset</button>
           </div>
         </div>
@@ -545,6 +554,14 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
           summary={summary}
           events={history}
           onClose={() => setResetOpen(false)}
+        />
+      )}
+      {summary && (
+        <StopFlowDialog
+          open={stopOpen}
+          summary={summary}
+          onClose={() => setStopOpen(false)}
+          onStopped={() => void refresh()}
         />
       )}
     </div>

--- a/web/app/flows/details/StopFlowDialog.tsx
+++ b/web/app/flows/details/StopFlowDialog.tsx
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+import { useState } from 'react';
+import type { FlowSummary } from '@/lib/types';
+
+const stopTypes = [
+  { value: 1, label: 'Cancel', needsReason: false },
+  { value: 2, label: 'Terminate', needsReason: true },
+  { value: 3, label: 'Fail', needsReason: true },
+];
+
+export function StopFlowDialog({
+  open,
+  summary,
+  onClose,
+  onStopped,
+}: {
+  open: boolean;
+  summary: FlowSummary;
+  onClose: () => void;
+  onStopped: () => void;
+}) {
+  const [stopType, setStopType] = useState(1);
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const selected = stopTypes.find((item) => item.value === stopType) || stopTypes[0];
+  const reasonRequired = selected.needsReason;
+  const canSubmit = !submitting && (!reasonRequired || reason.trim() !== '');
+
+  if (!open) return null;
+
+  async function submit() {
+    setSubmitting(true);
+    setError('');
+    try {
+      const response = await fetch('/api/flows/stop', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          flowId: summary.flowId,
+          runId: summary.runId,
+          stopType,
+          reason,
+        }),
+      });
+      const data = await response.json() as { error?: string };
+      if (!response.ok) throw new Error(data.error || 'Stop failed');
+      onStopped();
+      onClose();
+    } catch (stopError) {
+      setError(stopError instanceof Error ? stopError.message : 'Stop failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation" onMouseDown={onClose}>
+      <div className="modal" role="dialog" aria-modal="true" onMouseDown={(event) => event.stopPropagation()}>
+        <div className="modal-header">
+          <div><p className="eyebrow">Destructive operation</p><h2>Stop flow</h2></div>
+          <button className="icon-button" onClick={onClose}>×</button>
+        </div>
+        <p>
+          Stop ends the current run. Cancel requests graceful cancellation,
+          terminate forces an immediate stop, and fail records a client failure.
+        </p>
+        <label>
+          Stop type
+          <select value={stopType} onChange={(event) => setStopType(Number(event.target.value))}>
+            {stopTypes.map((item) => (
+              <option value={item.value} key={item.value}>{item.label}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Reason{reasonRequired ? '' : ' (optional)'}
+          <textarea rows={3} value={reason} onChange={(event) => setReason(event.target.value)} />
+        </label>
+        {error && <div className="error-banner">{error}</div>}
+        <div className="modal-actions">
+          <button className="button ghost" onClick={onClose}>Close</button>
+          <button
+            className="button danger"
+            disabled={!canSubmit}
+            onClick={() => void submit()}
+          >
+            {submitting ? 'Stopping…' : 'Stop flow'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/server_integ_test.go
+++ b/web/server_integ_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type flowService struct {
@@ -36,6 +37,7 @@ type flowService struct {
 	waitCanceled      chan struct{}
 	loadBlobsRequests chan *dexpb.LoadBlobsRequest
 	loadBlobsError    error
+	stopRequests      chan *dexpb.StopFlowRequest
 }
 
 func TestWebServerBridgesDexAndServesSPA(t *testing.T) {
@@ -195,6 +197,42 @@ func TestWaitRequestPropagatesCancellation(t *testing.T) {
 	}
 }
 
+func TestWebServerStopsFlow(t *testing.T) {
+	service := &flowService{
+		stopRequests: make(chan *dexpb.StopFlowRequest, 1),
+	}
+	harness := newHarness(t, service)
+
+	response := postJSON(t, harness.http.URL+"/api/flows/stop", `{
+		"flowId":"checkout-1",
+		"runId":"run-1",
+		"stopType":3,
+		"reason":"operator fail"
+	}`)
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("stop status = %d", response.StatusCode)
+	}
+	stopRequest := <-service.stopRequests
+	if stopRequest.GetFlowId() != "checkout-1" ||
+		stopRequest.GetRunId() != "run-1" ||
+		stopRequest.GetStopType() != dexpb.StopType_STOP_TYPE_FAIL ||
+		stopRequest.GetReason() != "operator fail" {
+		t.Fatalf("unexpected StopFlow request: %+v", stopRequest)
+	}
+
+	missingReason := postJSON(t, harness.http.URL+"/api/flows/stop", `{
+		"flowId":"checkout-1",
+		"runId":"run-1",
+		"stopType":2,
+		"reason":" "
+	}`)
+	defer missingReason.Body.Close()
+	if missingReason.StatusCode != http.StatusBadRequest {
+		t.Fatalf("missing reason status = %d", missingReason.StatusCode)
+	}
+}
+
 func (s *flowService) SearchFlows(
 	context.Context,
 	*dexpb.SearchFlowsRequest,
@@ -240,6 +278,14 @@ func (s *flowService) WaitForHistoryEvent(
 	<-ctx.Done()
 	close(s.waitCanceled)
 	return nil, ctx.Err()
+}
+
+func (s *flowService) StopFlow(
+	_ context.Context,
+	request *dexpb.StopFlowRequest,
+) (*emptypb.Empty, error) {
+	s.stopRequests <- request
+	return &emptypb.Empty{}, nil
 }
 
 type harness struct {


### PR DESCRIPTION
## Summary
- Add a Stop control on the run page with Cancel / Terminate / Fail.
- Expose `POST /api/flows/stop` in the web BFF, calling Dex `StopFlow`.
- Require a reason for terminate and fail; cover the bridge with a web integ test.

## Test plan
- [ ] Open a running flow in Dex Web and confirm Stop appears next to Reset
- [ ] Cancel a run and confirm status becomes Canceled
- [ ] Terminate a run with a reason and confirm the reason appears on Flow closed
- [ ] Fail a run with a reason and confirm status becomes Failed
- [ ] `cd web && npm run check && npm run build && GOWORK=off go test ./...`


Made with [Cursor](https://cursor.com)