### PR TITLE
Port remaining Java examples into examples/go

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 cli/dexcli
 examples/go/dex-samples
+examples/go/deepverify
 sdk-typescript/node_modules/
 sdk-rust/target/
 sdk-typescript/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage.out
 sdk-go/coverage/
 dex-server
 examples/go/dex-samples
+examples/go/deepverify
 cli/dexcli
 .bin/
 .build/

--- a/examples/go/.gitignore
+++ b/examples/go/.gitignore
@@ -4,7 +4,9 @@
 *.dll
 *.so
 *.dylib
-dex-samples
+/dex-samples
+/deepverify
+/dvdiag
 
 # Test binary, built with `go test -c`
 *.test

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -16,6 +16,17 @@ make bins
 ./dex-samples
 ```
 
+When Temporal search attributes are not pre-created:
+
+```bash
+temporal --address 127.0.0.1:7233 operator search-attribute create \
+  --name ActiveStepTypes --type KeywordList
+temporal --address 127.0.0.1:7233 operator search-attribute create \
+  --name CustomKeywordField --type Keyword
+temporal --address 127.0.0.1:7233 operator search-attribute create \
+  --name CustomStringField --type Text
+```
+
 The defaults connect to Dex at `localhost:8801`. These environment variables override the local addresses:
 
 - `DEX_FLOW_SERVICE_ADDRESS`: Dex gRPC target.
@@ -28,16 +39,38 @@ When Dex runs in Docker, set `DEX_WORKER_TARGET=host.docker.internal:8803`.
 
 ## Verify every example
 
-The E2E suite starts Dex through `dexcli dev` and runs every start, channel publish, and RPC path:
+The E2E suite starts Dex through `dexcli dev` and runs every start, channel publish, and RPC path covered by the existing product integ tests:
 
 ```bash
 make e2eTests
 ```
 
-## Examples
+## Product examples
 
 - [Money transfer saga](./workflows/moneytransfer)
 - [Microservice orchestration](./workflows/microservices)
 - [Employer/job-seeker engagement](./workflows/engagement)
 - [Subscription](./workflows/subscription)
 - [Polling and channel coordination](./workflows/polling)
+- [Signup](./workflows/signup)
+- [Job post](./workflows/jobpost)
+- [Shortlist candidates](./workflows/shortlistcandidates)
+
+## Design patterns
+
+All under [`workflows/patterns`](./workflows/patterns), HTTP under `/design-pattern/...`:
+
+- [Cron schedule](./workflows/patterns/cron) (auto-started; no HTTP)
+- [Drain internal / signal channels](./workflows/patterns/drainchannels)
+- [Interruptible execution](./workflows/patterns/interruptible)
+- [Manual intervention](./workflows/patterns/intervention)
+- [Parallel states](./workflows/patterns/parallel)
+- [Parent–child](./workflows/patterns/parentchild)
+- [Polling (simple / backoff)](./workflows/patterns/polling)
+- [Failure recovery](./workflows/patterns/recovery)
+- [Reminders](./workflows/patterns/reminders)
+- [Resettable timer](./workflows/patterns/resettabletimer)
+- [Scalable parallel](./workflows/patterns/scalableparallel)
+- [Storage singleton](./workflows/patterns/storage)
+- [Timeout handling](./workflows/patterns/timeout)
+- [Wait for state completion](./workflows/patterns/waitforstatecompletion)

--- a/examples/go/cmd/deepverify/main.go
+++ b/examples/go/cmd/deepverify/main.go
@@ -1,0 +1,1374 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Deep-verify every examples/go product and design-pattern flow against a live
+// Dex + samples worker (WaitForFlow / RPC / channels / attributes / side effects).
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/superdurable/dex/examples/go/workflows"
+	"github.com/superdurable/dex/examples/go/workflows/engagement"
+	"github.com/superdurable/dex/examples/go/workflows/jobpost"
+	"github.com/superdurable/dex/examples/go/workflows/microservices"
+	"github.com/superdurable/dex/examples/go/workflows/moneytransfer"
+	drainsignal "github.com/superdurable/dex/examples/go/workflows/patterns/drainchannels/signal"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/interruptible"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/intervention"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/parallel"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/recovery"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/scalableparallel"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/storage"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/waitforstatecompletion"
+	"github.com/superdurable/dex/examples/go/workflows/polling"
+	"github.com/superdurable/dex/examples/go/workflows/service"
+	"github.com/superdurable/dex/examples/go/workflows/shortlistcandidates"
+	"github.com/superdurable/dex/examples/go/workflows/signup"
+	"github.com/superdurable/dex/examples/go/workflows/subscription"
+	"github.com/superdurable/dex/sdk-go/dex"
+	"github.com/superdurable/dex/sdk-go/dex/blobcache"
+	"github.com/superdurable/dex/sdk-go/dex/ptr"
+)
+
+type result struct {
+	name    string
+	ok      bool
+	details string
+	err     error
+}
+
+func main() {
+	ctx := context.Background()
+	client, cleanup, err := newVerifyClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bootstrap: %v\n", err)
+		os.Exit(2)
+	}
+	defer cleanup()
+
+	if _, err := client.HealthCheck(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "dex health: %v\n", err)
+		os.Exit(2)
+	}
+
+	stamp := strconv.FormatInt(time.Now().UnixNano(), 10)
+	only := parseOnly(os.Getenv("DEEPVERIFY_ONLY"))
+	results := make([]result, 0, 40)
+	var mu sync.Mutex
+	record := func(r result) {
+		mu.Lock()
+		defer mu.Unlock()
+		results = append(results, r)
+		status := "PASS"
+		if !r.ok {
+			status = "FAIL"
+		}
+		line := fmt.Sprintf("[%s] %s — %s", status, r.name, r.details)
+		if r.err != nil {
+			line += " | err=" + r.err.Error()
+		}
+		fmt.Println(line)
+	}
+	want := func(name string) bool {
+		if len(only) == 0 {
+			return true
+		}
+		return only[name]
+	}
+
+	// Long-running flows first so their timers overlap with shorter scenarios.
+	var shortlistID, resetID string
+	if want("shortlist/email-path-start") || want("product/shortlist-email") {
+		id, startErr := startShortlistEmailPath(ctx, client, stamp)
+		if startErr != nil {
+			record(result{name: "shortlist/email-path-start", ok: false, err: startErr})
+		} else {
+			shortlistID = id
+			record(result{
+				name:    "shortlist/email-path-start",
+				ok:      true,
+				details: "flowID=" + shortlistID + " (waiting 5m for email)",
+			})
+		}
+	}
+	if want("resettabletimer/start+reset") || want("pattern/resettabletimer-fire") {
+		id, startErr := startResettableTimerPath(ctx, client, stamp)
+		if startErr != nil {
+			record(result{name: "resettabletimer/start+reset", ok: false, err: startErr})
+		} else {
+			resetID = id
+			record(result{
+				name:    "resettabletimer/start+reset",
+				ok:      true,
+				details: "flowID=" + resetID + " (waiting ~5m after reset)",
+			})
+		}
+	}
+
+	runProductScenarios(ctx, client, stamp, record, want)
+	runPatternScenarios(ctx, client, stamp, record, want)
+
+	if shortlistID != "" && want("product/shortlist-email") {
+		record(waitShortlistEmail(ctx, client, shortlistID))
+	}
+	if resetID != "" && want("pattern/resettabletimer-fire") {
+		record(waitResettableTimer(ctx, client, resetID))
+	}
+
+	failCount := 0
+	fmt.Println()
+	fmt.Println("=== SUMMARY ===")
+	for _, item := range results {
+		if item.ok {
+			continue
+		}
+		failCount++
+		fmt.Printf("FAIL %s: %s (%v)\n", item.name, item.details, item.err)
+	}
+	fmt.Printf("TOTAL=%d FAIL=%d\n", len(results), failCount)
+	if failCount > 0 {
+		os.Exit(1)
+	}
+}
+
+func newVerifyClient() (*dex.Client, func(), error) {
+	var client *dex.Client
+	flows := workflows.New(service.NewMyService(), func() *dex.Client { return client })
+	registry, err := dex.NewRegistry(flows)
+	if err != nil {
+		return nil, nil, err
+	}
+	cacheDir, err := os.MkdirTemp("", "dex-go-deepverify-")
+	if err != nil {
+		return nil, nil, err
+	}
+	cache, err := blobcache.New(&blobcache.Config{
+		Dir:      cacheDir,
+		MaxBytes: 64 << 20,
+	})
+	if err != nil {
+		_ = os.RemoveAll(cacheDir)
+		return nil, nil, err
+	}
+	flowAddr := envOr("DEX_FLOW_SERVICE_ADDRESS", "127.0.0.1:8801")
+	workerAddr := envOr("DEX_WORKER_TARGET", "127.0.0.1:8803")
+	client, err = dex.NewClient(registry, cache, dex.ClientOptions{
+		FlowServiceAddress: flowAddr,
+		WorkerTarget:       &dex.WorkerTarget{Address: workerAddr},
+	})
+	if err != nil {
+		_ = cache.Close()
+		_ = os.RemoveAll(cacheDir)
+		return nil, nil, err
+	}
+	cleanup := func() {
+		_ = client.Close()
+		_ = cache.Close()
+		_ = os.RemoveAll(cacheDir)
+	}
+	return client, cleanup, nil
+}
+
+func runProductScenarios(
+	ctx context.Context,
+	client *dex.Client,
+	stamp string,
+	record func(result),
+	want func(string) bool,
+) {
+	type caseFn struct {
+		name string
+		run  func() result
+	}
+	cases := []caseFn{
+		{"product/moneytransfer", func() result { return verifyMoneyTransfer(ctx, client, stamp) }},
+		{"product/microservices", func() result { return verifyMicroservices(ctx, client, stamp) }},
+		{"product/engagement", func() result { return verifyEngagement(ctx, client, stamp) }},
+		{"product/subscription", func() result { return verifySubscription(ctx, client, stamp) }},
+		{"product/polling", func() result { return verifyPolling(ctx, client, stamp) }},
+		{"product/signup", func() result { return verifySignup(ctx, client, stamp) }},
+		{"product/jobpost", func() result { return verifyJobPost(ctx, client, stamp) }},
+		{"product/shortlist-revoke", func() result { return verifyShortlistRevoke(ctx, client, stamp) }},
+	}
+	for _, item := range cases {
+		if want(item.name) {
+			record(item.run())
+		}
+	}
+}
+
+func runPatternScenarios(
+	ctx context.Context,
+	client *dex.Client,
+	stamp string,
+	record func(result),
+	want func(string) bool,
+) {
+	type caseFn struct {
+		name string
+		run  func() result
+	}
+	cases := []caseFn{
+		{"pattern/simple-polling", func() result { return verifySimplePolling(ctx, client, stamp) }},
+		{"pattern/backoff-polling", func() result { return verifyBackoffPolling(ctx, client, stamp) }},
+		{"pattern/interruptible", func() result { return verifyInterruptible(ctx, client, stamp) }},
+		{"pattern/reminder", func() result { return verifyReminder(ctx, client, stamp) }},
+		{"pattern/storage", func() result { return verifyStorage(ctx, client, stamp) }},
+		{"pattern/intervention-retry", func() result { return verifyInterventionRetry(ctx, client, stamp) }},
+		{"pattern/intervention-skip", func() result { return verifyInterventionSkip(ctx, client, stamp) }},
+		{"pattern/parallel-simple", func() result { return verifyParallelSimple(ctx, client, stamp) }},
+		{"pattern/parallel-await", func() result { return verifyParallelAwait(ctx, client, stamp) }},
+		{"pattern/recovery", func() result { return verifyRecovery(ctx, client, stamp) }},
+		{"pattern/scalable-parallel", func() result { return verifyScalableParallel(ctx, client, stamp) }},
+		{"pattern/parent-child", func() result { return verifyParentChild(ctx, client, stamp) }},
+		{"pattern/drain-internal", func() result { return verifyDrainInternal(ctx, client, stamp) }},
+		{"pattern/drain-signal", func() result { return verifyDrainSignal(ctx, client, stamp) }},
+		{"pattern/wait-for-state-completion", func() result { return verifyWaitForStateCompletion(ctx, client, stamp) }},
+		{"pattern/timeout-success", func() result { return verifyTimeoutSuccess(ctx, client, stamp) }},
+		{"pattern/timeout-fail", func() result { return verifyTimeoutFail(ctx, client, stamp) }},
+		{"pattern/cron-schedule", func() result { return verifyCron(ctx, client) }},
+	}
+	for _, item := range cases {
+		if want(item.name) {
+			record(item.run())
+		}
+	}
+}
+
+func parseOnly(raw string) map[string]bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	out := map[string]bool{}
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out[part] = true
+		}
+	}
+	return out
+}
+
+func verifyMoneyTransfer(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "product/moneytransfer"
+	flowID := "dv-money-" + stamp
+	_, err := client.StartFlow(ctx, workflows.MoneyTransfer, flowID, moneytransfer.TransferRequest{
+		FromAccount: "from-dv",
+		ToAccount:   "to-dv",
+		Amount:      17,
+		Notes:       "deepverify",
+	}, dex.StartFlowOptions{})
+	if err != nil {
+		return fail(name, "", err)
+	}
+	wait, err := waitCompleted(ctx, client, flowID, 45*time.Second)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	output, err := decodeStringCompletion(wait)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if !strings.Contains(output, "transfer is done") ||
+		!strings.Contains(output, "from-dv") ||
+		!strings.Contains(output, "to-dv") {
+		return fail(name, "unexpected output="+output, nil)
+	}
+	return pass(name, "completed output="+output)
+}
+
+func verifyMicroservices(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "product/microservices"
+	flowID := "dv-ms-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.Microservices, flowID, "initial-data", dex.StartFlowOptions{},
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if err := client.WaitForAttributeEqual(
+		ctx, flowID, microservices.Data, "initial-data",
+		dex.WaitOptions{Timeout: 20 * time.Second},
+	); err != nil {
+		return fail(name, "wait attribute", err)
+	}
+	var oldData string
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.Microservices.Swap, "updated-data", &oldData, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "swap", err)
+	}
+	if oldData != "initial-data" {
+		return fail(name, "swap returned "+oldData, nil)
+	}
+	if err := client.PublishToChannel(ctx, flowID, microservices.Ready, nil); err != nil {
+		return fail(name, "publish ready", err)
+	}
+	wait, err := waitCompleted(ctx, client, flowID, 45*time.Second)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	output, err := decodeStringCompletion(wait)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if output != "updated-data" {
+		return fail(name, "output="+output, nil)
+	}
+	return pass(name, "swap+ready completed with updated-data")
+}
+
+func verifyEngagement(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "product/engagement"
+	flowID := "dv-eng-" + stamp
+	_, err := client.StartFlow(ctx, workflows.Engagement, flowID, engagement.EngagementInput{
+		EmployerID:  "employer-dv",
+		JobSeekerID: "job-seeker-dv",
+		Notes:       "deepverify",
+	}, dex.StartFlowOptions{})
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if err := client.WaitForAttributeEqual(
+		ctx, flowID, engagement.EngagementStatus, engagement.StatusInitiated,
+		dex.WaitOptions{Timeout: 20 * time.Second},
+	); err != nil {
+		return fail(name, "wait initiated", err)
+	}
+	var description engagement.EngagementDescription
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.Engagement.Describe, nil, &description, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "describe", err)
+	}
+	if description.CurrentStatus != engagement.StatusInitiated {
+		return fail(name, "status="+string(description.CurrentStatus), nil)
+	}
+	if err := client.PublishToChannel(ctx, flowID, engagement.OptOutReminder, nil); err != nil {
+		return fail(name, "opt-out reminder", err)
+	}
+	var status engagement.Status
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.Engagement.Accept, "accepted deepverify", &status, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "accept", err)
+	}
+	if status != engagement.StatusAccepted {
+		return fail(name, "accept status="+string(status), nil)
+	}
+	wait, err := waitCompleted(ctx, client, flowID, 45*time.Second)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	output, err := decodeStringCompletion(wait)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if output != "done" {
+		return fail(name, "output="+output, nil)
+	}
+	return pass(name, "describe+optOut+accept completed")
+}
+
+func verifySubscription(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "product/subscription"
+	flowID := "dv-sub-" + stamp
+	customer := subscription.Customer{
+		FirstName: "Deep",
+		LastName:  "Verify",
+		ID:        flowID,
+		Email:     "deepverify@example.com",
+		Subscription: subscription.Subscription{
+			TrialPeriod:         30 * time.Second,
+			BillingPeriod:       30 * time.Second,
+			MaxBillingPeriods:   2,
+			BillingPeriodCharge: 100,
+		},
+	}
+	_, err := client.StartFlow(
+		ctx, workflows.Subscription, flowID, customer, dex.StartFlowOptions{},
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if err := client.WaitForAttributeEqual(
+		ctx, flowID, subscription.CustomerDetails, customer,
+		dex.WaitOptions{Timeout: 20 * time.Second},
+	); err != nil {
+		return fail(name, "wait customer", err)
+	}
+	var current subscription.Subscription
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.Subscription.Describe, nil, &current, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "describe", err)
+	}
+	if current.BillingPeriodCharge != 100 {
+		return fail(name, fmt.Sprintf("charge=%d", current.BillingPeriodCharge), nil)
+	}
+	if err := client.PublishToChannel(ctx, flowID, subscription.UpdateChargeAmount, 250); err != nil {
+		return fail(name, "update charge", err)
+	}
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		err = client.InvokeRPC(
+			ctx, flowID, workflows.Subscription.Describe, nil, &current, dex.InvokeOptions{},
+		)
+		if err == nil && current.BillingPeriodCharge == 250 {
+			break
+		}
+		if time.Now().After(deadline) {
+			return fail(name, "charge not updated", err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if err := client.PublishToChannel(ctx, flowID, subscription.CancelSubscription, nil); err != nil {
+		return fail(name, "cancel", err)
+	}
+	wait, err := waitCompleted(ctx, client, flowID, 45*time.Second)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	output, err := decodeStringCompletion(wait)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if output != "subscription canceled" {
+		return fail(name, "output="+output, nil)
+	}
+	return pass(name, "describe+updateCharge+cancel completed")
+}
+
+func verifyPolling(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "product/polling"
+	flowID := "dv-poll-" + stamp
+	_, err := client.StartFlow(ctx, workflows.Polling, flowID, 1, dex.StartFlowOptions{})
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if err := client.PublishToChannel(ctx, flowID, polling.TaskACompleted, nil); err != nil {
+		return fail(name, "task-a", err)
+	}
+	if err := client.PublishToChannel(ctx, flowID, polling.TaskBCompleted, nil); err != nil {
+		return fail(name, "task-b", err)
+	}
+	wait, err := waitCompleted(ctx, client, flowID, 45*time.Second)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	output, err := decodeStringCompletion(wait)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if output != "all tasks completed" {
+		return fail(name, "output="+output, nil)
+	}
+	var pollCount int
+	found, err := client.GetAttribute(ctx, flowID, polling.CurrentPolls, &pollCount)
+	if err != nil || !found || pollCount != 1 {
+		return fail(name, fmt.Sprintf("polls found=%v count=%d", found, pollCount), err)
+	}
+	return pass(name, "channels completed; CurrentPolls=1")
+}
+
+func verifySignup(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "product/signup"
+	flowID := "dv-user-" + stamp
+	form := signup.SignupForm{
+		Username:  flowID,
+		Email:     flowID + "@example.com",
+		FirstName: "Deep",
+		LastName:  "Verify",
+	}
+	_, err := client.StartFlow(ctx, workflows.Signup, flowID, form, dex.StartFlowOptions{})
+	if err != nil {
+		return fail(name, "", err)
+	}
+	var verifyOutput string
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.Signup.Verify, nil, &verifyOutput, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "verify rpc", err)
+	}
+	if verifyOutput != "done" {
+		return fail(name, "verify="+verifyOutput, nil)
+	}
+	wait, err := waitCompleted(ctx, client, flowID, 45*time.Second)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	_ = wait
+	var status string
+	found, err := client.GetAttribute(ctx, flowID, signup.Status, &status)
+	if err != nil || !found || status != "verified" {
+		return fail(name, fmt.Sprintf("status found=%v value=%s", found, status), err)
+	}
+	return pass(name, "verify RPC + Status=verified + completed")
+}
+
+func verifyJobPost(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "product/jobpost"
+	flowID := "dv-job-" + stamp
+	timeout := 24 * time.Hour
+	titleAttr, err := dex.InitialAttribute(jobpost.Title, "DeepVerify Engineer")
+	if err != nil {
+		return fail(name, "initial title", err)
+	}
+	descriptionAttr, err := dex.InitialAttribute(jobpost.JobDescription, "Build Dex examples")
+	if err != nil {
+		return fail(name, "initial description", err)
+	}
+	lastUpdateAttr, err := dex.InitialAttribute(jobpost.LastUpdateTimeMillis, time.Now().UnixMilli())
+	if err != nil {
+		return fail(name, "initial lastUpdate", err)
+	}
+	_, err = client.StartFlow(ctx, workflows.JobPost, flowID, nil, dex.StartFlowOptions{
+		Timeout: &timeout,
+		Attributes: []dex.InitialAttributeDef{
+			titleAttr, descriptionAttr, lastUpdateAttr,
+		},
+		ConfigOverride: &dex.FlowConfig{ContinueAsNewThreshold: ptr.Any(int32(10))},
+	})
+	if err != nil {
+		return fail(name, "start", err)
+	}
+	var info jobpost.JobInfo
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.JobPost.Get, nil, &info, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "get", err)
+	}
+	if info.Title != "DeepVerify Engineer" || info.Description != "Build Dex examples" {
+		return fail(name, fmt.Sprintf("get=%+v", info), nil)
+	}
+	var none dex.None
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.JobPost.Update,
+		jobpost.JobInfo{Title: "Senior DeepVerify", Description: "More depth", Notes: "n1"},
+		&none, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "update", err)
+	}
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.JobPost.Get, nil, &info, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "get after update", err)
+	}
+	if info.Title != "Senior DeepVerify" || info.Notes != "n1" {
+		return fail(name, fmt.Sprintf("after update=%+v", info), nil)
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	foundInSearch := false
+	for time.Now().Before(deadline) {
+		page, searchErr := client.SearchFlows(
+			ctx, "Title = 'Senior DeepVerify'", 50, "",
+		)
+		if searchErr == nil {
+			for _, entry := range page.Flows {
+				if entry.FlowID == flowID {
+					foundInSearch = true
+					break
+				}
+			}
+		}
+		if foundInSearch {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if !foundInSearch {
+		return fail(name, "not found in SearchFlows Title='Senior DeepVerify'", nil)
+	}
+	if err := client.StopFlow(ctx, flowID, dex.StopOptions{}); err != nil {
+		return fail(name, "stop", err)
+	}
+	return pass(name, "create+get+update+search+stop")
+}
+
+func verifyShortlistRevoke(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "product/shortlist-revoke"
+	employerID := "emp-revoke-" + stamp
+	candidateID := "cand-revoke-" + stamp
+	optInID := shortlistcandidates.EmployerOptInFlowID(employerID)
+	_, err := client.StartFlow(
+		ctx, workflows.EmployerOptIn, optInID,
+		shortlistcandidates.EmployerOptInInput{EmployerID: employerID},
+		dex.StartFlowOptions{},
+	)
+	if err != nil {
+		return fail(name, "opt-in", err)
+	}
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		optedIn, checkErr := shortlistcandidates.IsOptedIn(
+			ctx, client, workflows.EmployerOptIn, employerID,
+		)
+		if checkErr == nil && optedIn {
+			break
+		}
+		if time.Now().After(deadline) {
+			return fail(name, "isOptedIn", checkErr)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	shortlistID := shortlistcandidates.ShortlistFlowID(employerID, candidateID)
+	_, err = client.StartFlow(
+		ctx, workflows.Shortlist, shortlistID,
+		shortlistcandidates.ShortlistInput{EmployerID: employerID, CandidateID: candidateID},
+		dex.StartFlowOptions{},
+	)
+	if err != nil {
+		return fail(name, "shortlist start", err)
+	}
+	if err := client.PublishToChannel(
+		ctx, shortlistID, shortlistcandidates.RevokeShortlist, nil,
+	); err != nil {
+		return fail(name, "revoke", err)
+	}
+	wait, err := waitCompleted(ctx, client, shortlistID, 45*time.Second)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	_ = wait
+	var emailTS int64
+	found, err := client.GetAttribute(
+		ctx, shortlistID, shortlistcandidates.ShortlistEmailSentTimestamp, &emailTS,
+	)
+	if err != nil {
+		return fail(name, "email timestamp", err)
+	}
+	if found && emailTS != 0 {
+		return fail(name, fmt.Sprintf("email should not send; ts=%d", emailTS), nil)
+	}
+	return pass(name, "opt-in + shortlist + revoke completed without email")
+}
+
+func startShortlistEmailPath(
+	ctx context.Context,
+	client *dex.Client,
+	stamp string,
+) (string, error) {
+	employerID := "emp-email-" + stamp
+	candidateID := "cand-email-" + stamp
+	optInID := shortlistcandidates.EmployerOptInFlowID(employerID)
+	_, err := client.StartFlow(
+		ctx, workflows.EmployerOptIn, optInID,
+		shortlistcandidates.EmployerOptInInput{EmployerID: employerID},
+		dex.StartFlowOptions{},
+	)
+	if err != nil {
+		return "", err
+	}
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		optedIn, checkErr := shortlistcandidates.IsOptedIn(
+			ctx, client, workflows.EmployerOptIn, employerID,
+		)
+		if checkErr == nil && optedIn {
+			break
+		}
+		if time.Now().After(deadline) {
+			if checkErr != nil {
+				return "", checkErr
+			}
+			return "", fmt.Errorf("employer not opted in")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	shortlistID := shortlistcandidates.ShortlistFlowID(employerID, candidateID)
+	_, err = client.StartFlow(
+		ctx, workflows.Shortlist, shortlistID,
+		shortlistcandidates.ShortlistInput{EmployerID: employerID, CandidateID: candidateID},
+		dex.StartFlowOptions{},
+	)
+	return shortlistID, err
+}
+
+func waitShortlistEmail(ctx context.Context, client *dex.Client, flowID string) result {
+	name := "product/shortlist-email"
+	wait, err := waitCompleted(ctx, client, flowID, 6*time.Minute)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	_ = wait
+	var emailTS int64
+	found, err := client.GetAttribute(
+		ctx, flowID, shortlistcandidates.ShortlistEmailSentTimestamp, &emailTS,
+	)
+	if err != nil || !found || emailTS == 0 {
+		return fail(name, fmt.Sprintf("email ts found=%v ts=%d", found, emailTS), err)
+	}
+	return pass(name, fmt.Sprintf("email sent ts=%d after 5m timer", emailTS))
+}
+
+func startResettableTimerPath(
+	ctx context.Context,
+	client *dex.Client,
+	stamp string,
+) (string, error) {
+	flowID := "dv-reset-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.ResettableTimer, flowID, nil, hourStartOptions(),
+	)
+	if err != nil {
+		return "", err
+	}
+	time.Sleep(2 * time.Second)
+	var none dex.None
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.ResettableTimer.SendResetMessage, nil, &none, dex.InvokeOptions{},
+	); err != nil {
+		return "", err
+	}
+	return flowID, nil
+}
+
+func waitResettableTimer(ctx context.Context, client *dex.Client, flowID string) result {
+	name := "pattern/resettabletimer-fire"
+	wait, err := waitCompleted(ctx, client, flowID, 6*time.Minute)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	_ = wait
+	return pass(name, "completed after reset + 5m timer fire")
+}
+
+func verifySimplePolling(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/simple-polling"
+	flowID := "dv-simple-poll-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.SimplePolling, flowID, nil, hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if _, err := waitCompleted(ctx, client, flowID, 45*time.Second); err != nil {
+		return fail(name, "", err)
+	}
+	return pass(name, "completed after 10s poll timer")
+}
+
+func verifyBackoffPolling(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/backoff-polling"
+	flowID := "dv-backoff-poll-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.BackoffPolling, flowID, nil, hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	wait, err := waitCompleted(ctx, client, flowID, 90*time.Second)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	output, err := decodeStringCompletion(wait)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if output != "External data result" {
+		return fail(name, "output="+output, nil)
+	}
+	return pass(name, "retries then completed with External data result")
+}
+
+func verifyInterruptible(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/interruptible"
+	flowID := "dv-interrupt-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.InterruptibleExecution, flowID, nil, hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	var none dex.None
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.InterruptibleExecution.Interrupt, nil, &none, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "interrupt rpc", err)
+	}
+	if _, err := waitCompleted(ctx, client, flowID, 60*time.Second); err != nil {
+		return fail(name, "", err)
+	}
+	var signal string
+	found, err := client.GetAttribute(ctx, flowID, interruptible.InterruptSignal, &signal)
+	if err != nil {
+		return fail(name, "get interrupt signal", err)
+	}
+	if !found || signal != "cancel" {
+		return fail(name, fmt.Sprintf("signal found=%v value=%s", found, signal), nil)
+	}
+	return pass(name, "Interrupt RPC set cancel; flow completed")
+}
+
+func verifyReminder(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/reminder"
+	flowID := "dv-reminder-" + stamp
+	_, err := client.StartFlow(ctx, workflows.Reminder, flowID, nil, hourStartOptions())
+	if err != nil {
+		return fail(name, "", err)
+	}
+	time.Sleep(6 * time.Second) // allow at least one reminder timer tick
+	var none dex.None
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.Reminder.Accept, nil, &none, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "accept", err)
+	}
+	if _, err := waitCompleted(ctx, client, flowID, 45*time.Second); err != nil {
+		return fail(name, "", err)
+	}
+	return pass(name, "reminder tick + Accept completed")
+}
+
+func verifyStorage(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/storage"
+	key := "dv-key-" + stamp
+	value := "dv-val-" + stamp
+	if err := ensureStorage(ctx, client); err != nil {
+		return fail(name, "ensure start", err)
+	}
+	var none dex.None
+	if err := client.InvokeRPC(
+		ctx, storage.StorageFlowID, workflows.Storage.AddItem,
+		storage.AddStorageItemRequest{Key: key, Value: value},
+		&none, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "add", err)
+	}
+	var got string
+	if err := client.InvokeRPC(
+		ctx, storage.StorageFlowID, workflows.Storage.GetItem, key, &got, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "get", err)
+	}
+	if got != value {
+		return fail(name, "got="+got, nil)
+	}
+	if err := client.InvokeRPC(
+		ctx, storage.StorageFlowID, workflows.Storage.RemoveItem, key, &none, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "remove", err)
+	}
+	got = "still-here"
+	if err := client.InvokeRPC(
+		ctx, storage.StorageFlowID, workflows.Storage.GetItem, key, &got, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "get after remove", err)
+	}
+	if got != "" {
+		return fail(name, "expected empty after remove, got="+got, nil)
+	}
+	return pass(name, "add+get+remove round-trip on "+storage.StorageFlowID)
+}
+
+func ensureStorage(ctx context.Context, client *dex.Client) error {
+	_, err := client.StartFlow(
+		ctx, workflows.Storage, storage.StorageFlowID, nil, hourStartOptions(),
+	)
+	if err == nil {
+		return nil
+	}
+	var dexErr *dex.Error
+	if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorFlowAlreadyStarted {
+		return nil
+	}
+	return err
+}
+
+func verifyInterventionRetry(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/intervention-retry"
+	flowID := "dv-interv-retry-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.ManualIntervention, flowID, nil, hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "start", err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	if err := client.PublishToChannel(
+		ctx, flowID, intervention.DataChannel, "failed",
+	); err != nil {
+		return fail(name, "publish failed data", err)
+	}
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(300 * time.Millisecond)
+		if err := client.PublishToChannel(
+			ctx, flowID, intervention.RetrySignal, nil,
+		); err == nil {
+			break
+		}
+	}
+	time.Sleep(500 * time.Millisecond)
+	if err := client.PublishToChannel(
+		ctx, flowID, intervention.DataChannel, "ok",
+	); err != nil {
+		return fail(name, "publish ok data", err)
+	}
+	wait, err := waitCompleted(ctx, client, flowID, 60*time.Second)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	output, err := decodeStringCompletion(wait)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if !strings.Contains(output, "Number of retries: 1") {
+		return fail(name, "output="+output, nil)
+	}
+	return pass(name, output)
+}
+
+func verifyInterventionSkip(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/intervention-skip"
+	flowID := "dv-interv-skip-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.ManualIntervention, flowID, nil, hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "start", err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	if err := client.PublishToChannel(
+		ctx, flowID, intervention.DataChannel, "failed",
+	); err != nil {
+		return fail(name, "publish failed", err)
+	}
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(300 * time.Millisecond)
+		if err := client.PublishToChannel(
+			ctx, flowID, intervention.SkipSignal, nil,
+		); err == nil {
+			break
+		}
+	}
+	wait, err := waitCompleted(ctx, client, flowID, 45*time.Second)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	output, err := decodeStringCompletion(wait)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if !strings.Contains(output, "Number of retries: 0") {
+		return fail(name, "output="+output, nil)
+	}
+	return pass(name, output)
+}
+
+func verifyParallelSimple(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/parallel-simple"
+	flowID := "dv-par-simple-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.SimpleParallel, flowID,
+		parallel.JobSeeker{ID: "123", Email: "a@b.com", PhoneNumber: "1"},
+		hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if _, err := waitCompleted(ctx, client, flowID, 45*time.Second); err != nil {
+		return fail(name, "", err)
+	}
+	return pass(name, "completed")
+}
+
+func verifyParallelAwait(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/parallel-await"
+	flowID := "dv-par-await-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.ParallelWithAwait, flowID, 3, hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if _, err := waitCompleted(ctx, client, flowID, 60*time.Second); err != nil {
+		return fail(name, "", err)
+	}
+	return pass(name, "completed withAwait count=3")
+}
+
+func verifyRecovery(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/recovery"
+	flowID := "dv-recovery-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.FailureRecovery, flowID,
+		recovery.FailureRecoveryWorkflowInput{ItemName: "widget", RequestedQuantity: 0},
+		hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	wait, err := client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
+		NeedsResults: true,
+		Timeout:      90 * time.Second,
+	})
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if wait.Status != dex.FlowFailed {
+		return fail(name, fmt.Sprintf("expected FlowFailed got %v msg=%s", wait.Status, wait.ErrorMessage), nil)
+	}
+	if !strings.Contains(wait.ErrorMessage, "Failed to process transaction") {
+		return fail(name, "msg="+wait.ErrorMessage, nil)
+	}
+	return pass(name, "payment fail → void → ForceFail as designed")
+}
+
+func verifyScalableParallel(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/scalable-parallel"
+	parentID := "dv-sp-parent-" + stamp
+	taskA := "task-a-" + stamp
+	taskB := "task-b-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.ScalableParent, parentID,
+		scalableparallel.BatchEnqueueRequest{List: []string{taskA, taskB}},
+		hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "start unique parent", err)
+	}
+	// Parent ForceCompletes when queue drained and all children reported complete.
+	if _, err := waitCompleted(ctx, client, parentID, 3*time.Minute); err != nil {
+		return fail(name, "parent ForceComplete after children", err)
+	}
+	for _, childID := range []string{"processing-" + taskA, "processing-" + taskB} {
+		wait, waitErr := client.WaitForFlow(ctx, childID, dex.WaitForFlowOptions{
+			NeedsResults: true,
+			Timeout:      10 * time.Second,
+		})
+		if waitErr != nil {
+			return fail(name, "child "+childID, waitErr)
+		}
+		if wait.Status != dex.FlowCompleted {
+			return fail(name, fmt.Sprintf("%s status=%v", childID, wait.Status), nil)
+		}
+	}
+	return pass(name, "unique parent + 2 children completed end-to-end")
+}
+
+func verifyParentChild(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/parent-child"
+	flowID := "dv-parent-" + stamp
+	// Fixed child IDs child-wf-{n}; stop leftovers so StartFlow is clean.
+	for _, childID := range []string{"child-wf-0", "child-wf-1"} {
+		_ = client.StopFlow(ctx, childID, dex.StopOptions{})
+	}
+	_, err := client.StartFlow(
+		ctx, workflows.ParentChild, flowID, 2, idReuseHourOptions(),
+	)
+	if err != nil {
+		return fail(name, "start parent", err)
+	}
+	for _, childID := range []string{"child-wf-0", "child-wf-1"} {
+		if _, err := waitCompleted(ctx, client, childID, 90*time.Second); err != nil {
+			return fail(name, "wait "+childID, err)
+		}
+	}
+	// Parent keeps ConcurrencyPerParentWorkflow loop waiters forever after queue drain.
+	wait, err := client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
+		NeedsResults: false,
+		Timeout:      3 * time.Second,
+	})
+	if err != nil {
+		var dexErr *dex.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorLongPollTimeout {
+			return pass(name, "children completed; parent still running (by design)")
+		}
+		return fail(name, "parent status", err)
+	}
+	if wait.Status != dex.FlowRunning {
+		return fail(name, fmt.Sprintf("expected parent still running, got %v", wait.Status), nil)
+	}
+	return pass(name, "children completed; parent still running (by design)")
+}
+
+func verifyDrainInternal(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/drain-internal"
+	flowID := "dv-drain-int-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.DrainInternal, flowID, "doc-"+stamp, hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if _, err := waitCompleted(ctx, client, flowID, 90*time.Second); err != nil {
+		return fail(name, "", err)
+	}
+	return pass(name, "internal channel drain + finalize completed")
+}
+
+func verifyDrainSignal(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/drain-signal"
+	flowID := "dv-drain-sig-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.DrainSignal, flowID, "first message", hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	time.Sleep(1 * time.Second)
+	if err := client.PublishToChannel(
+		ctx, flowID, drainsignal.QueueSignalChannel, "second signal",
+	); err != nil {
+		return fail(name, "second signal", err)
+	}
+	if _, err := waitCompleted(ctx, client, flowID, 90*time.Second); err != nil {
+		return fail(name, "", err)
+	}
+	return pass(name, "start + extra signal drained to ForceComplete")
+}
+
+func verifyWaitForStateCompletion(
+	ctx context.Context,
+	client *dex.Client,
+	stamp string,
+) result {
+	name := "pattern/wait-for-state-completion"
+	flowID := "dv-waitstate-" + stamp
+	input := waitforstatecompletion.JobSeekerData{ID: 42, Name: "deep", Email: "a@b.c"}
+	_, err := client.StartFlow(
+		ctx, workflows.WaitForStateCompletion, flowID, input, hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "start", err)
+	}
+	if err := client.WaitForStepCompletion(
+		ctx, flowID,
+		dex.StepExecutionID{StepType: "PersistData"},
+		dex.WaitOptions{Timeout: 45 * time.Second},
+	); err != nil {
+		return fail(name, "WaitForStepCompletion PersistData", err)
+	}
+	var persisted waitforstatecompletion.JobSeekerData
+	if err := client.InvokeRPC(
+		ctx, flowID, workflows.WaitForStateCompletion.GetJobSeekerData,
+		nil, &persisted, dex.InvokeOptions{},
+	); err != nil {
+		return fail(name, "GetJobSeekerData", err)
+	}
+	if persisted.ID != 42 || persisted.Name != "deep" {
+		return fail(name, fmt.Sprintf("persisted=%+v", persisted), nil)
+	}
+	if _, err := waitCompleted(ctx, client, flowID, 45*time.Second); err != nil {
+		return fail(name, "wait complete", err)
+	}
+	return pass(name, "PersistData wait + RPC + complete")
+}
+
+func verifyTimeoutSuccess(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/timeout-success"
+	flowID := "dv-timeout-ok-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.GracefulTimeout, flowID, true, hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	wait, err := client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
+		NeedsResults: true,
+		Timeout:      45 * time.Second,
+	})
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if wait.Status != dex.FlowCompleted {
+		return fail(name, fmt.Sprintf("status=%v msg=%s", wait.Status, wait.ErrorMessage), nil)
+	}
+	output, err := decodeStringCompletion(wait)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if output != "Workflow completed successfully" {
+		return fail(name, "output="+output, nil)
+	}
+	return pass(name, "ForceComplete before 1m timeout")
+}
+
+func verifyTimeoutFail(ctx context.Context, client *dex.Client, stamp string) result {
+	name := "pattern/timeout-fail"
+	flowID := "dv-timeout-fail-" + stamp
+	_, err := client.StartFlow(
+		ctx, workflows.GracefulTimeout, flowID, false, hourStartOptions(),
+	)
+	if err != nil {
+		return fail(name, "", err)
+	}
+	// 1m ForceFail + worker backlog under reminder load needs headroom.
+	wait, err := client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
+		NeedsResults: true,
+		Timeout:      3 * time.Minute,
+	})
+	if err != nil {
+		return fail(name, "", err)
+	}
+	if wait.Status != dex.FlowFailed {
+		return fail(name, fmt.Sprintf("expected failed got %v msg=%s", wait.Status, wait.ErrorMessage), nil)
+	}
+	if !strings.Contains(wait.ErrorMessage, "did not finish the task in time") {
+		return fail(name, "msg="+wait.ErrorMessage, nil)
+	}
+	return pass(name, "1m timeout ForceFail as designed")
+}
+
+func verifyCron(ctx context.Context, client *dex.Client) result {
+	name := "pattern/cron-schedule"
+	cronID := fmt.Sprintf("cron-schedule-dv-%d", time.Now().UnixNano())
+	timeout := time.Hour
+	_, startErr := client.StartFlow(
+		ctx, workflows.CronSchedule, cronID, nil,
+		dex.StartFlowOptions{Timeout: &timeout, CronSchedule: "*/1 * * * *"},
+	)
+	// Temporal Schedule.Create returns an empty run ID; SDK surfaces that after register.
+	if startErr != nil && !strings.Contains(startErr.Error(), "no run ID") {
+		return fail(name, "start cron "+cronID, startErr)
+	}
+	// Schedule ticks use WorkflowId "<id>-<RFC3339>"; wait for one and complete it.
+	tickID, err := waitForCronTickID(cronID, 90*time.Second)
+	if err != nil {
+		return fail(name, "wait for schedule tick", err)
+	}
+	wait, err := client.WaitForFlow(ctx, tickID, dex.WaitForFlowOptions{
+		NeedsResults: true,
+		Timeout:      60 * time.Second,
+	})
+	if err != nil {
+		return fail(name, "WaitForFlow "+tickID, err)
+	}
+	if wait.Status != dex.FlowCompleted && wait.Status != dex.FlowContinuedAsNew {
+		return fail(name, fmt.Sprintf("status=%v msg=%s", wait.Status, wait.ErrorMessage), nil)
+	}
+	_ = client.StopFlow(ctx, cronID, dex.StopOptions{})
+	return pass(name, fmt.Sprintf("schedule tick completed id=%s", tickID))
+}
+
+func waitForCronTickID(cronID string, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	query := fmt.Sprintf(`WorkflowId STARTS_WITH "%s-"`, cronID)
+	for time.Now().Before(deadline) {
+		command := exec.Command(
+			"temporal", "workflow", "list",
+			"--address", envOr("TEMPORAL_ADDRESS", "127.0.0.1:17233"),
+			"--query", query,
+			"--limit", "5",
+			"--output", "json",
+		)
+		output, err := command.Output()
+		if err == nil {
+			var rows []struct {
+				Execution struct {
+					WorkflowID string `json:"workflow_id"`
+				} `json:"execution"`
+			}
+			if jsonErr := json.Unmarshal(output, &rows); jsonErr == nil {
+				for _, row := range rows {
+					if strings.HasPrefix(row.Execution.WorkflowID, cronID+"-") {
+						return row.Execution.WorkflowID, nil
+					}
+				}
+			}
+			// Fallback: plain-text table parsing.
+			for _, line := range strings.Split(string(output), "\n") {
+				line = strings.TrimSpace(line)
+				if strings.HasPrefix(line, cronID+"-") {
+					fields := strings.Fields(line)
+					if len(fields) > 0 {
+						return fields[0], nil
+					}
+				}
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return "", fmt.Errorf("no Temporal schedule tick for %s within %s", cronID, timeout)
+}
+
+func waitCompleted(
+	ctx context.Context,
+	client *dex.Client,
+	flowID string,
+	timeout time.Duration,
+) (dex.WaitForFlowResult, error) {
+	wait, err := client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
+		NeedsResults: true,
+		Timeout:      timeout,
+	})
+	if err != nil {
+		return wait, err
+	}
+	if wait.Status != dex.FlowCompleted {
+		return wait, fmt.Errorf(
+			"expected FlowCompleted got %v msg=%s", wait.Status, wait.ErrorMessage,
+		)
+	}
+	return wait, nil
+}
+
+func decodeStringCompletion(wait dex.WaitForFlowResult) (string, error) {
+	if len(wait.Completions) == 0 {
+		return "", fmt.Errorf("no completions")
+	}
+	var output string
+	if err := wait.Completions[0].Output.Decode(&output); err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
+func hourStartOptions() dex.StartFlowOptions {
+	timeout := time.Hour
+	return dex.StartFlowOptions{Timeout: &timeout}
+}
+
+func idReuseHourOptions() dex.StartFlowOptions {
+	timeout := time.Hour
+	return dex.StartFlowOptions{
+		Timeout:       &timeout,
+		IDReusePolicy: dex.IDReuseAllowIfPreviousFailed,
+	}
+}
+
+func envOr(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func pass(name, details string) result {
+	return result{name: name, ok: true, details: details}
+}
+
+func fail(name, details string, err error) result {
+	return result{name: name, ok: false, details: details, err: err}
+}

--- a/examples/go/cmd/server/dex/design_pattern_controller.go
+++ b/examples/go/cmd/server/dex/design_pattern_controller.go
@@ -1,0 +1,617 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/superdurable/dex/examples/go/workflows"
+	drainsignal "github.com/superdurable/dex/examples/go/workflows/patterns/drainchannels/signal"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/parallel"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/recovery"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/reminders"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/storage"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/waitforstatecompletion"
+	sdk "github.com/superdurable/dex/sdk-go/dex"
+)
+
+type designPatternController struct {
+	client *sdk.Client
+}
+
+func newDesignPatternController(client *sdk.Client) *designPatternController {
+	return &designPatternController{client: client}
+}
+
+func (controller *designPatternController) registerRoutes(router *gin.Engine) {
+	router.GET("/design-pattern/polling/start/simple", controller.startSimplePolling)
+	router.GET("/design-pattern/polling/start/backoff", controller.startBackoffPolling)
+	router.GET("/design-pattern/interruptible/start", controller.startInterruptible)
+	router.GET("/design-pattern/interruptible/cancel", controller.cancelInterruptible)
+	router.GET("/design-pattern/workflow-with-reminder/start", controller.startReminder)
+	router.GET("/design-pattern/workflow-with-reminder/accept", controller.acceptReminder)
+	router.GET("/design-pattern/workflow-with-reminder/optout", controller.optOutReminder)
+	router.POST("/design-pattern/storage/add", controller.addStorageItem)
+	router.GET("/design-pattern/storage/get", controller.getStorageItem)
+	router.POST("/design-pattern/storage/remove", controller.removeStorageItem)
+	router.GET("/design-pattern/intervention/start", controller.startIntervention)
+	router.GET("/design-pattern/resettabletimer/start", controller.startResettableTimer)
+	router.GET("/design-pattern/resettabletimer/reset", controller.resetResettableTimer)
+	router.GET("/design-pattern/parallel/start/simple", controller.startParallelSimple)
+	router.GET("/design-pattern/parallel/start/withAwait", controller.startParallelWithAwait)
+	router.GET("/design-pattern/recovery/start", controller.startRecovery)
+	router.GET("/design-pattern/scalableparallel/start", controller.startScalableParallel)
+	router.GET("/design-pattern/parentchild/start", controller.startParentChild)
+	router.GET("/design-pattern/drainchannels/internal/start", controller.startDrainInternal)
+	router.GET("/design-pattern/drainchannels/signal/startorsignal", controller.startOrSignalDrain)
+	router.GET("/design-pattern/waitforstatecompletion/start", controller.startWaitForStateCompletion)
+	router.GET("/design-pattern/timeout/start", controller.startTimeout)
+}
+
+func patternStartOptions() sdk.StartFlowOptions {
+	timeout := time.Hour
+	return sdk.StartFlowOptions{Timeout: &timeout}
+}
+
+func idReuseStartOptions() sdk.StartFlowOptions {
+	timeout := time.Hour
+	return sdk.StartFlowOptions{
+		Timeout:       &timeout,
+		IDReusePolicy: sdk.IDReuseAllowIfPreviousFailed,
+	}
+}
+
+func (controller *designPatternController) startSimplePolling(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	runID, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.SimplePolling,
+		flowID,
+		nil,
+		patternStartOptions(),
+	)
+	respondString(request, runID, err)
+}
+
+func (controller *designPatternController) startBackoffPolling(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	runID, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.BackoffPolling,
+		flowID,
+		nil,
+		patternStartOptions(),
+	)
+	respondString(request, runID, err)
+}
+
+func (controller *designPatternController) startInterruptible(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	runID, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.InterruptibleExecution,
+		flowID,
+		nil,
+		patternStartOptions(),
+	)
+	respondString(request, runID, err)
+}
+
+func (controller *designPatternController) cancelInterruptible(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	var none sdk.None
+	err := controller.client.InvokeRPC(
+		request.Request.Context(),
+		flowID,
+		workflows.InterruptibleExecution.Interrupt,
+		nil,
+		&none,
+		sdk.InvokeOptions{},
+	)
+	respondString(request, "done", err)
+}
+
+func (controller *designPatternController) startReminder(request *gin.Context) {
+	flowID := fmt.Sprintf("reminder_test_id_%d", time.Now().UnixNano())
+	_, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.Reminder,
+		flowID,
+		nil,
+		patternStartOptions(),
+	)
+	respondString(request, fmt.Sprintf("started workflowId: %s", flowID), err)
+}
+
+func (controller *designPatternController) acceptReminder(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	var none sdk.None
+	err := controller.client.InvokeRPC(
+		request.Request.Context(),
+		flowID,
+		workflows.Reminder.Accept,
+		nil,
+		&none,
+		sdk.InvokeOptions{},
+	)
+	respondString(request, "accepted", err)
+}
+
+func (controller *designPatternController) optOutReminder(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	err := controller.client.PublishToChannel(
+		request.Request.Context(),
+		flowID,
+		reminders.OptOutReminder,
+		nil,
+	)
+	respondString(request, "done", err)
+}
+
+func (controller *designPatternController) addStorageItem(request *gin.Context) {
+	itemRequest, ok := bindStorageItemRequest(request)
+	if !ok {
+		return
+	}
+	err := controller.invokeStorageRPC(
+		request.Request.Context(),
+		func() error {
+			var none sdk.None
+			return controller.client.InvokeRPC(
+				request.Request.Context(),
+				storage.StorageFlowID,
+				workflows.Storage.AddItem,
+				itemRequest,
+				&none,
+				sdk.InvokeOptions{},
+			)
+		},
+		true,
+	)
+	respondString(request, "Added storage item", err)
+}
+
+func (controller *designPatternController) getStorageItem(request *gin.Context) {
+	itemKey, found := requiredQuery(request, "itemKey")
+	if !found {
+		return
+	}
+	var itemValue string
+	err := controller.invokeStorageRPCWithOutput(
+		request.Request.Context(),
+		func() error {
+			return controller.client.InvokeRPC(
+				request.Request.Context(),
+				storage.StorageFlowID,
+				workflows.Storage.GetItem,
+				itemKey,
+				&itemValue,
+				sdk.InvokeOptions{},
+			)
+		},
+		true,
+	)
+	if err != nil {
+		respondString(request, "", err)
+		return
+	}
+	respondString(request, "Item: "+itemValue, nil)
+}
+
+func (controller *designPatternController) removeStorageItem(request *gin.Context) {
+	itemKey, found := requiredQuery(request, "itemKey")
+	if !found {
+		return
+	}
+	err := controller.invokeStorageRPC(
+		request.Request.Context(),
+		func() error {
+			var none sdk.None
+			return controller.client.InvokeRPC(
+				request.Request.Context(),
+				storage.StorageFlowID,
+				workflows.Storage.RemoveItem,
+				itemKey,
+				&none,
+				sdk.InvokeOptions{},
+			)
+		},
+		true,
+	)
+	respondString(request, "Removed storage item", err)
+}
+
+func bindStorageItemRequest(request *gin.Context) (storage.AddStorageItemRequest, bool) {
+	var raw map[string]string
+	if err := request.ShouldBindJSON(&raw); err != nil {
+		request.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return storage.AddStorageItemRequest{}, false
+	}
+	key := raw["key"]
+	if key == "" {
+		key = raw["Key"]
+	}
+	value := raw["value"]
+	if value == "" {
+		value = raw["Value"]
+	}
+	if key == "" || value == "" {
+		request.JSON(http.StatusBadRequest, gin.H{"error": "key and value are required"})
+		return storage.AddStorageItemRequest{}, false
+	}
+	return storage.AddStorageItemRequest{Key: key, Value: value}, true
+}
+
+func (controller *designPatternController) invokeStorageRPC(
+	ctx context.Context,
+	invoke func() error,
+	attemptStart bool,
+) error {
+	if attemptStart {
+		if err := controller.ensureStorageFlow(ctx); err != nil {
+			return err
+		}
+	}
+	return invoke()
+}
+
+func (controller *designPatternController) invokeStorageRPCWithOutput(
+	ctx context.Context,
+	invoke func() error,
+	attemptStart bool,
+) error {
+	return controller.invokeStorageRPC(ctx, invoke, attemptStart)
+}
+
+func (controller *designPatternController) ensureStorageFlow(ctx context.Context) error {
+	_, err := controller.client.StartFlow(
+		ctx,
+		workflows.Storage,
+		storage.StorageFlowID,
+		nil,
+		patternStartOptions(),
+	)
+	if err == nil {
+		return nil
+	}
+	var dexErr *sdk.Error
+	if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowAlreadyStarted {
+		return nil
+	}
+	return err
+}
+
+func (controller *designPatternController) startIntervention(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	runID, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.ManualIntervention,
+		flowID,
+		nil,
+		patternStartOptions(),
+	)
+	respondString(request, runID, err)
+}
+
+func (controller *designPatternController) startResettableTimer(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	runID, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.ResettableTimer,
+		flowID,
+		nil,
+		patternStartOptions(),
+	)
+	respondString(request, runID, err)
+}
+
+func (controller *designPatternController) resetResettableTimer(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	var none sdk.None
+	err := controller.client.InvokeRPC(
+		request.Request.Context(),
+		flowID,
+		workflows.ResettableTimer.SendResetMessage,
+		nil,
+		&none,
+		sdk.InvokeOptions{},
+	)
+	respondString(request, "reset", err)
+}
+
+func (controller *designPatternController) startParallelSimple(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	jobSeeker := parallel.JobSeeker{
+		ID:          "123",
+		Email:       "jobseeker@indeed.com",
+		PhoneNumber: "0987654321",
+	}
+	runID, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.SimpleParallel,
+		flowID,
+		jobSeeker,
+		patternStartOptions(),
+	)
+	respondString(request, runID, err)
+}
+
+func (controller *designPatternController) startParallelWithAwait(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	runID, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.ParallelWithAwait,
+		flowID,
+		50,
+		patternStartOptions(),
+	)
+	respondString(request, runID, err)
+}
+
+func (controller *designPatternController) startRecovery(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	itemName, found := requiredQuery(request, "itemName")
+	if !found {
+		return
+	}
+	quantityText, found := requiredQuery(request, "quantity")
+	if !found {
+		return
+	}
+	quantity, err := strconv.Atoi(quantityText)
+	if err != nil {
+		request.JSON(http.StatusBadRequest, gin.H{"error": "quantity must be an integer"})
+		return
+	}
+	_, err = controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.FailureRecovery,
+		flowID,
+		recovery.FailureRecoveryWorkflowInput{
+			ItemName:          itemName,
+			RequestedQuantity: quantity,
+		},
+		patternStartOptions(),
+	)
+	respondString(request, "recovery workflow started", err)
+}
+
+func (controller *designPatternController) startScalableParallel(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	numOfChildWorkflows, found := requiredQuery(request, "numOfChildWfs")
+	if !found {
+		return
+	}
+	childCount, err := strconv.Atoi(numOfChildWorkflows)
+	if err != nil {
+		request.JSON(http.StatusBadRequest, gin.H{"error": "numOfChildWfs must be an integer"})
+		return
+	}
+	_, err = controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.RequestReceiver,
+		flowID,
+		childCount,
+		idReuseStartOptions(),
+	)
+	respondString(request, "success", err)
+}
+
+func (controller *designPatternController) startParentChild(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	numOfChildWorkflows, found := requiredQuery(request, "numOfChildWfs")
+	if !found {
+		return
+	}
+	childCount, err := strconv.Atoi(numOfChildWorkflows)
+	if err != nil {
+		request.JSON(http.StatusBadRequest, gin.H{"error": "numOfChildWfs must be an integer"})
+		return
+	}
+	_, err = controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.ParentChild,
+		flowID,
+		childCount,
+		idReuseStartOptions(),
+	)
+	respondString(request, "success", err)
+}
+
+func (controller *designPatternController) startDrainInternal(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	runID, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.DrainInternal,
+		flowID,
+		"",
+		patternStartOptions(),
+	)
+	respondString(request, runID, err)
+}
+
+func (controller *designPatternController) startOrSignalDrain(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	err := controller.client.PublishToChannel(
+		request.Request.Context(),
+		flowID,
+		drainsignal.QueueSignalChannel,
+		"signal from startorsignal endpoint",
+	)
+	if err == nil {
+		respondString(request, "Signaled the workflow", nil)
+		return
+	}
+	var dexErr *sdk.Error
+	if !errors.As(err, &dexErr) || dexErr.SubStatus != sdk.ErrorFlowNotFound {
+		respondString(request, "", err)
+		return
+	}
+	runID, startErr := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.DrainSignal,
+		flowID,
+		"first message from start",
+		patternStartOptions(),
+	)
+	respondString(
+		request,
+		fmt.Sprintf("Started the workflow with runId %s", runID),
+		startErr,
+	)
+}
+
+func (controller *designPatternController) startWaitForStateCompletion(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	input := waitforstatecompletion.JobSeekerData{ID: 1}
+	_, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.WaitForStateCompletion,
+		flowID,
+		input,
+		patternStartOptions(),
+	)
+	if err != nil {
+		respondString(request, "", err)
+		return
+	}
+	err = controller.client.WaitForStepCompletion(
+		request.Request.Context(),
+		flowID,
+		sdk.StepExecutionID{StepType: "PersistData"},
+		sdk.WaitOptions{Timeout: 5 * time.Minute},
+	)
+	if err != nil {
+		respondString(request, "", err)
+		return
+	}
+	var persistedData waitforstatecompletion.JobSeekerData
+	err = controller.client.InvokeRPC(
+		request.Request.Context(),
+		flowID,
+		workflows.WaitForStateCompletion.GetJobSeekerData,
+		nil,
+		&persistedData,
+		sdk.InvokeOptions{},
+	)
+	if err != nil {
+		respondString(request, "", err)
+		return
+	}
+	serialized, err := json.Marshal(persistedData)
+	if err != nil {
+		respondString(request, "", err)
+		return
+	}
+	respondString(
+		request,
+		fmt.Sprintf("success for workflow %s with data %s", flowID, serialized),
+		nil,
+	)
+}
+
+func (controller *designPatternController) startTimeout(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	successfulWorkflow, err := strconv.ParseBool(
+		request.DefaultQuery("successfulWorkflow", "true"),
+	)
+	if err != nil {
+		request.JSON(http.StatusBadRequest, gin.H{"error": "successfulWorkflow must be a boolean"})
+		return
+	}
+	_, err = controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.GracefulTimeout,
+		flowID,
+		successfulWorkflow,
+		patternStartOptions(),
+	)
+	respondString(request, fmt.Sprintf("success for workflow %s", flowID), err)
+}
+
+func respondString(request *gin.Context, value string, err error) {
+	if err != nil {
+		request.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	request.String(http.StatusOK, value)
+}

--- a/examples/go/cmd/server/dex/dex.go
+++ b/examples/go/cmd/server/dex/dex.go
@@ -28,10 +28,12 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/superdurable/dex/examples/go/workflows"
+	"github.com/superdurable/dex/examples/go/workflows/service"
 	sdk "github.com/superdurable/dex/sdk-go/dex"
 	"github.com/superdurable/dex/sdk-go/dex/blobcache"
 )
@@ -54,7 +56,9 @@ func Run(ctx context.Context) error {
 }
 
 func newSampleServer() (*sampleServer, error) {
-	registry, err := sdk.NewRegistry(workflows.Flows())
+	var client *sdk.Client
+	flows := workflows.New(service.NewMyService(), func() *sdk.Client { return client })
+	registry, err := sdk.NewRegistry(flows)
 	if err != nil {
 		return nil, fmt.Errorf("register example flows: %w", err)
 	}
@@ -76,7 +80,7 @@ func newSampleServer() (*sampleServer, error) {
 	if err != nil {
 		return nil, errors.Join(err, cache.Close())
 	}
-	client, err := sdk.NewClient(registry, cache, sdk.ClientOptions{
+	client, err = sdk.NewClient(registry, cache, sdk.ClientOptions{
 		FlowServiceAddress: os.Getenv("DEX_FLOW_SERVICE_ADDRESS"),
 		WorkerTarget:       worker.WorkerTarget(),
 	})
@@ -113,10 +117,15 @@ func (server *sampleServer) router() http.Handler {
 	newMicroserviceController(server.client).registerRoutes(router)
 	newMoneyTransferController(server.client).registerRoutes(router)
 	newPollingController(server.client).registerRoutes(router)
+	newSignupController(server.client).registerRoutes(router)
+	newJobPostController(server.client).registerRoutes(router)
+	newShortlistController(server.client).registerRoutes(router)
+	newDesignPatternController(server.client).registerRoutes(router)
 	return router
 }
 
 func (server *sampleServer) Run(ctx context.Context) error {
+	startCronSchedule(server.client)
 	go func() {
 		server.workerResult <- server.worker.Start()
 	}()
@@ -185,4 +194,29 @@ func respond(request *gin.Context, value any, err error) {
 
 func newFlowID(prefix string) string {
 	return prefix + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+}
+
+func startCronSchedule(client *sdk.Client) {
+	timeout := time.Hour
+	_, err := client.StartFlow(
+		context.Background(),
+		workflows.CronSchedule,
+		"cron-schedule-sample",
+		nil,
+		sdk.StartFlowOptions{
+			Timeout:      &timeout,
+			CronSchedule: "*/1 * * * *",
+		},
+	)
+	if err != nil {
+		var dexErr *sdk.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowAlreadyStarted {
+			return
+		}
+		// Temporal Schedule.Create returns no run ID; SDK surfaces that after register.
+		if strings.Contains(err.Error(), "no run ID") {
+			return
+		}
+		panic(fmt.Errorf("start cron schedule sample: %w", err))
+	}
 }

--- a/examples/go/cmd/server/dex/jobpost_controller.go
+++ b/examples/go/cmd/server/dex/jobpost_controller.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dex
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/superdurable/dex/examples/go/workflows"
+	"github.com/superdurable/dex/examples/go/workflows/jobpost"
+	sdk "github.com/superdurable/dex/sdk-go/dex"
+	"github.com/superdurable/dex/sdk-go/dex/ptr"
+)
+
+type jobPostController struct {
+	client *sdk.Client
+}
+
+func newJobPostController(client *sdk.Client) *jobPostController {
+	return &jobPostController{client: client}
+}
+
+func (controller *jobPostController) registerRoutes(router *gin.Engine) {
+	router.GET("/jobpost/create", controller.create)
+	router.GET("/jobpost/read", controller.read)
+	router.GET("/jobpost/update", controller.update)
+	router.GET("/jobpost/delete", controller.delete)
+	router.GET("/jobpost/search", controller.search)
+}
+
+func (controller *jobPostController) create(request *gin.Context) {
+	title, found := requiredQuery(request, "title")
+	if !found {
+		return
+	}
+	description, found := requiredQuery(request, "description")
+	if !found {
+		return
+	}
+	flowID := fmt.Sprintf("job_id_%d", time.Now().Unix())
+	timeout := 24 * time.Hour
+	titleAttr, err := sdk.InitialAttribute(jobpost.Title, title)
+	if err != nil {
+		respond(request, nil, err)
+		return
+	}
+	descriptionAttr, err := sdk.InitialAttribute(jobpost.JobDescription, description)
+	if err != nil {
+		respond(request, nil, err)
+		return
+	}
+	lastUpdateAttr, err := sdk.InitialAttribute(
+		jobpost.LastUpdateTimeMillis,
+		time.Now().UnixMilli(),
+	)
+	if err != nil {
+		respond(request, nil, err)
+		return
+	}
+	runID, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.JobPost,
+		flowID,
+		nil,
+		sdk.StartFlowOptions{
+			Timeout: &timeout,
+			Attributes: []sdk.InitialAttributeDef{
+				titleAttr,
+				descriptionAttr,
+				lastUpdateAttr,
+			},
+			ConfigOverride: &sdk.FlowConfig{
+				ContinueAsNewThreshold: ptr.Any(int32(10)),
+			},
+		},
+	)
+	respond(request, gin.H{"flowID": flowID, "runID": runID}, err)
+}
+
+func (controller *jobPostController) read(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	var output jobpost.JobInfo
+	err := controller.client.InvokeRPC(
+		request.Request.Context(),
+		flowID,
+		workflows.JobPost.Get,
+		nil,
+		&output,
+		sdk.InvokeOptions{},
+	)
+	respond(request, output, err)
+}
+
+func (controller *jobPostController) update(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	title, found := requiredQuery(request, "title")
+	if !found {
+		return
+	}
+	description, found := requiredQuery(request, "description")
+	if !found {
+		return
+	}
+	notes := request.Query("notes")
+	if notes == "" {
+		notes = "test-notes"
+	}
+	var none sdk.None
+	err := controller.client.InvokeRPC(
+		request.Request.Context(),
+		flowID,
+		workflows.JobPost.Update,
+		jobpost.JobInfo{Title: title, Description: description, Notes: notes},
+		&none,
+		sdk.InvokeOptions{},
+	)
+	respond(request, gin.H{"updated": true}, err)
+}
+
+func (controller *jobPostController) delete(request *gin.Context) {
+	flowID, found := requiredQuery(request, "workflowId")
+	if !found {
+		return
+	}
+	err := controller.client.StopFlow(request.Request.Context(), flowID, sdk.StopOptions{})
+	respond(request, gin.H{"stopped": flowID}, err)
+}
+
+func (controller *jobPostController) search(request *gin.Context) {
+	query := request.Query("query")
+	page, err := controller.client.SearchFlows(
+		request.Request.Context(),
+		query,
+		20,
+		"",
+	)
+	if err != nil {
+		respond(request, nil, err)
+		return
+	}
+	ids := make([]string, 0, len(page.Flows))
+	for _, flow := range page.Flows {
+		ids = append(ids, flow.FlowID)
+	}
+	respond(request, gin.H{"flowIDs": ids, "nextPageToken": page.NextPageToken}, nil)
+}

--- a/examples/go/cmd/server/dex/shortlist_controller.go
+++ b/examples/go/cmd/server/dex/shortlist_controller.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dex
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/superdurable/dex/examples/go/workflows"
+	"github.com/superdurable/dex/examples/go/workflows/shortlistcandidates"
+	sdk "github.com/superdurable/dex/sdk-go/dex"
+)
+
+type shortlistController struct {
+	client *sdk.Client
+}
+
+func newShortlistController(client *sdk.Client) *shortlistController {
+	return &shortlistController{client: client}
+}
+
+func (controller *shortlistController) registerRoutes(router *gin.Engine) {
+	router.POST("/shortlist_candidates/opt_in", controller.optIn)
+	router.POST("/shortlist_candidates/opt_out", controller.optOut)
+	router.GET("/shortlist_candidates/is_opted_in", controller.isOptedIn)
+	router.POST("/shortlist_candidates/shortlist", controller.shortlist)
+	router.POST("/shortlist_candidates/revoke_shortlist", controller.revokeShortlist)
+	router.GET("/shortlist_candidates/email_sent_timestamp", controller.emailSentTimestamp)
+}
+
+func (controller *shortlistController) optIn(request *gin.Context) {
+	var body map[string]string
+	if err := request.ShouldBindJSON(&body); err != nil {
+		request.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	employerID := body["employerId"]
+	flowID := shortlistcandidates.EmployerOptInFlowID(employerID)
+	timeout := time.Hour
+	_, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.EmployerOptIn,
+		flowID,
+		shortlistcandidates.EmployerOptInInput{EmployerID: employerID},
+		sdk.StartFlowOptions{Timeout: &timeout},
+	)
+	if err != nil {
+		var dexErr *sdk.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowAlreadyStarted {
+			request.String(
+				http.StatusOK,
+				fmt.Sprintf("Employer %s has already opted in", employerID),
+			)
+			return
+		}
+		respond(request, nil, err)
+		return
+	}
+	request.String(http.StatusOK, fmt.Sprintf("Started workflowId: %s", flowID))
+}
+
+func (controller *shortlistController) optOut(request *gin.Context) {
+	var body map[string]string
+	if err := request.ShouldBindJSON(&body); err != nil {
+		request.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	employerID := body["employerId"]
+	flowID := shortlistcandidates.EmployerOptInFlowID(employerID)
+	var none sdk.None
+	err := controller.client.InvokeRPC(
+		request.Request.Context(),
+		flowID,
+		workflows.EmployerOptIn.OptOut,
+		nil,
+		&none,
+		sdk.InvokeOptions{},
+	)
+	if err != nil {
+		var dexErr *sdk.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowNotFound {
+			request.String(
+				http.StatusOK,
+				fmt.Sprintf("Employer %s is not in the opt-in status", employerID),
+			)
+			return
+		}
+		respond(request, nil, err)
+		return
+	}
+	request.String(http.StatusOK, fmt.Sprintf("Employer %s has opted out", employerID))
+}
+
+func (controller *shortlistController) isOptedIn(request *gin.Context) {
+	employerID := request.DefaultQuery("employerId", "test-employer")
+	optedIn, err := shortlistcandidates.IsOptedIn(
+		request.Request.Context(),
+		controller.client,
+		workflows.EmployerOptIn,
+		employerID,
+	)
+	respond(request, optedIn, err)
+}
+
+func (controller *shortlistController) shortlist(request *gin.Context) {
+	var body map[string]string
+	if err := request.ShouldBindJSON(&body); err != nil {
+		request.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	employerID := body["employerId"]
+	candidateID := body["candidateId"]
+	optedIn, err := shortlistcandidates.IsOptedIn(
+		request.Request.Context(),
+		controller.client,
+		workflows.EmployerOptIn,
+		employerID,
+	)
+	if err != nil {
+		respond(request, nil, err)
+		return
+	}
+	if !optedIn {
+		request.String(
+			http.StatusOK,
+			fmt.Sprintf("Do nothing for %s because of no opt-in", employerID+"-"+candidateID),
+		)
+		return
+	}
+	flowID := shortlistcandidates.ShortlistFlowID(employerID, candidateID)
+	timeout := time.Hour
+	_, err = controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.Shortlist,
+		flowID,
+		shortlistcandidates.ShortlistInput{
+			EmployerID:  employerID,
+			CandidateID: candidateID,
+		},
+		sdk.StartFlowOptions{Timeout: &timeout},
+	)
+	if err != nil {
+		var dexErr *sdk.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowAlreadyStarted {
+			request.String(
+				http.StatusOK,
+				fmt.Sprintf("Already running workflowId: %s", flowID),
+			)
+			return
+		}
+		respond(request, nil, err)
+		return
+	}
+	request.String(http.StatusOK, fmt.Sprintf("Started workflowId: %s", flowID))
+}
+
+func (controller *shortlistController) revokeShortlist(request *gin.Context) {
+	var body map[string]string
+	if err := request.ShouldBindJSON(&body); err != nil {
+		request.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	employerID := body["employerId"]
+	candidateID := body["candidateId"]
+	flowID := shortlistcandidates.ShortlistFlowID(employerID, candidateID)
+	err := controller.client.PublishToChannel(
+		request.Request.Context(),
+		flowID,
+		shortlistcandidates.RevokeShortlist,
+		nil,
+	)
+	if err != nil {
+		var dexErr *sdk.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowNotFound {
+			request.String(
+				http.StatusOK,
+				fmt.Sprintf("No running workflow to revoke for %s", employerID+"-"+candidateID),
+			)
+			return
+		}
+		respond(request, nil, err)
+		return
+	}
+	request.String(
+		http.StatusOK,
+		fmt.Sprintf("Revoked shortlist for %s", employerID+"-"+candidateID),
+	)
+}
+
+func (controller *shortlistController) emailSentTimestamp(request *gin.Context) {
+	employerID := request.DefaultQuery("employerId", "test-employer")
+	candidateID := request.DefaultQuery("candidateId", "test-candidate")
+	flowID := shortlistcandidates.ShortlistFlowID(employerID, candidateID)
+	var timestamp int64
+	err := controller.client.InvokeRPC(
+		request.Request.Context(),
+		flowID,
+		workflows.Shortlist.GetEmailSentTimestamp,
+		nil,
+		&timestamp,
+		sdk.InvokeOptions{},
+	)
+	if err != nil {
+		var dexErr *sdk.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowNotFound {
+			request.Status(http.StatusNotFound)
+			return
+		}
+		respond(request, nil, err)
+		return
+	}
+	respond(request, timestamp, nil)
+}

--- a/examples/go/cmd/server/dex/signup_controller.go
+++ b/examples/go/cmd/server/dex/signup_controller.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dex
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/superdurable/dex/examples/go/workflows"
+	"github.com/superdurable/dex/examples/go/workflows/signup"
+	sdk "github.com/superdurable/dex/sdk-go/dex"
+)
+
+type signupController struct {
+	client *sdk.Client
+}
+
+func newSignupController(client *sdk.Client) *signupController {
+	return &signupController{client: client}
+}
+
+func (controller *signupController) registerRoutes(router *gin.Engine) {
+	router.GET("/signup/submit", controller.submit)
+	router.GET("/signup/verify", controller.verify)
+}
+
+func (controller *signupController) submit(request *gin.Context) {
+	username, found := requiredQuery(request, "username")
+	if !found {
+		return
+	}
+	email, found := requiredQuery(request, "email")
+	if !found {
+		return
+	}
+	form := signup.SignupForm{
+		Username:  username,
+		Email:     email,
+		FirstName: "Test",
+		LastName:  "Test",
+	}
+	timeout := time.Hour
+	_, err := controller.client.StartFlow(
+		request.Request.Context(),
+		workflows.Signup,
+		username,
+		form,
+		sdk.StartFlowOptions{Timeout: &timeout},
+	)
+	if err != nil {
+		var dexErr *sdk.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowAlreadyStarted {
+			request.JSON(http.StatusOK, "username already started registry")
+			return
+		}
+		respond(request, nil, err)
+		return
+	}
+	respond(request, gin.H{"flowID": username}, nil)
+}
+
+func (controller *signupController) verify(request *gin.Context) {
+	username, found := requiredQuery(request, "username")
+	if !found {
+		return
+	}
+	var output string
+	err := controller.client.InvokeRPC(
+		request.Request.Context(),
+		username,
+		workflows.Signup.Verify,
+		nil,
+		&output,
+		sdk.InvokeOptions{},
+	)
+	respond(request, output, err)
+}

--- a/examples/go/integ/main_test.go
+++ b/examples/go/integ/main_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/superdurable/dex/examples/go/workflows"
+	"github.com/superdurable/dex/examples/go/workflows/service"
 	"github.com/superdurable/dex/sdk-go/dex"
 	"github.com/superdurable/dex/sdk-go/dex/blobcache"
 )
@@ -51,7 +52,9 @@ type integrationEnvironment struct {
 }
 
 func newIntegrationEnvironment() (*integrationEnvironment, error) {
-	registry, err := dex.NewRegistry(workflows.Flows())
+	var client *dex.Client
+	flows := workflows.New(service.NewMyService(), func() *dex.Client { return client })
+	registry, err := dex.NewRegistry(flows)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +84,7 @@ func newIntegrationEnvironment() (*integrationEnvironment, error) {
 	go func() {
 		workerResult <- worker.Start()
 	}()
-	client, err := dex.NewClient(registry, cache, dex.ClientOptions{
+	client, err = dex.NewClient(registry, cache, dex.ClientOptions{
 		FlowServiceAddress: flowServiceAddress(),
 		WorkerTarget:       worker.WorkerTarget(),
 	})
@@ -97,6 +100,7 @@ func newIntegrationEnvironment() (*integrationEnvironment, error) {
 		worker:       worker,
 		workerResult: workerResult,
 	}
+	integClient = client
 	if err := environment.waitUntilReady(); err != nil {
 		return nil, errors.Join(err, environment.Close())
 	}

--- a/examples/go/workflows/jobpost/README.md
+++ b/examples/go/workflows/jobpost/README.md
@@ -1,0 +1,13 @@
+# Job post
+
+CRUD job post with indexed attributes and external-system updates. Create seeds initial attributes; update starts the ExternalUpdate step; search uses Dex SearchFlows.
+
+With the sample server running:
+
+```text
+http://localhost:8080/jobpost/create?title=<title>&description=<description>
+http://localhost:8080/jobpost/read?workflowId=<flow-id>
+http://localhost:8080/jobpost/update?workflowId=<flow-id>&title=<title>&description=<description>&notes=<notes>
+http://localhost:8080/jobpost/delete?workflowId=<flow-id>
+http://localhost:8080/jobpost/search?query=<query>
+```

--- a/examples/go/workflows/jobpost/workflow.go
+++ b/examples/go/workflows/jobpost/workflow.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package jobpost
+
+import (
+	"errors"
+	"time"
+
+	"github.com/superdurable/dex/examples/go/workflows/service"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+var (
+	Title = dex.DefineAttribute[string](
+		"Title",
+		dex.Indexed(dex.AttributeIndex{Type: dex.IndexText}),
+	)
+	JobDescription = dex.DefineAttribute[string](
+		"JobDescription",
+		dex.Indexed(dex.AttributeIndex{Type: dex.IndexText}),
+	)
+	LastUpdateTimeMillis = dex.DefineAttribute[int64](
+		"LastUpdateTimeMillis",
+		dex.Indexed(dex.AttributeIndex{Type: dex.IndexInt}),
+	)
+	Notes = dex.DefineAttribute[string]("Notes")
+)
+
+type JobInfo struct {
+	Title       string
+	Description string
+	Notes       string
+}
+
+type JobPostFlow struct {
+	dex.FlowDefaults
+	service service.MyService
+}
+
+func NewJobPostFlow(applicationService service.MyService) *JobPostFlow {
+	return &JobPostFlow{service: applicationService}
+}
+
+func (flow *JobPostFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStep(externalUpdateStep{service: flow.service}),
+	}
+}
+
+func (*JobPostFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{Title, JobDescription, LastUpdateTimeMillis, Notes},
+	}
+}
+
+func (*JobPostFlow) Get(
+	ctx dex.Context,
+	_ dex.None,
+) (dex.RPCResult[JobInfo], error) {
+	info, err := readJobInfo(ctx)
+	return dex.RPCResult[JobInfo]{Output: info}, err
+}
+
+func (*JobPostFlow) GetWithStrongConsistency(
+	ctx dex.Context,
+	_ dex.None,
+) (dex.RPCResult[JobInfo], error) {
+	info, err := readJobInfo(ctx)
+	return dex.RPCResult[JobInfo]{Output: info}, err
+}
+
+func (*JobPostFlow) Update(
+	ctx dex.Context,
+	input JobInfo,
+) (dex.RPCResult[dex.None], error) {
+	if err := Title.Set(ctx, input.Title); err != nil {
+		return dex.RPCResult[dex.None]{}, err
+	}
+	if err := JobDescription.Set(ctx, input.Description); err != nil {
+		return dex.RPCResult[dex.None]{}, err
+	}
+	if err := LastUpdateTimeMillis.Set(ctx, time.Now().UnixMilli()); err != nil {
+		return dex.RPCResult[dex.None]{}, err
+	}
+	if input.Notes != "" {
+		if err := Notes.Set(ctx, input.Notes); err != nil {
+			return dex.RPCResult[dex.None]{}, err
+		}
+	}
+	return dex.RPCResult[dex.None]{
+		NextSteps: []dex.StepMovement{dex.MovementOf(externalUpdateStep{}, nil)},
+	}, nil
+}
+
+func readJobInfo(ctx dex.Context) (JobInfo, error) {
+	title, err := Title.Get(ctx)
+	if err != nil {
+		return JobInfo{}, err
+	}
+	description, err := JobDescription.Get(ctx)
+	if err != nil {
+		return JobInfo{}, err
+	}
+	notes, err := Notes.Get(ctx)
+	if err != nil {
+		var notFound *dex.AttributeNotFoundError
+		if !errors.As(err, &notFound) {
+			return JobInfo{}, err
+		}
+		notes = ""
+	}
+	return JobInfo{Title: title, Description: description, Notes: notes}, nil
+}
+
+type externalUpdateStep struct {
+	dex.StepDefaultsNoWaitFor[dex.None]
+	service service.MyService
+}
+
+func (externalUpdateStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		ExecuteRetry: &dex.RetryPolicy{
+			InitialInterval:    3 * time.Second,
+			BackoffCoefficient: 2,
+			MaximumInterval:    60 * time.Second,
+			MaximumAttempts:    100,
+			TotalDuration:      time.Hour,
+		},
+	}
+}
+
+func (step externalUpdateStep) Execute(
+	_ dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	step.service.UpdateExternalSystem("this is an update to external service")
+	return dex.DeadEnd(), nil
+}
+
+var _ dex.Flow = (*JobPostFlow)(nil)

--- a/examples/go/workflows/patterns/cron/README.md
+++ b/examples/go/workflows/patterns/cron/README.md
@@ -1,0 +1,9 @@
+# Cron Schedule Workflow
+
+Demonstrates starting a Dex flow with a cron schedule so each tick runs the flow
+like a recurring job.
+
+## Endpoints
+
+- `GET /design-pattern/cron/start` — start flow ID `cron-schedule-sample` with
+  cron `*/1 * * * *`

--- a/examples/go/workflows/patterns/cron/workflow.go
+++ b/examples/go/workflows/patterns/cron/workflow.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cron
+
+import (
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+type CronScheduleFlow struct {
+	dex.FlowDefaults
+}
+
+func NewCronScheduleFlow() *CronScheduleFlow {
+	return &CronScheduleFlow{}
+}
+
+func (*CronScheduleFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(cronScheduleStep{}),
+	}
+}
+
+func (*CronScheduleFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{}
+}
+
+type cronScheduleStep struct {
+	dex.StepDefaultsNoWaitFor[dex.None]
+}
+
+func (cronScheduleStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	return dex.GracefulComplete(nil), nil
+}
+
+var _ dex.Flow = (*CronScheduleFlow)(nil)

--- a/examples/go/workflows/patterns/drainchannels/README.md
+++ b/examples/go/workflows/patterns/drainchannels/README.md
@@ -1,0 +1,4 @@
+# Drain channels
+
+- [Internal channel drain](./draininternal)
+- [Signal channel drain](./signal)

--- a/examples/go/workflows/patterns/drainchannels/draininternal/README.md
+++ b/examples/go/workflows/patterns/drainchannels/draininternal/README.md
@@ -1,0 +1,5 @@
+# DrainInternalChannelsFlow
+
+## Endpoints
+
+- `GET /design-pattern/drainchannels/internal/start?workflowId={workflowId}`

--- a/examples/go/workflows/patterns/drainchannels/draininternal/mongo_document.go
+++ b/examples/go/workflows/patterns/drainchannels/draininternal/mongo_document.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package draininternal
+
+type MongoDocument struct {
+	ID           string
+	Status       string
+	FinalCommand bool
+}

--- a/examples/go/workflows/patterns/drainchannels/draininternal/workflow.go
+++ b/examples/go/workflows/patterns/drainchannels/draininternal/workflow.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package draininternal
+
+import (
+	"fmt"
+
+	patternsservice "github.com/superdurable/dex/examples/go/workflows/patterns/service"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const (
+	UpsertMongoDataInternalChannel   = "upsert_mongo_data_internal_channel"
+	ProcessDataStateExecutionCounter = "process_data_state_execution_counter"
+)
+
+var (
+	ProcessDataStateExecutionCounterAttribute = dex.DefineAttribute[int](
+		ProcessDataStateExecutionCounter,
+	)
+	UpsertMongoData = dex.DefineChannel[MongoDocument](UpsertMongoDataInternalChannel)
+)
+
+type DrainInternalChannelsFlow struct {
+	dex.FlowDefaults
+	service patternsservice.ServiceDependency
+}
+
+func NewDrainInternalChannelsFlow(
+	service patternsservice.ServiceDependency,
+) *DrainInternalChannelsFlow {
+	return &DrainInternalChannelsFlow{service: service}
+}
+
+func (flow *DrainInternalChannelsFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(initStep{}),
+		dex.DefineStep(upsertMongoRecordStep{service: flow.service}),
+		dex.DefineStep(processDataStep{service: flow.service}),
+		dex.DefineStep(finalizeStep{}),
+	}
+}
+
+func (*DrainInternalChannelsFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{ProcessDataStateExecutionCounterAttribute},
+		Channels:   []dex.ChannelDef{UpsertMongoData},
+	}
+}
+
+type initStep struct {
+	dex.StepDefaultsNoWaitFor[string]
+}
+
+func (initStep) Execute(
+	ctx dex.Context,
+	input string,
+) (*dex.StepDecision, error) {
+	if err := ProcessDataStateExecutionCounterAttribute.Set(ctx, 0); err != nil {
+		return nil, err
+	}
+	return dex.GoToMulti(
+		dex.MovementOf(upsertMongoRecordStep{}, nil),
+		dex.MovementOf(processDataStep{}, input),
+	), nil
+}
+
+type upsertMongoRecordStep struct {
+	dex.StepDefaults
+	service patternsservice.ServiceDependency
+}
+
+func (upsertMongoRecordStep) WaitFor(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.Wait, error) {
+	return dex.AnyOf(UpsertMongoData.ForOne()), nil
+}
+
+func (step upsertMongoRecordStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	documents, err := UpsertMongoData.GetConditionResults(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(documents) == 0 {
+		return nil, fmt.Errorf("no document was sent")
+	}
+	document := documents[0]
+	if err := step.service.Upsert(document); err != nil {
+		return nil, err
+	}
+	if document.FinalCommand {
+		return dex.GracefulComplete(nil), nil
+	}
+	return dex.GoTo(upsertMongoRecordStep{}, nil), nil
+}
+
+type processDataStep struct {
+	dex.StepDefaultsNoWaitFor[string]
+	service patternsservice.ServiceDependency
+}
+
+func (step processDataStep) Execute(
+	ctx dex.Context,
+	input string,
+) (*dex.StepDecision, error) {
+	executionCount, err := ProcessDataStateExecutionCounterAttribute.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	executionCount++
+	if err := ProcessDataStateExecutionCounterAttribute.Set(ctx, executionCount); err != nil {
+		return nil, err
+	}
+	status := "ERROR"
+	switch executionCount {
+	case 1:
+		status = "RECEIVED"
+	case 2:
+		status = "ACCEPTED"
+	case 3:
+		status = "PASSED"
+	}
+	if err := UpsertMongoData.Publish(ctx, MongoDocument{
+		ID:           input,
+		Status:       status,
+		FinalCommand: false,
+	}); err != nil {
+		return nil, err
+	}
+	step.service.ExternalAPICall(
+		"external service call to process data (e.g. notify the job seeker)",
+	)
+	step.service.ExternalAPICall("a call to send metrics or add a log to logrepo")
+	if executionCount <= 3 {
+		return dex.GoTo(processDataStep{}, input), nil
+	}
+	return dex.GoTo(finalizeStep{}, nil), nil
+}
+
+type finalizeStep struct {
+	dex.StepDefaultsNoWaitFor[dex.None]
+}
+
+func (finalizeStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	if err := UpsertMongoData.Publish(ctx, MongoDocument{
+		ID:           "documentId-1",
+		Status:       "FINALIZED",
+		FinalCommand: true,
+	}); err != nil {
+		return nil, err
+	}
+	return dex.GracefulComplete(nil), nil
+}
+
+var _ dex.Flow = (*DrainInternalChannelsFlow)(nil)

--- a/examples/go/workflows/patterns/drainchannels/signal/README.md
+++ b/examples/go/workflows/patterns/drainchannels/signal/README.md
@@ -1,0 +1,7 @@
+# DrainSignalChannelsFlow
+
+## Endpoints
+
+- `GET /drainchannels/signal/startorsignal?workflowId={workflowId}`
+
+Call twice in a row to start then signal.

--- a/examples/go/workflows/patterns/drainchannels/signal/workflow.go
+++ b/examples/go/workflows/patterns/drainchannels/signal/workflow.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package signal
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const QueueSignalChannelName = "queueSignalChannel"
+
+var QueueSignalChannel = dex.DefineChannel[string](QueueSignalChannelName)
+
+type DrainSignalChannelsFlow struct {
+	dex.FlowDefaults
+}
+
+func NewDrainSignalChannelsFlow() *DrainSignalChannelsFlow {
+	return &DrainSignalChannelsFlow{}
+}
+
+func (*DrainSignalChannelsFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(processSignalStep{}),
+	}
+}
+
+func (*DrainSignalChannelsFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Channels: []dex.ChannelDef{QueueSignalChannel},
+	}
+}
+
+type processSignalStep struct {
+	dex.StepDefaults
+}
+
+func (processSignalStep) WaitFor(
+	_ dex.Context,
+	input string,
+) (*dex.Wait, error) {
+	if input == "" {
+		return dex.AnyOf(QueueSignalChannel.ForOne()), nil
+	}
+	return dex.SkipWaitImmediately(), nil
+}
+
+func (processSignalStep) Execute(
+	ctx dex.Context,
+	input string,
+) (*dex.StepDecision, error) {
+	if input != "" {
+		fmt.Printf("DrainSignalChannelsFlow process signal value: %s\n", input)
+	} else {
+		values, err := QueueSignalChannel.GetConditionResults(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if len(values) == 0 {
+			return nil, fmt.Errorf("no signal request found")
+		}
+		fmt.Printf("DrainSignalChannelsFlow process signal value: %s\n", values[0])
+	}
+	time.Sleep(20 * time.Second)
+	return dex.ForceCompleteOnChannelsEmpty(
+		nil,
+		[]dex.ChannelDef{QueueSignalChannel},
+		dex.MovementOf(processSignalStep{}, ""),
+	), nil
+}
+
+var _ dex.Flow = (*DrainSignalChannelsFlow)(nil)

--- a/examples/go/workflows/patterns/interruptible/README.md
+++ b/examples/go/workflows/patterns/interruptible/README.md
@@ -1,0 +1,6 @@
+# Interruptible Workflow Pattern
+
+## Endpoints
+
+- `GET /design-pattern/interruptible/start?workflowId={workflowId}`
+- `GET /design-pattern/interruptible/cancel?workflowId={workflowId}`

--- a/examples/go/workflows/patterns/interruptible/workflow.go
+++ b/examples/go/workflows/patterns/interruptible/workflow.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package interruptible
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const DAInterruptSignal = "interruptSignal"
+
+var InterruptSignal = dex.DefineAttribute[string](DAInterruptSignal)
+
+type WorkJobParametersInput struct {
+	JobUpperBound int
+	Progress      int
+}
+
+type InterruptibleExecutionFlow struct {
+	dex.FlowDefaults
+}
+
+func NewInterruptibleExecutionFlow() *InterruptibleExecutionFlow {
+	return &InterruptibleExecutionFlow{}
+}
+
+func (*InterruptibleExecutionFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(initStep{}),
+		dex.DefineStep(workAExecutionStep{}),
+		dex.DefineStep(workNExecutionStep{}),
+	}
+}
+
+func (*InterruptibleExecutionFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{InterruptSignal},
+	}
+}
+
+func (*InterruptibleExecutionFlow) Interrupt(
+	ctx dex.Context,
+	_ dex.None,
+) (dex.RPCResult[dex.None], error) {
+	if err := InterruptSignal.Set(ctx, "cancel"); err != nil {
+		return dex.RPCResult[dex.None]{}, err
+	}
+	return dex.RPCResult[dex.None]{}, nil
+}
+
+type initStep struct {
+	dex.StepDefaultsNoWaitFor[dex.None]
+}
+
+func (initStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	input := WorkJobParametersInput{JobUpperBound: 15, Progress: 1}
+	return dex.GoToMulti(
+		dex.MovementOf(workAExecutionStep{}, input),
+		dex.MovementOf(workNExecutionStep{}, input),
+	), nil
+}
+
+type workAExecutionStep struct {
+	dex.StepDefaults
+}
+
+func (workAExecutionStep) WaitFor(
+	ctx dex.Context,
+	input WorkJobParametersInput,
+) (*dex.Wait, error) {
+	return dex.AnyOf(dex.Timer(1500 * time.Millisecond)), nil
+}
+
+func (workAExecutionStep) Execute(
+	ctx dex.Context,
+	input WorkJobParametersInput,
+) (*dex.StepDecision, error) {
+	signal, err := InterruptSignal.Get(ctx)
+	if err == nil && signal == "cancel" {
+		fmt.Println("A: Interrupted!")
+		return dex.GracefulComplete(nil), nil
+	}
+	if input.Progress > input.JobUpperBound {
+		fmt.Println("Executing WorkAExecution completed")
+		return dex.GracefulComplete(nil), nil
+	}
+	fmt.Printf(
+		"[%s][%s]: Doing job %d\n",
+		ctx.FlowID(),
+		ctx.StepExecutionID(),
+		input.Progress,
+	)
+	next := WorkJobParametersInput{
+		JobUpperBound: input.JobUpperBound,
+		Progress:      input.Progress + 1,
+	}
+	return dex.GoTo(workAExecutionStep{}, next), nil
+}
+
+type workNExecutionStep struct {
+	dex.StepDefaults
+}
+
+func (workNExecutionStep) WaitFor(
+	ctx dex.Context,
+	input WorkJobParametersInput,
+) (*dex.Wait, error) {
+	return dex.AnyOf(dex.Timer(3 * time.Second)), nil
+}
+
+func (workNExecutionStep) Execute(
+	ctx dex.Context,
+	input WorkJobParametersInput,
+) (*dex.StepDecision, error) {
+	signal, err := InterruptSignal.Get(ctx)
+	if err == nil && signal == "cancel" {
+		fmt.Println("N: Interrupted!")
+		return dex.GracefulComplete(nil), nil
+	}
+	if input.Progress > input.JobUpperBound {
+		fmt.Println("Executing WorkNExecution completed")
+		return dex.GracefulComplete(nil), nil
+	}
+	fmt.Printf(
+		"[%s][%s]: Processing job %d\n",
+		ctx.FlowID(),
+		ctx.StepExecutionID(),
+		input.Progress,
+	)
+	next := WorkJobParametersInput{
+		JobUpperBound: input.JobUpperBound,
+		Progress:      input.Progress + 1,
+	}
+	return dex.GoTo(workNExecutionStep{}, next), nil
+}
+
+var (
+	_ dex.Flow                    = (*InterruptibleExecutionFlow)(nil)
+	_ dex.RPC[dex.None, dex.None] = (*InterruptibleExecutionFlow)(nil).Interrupt
+)

--- a/examples/go/workflows/patterns/intervention/README.md
+++ b/examples/go/workflows/patterns/intervention/README.md
@@ -1,0 +1,5 @@
+# Manual Intervention Workflow Pattern
+
+## Endpoints
+
+- `GET /design-pattern/intervention/start?workflowId={workflowId}`

--- a/examples/go/workflows/patterns/intervention/workflow.go
+++ b/examples/go/workflows/patterns/intervention/workflow.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package intervention
+
+import (
+	"fmt"
+
+	patternsservice "github.com/superdurable/dex/examples/go/workflows/patterns/service"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const (
+	InternalChannelCommand       = "internal_channel_command"
+	SignalChannelCommandRetry    = "signal_channel_command_retry"
+	SignalChannelCommandSkip     = "signal_channel_command_skip"
+	NumberOfRetriesAttributeName = "number_of_retries"
+)
+
+var (
+	DataChannel     = dex.DefineChannel[string](InternalChannelCommand)
+	RetrySignal     = dex.DefineChannel[dex.None](SignalChannelCommandRetry)
+	SkipSignal      = dex.DefineChannel[dex.None](SignalChannelCommandSkip)
+	NumberOfRetries = dex.DefineAttribute[int](NumberOfRetriesAttributeName)
+)
+
+type ManualInterventionFlow struct {
+	dex.FlowDefaults
+	service patternsservice.ServiceDependency
+}
+
+func NewManualInterventionFlow(service patternsservice.ServiceDependency) *ManualInterventionFlow {
+	return &ManualInterventionFlow{service: service}
+}
+
+func (*ManualInterventionFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(initStep{}),
+		dex.DefineStep(getDataStep{}),
+		dex.DefineStep(errorStep{}),
+		dex.DefineStep(finalStep{}),
+	}
+}
+
+func (*ManualInterventionFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{NumberOfRetries},
+		Channels:   []dex.ChannelDef{DataChannel, RetrySignal, SkipSignal},
+	}
+}
+
+type initStep struct {
+	dex.StepDefaultsNoWaitFor[dex.None]
+}
+
+func (initStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	if err := NumberOfRetries.Set(ctx, 0); err != nil {
+		return nil, err
+	}
+	return dex.GoTo(getDataStep{}, false), nil
+}
+
+type getDataStep struct {
+	dex.StepDefaults
+}
+
+func (getDataStep) WaitFor(
+	ctx dex.Context,
+	isRetry bool,
+) (*dex.Wait, error) {
+	fmt.Println("Waiting for incoming data")
+	return dex.AllOf(DataChannel.ForOne()), nil
+}
+
+func (getDataStep) Execute(
+	ctx dex.Context,
+	isRetry bool,
+) (*dex.StepDecision, error) {
+	if isRetry {
+		retries, err := NumberOfRetries.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if err := NumberOfRetries.Set(ctx, retries+1); err != nil {
+			return nil, err
+		}
+	}
+	if err := pretendAPICall(ctx); err != nil {
+		return dex.GoTo(errorStep{}, nil), nil
+	}
+	return dex.GoTo(finalStep{}, nil), nil
+}
+
+func pretendAPICall(ctx dex.Context) error {
+	results, err := DataChannel.GetConditionResults(ctx)
+	if err != nil {
+		return err
+	}
+	if len(results) > 0 {
+		data := results[0]
+		fmt.Println("Received data result: " + data)
+		if data == "failed" {
+			return fmt.Errorf("non-retryable exception")
+		}
+	}
+	return nil
+}
+
+type errorStep struct {
+	dex.StepDefaults
+}
+
+func (errorStep) WaitFor(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.Wait, error) {
+	return dex.AnyOf(RetrySignal.ForOne(), SkipSignal.ForOne()), nil
+}
+
+func (errorStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	retryResults, err := RetrySignal.GetConditionResults(ctx)
+	if err != nil {
+		return nil, err
+	}
+	retry := len(retryResults) > 0
+	signalName := SignalChannelCommandSkip
+	if retry {
+		signalName = SignalChannelCommandRetry
+	}
+	fmt.Println("signal received: " + signalName)
+	if retry {
+		return dex.GoTo(getDataStep{}, true), nil
+	}
+	return dex.GoTo(finalStep{}, nil), nil
+}
+
+type finalStep struct {
+	dex.StepDefaultsNoWaitFor[dex.None]
+}
+
+func (finalStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	retries, err := NumberOfRetries.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return dex.GracefulComplete(
+		fmt.Sprintf("Workflow Completed. Number of retries: %d", retries),
+	), nil
+}
+
+var _ dex.Flow = (*ManualInterventionFlow)(nil)

--- a/examples/go/workflows/patterns/parallel/README.md
+++ b/examples/go/workflows/patterns/parallel/README.md
@@ -1,0 +1,6 @@
+# Parallel Running States Pattern
+
+## Endpoints
+
+- `GET /parallel/start/simple?workflowId={workflowId}`
+- `GET /parallel/start/withAwait?workflowId={workflowId}`

--- a/examples/go/workflows/patterns/parallel/await.go
+++ b/examples/go/workflows/patterns/parallel/await.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package parallel
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	patternsservice "github.com/superdurable/dex/examples/go/workflows/patterns/service"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const NotifyChannelName = "test_notify_channel"
+
+var NotifyChannel = dex.DefineChannel[string](NotifyChannelName)
+
+type ParallelStatesWithAwaitFlow struct {
+	dex.FlowDefaults
+	service patternsservice.ServiceDependency
+}
+
+func NewParallelStatesWithAwaitFlow(
+	service patternsservice.ServiceDependency,
+) *ParallelStatesWithAwaitFlow {
+	return &ParallelStatesWithAwaitFlow{service: service}
+}
+
+func (*ParallelStatesWithAwaitFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(startingStep{}),
+		dex.DefineStep(notifyUserStep{}),
+		dex.DefineStep(awaitAllUsersNotifiedStep{}),
+	}
+}
+
+func (*ParallelStatesWithAwaitFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Channels: []dex.ChannelDef{NotifyChannel},
+	}
+}
+
+type startingStep struct {
+	dex.StepDefaultsNoWaitFor[int]
+}
+
+func (startingStep) Execute(
+	ctx dex.Context,
+	countOfJobSeekers int,
+) (*dex.StepDecision, error) {
+	movements := make([]dex.StepMovement, 0, countOfJobSeekers+1)
+	movements = append(
+		movements,
+		dex.MovementOf(awaitAllUsersNotifiedStep{}, countOfJobSeekers),
+	)
+	for index := 1; index <= countOfJobSeekers; index++ {
+		movements = append(movements, dex.MovementOf(
+			notifyUserStep{},
+			JobSeeker{
+				ID:          fmt.Sprintf("%d", index),
+				Email:       "jobseeker@indeed.com",
+				PhoneNumber: "0987654321",
+			},
+		))
+	}
+	return dex.GoToMulti(movements...), nil
+}
+
+type notifyUserStep struct {
+	dex.StepDefaultsNoWaitFor[JobSeeker]
+}
+
+func (notifyUserStep) Execute(
+	ctx dex.Context,
+	jobSeeker JobSeeker,
+) (*dex.StepDecision, error) {
+	time.Sleep(time.Duration(rand.Intn(5000)) * time.Millisecond)
+	message := "[FAKE] Notifying user of something: " + jobSeeker.ID
+	fmt.Println(message)
+	if err := ctx.RecordEvent("notification", message); err != nil {
+		return nil, err
+	}
+	if err := NotifyChannel.Publish(ctx, "I sent something"); err != nil {
+		return nil, err
+	}
+	return dex.DeadEnd(), nil
+}
+
+type awaitAllUsersNotifiedStep struct {
+	dex.StepDefaults
+}
+
+func (awaitAllUsersNotifiedStep) WaitFor(
+	_ dex.Context,
+	countOfJobSeekers int,
+) (*dex.Wait, error) {
+	return dex.AllOf(NotifyChannel.ForN(countOfJobSeekers)), nil
+}
+
+func (awaitAllUsersNotifiedStep) Execute(
+	ctx dex.Context,
+	countOfJobSeekers int,
+) (*dex.StepDecision, error) {
+	message := fmt.Sprintf("[FAKE] Sent all %d notifications", countOfJobSeekers)
+	if err := ctx.RecordEvent("sent-notifications", message); err != nil {
+		return nil, err
+	}
+	return dex.GracefulComplete(nil), nil
+}
+
+var _ dex.Flow = (*ParallelStatesWithAwaitFlow)(nil)

--- a/examples/go/workflows/patterns/parallel/job_seeker.go
+++ b/examples/go/workflows/patterns/parallel/job_seeker.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package parallel
+
+type JobSeeker struct {
+	ID          string
+	Email       string
+	PhoneNumber string
+}

--- a/examples/go/workflows/patterns/parallel/simple.go
+++ b/examples/go/workflows/patterns/parallel/simple.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package parallel
+
+import (
+	"fmt"
+
+	patternsservice "github.com/superdurable/dex/examples/go/workflows/patterns/service"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+type SimpleParallelStatesFlow struct {
+	dex.FlowDefaults
+	service patternsservice.ServiceDependency
+}
+
+func NewSimpleParallelStatesFlow(
+	service patternsservice.ServiceDependency,
+) *SimpleParallelStatesFlow {
+	return &SimpleParallelStatesFlow{service: service}
+}
+
+func (*SimpleParallelStatesFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(initStep{}),
+		dex.DefineStep(sendTextMessageStep{}),
+		dex.DefineStep(sendEmailStep{}),
+	}
+}
+
+func (*SimpleParallelStatesFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{}
+}
+
+type initStep struct {
+	dex.StepDefaultsNoWaitFor[JobSeeker]
+}
+
+func (initStep) Execute(
+	ctx dex.Context,
+	input JobSeeker,
+) (*dex.StepDecision, error) {
+	return dex.GoToMulti(
+		dex.MovementOf(sendTextMessageStep{}, input.PhoneNumber),
+		dex.MovementOf(sendEmailStep{}, input.Email),
+	), nil
+}
+
+type sendTextMessageStep struct {
+	dex.StepDefaultsNoWaitFor[string]
+}
+
+func (sendTextMessageStep) Execute(
+	ctx dex.Context,
+	input string,
+) (*dex.StepDecision, error) {
+	message := "[FAKE] Sending text message to: " + input
+	fmt.Println(message)
+	if err := ctx.RecordEvent("text-message", message); err != nil {
+		return nil, err
+	}
+	return dex.GracefulComplete(nil), nil
+}
+
+type sendEmailStep struct {
+	dex.StepDefaultsNoWaitFor[string]
+}
+
+func (sendEmailStep) Execute(
+	ctx dex.Context,
+	input string,
+) (*dex.StepDecision, error) {
+	message := "[FAKE] Sending email to: " + input
+	fmt.Println(message)
+	if err := ctx.RecordEvent("email-notification", message); err != nil {
+		return nil, err
+	}
+	return dex.GracefulComplete(nil), nil
+}
+
+var _ dex.Flow = (*SimpleParallelStatesFlow)(nil)

--- a/examples/go/workflows/patterns/parentchild/README.md
+++ b/examples/go/workflows/patterns/parentchild/README.md
@@ -1,0 +1,7 @@
+# Parent Child Design Pattern (Option 2)
+
+## Endpoints
+
+- `GET /design-pattern/parentchild/start?workflowId={workflowId}&numRequests={n}`
+
+Concurrency per parent: 3

--- a/examples/go/workflows/patterns/parentchild/child.go
+++ b/examples/go/workflows/patterns/parentchild/child.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package parentchild
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+type ChildFlow struct {
+	dex.FlowDefaults
+}
+
+func NewChildFlow() *ChildFlow {
+	return &ChildFlow{}
+}
+
+func (*ChildFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(childProcessingStep{}),
+	}
+}
+
+func (*ChildFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{}
+}
+
+type childProcessingStep struct {
+	dex.StepDefaults
+}
+
+func (childProcessingStep) WaitFor(
+	ctx dex.Context,
+	input string,
+) (*dex.Wait, error) {
+	delay := time.Duration(rand.Intn(5)) * time.Second
+	return dex.AnyOf(dex.Timer(delay)), nil
+}
+
+func (childProcessingStep) Execute(
+	ctx dex.Context,
+	input string,
+) (*dex.StepDecision, error) {
+	fmt.Printf("ChildFlow completed work for: %s\n", input)
+	return dex.GracefulComplete(nil), nil
+}
+
+var _ dex.Flow = (*ChildFlow)(nil)

--- a/examples/go/workflows/patterns/parentchild/parent.go
+++ b/examples/go/workflows/patterns/parentchild/parent.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package parentchild
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const (
+	ConcurrencyPerParentWorkflow = 3
+	TaskQueueChannelName         = "task_queue"
+)
+
+var TaskQueue = dex.DefineChannel[int](TaskQueueChannelName)
+
+type WaitForChildInput struct {
+	ChildWFID    string
+	TimerSeconds int
+}
+
+type ParentFlowV2 struct {
+	dex.FlowDefaults
+	getClient func() *dex.Client
+	childFlow *ChildFlow
+}
+
+func NewParentFlowV2(
+	getClient func() *dex.Client,
+	childFlow *ChildFlow,
+) *ParentFlowV2 {
+	return &ParentFlowV2{getClient: getClient, childFlow: childFlow}
+}
+
+func (flow *ParentFlowV2) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(initStep{}),
+		dex.DefineStep(loopForNextTaskStep{}),
+		dex.DefineStep(startChildWorkflowStep{
+			getClient: flow.getClient,
+			childFlow: flow.childFlow,
+		}),
+		dex.DefineStep(awaitChildWorkflowCompletionStep{getClient: flow.getClient}),
+	}
+}
+
+func (*ParentFlowV2) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Channels: []dex.ChannelDef{TaskQueue},
+	}
+}
+
+type initStep struct {
+	dex.StepDefaultsNoWaitFor[int]
+}
+
+func (initStep) Execute(
+	ctx dex.Context,
+	numRequests int,
+) (*dex.StepDecision, error) {
+	for index := 0; index < numRequests; index++ {
+		if err := TaskQueue.Publish(ctx, index); err != nil {
+			return nil, err
+		}
+	}
+	movements := make([]dex.StepMovement, ConcurrencyPerParentWorkflow)
+	for index := 0; index < ConcurrencyPerParentWorkflow; index++ {
+		movements[index] = dex.MovementOf(loopForNextTaskStep{}, nil)
+	}
+	return dex.GoToMulti(movements...), nil
+}
+
+type loopForNextTaskStep struct {
+	dex.StepDefaults
+}
+
+func (loopForNextTaskStep) WaitFor(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.Wait, error) {
+	return dex.AnyOf(TaskQueue.ForOne()), nil
+}
+
+func (loopForNextTaskStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	results, err := TaskQueue.GetConditionResults(ctx)
+	if err != nil {
+		return nil, err
+	}
+	request := results[0]
+	return dex.GoTo(startChildWorkflowStep{}, request), nil
+}
+
+type startChildWorkflowStep struct {
+	dex.StepDefaultsNoWaitFor[int]
+	getClient func() *dex.Client
+	childFlow *ChildFlow
+}
+
+func (step startChildWorkflowStep) Execute(
+	_ dex.Context,
+	uuid int,
+) (*dex.StepDecision, error) {
+	childWorkflowID := fmt.Sprintf("child-wf-%d", uuid)
+	client := step.getClient()
+	if client == nil {
+		return nil, fmt.Errorf("dex client is not available")
+	}
+	_, err := client.StartFlow(
+		context.Background(),
+		step.childFlow,
+		childWorkflowID,
+		fmt.Sprintf("%d", uuid),
+		dex.StartFlowOptions{},
+	)
+	if err != nil {
+		var dexErr *dex.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorFlowAlreadyStarted {
+			fmt.Println("ignore this error because it is already started")
+		} else {
+			return nil, err
+		}
+	}
+	return dex.GoTo(awaitChildWorkflowCompletionStep{}, WaitForChildInput{
+		ChildWFID:    childWorkflowID,
+		TimerSeconds: 1,
+	}), nil
+}
+
+type awaitChildWorkflowCompletionStep struct {
+	dex.StepDefaults
+	getClient func() *dex.Client
+}
+
+func (awaitChildWorkflowCompletionStep) WaitFor(
+	_ dex.Context,
+	input WaitForChildInput,
+) (*dex.Wait, error) {
+	return dex.AnyOf(dex.Timer(time.Duration(input.TimerSeconds) * time.Second)), nil
+}
+
+func (step awaitChildWorkflowCompletionStep) Execute(
+	_ dex.Context,
+	input WaitForChildInput,
+) (*dex.StepDecision, error) {
+	client := step.getClient()
+	if client == nil {
+		return nil, fmt.Errorf("dex client is not available")
+	}
+	waitSeconds := input.TimerSeconds
+	if waitSeconds < 1 {
+		waitSeconds = 1
+	}
+	_, err := client.WaitForFlow(
+		context.Background(),
+		input.ChildWFID,
+		dex.WaitForFlowOptions{Timeout: time.Duration(waitSeconds) * time.Second},
+	)
+	if err != nil {
+		var dexErr *dex.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorLongPollTimeout {
+			nextTimer := input.TimerSeconds * 2
+			if nextTimer > 10 {
+				nextTimer = 10
+			}
+			return dex.GoTo(awaitChildWorkflowCompletionStep{}, WaitForChildInput{
+				ChildWFID:    input.ChildWFID,
+				TimerSeconds: nextTimer,
+			}), nil
+		}
+		return nil, err
+	}
+	return dex.GoTo(loopForNextTaskStep{}, nil), nil
+}
+
+var _ dex.Flow = (*ParentFlowV2)(nil)

--- a/examples/go/workflows/patterns/polling/README.md
+++ b/examples/go/workflows/patterns/polling/README.md
@@ -1,0 +1,6 @@
+# Polling Workflow Patterns
+
+## Endpoints
+
+- `GET /design-pattern/polling/start/simple?workflowId={workflowId}`
+- `GET /design-pattern/polling/start/backoff?workflowId={workflowId}`

--- a/examples/go/workflows/patterns/polling/backoff.go
+++ b/examples/go/workflows/patterns/polling/backoff.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package polling
+
+import (
+	"fmt"
+	"time"
+
+	patternsservice "github.com/superdurable/dex/examples/go/workflows/patterns/service"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+type BackoffPollingFlow struct {
+	dex.FlowDefaults
+	service patternsservice.ServiceDependency
+}
+
+func NewBackoffPollingFlow(service patternsservice.ServiceDependency) *BackoffPollingFlow {
+	return &BackoffPollingFlow{service: service}
+}
+
+func (flow *BackoffPollingFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(readExternalDepStep{service: flow.service}),
+		dex.DefineStep(pollingCompleteStep{}),
+	}
+}
+
+func (*BackoffPollingFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{}
+}
+
+type readExternalDepStep struct {
+	dex.DefaultStepType
+	dex.NoWaitFor[dex.None]
+	service patternsservice.ServiceDependency
+}
+
+func (readExternalDepStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		ExecuteRetry: &dex.RetryPolicy{
+			InitialInterval:    3 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    60 * time.Second,
+			MaximumAttempts:    5,
+			TotalDuration:      3600 * time.Second,
+		},
+	}
+}
+
+func (step readExternalDepStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	result, err := step.service.AttemptExternalAPICall("Read for BackoffPollingFlow")
+	if err != nil {
+		return nil, err
+	}
+	return dex.GoTo(pollingCompleteStep{}, result), nil
+}
+
+type pollingCompleteStep struct {
+	dex.StepDefaultsNoWaitFor[string]
+}
+
+func (pollingCompleteStep) Execute(
+	ctx dex.Context,
+	externalDataInput string,
+) (*dex.StepDecision, error) {
+	fmt.Printf(
+		"Executing final state to complete the workflow: (%s)\n",
+		externalDataInput,
+	)
+	return dex.GracefulComplete(externalDataInput), nil
+}
+
+var _ dex.Flow = (*BackoffPollingFlow)(nil)

--- a/examples/go/workflows/patterns/polling/simple.go
+++ b/examples/go/workflows/patterns/polling/simple.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package polling
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+type SimplePollingFlow struct {
+	dex.FlowDefaults
+}
+
+func NewSimplePollingFlow() *SimplePollingFlow {
+	return &SimplePollingFlow{}
+}
+
+func (*SimplePollingFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(simplePollingStep{}),
+		dex.DefineStep(simplePollingCompleteStep{}),
+	}
+}
+
+func (*SimplePollingFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{}
+}
+
+type simplePollingStep struct {
+	dex.StepDefaults
+}
+
+func (simplePollingStep) WaitFor(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.Wait, error) {
+	return dex.AnyOf(dex.Timer(10 * time.Second)), nil
+}
+
+func (simplePollingStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	if isSystemReady() {
+		return dex.GoTo(simplePollingCompleteStep{}, nil), nil
+	}
+	return dex.GoTo(simplePollingStep{}, nil), nil
+}
+
+func isSystemReady() bool {
+	fmt.Println("Executing external system check for readiness...")
+	return true
+}
+
+type simplePollingCompleteStep struct {
+	dex.StepDefaultsNoWaitFor[dex.None]
+}
+
+func (simplePollingCompleteStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	fmt.Println("Executing final state to complete the workflow...")
+	return dex.GracefulComplete(nil), nil
+}
+
+var _ dex.Flow = (*SimplePollingFlow)(nil)

--- a/examples/go/workflows/patterns/recovery/README.md
+++ b/examples/go/workflows/patterns/recovery/README.md
@@ -1,0 +1,5 @@
+# Failure Recovery in Dex
+
+## Endpoints
+
+- `GET /design-pattern/recovery/start?workflowId={workflowId}`

--- a/examples/go/workflows/patterns/recovery/workflow.go
+++ b/examples/go/workflows/patterns/recovery/workflow.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package recovery
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const WorkflowInputKey = "workflow-input-data-attribute-key"
+
+var WorkflowInput = dex.DefineAttribute[FailureRecoveryWorkflowInput](WorkflowInputKey)
+
+type FailureRecoveryWorkflowInput struct {
+	ItemName          string
+	RequestedQuantity int
+}
+
+type FailureRecoveryFlow struct {
+	dex.FlowDefaults
+	database         databaseConnection
+	paymentProcessor paymentProcessor
+}
+
+func NewFailureRecoveryFlow() *FailureRecoveryFlow {
+	return &FailureRecoveryFlow{
+		database:         databaseConnection{},
+		paymentProcessor: paymentProcessor{},
+	}
+}
+
+func (flow *FailureRecoveryFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(updateItemQuantityStep{database: flow.database}),
+		dex.DefineStep(chargeForItemsStep{
+			database:         flow.database,
+			paymentProcessor: flow.paymentProcessor,
+		}),
+		dex.DefineStep(updateQuantityRecoveryStep{database: flow.database}),
+		dex.DefineStep(voidPaymentRecoveryStep{
+			database:         flow.database,
+			paymentProcessor: flow.paymentProcessor,
+		}),
+	}
+}
+
+func (*FailureRecoveryFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{WorkflowInput},
+	}
+}
+
+type updateItemQuantityStep struct {
+	dex.DefaultStepType
+	dex.NoWaitFor[FailureRecoveryWorkflowInput]
+	database databaseConnection
+}
+
+func (updateItemQuantityStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		ExecuteFailure: dex.ProceedToOnExecuteFailure(updateQuantityRecoveryStep{}, nil),
+		ExecuteRetry:   &dex.RetryPolicy{MaximumAttempts: 5},
+	}
+}
+
+func (step updateItemQuantityStep) Execute(
+	ctx dex.Context,
+	input FailureRecoveryWorkflowInput,
+) (*dex.StepDecision, error) {
+	if err := WorkflowInput.Set(ctx, input); err != nil {
+		return nil, err
+	}
+	if err := step.database.reduceQuantity(input.ItemName, input.RequestedQuantity); err != nil {
+		return nil, err
+	}
+	return dex.GoTo(chargeForItemsStep{}, input.RequestedQuantity), nil
+}
+
+type chargeForItemsStep struct {
+	dex.DefaultStepType
+	dex.NoWaitFor[int]
+	database         databaseConnection
+	paymentProcessor paymentProcessor
+}
+
+func (chargeForItemsStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		ExecuteFailure: dex.ProceedToOnExecuteFailure(voidPaymentRecoveryStep{}, nil),
+		ExecuteRetry:   &dex.RetryPolicy{MaximumAttempts: 5},
+	}
+}
+
+func (step chargeForItemsStep) Execute(
+	ctx dex.Context,
+	_ int,
+) (*dex.StepDecision, error) {
+	input, err := WorkflowInput.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	itemValue := step.database.getItemPrice(input.ItemName)
+	orderValue := float64(input.RequestedQuantity) * itemValue
+	if err := step.paymentProcessor.processPayment(orderValue); err != nil {
+		return nil, err
+	}
+	return dex.GracefulComplete(nil), nil
+}
+
+type updateQuantityRecoveryStep struct {
+	dex.StepDefaultsNoWaitFor[FailureRecoveryWorkflowInput]
+	database databaseConnection
+}
+
+func (step updateQuantityRecoveryStep) Execute(
+	ctx dex.Context,
+	input FailureRecoveryWorkflowInput,
+) (*dex.StepDecision, error) {
+	step.database.increaseQuantity(input.ItemName, input.RequestedQuantity)
+	return dex.ForceFail("Failed to process transaction"), nil
+}
+
+type voidPaymentRecoveryStep struct {
+	dex.StepDefaultsNoWaitFor[int]
+	database         databaseConnection
+	paymentProcessor paymentProcessor
+}
+
+func (step voidPaymentRecoveryStep) Execute(
+	ctx dex.Context,
+	_ int,
+) (*dex.StepDecision, error) {
+	workflow, err := WorkflowInput.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	itemValue := step.database.getItemPrice(workflow.ItemName)
+	orderValue := float64(workflow.RequestedQuantity) * itemValue
+	step.paymentProcessor.voidPayment(orderValue)
+	return dex.GoTo(updateQuantityRecoveryStep{}, workflow), nil
+}
+
+type databaseConnection struct{}
+
+func (databaseConnection) reduceQuantity(_ string, quantity int) error {
+	fmt.Printf("Reducing quantity: %d\n", quantity)
+	if quantity > rand.Intn(10) {
+		return fmt.Errorf("not enough items available")
+	}
+	return nil
+}
+
+func (databaseConnection) increaseQuantity(_ string, quantity int) {
+	fmt.Printf("Increasing quantity: %d\n", quantity)
+}
+
+func (databaseConnection) getItemPrice(_ string) float64 {
+	return 3.14
+}
+
+type paymentProcessor struct{}
+
+func (paymentProcessor) processPayment(_ float64) error {
+	return fmt.Errorf("Payment could not be processed")
+}
+
+func (paymentProcessor) voidPayment(price float64) {
+	fmt.Printf("Voiding payment for $ %.2f\n", price)
+}
+
+var _ dex.Flow = (*FailureRecoveryFlow)(nil)

--- a/examples/go/workflows/patterns/reminders/README.md
+++ b/examples/go/workflows/patterns/reminders/README.md
@@ -1,0 +1,7 @@
+# Reminder Workflow Pattern
+
+## Endpoints
+
+- `GET /design-pattern/workflow-with-reminder/start`
+- `GET /design-pattern/workflow-with-reminder/accept?workflowId={workflowId}`
+- `GET /design-pattern/workflow-with-reminder/optout?workflowId={workflowId}`

--- a/examples/go/workflows/patterns/reminders/workflow.go
+++ b/examples/go/workflows/patterns/reminders/workflow.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package reminders
+
+import (
+	"fmt"
+	"time"
+
+	patternsservice "github.com/superdurable/dex/examples/go/workflows/patterns/service"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const (
+	DAStatus                       = "Status"
+	SignalNameOptOutReminder       = "OptOutReminder"
+	InternalChannelCompleteProcess = "CompleteProcess"
+)
+
+type Status string
+
+const (
+	StatusInitiated Status = "INITIATED"
+	StatusAccepted  Status = "ACCEPTED"
+)
+
+var (
+	StatusAttribute = dex.DefineAttribute[string](DAStatus)
+	OptOutReminder  = dex.DefineChannel[dex.None](SignalNameOptOutReminder)
+	CompleteProcess = dex.DefineChannel[dex.None](InternalChannelCompleteProcess)
+)
+
+type ReminderFlow struct {
+	dex.FlowDefaults
+	service patternsservice.ServiceDependency
+}
+
+func NewReminderFlow(service patternsservice.ServiceDependency) *ReminderFlow {
+	return &ReminderFlow{service: service}
+}
+
+func (flow *ReminderFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(initStep{}),
+		dex.DefineStep(processTimeoutStep{service: flow.service}),
+		dex.DefineStep(reminderStep{service: flow.service}),
+	}
+}
+
+func (*ReminderFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{StatusAttribute},
+		Channels:   []dex.ChannelDef{OptOutReminder, CompleteProcess},
+	}
+}
+
+func (*ReminderFlow) Accept(
+	ctx dex.Context,
+	_ dex.None,
+) (dex.RPCResult[dex.None], error) {
+	currentStatus, err := StatusAttribute.Get(ctx)
+	if err != nil {
+		return dex.RPCResult[dex.None]{}, err
+	}
+	if currentStatus != string(StatusInitiated) {
+		return dex.RPCResult[dex.None]{}, fmt.Errorf(
+			"can only accept in INITIATED status",
+		)
+	}
+	if err := StatusAttribute.Set(ctx, string(StatusAccepted)); err != nil {
+		return dex.RPCResult[dex.None]{}, err
+	}
+	if err := CompleteProcess.Publish(ctx, nil); err != nil {
+		return dex.RPCResult[dex.None]{}, err
+	}
+	return dex.RPCResult[dex.None]{}, nil
+}
+
+type initStep struct {
+	dex.StepDefaultsNoWaitFor[dex.None]
+}
+
+func (initStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	if err := StatusAttribute.Set(ctx, string(StatusInitiated)); err != nil {
+		return nil, err
+	}
+	return dex.GoToMulti(
+		dex.MovementOf(processTimeoutStep{}, nil),
+		dex.MovementOf(reminderStep{}, nil),
+	), nil
+}
+
+type processTimeoutStep struct {
+	dex.StepDefaults
+	service patternsservice.ServiceDependency
+}
+
+func (processTimeoutStep) WaitFor(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.Wait, error) {
+	return dex.AnyOf(
+		dex.Timer(60*24*time.Hour),
+		CompleteProcess.ForOne(),
+	), nil
+}
+
+func (step processTimeoutStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	currentStatus, err := StatusAttribute.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resultStatus := "TIMEOUT"
+	if currentStatus == string(StatusAccepted) {
+		resultStatus = "ACCEPTED"
+	}
+	step.service.UpdateExternalSystem("notify for status: " + resultStatus)
+	return dex.ForceComplete("done"), nil
+}
+
+type reminderStep struct {
+	dex.StepDefaults
+	service patternsservice.ServiceDependency
+}
+
+func (reminderStep) WaitFor(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.Wait, error) {
+	return dex.AnyOf(
+		dex.Timer(5*time.Second),
+		OptOutReminder.ForOne(),
+	), nil
+}
+
+func (step reminderStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	currentStatus, err := StatusAttribute.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if currentStatus == string(StatusAccepted) {
+		fmt.Println("Reminder state timer expired, but status already ACCEPTED")
+		return dex.ForceComplete("done"), nil
+	}
+	optOuts, err := OptOutReminder.GetConditionResults(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(optOuts) > 0 {
+		step.service.UpdateExternalSystem("user opted out - no more reminders")
+		return dex.ForceComplete("done - opt out"), nil
+	}
+	step.service.SendEmail("Reminder:xxx please respond", "Hello xxx, ...")
+	return dex.GoTo(reminderStep{}, nil), nil
+}
+
+var (
+	_ dex.Flow                    = (*ReminderFlow)(nil)
+	_ dex.RPC[dex.None, dex.None] = (*ReminderFlow)(nil).Accept
+)

--- a/examples/go/workflows/patterns/resettabletimer/README.md
+++ b/examples/go/workflows/patterns/resettabletimer/README.md
@@ -1,0 +1,6 @@
+# Resettable Timer Workflow Pattern
+
+## Endpoints
+
+- `GET /design-pattern/resettabletimer/start?workflowId={workflowId}`
+- `GET /design-pattern/resettabletimer/reset?workflowId={workflowId}`

--- a/examples/go/workflows/patterns/resettabletimer/workflow.go
+++ b/examples/go/workflows/patterns/resettabletimer/workflow.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package resettabletimer
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const ResetTimerChannelName = "RESET_TIMER_CHANNEL"
+
+var (
+	TimerDuration     = 5 * time.Minute
+	ResetTimerChannel = dex.DefineChannel[string](ResetTimerChannelName)
+)
+
+type ResettableTimerFlow struct {
+	dex.FlowDefaults
+}
+
+func NewResettableTimerFlow() *ResettableTimerFlow {
+	return &ResettableTimerFlow{}
+}
+
+func (*ResettableTimerFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(resettableTimerStep{}),
+		dex.DefineStep(timerExpiredStep{}),
+	}
+}
+
+func (*ResettableTimerFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Channels: []dex.ChannelDef{ResetTimerChannel},
+	}
+}
+
+func (*ResettableTimerFlow) SendResetMessage(
+	ctx dex.Context,
+	_ dex.None,
+) (dex.RPCResult[dex.None], error) {
+	if err := ResetTimerChannel.Publish(ctx, "reset"); err != nil {
+		return dex.RPCResult[dex.None]{}, err
+	}
+	return dex.RPCResult[dex.None]{}, nil
+}
+
+type resettableTimerStep struct {
+	dex.StepDefaults
+}
+
+func (resettableTimerStep) WaitFor(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.Wait, error) {
+	return dex.AnyOf(
+		dex.Timer(TimerDuration),
+		ResetTimerChannel.ForOne(),
+	), nil
+}
+
+func (resettableTimerStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	if ctx.HasTimerFired() {
+		return dex.GoTo(timerExpiredStep{}, nil), nil
+	}
+	return dex.GoTo(resettableTimerStep{}, nil), nil
+}
+
+type timerExpiredStep struct {
+	dex.StepDefaultsNoWaitFor[dex.None]
+}
+
+func (timerExpiredStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	fmt.Println("Timer fired; this is where we would send an email")
+	return dex.GracefulComplete(nil), nil
+}
+
+var (
+	_ dex.Flow                    = (*ResettableTimerFlow)(nil)
+	_ dex.RPC[dex.None, dex.None] = (*ResettableTimerFlow)(nil).SendResetMessage
+)

--- a/examples/go/workflows/patterns/scalableparallel/README.md
+++ b/examples/go/workflows/patterns/scalableparallel/README.md
@@ -1,0 +1,7 @@
+# Scalable Parallelism Control Pattern
+
+## Endpoints
+
+- `GET /design-pattern/scalableparallel/start?workflowId={workflowId}&numberOfChildWfs={n}`
+
+Constants: NUM_PARENTS=2, CONCURRENCY=3, MAX_BUFFER=10

--- a/examples/go/workflows/patterns/scalableparallel/child.go
+++ b/examples/go/workflows/patterns/scalableparallel/child.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package scalableparallel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const ParentWorkflowIDAttributeName = "ParentWorkflowId"
+
+var ParentWorkflowID = dex.DefineAttribute[string](ParentWorkflowIDAttributeName)
+
+type ChildFlow struct {
+	dex.FlowDefaults
+	getClient func() *dex.Client
+	getParent func() *ParentFlow
+}
+
+func NewChildFlow(
+	getClient func() *dex.Client,
+	getParent func() *ParentFlow,
+) *ChildFlow {
+	return &ChildFlow{getClient: getClient, getParent: getParent}
+}
+
+func (flow *ChildFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(processingStep{
+			getClient: flow.getClient,
+			getParent: flow.getParent,
+		}),
+	}
+}
+
+func (*ChildFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{ParentWorkflowID},
+	}
+}
+
+type processingStep struct {
+	dex.StepDefaults
+	getClient func() *dex.Client
+	getParent func() *ParentFlow
+}
+
+func (processingStep) WaitFor(
+	ctx dex.Context,
+	input string,
+) (*dex.Wait, error) {
+	delay := time.Duration(rand.Intn(60)) * time.Second
+	return dex.AnyOf(dex.Timer(delay)), nil
+}
+
+func (step processingStep) Execute(
+	ctx dex.Context,
+	input string,
+) (*dex.StepDecision, error) {
+	parentID, err := ParentWorkflowID.Get(ctx)
+	if err == nil && parentID != "" {
+		client := step.getClient()
+		parent := step.getParent()
+		if client != nil && parent != nil {
+			var output dex.None
+			rpcErr := client.InvokeRPC(
+				context.Background(),
+				parentID,
+				parent.CompleteChildWorkflow,
+				ctx.FlowID(),
+				&output,
+				dex.InvokeOptions{},
+			)
+			if rpcErr != nil {
+				var dexErr *dex.Error
+				if errors.As(rpcErr, &dexErr) && dexErr.SubStatus == dex.ErrorFlowNotFound {
+					fmt.Println(
+						"Parent workflow may have completed, might be duplicate " +
+							"completion request, ignore it.",
+					)
+				} else {
+					return nil, rpcErr
+				}
+			}
+		}
+	}
+	fmt.Printf("ChildFlow completed processing: %s (%s)\n", input, ctx.FlowID())
+	return dex.GracefulComplete(nil), nil
+}
+
+var _ dex.Flow = (*ChildFlow)(nil)

--- a/examples/go/workflows/patterns/scalableparallel/models.go
+++ b/examples/go/workflows/patterns/scalableparallel/models.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package scalableparallel
+
+const (
+	NumParentWorkflows           = 2
+	ConcurrencyPerParentWorkflow = 3
+	MaxBufferedTasks             = 10
+)
+
+type BatchEnqueueRequest struct {
+	List []string
+}
+
+type EnqueueFailedError struct {
+	Message string
+}
+
+func (err *EnqueueFailedError) Error() string {
+	if err.Message == "" {
+		return "enqueue failed"
+	}
+	return err.Message
+}
+
+func newEnqueueFailedError(message string) error {
+	return &EnqueueFailedError{Message: message}
+}

--- a/examples/go/workflows/patterns/scalableparallel/parent.go
+++ b/examples/go/workflows/patterns/scalableparallel/parent.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package scalableparallel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+	"github.com/superdurable/dex/sdk-go/dex/ptr"
+)
+
+const (
+	TaskQueueChannelName         = "TaskQueue"
+	ChildCompleteChannelPrefix   = "ChildComplete_"
+	CurrentWaitChildWfsAttribute = "CurrentWaitChildWfs"
+)
+
+var (
+	TaskQueue           = dex.DefineChannel[string](TaskQueueChannelName)
+	ChildComplete       = dex.DefineChannelMap[dex.None](ChildCompleteChannelPrefix)
+	CurrentWaitChildWfs = dex.DefineAttribute[[]string](CurrentWaitChildWfsAttribute)
+)
+
+type ParentFlow struct {
+	dex.FlowDefaults
+	getClient func() *dex.Client
+	childFlow *ChildFlow
+}
+
+func NewParentFlow(getClient func() *dex.Client, childFlow *ChildFlow) *ParentFlow {
+	return &ParentFlow{getClient: getClient, childFlow: childFlow}
+}
+
+func (flow *ParentFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(initStep{}),
+		dex.DefineStep(loopForNextMessageStep{
+			getClient: flow.getClient,
+			childFlow: flow.childFlow,
+		}),
+	}
+}
+
+func (*ParentFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{CurrentWaitChildWfs},
+		Channels:   []dex.ChannelDef{TaskQueue, ChildComplete},
+	}
+}
+
+func (*ParentFlow) Enqueue(
+	ctx dex.Context,
+	request BatchEnqueueRequest,
+) (dex.RPCResult[bool], error) {
+	if TaskQueue.Size(ctx)+len(request.List) > MaxBufferedTasks {
+		return dex.RPCResult[bool]{Output: false}, nil
+	}
+	for _, uuid := range request.List {
+		if err := TaskQueue.Publish(ctx, uuid); err != nil {
+			return dex.RPCResult[bool]{}, err
+		}
+	}
+	return dex.RPCResult[bool]{Output: true}, nil
+}
+
+func (*ParentFlow) CompleteChildWorkflow(
+	ctx dex.Context,
+	childWorkflowID string,
+) (dex.RPCResult[dex.None], error) {
+	if err := ChildComplete.Publish(ctx, childWorkflowID, nil); err != nil {
+		return dex.RPCResult[dex.None]{}, err
+	}
+	return dex.RPCResult[dex.None]{}, nil
+}
+
+type initStep struct {
+	dex.StepDefaultsNoWaitFor[BatchEnqueueRequest]
+}
+
+func (initStep) Execute(
+	ctx dex.Context,
+	initRequest BatchEnqueueRequest,
+) (*dex.StepDecision, error) {
+	for _, uuid := range initRequest.List {
+		if err := TaskQueue.Publish(ctx, uuid); err != nil {
+			return nil, err
+		}
+	}
+	return dex.GoTo(loopForNextMessageStep{}, nil), nil
+}
+
+type loopForNextMessageStep struct {
+	dex.StepDefaults
+	getClient func() *dex.Client
+	childFlow *ChildFlow
+}
+
+func (loopForNextMessageStep) WaitFor(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.Wait, error) {
+	waiting, err := CurrentWaitChildWfs.Get(ctx)
+	if err != nil {
+		var notFound *dex.AttributeNotFoundError
+		if !errors.As(err, &notFound) {
+			return nil, err
+		}
+		waiting = nil
+	}
+	conditions := make([]dex.Condition, 0, len(waiting)+1)
+	if len(waiting) < ConcurrencyPerParentWorkflow {
+		conditions = append(conditions, TaskQueue.ForOne())
+	}
+	for _, childWfID := range waiting {
+		conditions = append(conditions, ChildComplete.ForOne(childWfID))
+	}
+	return dex.AnyOf(conditions...), nil
+}
+
+func (step loopForNextMessageStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	waiting, err := CurrentWaitChildWfs.Get(ctx)
+	if err != nil {
+		var notFound *dex.AttributeNotFoundError
+		if !errors.As(err, &notFound) {
+			return nil, err
+		}
+		waiting = nil
+	}
+	newWaitList := append([]string(nil), waiting...)
+
+	taskResults, err := TaskQueue.GetConditionResults(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(taskResults) > 0 {
+		request := taskResults[0]
+		childWorkflowID := "processing-" + request
+		client := step.getClient()
+		if client == nil {
+			return nil, fmt.Errorf("dex client is not available")
+		}
+		parentAttr, attrErr := dex.InitialAttribute(
+			ParentWorkflowID,
+			ctx.FlowID(),
+		)
+		if attrErr != nil {
+			return nil, attrErr
+		}
+		flowTimeout := time.Hour
+		_, startErr := client.StartFlow(
+			context.Background(),
+			step.childFlow,
+			childWorkflowID,
+			request,
+			dex.StartFlowOptions{
+				Timeout:       &flowTimeout,
+				IDReusePolicy: dex.IDReuseDisallow,
+				RequestID:     ptr.Any(ctx.StepExecutionID()),
+				AlreadyStarted: &dex.AlreadyStartedOptions{
+					IgnoreError: true,
+				},
+				Attributes: []dex.InitialAttributeDef{parentAttr},
+			},
+		)
+		if startErr != nil {
+			var dexErr *dex.Error
+			if errors.As(startErr, &dexErr) &&
+				dexErr.SubStatus == dex.ErrorFlowAlreadyStarted {
+				fmt.Println(
+					"already started by other state/workflow, ignore it " +
+						"-- not waiting for it",
+				)
+			} else {
+				return nil, startErr
+			}
+		} else {
+			newWaitList = append(newWaitList, childWorkflowID)
+		}
+	}
+
+	for _, childWfID := range append([]string(nil), newWaitList...) {
+		completions, completeErr := ChildComplete.GetConditionResults(ctx, childWfID)
+		if completeErr != nil {
+			return nil, completeErr
+		}
+		if len(completions) > 0 {
+			removed := false
+			for index, waitingID := range newWaitList {
+				if waitingID == childWfID {
+					newWaitList = append(newWaitList[:index], newWaitList[index+1:]...)
+					removed = true
+					break
+				}
+			}
+			if !removed {
+				return nil, fmt.Errorf(
+					"child workflow %s is not in the waiting list?",
+					childWfID,
+				)
+			}
+		}
+	}
+
+	if err := CurrentWaitChildWfs.Set(ctx, newWaitList); err != nil {
+		return nil, err
+	}
+
+	if len(newWaitList) == 0 {
+		return dex.ForceCompleteOnChannelsEmpty(
+			nil,
+			[]dex.ChannelDef{TaskQueue},
+			dex.MovementOf(loopForNextMessageStep{}, nil),
+		), nil
+	}
+	return dex.GoTo(loopForNextMessageStep{}, nil), nil
+}
+
+var (
+	_ dex.Flow                           = (*ParentFlow)(nil)
+	_ dex.RPC[BatchEnqueueRequest, bool] = (*ParentFlow)(nil).Enqueue
+	_ dex.RPC[string, dex.None]          = (*ParentFlow)(nil).CompleteChildWorkflow
+)

--- a/examples/go/workflows/patterns/scalableparallel/receiver.go
+++ b/examples/go/workflows/patterns/scalableparallel/receiver.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package scalableparallel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+type RequestReceiverFlow struct {
+	dex.FlowDefaults
+	getClient  func() *dex.Client
+	parentFlow *ParentFlow
+}
+
+func NewRequestReceiverFlow(
+	getClient func() *dex.Client,
+	parentFlow *ParentFlow,
+) *RequestReceiverFlow {
+	return &RequestReceiverFlow{getClient: getClient, parentFlow: parentFlow}
+}
+
+func (flow *RequestReceiverFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(requestStep{
+			getClient:  flow.getClient,
+			parentFlow: flow.parentFlow,
+		}),
+	}
+}
+
+func (*RequestReceiverFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{}
+}
+
+type requestStep struct {
+	dex.StepDefaultsNoWaitFor[int]
+	getClient  func() *dex.Client
+	parentFlow *ParentFlow
+}
+
+func (step requestStep) Execute(
+	_ dex.Context,
+	numberOfChildWfs int,
+) (*dex.StepDecision, error) {
+	batch := generateTasks(numberOfChildWfs)
+	randSuffix := rand.Intn(NumParentWorkflows) + 1
+	parentWorkflowID := fmt.Sprintf("parent_workflow_%d", randSuffix)
+
+	client := step.getClient()
+	if client == nil {
+		return nil, fmt.Errorf("dex client is not available")
+	}
+	var success bool
+	err := client.InvokeRPC(
+		context.Background(),
+		parentWorkflowID,
+		step.parentFlow.Enqueue,
+		batch,
+		&success,
+		dex.InvokeOptions{},
+	)
+	if err != nil {
+		var dexErr *dex.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorFlowNotFound {
+			flowTimeout := time.Hour
+			_, startErr := client.StartFlow(
+				context.Background(),
+				step.parentFlow,
+				parentWorkflowID,
+				batch,
+				dex.StartFlowOptions{Timeout: &flowTimeout},
+			)
+			if startErr != nil {
+				return nil, startErr
+			}
+		} else {
+			return nil, err
+		}
+	} else if !success {
+		return nil, newEnqueueFailedError("Enqueue failed, retry in next attempt")
+	}
+	return dex.GracefulComplete(nil), nil
+}
+
+func generateTasks(numberOfChildWfs int) BatchEnqueueRequest {
+	uuids := make([]string, 0, numberOfChildWfs)
+	for index := 0; index < numberOfChildWfs; index++ {
+		uuids = append(uuids, uuid.NewString())
+	}
+	return BatchEnqueueRequest{List: uuids}
+}
+
+var _ dex.Flow = (*RequestReceiverFlow)(nil)

--- a/examples/go/workflows/patterns/service/service.go
+++ b/examples/go/workflows/patterns/service/service.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type ServiceDependency interface {
+	AttemptExternalAPICall(message string) (string, error)
+	ExternalAPICall(message string) string
+	UpdateExternalSystem(message string)
+	SendEmail(subject, content string)
+	Upsert(document any) error
+}
+
+type serviceDependencyImpl struct {
+	readExternalCounter int
+}
+
+func NewServiceDependency() ServiceDependency {
+	return &serviceDependencyImpl{}
+}
+
+func (service *serviceDependencyImpl) AttemptExternalAPICall(message string) (string, error) {
+	fmt.Printf("Try external system call: (%d)\n", service.readExternalCounter)
+	if service.readExternalCounter < 2 {
+		service.readExternalCounter++
+		return "", fmt.Errorf("there is an error when calling external system, retry it")
+	}
+	service.readExternalCounter = 0
+	fmt.Printf("Data read from external system: (%s)\n", message)
+	return "External data result", nil
+}
+
+func (service *serviceDependencyImpl) ExternalAPICall(message string) string {
+	fmt.Printf("Data read from external system: (%s)\n", message)
+	return "External data result"
+}
+
+func (*serviceDependencyImpl) UpdateExternalSystem(message string) {
+	fmt.Printf(
+		"update external system(like sending Kafka message or upsert to database): %s\n",
+		message,
+	)
+}
+
+func (*serviceDependencyImpl) SendEmail(subject, content string) {
+	fmt.Printf("send an email to job seeker, title: %s, content: %s \n", subject, content)
+}
+
+func (*serviceDependencyImpl) Upsert(document any) error {
+	serialized, err := json.Marshal(document)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("upsert: %s \n", string(serialized))
+	return nil
+}

--- a/examples/go/workflows/patterns/storage/README.md
+++ b/examples/go/workflows/patterns/storage/README.md
@@ -1,0 +1,11 @@
+# Storage Pattern
+
+Singleton flow key-value store via RPC.
+
+## Endpoints
+
+- `POST /design-pattern/storage/add`
+- `GET /design-pattern/storage/get`
+- `POST /design-pattern/storage/remove`
+
+Flow ID: `sample-storage-test`

--- a/examples/go/workflows/patterns/storage/workflow.go
+++ b/examples/go/workflows/patterns/storage/workflow.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package storage
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const (
+	DAStore       = "Store"
+	StorageFlowID = "sample-storage-test"
+)
+
+var Store = dex.DefineAttributeMap[string](DAStore)
+
+type AddStorageItemRequest struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type StorageFlow struct {
+	dex.FlowDefaults
+}
+
+func NewStorageFlow() *StorageFlow {
+	return &StorageFlow{}
+}
+
+func (*StorageFlow) GetFlowType() string {
+	return "StorageFlow"
+}
+
+func (*StorageFlow) GetSteps() []dex.StepDef {
+	return nil
+}
+
+func (*StorageFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{Store},
+	}
+}
+
+func (*StorageFlow) AddItem(
+	ctx dex.Context,
+	request AddStorageItemRequest,
+) (dex.RPCResult[dex.None], error) {
+	if request.Key == "" {
+		return dex.RPCResult[dex.None]{}, fmt.Errorf("key is null")
+	}
+	if request.Value == "" {
+		return dex.RPCResult[dex.None]{}, fmt.Errorf("value is null")
+	}
+	if err := Store.Set(ctx, request.Key, request.Value); err != nil {
+		return dex.RPCResult[dex.None]{}, err
+	}
+	return dex.RPCResult[dex.None]{}, nil
+}
+
+func (*StorageFlow) GetItem(
+	ctx dex.Context,
+	itemKey string,
+) (dex.RPCResult[string], error) {
+	value, err := Store.Get(ctx, itemKey)
+	if err != nil {
+		var notFound *dex.AttributeNotFoundError
+		if errors.As(err, &notFound) {
+			return dex.RPCResult[string]{}, nil
+		}
+		return dex.RPCResult[string]{}, err
+	}
+	return dex.RPCResult[string]{Output: value}, nil
+}
+
+func (*StorageFlow) RemoveItem(
+	ctx dex.Context,
+	itemKey string,
+) (dex.RPCResult[dex.None], error) {
+	if err := Store.Delete(ctx, itemKey); err != nil {
+		return dex.RPCResult[dex.None]{}, err
+	}
+	return dex.RPCResult[dex.None]{}, nil
+}
+
+var (
+	_ dex.Flow                                 = (*StorageFlow)(nil)
+	_ dex.RPC[AddStorageItemRequest, dex.None] = (*StorageFlow)(nil).AddItem
+	_ dex.RPC[string, string]                  = (*StorageFlow)(nil).GetItem
+	_ dex.RPC[string, dex.None]                = (*StorageFlow)(nil).RemoveItem
+)

--- a/examples/go/workflows/patterns/timeout/README.md
+++ b/examples/go/workflows/patterns/timeout/README.md
@@ -1,0 +1,6 @@
+# FlowGracefulTimeout
+
+## Endpoints
+
+- `GET /design-pattern/timeout/start?workflowId={workflowId}`
+- `GET /design-pattern/timeout/start?workflowId={workflowId}&successfulWorkflow=false`

--- a/examples/go/workflows/patterns/timeout/workflow.go
+++ b/examples/go/workflows/patterns/timeout/workflow.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package timeout
+
+import (
+	"time"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+type FlowGracefulTimeout struct {
+	dex.FlowDefaults
+}
+
+func NewFlowGracefulTimeout() *FlowGracefulTimeout {
+	return &FlowGracefulTimeout{}
+}
+
+func (*FlowGracefulTimeout) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(initStep{}),
+		dex.DefineStep(timeoutStep{}),
+		dex.DefineStep(taskStep{}),
+	}
+}
+
+func (*FlowGracefulTimeout) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{}
+}
+
+type initStep struct {
+	dex.StepDefaultsNoWaitFor[bool]
+}
+
+func (initStep) Execute(
+	ctx dex.Context,
+	workflowSuccessful bool,
+) (*dex.StepDecision, error) {
+	return dex.GoToMulti(
+		dex.MovementOf(timeoutStep{}, nil),
+		dex.MovementOf(taskStep{}, workflowSuccessful),
+	), nil
+}
+
+type timeoutStep struct {
+	dex.StepDefaults
+}
+
+func (timeoutStep) WaitFor(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.Wait, error) {
+	return dex.AnyOf(dex.Timer(time.Minute)), nil
+}
+
+func (timeoutStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	return dex.ForceFail("Workflow did not finish the task in time"), nil
+}
+
+type taskStep struct {
+	dex.StepDefaults
+}
+
+func (taskStep) WaitFor(
+	ctx dex.Context,
+	workflowSuccessful bool,
+) (*dex.Wait, error) {
+	if workflowSuccessful {
+		return dex.SkipWaitImmediately(), nil
+	}
+	return dex.AnyOf(dex.Timer(65 * time.Second)), nil
+}
+
+func (taskStep) Execute(
+	ctx dex.Context,
+	_ bool,
+) (*dex.StepDecision, error) {
+	return dex.ForceComplete("Workflow completed successfully"), nil
+}
+
+var _ dex.Flow = (*FlowGracefulTimeout)(nil)

--- a/examples/go/workflows/patterns/waitforstatecompletion/README.md
+++ b/examples/go/workflows/patterns/waitforstatecompletion/README.md
@@ -1,0 +1,7 @@
+# WaitForStateCompletionFlow
+
+## Endpoints
+
+- `GET /design-pattern/waitforstatecompletion/start?workflowId={workflowId}`
+
+PersistData step type: `PersistData`

--- a/examples/go/workflows/patterns/waitforstatecompletion/workflow.go
+++ b/examples/go/workflows/patterns/waitforstatecompletion/workflow.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package waitforstatecompletion
+
+import (
+	"encoding/json"
+
+	patternsservice "github.com/superdurable/dex/examples/go/workflows/patterns/service"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const JobSeekerDataAttributeName = "job_seeker_data"
+
+var JobSeekerDataAttribute = dex.DefineAttribute[JobSeekerData](JobSeekerDataAttributeName)
+
+type JobSeekerData struct {
+	ID     int
+	Name   string
+	Resume string
+	Email  string
+}
+
+type WaitForStateCompletionFlow struct {
+	dex.FlowDefaults
+	service patternsservice.ServiceDependency
+}
+
+func NewWaitForStateCompletionFlow(
+	service patternsservice.ServiceDependency,
+) *WaitForStateCompletionFlow {
+	return &WaitForStateCompletionFlow{service: service}
+}
+
+func (flow *WaitForStateCompletionFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(persistDataStep{service: flow.service}),
+		dex.DefineStep(updateExternalSystemStep{service: flow.service}),
+	}
+}
+
+func (*WaitForStateCompletionFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{JobSeekerDataAttribute},
+	}
+}
+
+func (*WaitForStateCompletionFlow) GetJobSeekerData(
+	ctx dex.Context,
+	_ dex.None,
+) (dex.RPCResult[JobSeekerData], error) {
+	data, err := JobSeekerDataAttribute.Get(ctx)
+	if err != nil {
+		return dex.RPCResult[JobSeekerData]{}, err
+	}
+	return dex.RPCResult[JobSeekerData]{Output: data}, nil
+}
+
+type persistDataStep struct {
+	dex.StepDefaultsNoWaitFor[JobSeekerData]
+	service patternsservice.ServiceDependency
+}
+
+func (persistDataStep) GetStepType() string {
+	return "PersistData"
+}
+
+func (step persistDataStep) Execute(
+	ctx dex.Context,
+	input JobSeekerData,
+) (*dex.StepDecision, error) {
+	if err := step.service.Upsert(input); err != nil {
+		return nil, err
+	}
+	if err := JobSeekerDataAttribute.Set(ctx, input); err != nil {
+		return nil, err
+	}
+	return dex.GoTo(updateExternalSystemStep{}, input), nil
+}
+
+type updateExternalSystemStep struct {
+	dex.StepDefaultsNoWaitFor[JobSeekerData]
+	service patternsservice.ServiceDependency
+}
+
+func (step updateExternalSystemStep) Execute(
+	_ dex.Context,
+	input JobSeekerData,
+) (*dex.StepDecision, error) {
+	serialized, err := json.Marshal(input)
+	if err != nil {
+		return nil, err
+	}
+	step.service.UpdateExternalSystem(string(serialized))
+	return dex.GracefulComplete(nil), nil
+}
+
+var (
+	_ dex.Flow                         = (*WaitForStateCompletionFlow)(nil)
+	_ dex.RPC[dex.None, JobSeekerData] = (*WaitForStateCompletionFlow)(nil).GetJobSeekerData
+)

--- a/examples/go/workflows/registry.go
+++ b/examples/go/workflows/registry.go
@@ -22,23 +22,122 @@ package workflows
 
 import (
 	"github.com/superdurable/dex/examples/go/workflows/engagement"
+	"github.com/superdurable/dex/examples/go/workflows/jobpost"
 	"github.com/superdurable/dex/examples/go/workflows/microservices"
 	"github.com/superdurable/dex/examples/go/workflows/moneytransfer"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/cron"
+	draininternal "github.com/superdurable/dex/examples/go/workflows/patterns/drainchannels/draininternal"
+	drainsignal "github.com/superdurable/dex/examples/go/workflows/patterns/drainchannels/signal"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/interruptible"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/intervention"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/parallel"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/parentchild"
+	patternspolling "github.com/superdurable/dex/examples/go/workflows/patterns/polling"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/recovery"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/reminders"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/resettabletimer"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/scalableparallel"
+	patternsservice "github.com/superdurable/dex/examples/go/workflows/patterns/service"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/storage"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/timeout"
+	"github.com/superdurable/dex/examples/go/workflows/patterns/waitforstatecompletion"
 	"github.com/superdurable/dex/examples/go/workflows/polling"
 	"github.com/superdurable/dex/examples/go/workflows/service"
+	"github.com/superdurable/dex/examples/go/workflows/shortlistcandidates"
+	"github.com/superdurable/dex/examples/go/workflows/signup"
 	"github.com/superdurable/dex/examples/go/workflows/subscription"
 	"github.com/superdurable/dex/sdk-go/dex"
 )
 
+// ClientProvider returns the shared Client after bootstrap completes.
+type ClientProvider func() *dex.Client
+
 var (
 	applicationService = service.NewMyService()
+	patternService     = patternsservice.NewServiceDependency()
 
-	Engagement    = engagement.NewEngagementFlow(applicationService)
+	Engagement    *engagement.EngagementFlow
+	Microservices *microservices.OrchestrationFlow
+	MoneyTransfer *moneytransfer.MoneyTransferFlow
+	Polling       *polling.PollingFlow
+	Subscription  *subscription.SubscriptionFlow
+	Signup        *signup.UserSignupFlow
+	JobPost       *jobpost.JobPostFlow
+	EmployerOptIn *shortlistcandidates.EmployerOptInFlow
+	Shortlist     *shortlistcandidates.ShortlistFlow
+
+	CronSchedule           *cron.CronScheduleFlow
+	SimplePolling          *patternspolling.SimplePollingFlow
+	BackoffPolling         *patternspolling.BackoffPollingFlow
+	InterruptibleExecution *interruptible.InterruptibleExecutionFlow
+	Reminder               *reminders.ReminderFlow
+	Storage                *storage.StorageFlow
+	ManualIntervention     *intervention.ManualInterventionFlow
+	ResettableTimer        *resettabletimer.ResettableTimerFlow
+	SimpleParallel         *parallel.SimpleParallelStatesFlow
+	ParallelWithAwait      *parallel.ParallelStatesWithAwaitFlow
+	FailureRecovery        *recovery.FailureRecoveryFlow
+	RequestReceiver        *scalableparallel.RequestReceiverFlow
+	ScalableParent         *scalableparallel.ParentFlow
+	ScalableChild          *scalableparallel.ChildFlow
+	ParentChild            *parentchild.ParentFlowV2
+	ParentChildChild       *parentchild.ChildFlow
+	DrainInternal          *draininternal.DrainInternalChannelsFlow
+	DrainSignal            *drainsignal.DrainSignalChannelsFlow
+	WaitForStateCompletion *waitforstatecompletion.WaitForStateCompletionFlow
+	GracefulTimeout        *timeout.FlowGracefulTimeout
+)
+
+// New constructs every sample flow. getClient may return nil until the Client
+// is created; flows that need it call the provider at Execute/RPC time.
+func New(applicationSvc service.MyService, getClient ClientProvider) []dex.Flow {
+	if applicationSvc == nil {
+		panic("workflows: application service is required")
+	}
+	if getClient == nil {
+		panic("workflows: client provider is required")
+	}
+	applicationService = applicationSvc
+
+	Engagement = engagement.NewEngagementFlow(applicationService)
 	Microservices = microservices.NewOrchestrationFlow(applicationService)
 	MoneyTransfer = moneytransfer.NewMoneyTransferFlow(applicationService)
-	Polling       = polling.NewPollingFlow(applicationService)
-	Subscription  = subscription.NewSubscriptionFlow(applicationService)
-)
+	Polling = polling.NewPollingFlow(applicationService)
+	Subscription = subscription.NewSubscriptionFlow(applicationService)
+	Signup = signup.NewUserSignupFlow(applicationService)
+	JobPost = jobpost.NewJobPostFlow(applicationService)
+	EmployerOptIn = shortlistcandidates.NewEmployerOptInFlow()
+	Shortlist = shortlistcandidates.NewShortlistFlow(
+		applicationService,
+		getClient,
+		EmployerOptIn,
+	)
+
+	CronSchedule = cron.NewCronScheduleFlow()
+	SimplePolling = patternspolling.NewSimplePollingFlow()
+	BackoffPolling = patternspolling.NewBackoffPollingFlow(patternService)
+	InterruptibleExecution = interruptible.NewInterruptibleExecutionFlow()
+	Reminder = reminders.NewReminderFlow(patternService)
+	Storage = storage.NewStorageFlow()
+	ManualIntervention = intervention.NewManualInterventionFlow(patternService)
+	ResettableTimer = resettabletimer.NewResettableTimerFlow()
+	SimpleParallel = parallel.NewSimpleParallelStatesFlow(patternService)
+	ParallelWithAwait = parallel.NewParallelStatesWithAwaitFlow(patternService)
+	FailureRecovery = recovery.NewFailureRecoveryFlow()
+	ScalableChild = scalableparallel.NewChildFlow(getClient, func() *scalableparallel.ParentFlow {
+		return ScalableParent
+	})
+	ScalableParent = scalableparallel.NewParentFlow(getClient, ScalableChild)
+	RequestReceiver = scalableparallel.NewRequestReceiverFlow(getClient, ScalableParent)
+	ParentChildChild = parentchild.NewChildFlow()
+	ParentChild = parentchild.NewParentFlowV2(getClient, ParentChildChild)
+	DrainInternal = draininternal.NewDrainInternalChannelsFlow(patternService)
+	DrainSignal = drainsignal.NewDrainSignalChannelsFlow()
+	WaitForStateCompletion = waitforstatecompletion.NewWaitForStateCompletionFlow(patternService)
+	GracefulTimeout = timeout.NewFlowGracefulTimeout()
+
+	return Flows()
+}
 
 func Flows() []dex.Flow {
 	return []dex.Flow{
@@ -47,5 +146,29 @@ func Flows() []dex.Flow {
 		MoneyTransfer,
 		Polling,
 		Subscription,
+		Signup,
+		JobPost,
+		EmployerOptIn,
+		Shortlist,
+		CronSchedule,
+		SimplePolling,
+		BackoffPolling,
+		InterruptibleExecution,
+		Reminder,
+		Storage,
+		ManualIntervention,
+		ResettableTimer,
+		SimpleParallel,
+		ParallelWithAwait,
+		FailureRecovery,
+		RequestReceiver,
+		ScalableParent,
+		ScalableChild,
+		ParentChild,
+		ParentChildChild,
+		DrainInternal,
+		DrainSignal,
+		WaitForStateCompletion,
+		GracefulTimeout,
 	}
 }

--- a/examples/go/workflows/shortlistcandidates/README.md
+++ b/examples/go/workflows/shortlistcandidates/README.md
@@ -1,0 +1,14 @@
+# Shortlist candidates
+
+Employer opt-in singleton plus shortlist/revoke automation. Shortlist waits five minutes (or revoke) before emailing when the employer is opted in.
+
+With the sample server running:
+
+```text
+POST http://localhost:8080/shortlist_candidates/opt_in
+POST http://localhost:8080/shortlist_candidates/opt_out
+GET  http://localhost:8080/shortlist_candidates/is_opted_in?employerId=<id>
+POST http://localhost:8080/shortlist_candidates/shortlist
+POST http://localhost:8080/shortlist_candidates/revoke_shortlist
+GET  http://localhost:8080/shortlist_candidates/email_sent_timestamp?employerId=<id>&candidateId=<id>
+```

--- a/examples/go/workflows/shortlistcandidates/employer_opt_in.go
+++ b/examples/go/workflows/shortlistcandidates/employer_opt_in.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shortlistcandidates
+
+import (
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const EmployerIDSearchKey = "CustomKeywordField"
+
+var (
+	EmployerOptInEmployerID = dex.DefineAttribute[string](
+		"EMPLOYER_OPT_IN_EmployerId",
+		dex.Indexed(dex.AttributeIndex{
+			Type:     dex.IndexKeyword,
+			IndexKey: EmployerIDSearchKey,
+		}),
+	)
+	EmployerOptInStatus = dex.DefineAttribute[bool]("EMPLOYER_OPT_IN_Status")
+)
+
+type EmployerOptInInput struct {
+	EmployerID string
+}
+
+type EmployerOptInFlow struct {
+	dex.FlowDefaults
+}
+
+func NewEmployerOptInFlow() *EmployerOptInFlow {
+	return &EmployerOptInFlow{}
+}
+
+func (*EmployerOptInFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(optInStep{}),
+		dex.DefineStep(optOutStep{}),
+	}
+}
+
+func (*EmployerOptInFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{EmployerOptInEmployerID, EmployerOptInStatus},
+	}
+}
+
+func (*EmployerOptInFlow) IsOptedIn(
+	ctx dex.Context,
+	_ dex.None,
+) (dex.RPCResult[bool], error) {
+	optedIn, err := EmployerOptInStatus.Get(ctx)
+	if err != nil {
+		return dex.RPCResult[bool]{}, err
+	}
+	return dex.RPCResult[bool]{Output: optedIn}, nil
+}
+
+func (*EmployerOptInFlow) OptOut(
+	_ dex.Context,
+	_ dex.None,
+) (dex.RPCResult[dex.None], error) {
+	return dex.RPCResult[dex.None]{
+		NextSteps: []dex.StepMovement{dex.MovementOf(optOutStep{}, nil)},
+	}, nil
+}
+
+type optInStep struct {
+	dex.StepDefaultsNoWaitFor[EmployerOptInInput]
+}
+
+func (optInStep) Execute(
+	ctx dex.Context,
+	input EmployerOptInInput,
+) (*dex.StepDecision, error) {
+	if err := EmployerOptInEmployerID.Set(ctx, input.EmployerID); err != nil {
+		return nil, err
+	}
+	if err := EmployerOptInStatus.Set(ctx, true); err != nil {
+		return nil, err
+	}
+	return dex.DeadEnd(), nil
+}
+
+type optOutStep struct {
+	dex.StepDefaultsNoWaitFor[dex.None]
+}
+
+func (optOutStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	if err := EmployerOptInStatus.Set(ctx, false); err != nil {
+		return nil, err
+	}
+	return dex.ForceComplete(nil), nil
+}
+
+var _ dex.Flow = (*EmployerOptInFlow)(nil)

--- a/examples/go/workflows/shortlistcandidates/ids.go
+++ b/examples/go/workflows/shortlistcandidates/ids.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shortlistcandidates
+
+import (
+	"context"
+	"errors"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+func EmployerOptInFlowID(employerID string) string {
+	return "shortlist_candidates_opt_in_" + employerID
+}
+
+func ShortlistFlowID(employerID, candidateID string) string {
+	return "shortlist_candidates_shortlist_" + employerID + "_" + candidateID
+}
+
+func IsOptedIn(
+	ctx context.Context,
+	client *dex.Client,
+	employerOptIn *EmployerOptInFlow,
+	employerID string,
+) (bool, error) {
+	var optedIn bool
+	err := client.InvokeRPC(
+		ctx,
+		EmployerOptInFlowID(employerID),
+		employerOptIn.IsOptedIn,
+		nil,
+		&optedIn,
+		dex.InvokeOptions{},
+	)
+	if err != nil {
+		var dexErr *dex.Error
+		if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorFlowNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return optedIn, nil
+}

--- a/examples/go/workflows/shortlistcandidates/shortlist.go
+++ b/examples/go/workflows/shortlistcandidates/shortlist.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shortlistcandidates
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/superdurable/dex/examples/go/workflows/service"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+var (
+	ShortlistEmployerID = dex.DefineAttribute[string](
+		"SHORTLIST_EmployerId",
+		dex.Indexed(dex.AttributeIndex{
+			Type:     dex.IndexKeyword,
+			IndexKey: EmployerIDSearchKey,
+		}),
+	)
+	ShortlistCandidateID        = dex.DefineAttribute[string]("SHORTLIST_CandidateId")
+	ShortlistEmailSentTimestamp = dex.DefineAttribute[int64]("SHORTLIST_EmailSentTimestamp")
+	RevokeShortlist             = dex.DefineChannel[dex.None]("SHORTLIST_SIGNAL_RevokeShortlist")
+)
+
+type ShortlistInput struct {
+	EmployerID  string
+	CandidateID string
+}
+
+type ShortlistFlow struct {
+	dex.FlowDefaults
+	service       service.MyService
+	getClient     func() *dex.Client
+	employerOptIn *EmployerOptInFlow
+}
+
+func NewShortlistFlow(
+	applicationService service.MyService,
+	getClient func() *dex.Client,
+	employerOptIn *EmployerOptInFlow,
+) *ShortlistFlow {
+	return &ShortlistFlow{
+		service:       applicationService,
+		getClient:     getClient,
+		employerOptIn: employerOptIn,
+	}
+}
+
+func (flow *ShortlistFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(shortlistStep{}),
+		dex.DefineStep(sendEmailStep{
+			service:       flow.service,
+			getClient:     flow.getClient,
+			employerOptIn: flow.employerOptIn,
+		}),
+	}
+}
+
+func (*ShortlistFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{
+			ShortlistEmployerID,
+			ShortlistCandidateID,
+			ShortlistEmailSentTimestamp,
+		},
+		Channels: []dex.ChannelDef{RevokeShortlist},
+	}
+}
+
+func (*ShortlistFlow) GetEmailSentTimestamp(
+	ctx dex.Context,
+	_ dex.None,
+) (dex.RPCResult[int64], error) {
+	timestamp, err := ShortlistEmailSentTimestamp.Get(ctx)
+	return dex.RPCResult[int64]{Output: timestamp}, err
+}
+
+type shortlistStep struct {
+	dex.StepDefaultsNoWaitFor[ShortlistInput]
+}
+
+func (shortlistStep) Execute(
+	ctx dex.Context,
+	input ShortlistInput,
+) (*dex.StepDecision, error) {
+	if err := ShortlistEmployerID.Set(ctx, input.EmployerID); err != nil {
+		return nil, err
+	}
+	if err := ShortlistCandidateID.Set(ctx, input.CandidateID); err != nil {
+		return nil, err
+	}
+	if err := ShortlistEmailSentTimestamp.Set(ctx, 0); err != nil {
+		return nil, err
+	}
+	return dex.GoTo(sendEmailStep{}, nil), nil
+}
+
+type sendEmailStep struct {
+	dex.StepDefaults
+	service       service.MyService
+	getClient     func() *dex.Client
+	employerOptIn *EmployerOptInFlow
+}
+
+func (sendEmailStep) WaitFor(dex.Context, dex.None) (*dex.Wait, error) {
+	return dex.AnyOf(dex.Timer(5*time.Minute), RevokeShortlist.ForOne()), nil
+}
+
+func (step sendEmailStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	employer, err := ShortlistEmployerID.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	candidate, err := ShortlistCandidateID.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	results, err := RevokeShortlist.GetConditionResults(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) > 0 {
+		fmt.Printf(
+			"Not sending the email to %s-%s because of revoking\n",
+			employer,
+			candidate,
+		)
+		return dex.ForceComplete(nil), nil
+	}
+	optedIn, err := IsOptedIn(
+		context.Background(),
+		step.getClient(),
+		step.employerOptIn,
+		employer,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !optedIn {
+		fmt.Printf(
+			"Not sending the email to %s-%s because of not opted-in\n",
+			employer,
+			candidate,
+		)
+		return dex.ForceComplete(nil), nil
+	}
+	step.service.SendEmail(
+		employer+"-"+candidate,
+		fmt.Sprintf("Employer %s wants to know more about you", employer),
+		"Hello xxx, ...",
+	)
+	if err := ShortlistEmailSentTimestamp.Set(ctx, time.Now().UnixMilli()); err != nil {
+		return nil, err
+	}
+	return dex.ForceComplete(nil), nil
+}
+
+var _ dex.Flow = (*ShortlistFlow)(nil)

--- a/examples/go/workflows/signup/README.md
+++ b/examples/go/workflows/signup/README.md
@@ -1,0 +1,10 @@
+# Signup
+
+User signup with email verification reminders. Submit starts the flow; verify completes it via RPC.
+
+With the sample server running:
+
+```text
+http://localhost:8080/signup/submit?username=<user>&email=<email>
+http://localhost:8080/signup/verify?username=<user>
+```

--- a/examples/go/workflows/signup/workflow.go
+++ b/examples/go/workflows/signup/workflow.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package signup
+
+import (
+	"time"
+
+	"github.com/superdurable/dex/examples/go/workflows/service"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+var (
+	Form   = dex.DefineAttribute[SignupForm]("Form")
+	Status = dex.DefineAttribute[string]("Status")
+	Verify = dex.DefineChannel[dex.None]("Verify")
+)
+
+type SignupForm struct {
+	Username  string
+	Email     string
+	FirstName string
+	LastName  string
+}
+
+type UserSignupFlow struct {
+	dex.FlowDefaults
+	service service.MyService
+}
+
+func NewUserSignupFlow(applicationService service.MyService) *UserSignupFlow {
+	return &UserSignupFlow{service: applicationService}
+}
+
+func (flow *UserSignupFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(submitStep{service: flow.service}),
+		dex.DefineStep(verifyStep{service: flow.service}),
+	}
+}
+
+func (*UserSignupFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{
+		Attributes: []dex.AttributeDef{Form, Status},
+		Channels:   []dex.ChannelDef{Verify},
+	}
+}
+
+func (*UserSignupFlow) Verify(
+	ctx dex.Context,
+	_ dex.None,
+) (dex.RPCResult[string], error) {
+	status, err := Status.Get(ctx)
+	if err != nil {
+		return dex.RPCResult[string]{}, err
+	}
+	if status == "verified" {
+		return dex.RPCResult[string]{Output: "already verified"}, nil
+	}
+	if err := Status.Set(ctx, "verified"); err != nil {
+		return dex.RPCResult[string]{}, err
+	}
+	if err := Verify.Publish(ctx, nil); err != nil {
+		return dex.RPCResult[string]{}, err
+	}
+	return dex.RPCResult[string]{Output: "done"}, nil
+}
+
+type submitStep struct {
+	dex.StepDefaultsNoWaitFor[SignupForm]
+	service service.MyService
+}
+
+func (step submitStep) Execute(
+	ctx dex.Context,
+	input SignupForm,
+) (*dex.StepDecision, error) {
+	if err := Form.Set(ctx, input); err != nil {
+		return nil, err
+	}
+	if err := Status.Set(ctx, "waiting"); err != nil {
+		return nil, err
+	}
+	step.service.SendEmail(input.Email, "please verify the signup", "content")
+	return dex.GoTo(verifyStep{}, nil), nil
+}
+
+type verifyStep struct {
+	dex.StepDefaults
+	service service.MyService
+}
+
+func (verifyStep) WaitFor(dex.Context, dex.None) (*dex.Wait, error) {
+	return dex.AnyOf(dex.Timer(24*time.Second), Verify.ForOne()), nil
+}
+
+func (step verifyStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	form, err := Form.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	results, err := Verify.GetConditionResults(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) > 0 {
+		step.service.SendEmail(form.Email, "welcome", "welcome to Indeed!")
+		return dex.GracefulComplete("done"), nil
+	}
+	step.service.SendEmail(form.Email, "reminder", "please verify your email")
+	return dex.GoTo(verifyStep{}, nil), nil
+}
+
+var _ dex.Flow = (*UserSignupFlow)(nil)


### PR DESCRIPTION
## Summary
- Port signup, jobpost, shortlistcandidates, and all Java design-pattern flows into `examples/go` with Gin controllers and READMEs.
- Wire lazy Client injection through `workflows.New` / samples bootstrap (including cron schedule starter).
- Add `cmd/deepverify` for live Dex WaitForFlow/RPC/channel deep checks against the samples worker.

## Test plan
- [ ] `make -C examples/go unitTests`
- [ ] `make -C examples/go e2eTests`
- [ ] Against `dexcli` + `./dex-samples`: exercise product HTTP paths and `/design-pattern/*` endpoints
- [ ] Optionally run `./deepverify` against live Dex (`DEX_FLOW_SERVICE_ADDRESS` / `DEX_WORKER_TARGET`)


Made with [Cursor](https://cursor.com)