### PR TITLE
Support async Step / waitFor / RPC handlers in TypeScript SDK

### DIFF
--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -62,6 +62,33 @@ Flows without a start input.
 `StepOptions.waitForMethodTimeoutMs` and `executeMethodTimeoutMs` bound the two
 handler calls. Timer and channel conditions determine how long a Step waits.
 
+### Async handlers
+
+`Step.execute`, `Step.waitFor`, and RPC methods may be `async` and return a
+`Promise` of their result. Because the Worker runs on Node's single event loop,
+an async handler that `await`s `Client` calls (`startFlow`, `waitForFlow`,
+`invokeRPC`, ...) yields the loop, so the **same** Worker keeps serving other
+WorkerService calls — including the child Flow or RPC you just started. One
+Worker is enough; no sidecar Worker is needed.
+
+```ts
+async execute(context: Context, childId: string): Promise<StepDecision> {
+  await client.startFlow(childFlow, childId, input);
+  const output = await client.waitForFlow(childId, stringCodec, 5_000);
+  return gracefulComplete(output);
+}
+```
+
+Synchronous handlers stay valid — returning a plain `StepDecision` / `Wait` /
+`RPCResult` needs no change. Two rules keep the loop healthy:
+
+- Never block the event loop from a handler (`Atomics.wait`,
+  `child_process.spawnSync`). That freezes the Worker and defeats the point.
+- A long `await client.waitForFlow(...)` holds the current WorkerService call
+  until it resolves or times out. Prefer a short timeout plus Step retry (or a
+  timer-backed re-check) over one unbounded poll. `executeMethodTimeoutMs` /
+  `waitForMethodTimeoutMs` clock the full async handler duration.
+
 Every TypeScript Flow and Step must return an explicit durable name from
 `getFlowType()` or `getStepType()`. Class names are never used as fallbacks
 because bundlers and minifiers may rename them.

--- a/sdk-typescript/src/rpc.ts
+++ b/sdk-typescript/src/rpc.ts
@@ -18,7 +18,10 @@ export interface RPCResult<Output> {
   readonly nextSteps?: readonly StepMovement<unknown>[];
 }
 
-export type RPC<Input, Output> = (context: Context, input: Input) => RPCResult<Output>;
+export type RPC<Input, Output> = (
+  context: Context,
+  input: Input,
+) => RPCResult<Output> | Promise<RPCResult<Output>>;
 
 export interface RPCOptions<Input = unknown, Output = unknown> {
   readonly name?: string;
@@ -40,10 +43,18 @@ export function rpc<Input, Output>(options: RPCOptions<Input, Output> & {
   readonly inputCodec: Codec<Input>;
   readonly outputCodec: Codec<Output>;
 }): <This>(
-  method: (this: This, context: Context, input: Input) => RPCResult<Output>,
+  method: (
+    this: This,
+    context: Context,
+    input: Input,
+  ) => RPCResult<Output> | Promise<RPCResult<Output>>,
   context: ClassMethodDecoratorContext<
     This,
-    (this: This, context: Context, input: Input) => RPCResult<Output>
+    (
+      this: This,
+      context: Context,
+      input: Input,
+    ) => RPCResult<Output> | Promise<RPCResult<Output>>
   >,
 ) => void;
 
@@ -51,10 +62,10 @@ export function rpc<Output>(options: RPCOptions<never, Output> & {
   readonly inputCodec?: never;
   readonly outputCodec: Codec<Output>;
 }): <This>(
-  method: (this: This, context: Context) => RPCResult<Output>,
+  method: (this: This, context: Context) => RPCResult<Output> | Promise<RPCResult<Output>>,
   context: ClassMethodDecoratorContext<
     This,
-    (this: This, context: Context) => RPCResult<Output>
+    (this: This, context: Context) => RPCResult<Output> | Promise<RPCResult<Output>>
   >,
 ) => void;
 
@@ -62,16 +73,19 @@ export function rpc<Input>(options: RPCOptions<Input, never> & {
   readonly inputCodec: Codec<Input>;
   readonly outputCodec?: never;
 }): <This>(
-  method: (this: This, context: Context, input: Input) => void,
-  context: ClassMethodDecoratorContext<This, (this: This, context: Context, input: Input) => void>,
+  method: (this: This, context: Context, input: Input) => void | Promise<void>,
+  context: ClassMethodDecoratorContext<
+    This,
+    (this: This, context: Context, input: Input) => void | Promise<void>
+  >,
 ) => void;
 
 export function rpc(options?: RPCOptions<never, never> & {
   readonly inputCodec?: never;
   readonly outputCodec?: never;
 }): <This>(
-  method: (this: This, context: Context) => void,
-  context: ClassMethodDecoratorContext<This, (this: This, context: Context) => void>,
+  method: (this: This, context: Context) => void | Promise<void>,
+  context: ClassMethodDecoratorContext<This, (this: This, context: Context) => void | Promise<void>>,
 ) => void;
 
 export function rpc(options: RPCOptions<any, any> = {}) {

--- a/sdk-typescript/src/step.ts
+++ b/sdk-typescript/src/step.ts
@@ -53,8 +53,8 @@ export interface Step<Input> {
   readonly inputCodec: Codec<Input>;
   getStepType(): string;
   getStepOptions?(): StepOptions | undefined;
-  waitFor?(context: Context, input: Input): Wait;
-  execute(context: Context, input: Input): StepDecision;
+  waitFor?(context: Context, input: Input): Wait | Promise<Wait>;
+  execute(context: Context, input: Input): StepDecision | Promise<StepDecision>;
 }
 
 interface StartStepDefinition<StartInput> {

--- a/sdk-typescript/src/worker-dispatcher.ts
+++ b/sdk-typescript/src/worker-dispatcher.ts
@@ -76,7 +76,7 @@ export class WorkerDispatcher {
     if (step.step.waitFor === undefined) {
       throw new TypeError(`Step ${step.name} does not implement waitFor`);
     }
-    const wait = step.step.waitFor(context, input);
+    const wait = await step.step.waitFor(context, input);
     return InvokeWaitForMethodResponse.create({
       upsertAttributes: [...context.getAttributeWrites()],
       waitingCondition: mapWait(flow, wait),
@@ -101,7 +101,7 @@ export class WorkerDispatcher {
       request.conditionResults,
     );
     const input = decodeValue(step.step.inputCodec, requireValue(request.stepInput, "Step input"));
-    const decision = step.step.execute(context, input);
+    const decision = await step.step.execute(context, input);
     return InvokeExecuteMethodResponse.create({
       stepDecision: mapDecision(flow, decision),
       upsertAttributes: [...context.getAttributeWrites()],
@@ -124,7 +124,7 @@ export class WorkerDispatcher {
       undefined,
       request.channelInfos,
     );
-    const returned = invokeRPC(flow, rpc, context, request.input);
+    const returned = await invokeRPC(flow, rpc, context, request.input);
     const result = rpcResult(rpc, returned);
     return InvokeWorkerRPCResponse.create({
       output:

--- a/sdk-typescript/test/integ/async-handlers.integration.test.ts
+++ b/sdk-typescript/test/integ/async-handlers.integration.test.ts
@@ -1,0 +1,57 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { stringCodec } from "../../src/index.js";
+import {
+  AsyncRpcFlow,
+  AsyncStartAndWaitFlow,
+  AsyncWaitForFlow,
+} from "./async_handlers_flows.js";
+import { flowId, withEnvironment } from "./environment.js";
+
+// A synchronous Step could not await the child; that these pass on a single Worker
+// proves the async handler yields the event loop so the same Worker serves the child.
+
+test("async execute awaits Client.startFlow and Client.waitForFlow on one Worker", async () => {
+  const parent = new AsyncStartAndWaitFlow();
+  await withEnvironment([parent, parent.child], async ({ client }) => {
+    parent.client = client;
+    const parentId = flowId("async-parent");
+    const childId = flowId("async-child");
+    await client.startFlow(parent, parentId, childId);
+    assert.equal(
+      await client.waitForFlow(parentId, stringCodec, 30_000),
+      `child-of-${childId}`,
+    );
+  });
+});
+
+test("async execute awaits Client.invokeRPC against a flow on the same Worker", async () => {
+  const parent = new AsyncRpcFlow();
+  await withEnvironment([parent, parent.target], async ({ client }) => {
+    parent.client = client;
+    const parentId = flowId("async-rpc-parent");
+    const targetId = flowId("async-rpc-target");
+    await client.startFlow(parent, parentId, targetId);
+    assert.equal(await client.waitForFlow(parentId, stringCodec, 30_000), "rpc-echo:hello");
+  });
+});
+
+test("Step waitFor may resolve a Wait asynchronously", async () => {
+  const flow = new AsyncWaitForFlow();
+  await withEnvironment([flow], async ({ client }) => {
+    const id = flowId("async-waitfor");
+    await client.startFlow(flow, id, "done");
+    assert.equal(await client.waitForFlow(id, stringCodec, 30_000), "done");
+  });
+});

--- a/sdk-typescript/test/integ/async_handlers_flows.ts
+++ b/sdk-typescript/test/integ/async_handlers_flows.ts
@@ -1,0 +1,200 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+import {
+  Channel,
+  StepList,
+  Wait,
+  gracefulComplete,
+  rpc,
+  stringCodec,
+  voidCodec,
+  type Client,
+  type Context,
+  type Flow,
+  type PersistenceSchema,
+  type RPCResult,
+  type Step,
+  type StepDecision,
+} from "../../src/index.js";
+
+// Child flow started by an async parent Step; echoes its input back.
+class EchoStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public getStepType(): string {
+    return "EchoStep";
+  }
+
+  public execute(_context: Context, input: string): StepDecision {
+    return gracefulComplete(input);
+  }
+}
+
+export class EchoFlow implements Flow<string> {
+  private readonly start = new EchoStep();
+
+  public getFlowType(): string {
+    return "AsyncEchoFlow";
+  }
+
+  public getSteps() {
+    return StepList.startStep(this.start);
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return {};
+  }
+}
+
+// Parent whose Step awaits Client.startFlow + Client.waitForFlow on the same Worker.
+class StartAndWaitStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public constructor(private readonly flow: AsyncStartAndWaitFlow) {}
+
+  public getStepType(): string {
+    return "StartAndWaitStep";
+  }
+
+  public async execute(_context: Context, childId: string): Promise<StepDecision> {
+    await this.flow.client.startFlow(this.flow.child, childId, `child-of-${childId}`);
+    const childOutput = await this.flow.client.waitForFlow(childId, stringCodec, 30_000);
+    return gracefulComplete(childOutput);
+  }
+}
+
+export class AsyncStartAndWaitFlow implements Flow<string> {
+  public client!: Client;
+  public readonly child = new EchoFlow();
+  private readonly start = new StartAndWaitStep(this);
+
+  public getFlowType(): string {
+    return "AsyncStartAndWaitFlow";
+  }
+
+  public getSteps() {
+    return StepList.startStep(this.start);
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return {};
+  }
+}
+
+// RPC target: stays running on a channel wait; echo RPC returns its input.
+class RpcEchoStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public constructor(private readonly proceed: Channel<void>) {}
+
+  public getStepType(): string {
+    return "RpcEchoStep";
+  }
+
+  public waitFor(): Wait {
+    return Wait.anyOf(this.proceed.forOne());
+  }
+
+  public execute(_context: Context, input: string): StepDecision {
+    return gracefulComplete(input);
+  }
+}
+
+export class RpcEchoFlow implements Flow<string> {
+  public readonly proceed = new Channel("async-rpc-proceed", voidCodec);
+  private readonly start = new RpcEchoStep(this.proceed);
+
+  public getFlowType(): string {
+    return "AsyncRpcEchoFlow";
+  }
+
+  public getSteps() {
+    return StepList.startStep(this.start);
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return { channels: [this.proceed] };
+  }
+
+  @rpc({ inputCodec: stringCodec, outputCodec: stringCodec })
+  public echo(_context: Context, input: string): RPCResult<string> {
+    return { output: input };
+  }
+}
+
+// Parent whose Step awaits Client.invokeRPC against a flow on the same Worker.
+class InvokeRpcStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public constructor(private readonly flow: AsyncRpcFlow) {}
+
+  public getStepType(): string {
+    return "InvokeRpcStep";
+  }
+
+  public async execute(_context: Context, targetId: string): Promise<StepDecision> {
+    await this.flow.client.startFlow(this.flow.target, targetId, "start");
+    const echoed = await this.flow.client.invokeRPC(this.flow.target.echo, targetId, "hello");
+    return gracefulComplete(`rpc-echo:${echoed}`);
+  }
+}
+
+export class AsyncRpcFlow implements Flow<string> {
+  public client!: Client;
+  public readonly target = new RpcEchoFlow();
+  private readonly start = new InvokeRpcStep(this);
+
+  public getFlowType(): string {
+    return "AsyncRpcParentFlow";
+  }
+
+  public getSteps() {
+    return StepList.startStep(this.start);
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return {};
+  }
+}
+
+// Step whose waitFor resolves a Wait asynchronously.
+class AsyncWaitStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public getStepType(): string {
+    return "AsyncWaitStep";
+  }
+
+  public async waitFor(): Promise<Wait> {
+    await Promise.resolve();
+    return Wait.skipImmediately();
+  }
+
+  public execute(_context: Context, input: string): StepDecision {
+    return gracefulComplete(input);
+  }
+}
+
+export class AsyncWaitForFlow implements Flow<string> {
+  private readonly start = new AsyncWaitStep();
+
+  public getFlowType(): string {
+    return "AsyncWaitForFlow";
+  }
+
+  public getSteps() {
+    return StepList.startStep(this.start);
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return {};
+  }
+}


### PR DESCRIPTION
## Problem
The TS SDK copied Java's synchronous handler shape (`Step.execute` / `waitFor` / RPC return `StepDecision` / `Wait` / `RPCResult`), while `Client` is fully async. Java tolerates blocking `Client` calls inside a Step because its Worker is multithreaded. Node is single-threaded: to call the async Client from a sync Step an app must bridge with `worker_threads` + `Atomics.wait` and run a **second** gRPC Worker as the sync `workerTarget`, or the primary Worker's event loop freezes and the process deadlocks. That dual-Worker topology must not be the recommended pattern.

## Goal
Let application code write idiomatic async Steps in one process, on one Worker — no `Atomics.wait`, no sidecar Worker:

```ts
async execute(context: Context, childId: string): Promise<StepDecision> {
  await client.startFlow(childFlow, childId, input);
  const output = await client.waitForFlow(childId, stringCodec, 5_000);
  return gracefulComplete(output);
}
```

## Changes
- **Types widened** (`src/step.ts`, `src/rpc.ts`): `execute` → `StepDecision | Promise<StepDecision>`, `waitFor` → `Wait | Promise<Wait>`, RPC methods → their result or a `Promise` of it (all four `rpc(...)` overloads). `T` is assignable to `T | Promise<T>`, so existing synchronous handlers stay valid with no migration.
- **Dispatcher awaits handler results** (`src/worker-dispatcher.ts`): `invokeExecute` / `invokeWaitFor` / `invokeRPC` are already `async`; they now `await` the handler at the three call sites. A real Promise (unlike `Atomics.wait`) yields the event loop, and `worker.ts`'s `invoke()` helper is already non-blocking, so the **same** Worker serves the child's `invokeExecute` / RPC while the parent awaits. One Worker is enough.
- **Client API** — already fully async, no signature change.
- **Timeouts** — `executeMethodTimeoutMs` / `waitForMethodTimeoutMs` are server-enforced over the WorkerService call, which equals the full async handler duration; no SDK-side change.

## Non-goals
- No changes to Java / Go / Python handler signatures.
- No public sync Client API based on `Atomics.wait`.
- Durable "wait for child completion" as a first-class `Wait` condition — future.

## Tests
`sdk-typescript/test/integ/async-handlers.integration.test.ts` (against `dexcli dev`):
1. async `execute` awaits `Client.startFlow` + `Client.waitForFlow` — parent starts a child on the same Worker, waits for it, completes. Proves single-Worker, no deadlock.
2. async `execute` awaits `Client.invokeRPC` against a flow registered on the same Worker.
3. `Step.waitFor` resolves a `Wait` asynchronously.
Existing synchronous-handler integ suites are unchanged (regression). Verified locally: `npm run typecheck`, `npm test` (unit + contracts), and the three new integ tests pass against `dexcli dev`; `make copyright-check` clean.

## Documentation
- `sdk-typescript/README.md` — new "Async handlers" section: handlers may be `async` and `await` `Client` on the same Worker; warns against blocking the event loop (`Atomics.wait`, `spawnSync`) and against unbounded `waitForFlow` polls.

## Follow-up (not this change)
`examples/typescript` does not exist in the repo yet. When TS examples are created, build them with a single Worker and async steps — no `client-sync` / `Atomics.wait` / sidecar Worker. A more Dex-shaped "wait for flow X completed" `Wait` condition is a separate future improvement.

## UI/UX
N/A: no in-repo web UI.