### PR TITLE
Add Python AsyncClient/AsyncWorker and async SDK design notes

### DIFF
--- a/docs/design/plan/python-sdk-async-apis.md
+++ b/docs/design/plan/python-sdk-async-apis.md
@@ -160,12 +160,16 @@ These are independent workstreams; no doc cross-links required.
 
 Integration tests against a running Dex (`sdk-python` integ suite). Do not add unit tests unless an edge cannot be reached through integ.
 
+About half of the runtime integ modules use `AsyncClient` / `AsyncWorker`
+(`test_basic_runtime`, `test_rpc_runtime`, `test_channels_runtime`, plus
+`test_async_runtime`); the rest stay on sync `Client` / `Worker`.
+
 ### Phase 1
 
 1. `AsyncClient.start_flow` + `wait_for_flow` happy path.
 2. `AsyncClient.invoke_rpc` / `publish` parity with sync `Client`.
 3. Concurrent awaits on one `AsyncClient` (multiple in-flight RPCs) without deadlock.
-4. Existing sync `Client` integ suite unchanged (regression).
+4. Remaining sync `Client` integ modules still pass (regression).
 
 ### Phase 2
 

--- a/docs/design/plan/python-sdk-async-apis.md
+++ b/docs/design/plan/python-sdk-async-apis.md
@@ -161,8 +161,9 @@ These are independent workstreams; no doc cross-links required.
 Integration tests against a running Dex (`sdk-python` integ suite). Do not add unit tests unless an edge cannot be reached through integ.
 
 About half of the runtime integ modules use `AsyncClient` / `AsyncWorker`
-(`test_basic_runtime`, `test_rpc_runtime`, `test_channels_runtime`, plus
-`test_async_runtime`); the rest stay on sync `Client` / `Worker`.
+(`test_basic_runtime_async`, `test_rpc_runtime`, `test_channels_runtime`,
+plus `test_async_runtime`); `test_basic_runtime_sync` keeps the basic suite
+on sync `Client` / `Worker`, and the remaining modules stay sync.
 
 ### Phase 1
 

--- a/docs/design/plan/python-sdk-async-apis.md
+++ b/docs/design/plan/python-sdk-async-apis.md
@@ -1,0 +1,186 @@
+# Python SDK: optional asyncio APIs
+
+Status: implemented (Phase 1 + Phase 2 in `sdk-python`)
+Audience: SDK consumers; examples remain sync unless a later FastAPI sample is added
+
+## Problem
+
+The Python SDK today is entirely synchronous:
+
+- [`Client`](../../sdk-python/dex/client.py) — sync `grpc` + `FlowServiceStub`
+- [`Worker`](../../sdk-python/dex/worker.py) — `ThreadPoolExecutor` + sync `grpc.server`
+- [`Step.execute` / `wait_for`](../../sdk-python/dex/step.py) — sync return types
+- Registry rejects coroutine handlers on the sync path
+
+That model is **correct** for Dex Workers. Like Java, a blocking `client.start_flow` / `wait_for_flow` / `invoke_rpc` inside `Step.execute` only occupies one pool thread; other WorkerService RPCs still run. Parent–child examples already do this (e.g. [`parent_flow_v2.py`](../../examples/python/dex_examples/patterns/workflow/parentchild/parent_flow_v2.py)).
+
+Async support is **not** required to avoid a deadlock class. It is for **asyncio hosts**: FastAPI (or similar) controllers that should not block the event loop on gRPC, and optionally Steps that `await` async I/O (HTTP, DB) or `AsyncClient`.
+
+```mermaid
+flowchart LR
+  subgraph syncPath [Sync path today]
+    SyncStep[Step.execute sync]
+    SyncClient[Client sync gRPC]
+    Pool[ThreadPoolExecutor]
+    SyncStep --> SyncClient --> Pool
+    Pool --> OtherRPC[Other Worker RPCs still run]
+  end
+  subgraph asyncPath [Async path proposed]
+    AsyncStep[async execute]
+    AClient[AsyncClient grpc.aio]
+    AWorker[AsyncWorker aio loop]
+    AsyncStep --> AClient
+    AWorker --> AsyncStep
+  end
+```
+
+## Goal
+
+Ship a **parallel** asyncio surface while keeping sync as the default:
+
+```python
+# Phase 1 — app / controller
+client = AsyncClient(registry, blob_cache, ClientOptions(server_address="..."))
+run_id = await client.start_flow(flow, flow_id, input, options)
+
+# Phase 2 — async Steps on AsyncWorker
+class Run(Step[str]):
+    async def execute(self, context: Context, input: str) -> StepDecision:
+        await async_client.start_flow(child, child_id, ...)
+        return go_to(...)
+
+worker = AsyncWorker(registry, blob_cache, WorkerOptions(...))
+await worker.start()
+```
+
+Exports: `from dex import AsyncClient, AsyncWorker` alongside existing `Client` and `Worker`.
+
+## Non-goals
+
+- Replacing sync examples or requiring async for parent/child.
+- Marketing `asyncio.to_thread(sync_client.method)` as `AsyncClient` — real `grpc.aio` only.
+- Changing `StepDurability.ASYNC` (server durability flag; unrelated to asyncio).
+- Treating Python async as the same urgency as TypeScript async Step handlers (TS is a correctness fix for event-loop deadlock; Python is ergonomics).
+- Dual method names on every API (`start_flow` / `async_start_flow`); use separate types instead.
+
+## Locked design choices
+
+1. **Sync remains default.** Existing `Client` / `Worker` / `Step` / `@rpc` stay unchanged; `examples/python` stays sync.
+2. **Parallel types, not suffixes.** `AsyncClient`, `AsyncWorker`, and coroutine-capable handlers when served by `AsyncWorker`.
+3. **Transport:** `grpc.aio` for both `AsyncClient` and `AsyncWorker` (reuse generated stubs with aio channel/server where possible).
+4. **Mixing rules:**
+   - Sync `Worker` must not run coroutine handlers (fail fast at registration or start; keep today’s “must be synchronous” contract for the sync path).
+   - `AsyncWorker` may run sync or async handlers (sync handlers return values directly; awaitables are awaited).
+   - Inside async `execute`, apps inject and use `AsyncClient` — do not call sync `Client` on the Worker’s event loop (blocks the loop).
+5. **Phased delivery** (below).
+
+## Phase 1 — `AsyncClient` (app / controller side)
+
+### Scope
+
+- New `AsyncClient` mirroring the sync `Client` method set with `async def`: at least `start_flow`, `wait_for_flow`, `invoke_rpc`, `publish`, `stop_flow`, `search_flows`, and other public Client RPCs needed for parity.
+- `async with AsyncClient(...)` / `await client.close()`.
+- Share protobuf build / mapping / hydration with sync Client where practical (extract pure helpers; avoid duplicating request construction).
+- Steps and Worker remain sync.
+
+### Use case
+
+Asyncio HTTP layer starts, signals, and waits on flows without `asyncio.to_thread(client.start_flow)`.
+
+### Out of scope for Phase 1
+
+- Coroutine `Step.execute` / `wait_for` / `@rpc`
+- `AsyncWorker`
+
+## Phase 2 — `AsyncWorker` + async handlers
+
+### Scope
+
+- `AsyncWorker` serves `WorkerService` via `grpc.aio` server.
+- **Loop model:** a single asyncio event loop owned by `AsyncWorker.start()` (document the lifecycle clearly: `await worker.start()` runs until stop/close; or an equivalent documented run pattern — pick one and stick to it).
+- Dispatcher awaits handler results when they are awaitables (same idea as awaiting `Promise` in TypeScript).
+- Registry / dispatcher:
+  - Allow `async def execute` / `wait_for` / RPC methods returning awaitables when the process uses `AsyncWorker`.
+  - Sync handlers still allowed on `AsyncWorker`.
+  - Sync `Worker` continues to reject coroutine handlers.
+- Inside async `execute`, call `AsyncClient` so awaits yield the loop; child / RPC work on the same `AsyncWorker` can proceed.
+
+### Caveats to document
+
+- Long `await async_client.wait_for_flow(...)` inside `execute` holds that WorkerService call until the poll finishes or times out. Prefer short timeouts + step retry (as parent–child examples already do), or a later durable Wait API.
+- Do not use blocking sync gRPC or `time.sleep` inside async handlers on `AsyncWorker`.
+- `StepDurability.ASYNC` remains a server-side durability option and must not be confused with Python `async def`.
+
+## API sketch
+
+```python
+from dex import (
+    AsyncClient,
+    AsyncWorker,
+    ClientOptions,
+    WorkerOptions,
+    Step,
+    StepDecision,
+    Context,
+    go_to,
+)
+
+# Phase 1
+async_client = AsyncClient(registry, blob_cache, ClientOptions(server_address="127.0.0.1:8801"))
+async with async_client:
+    run_id = await async_client.start_flow(flow, flow_id, input, options)
+
+# Phase 2
+class StartChild(Step[int]):
+    def __init__(self, client: AsyncClient, child_flow: Flow[str]) -> None:
+        self._client = client
+        self._child = child_flow
+
+    async def execute(self, context: Context, uuid: int) -> StepDecision:
+        child_id = f"child-wf-{uuid}"
+        await self._client.start_flow(self._child, child_id, str(uuid), options)
+        return go_to(self.await_child, {"child_wf_id": child_id})
+
+worker = AsyncWorker(registry, blob_cache, WorkerOptions(bind_address="127.0.0.1:8803"))
+await worker.start()
+```
+
+## Contrast with TypeScript (context only)
+
+| Concern | TypeScript | Python |
+|---------|------------|--------|
+| Motivation | Unblock Step↔Client on one Worker | Idiomatic asyncio apps |
+| Sync default | Client already async; Step becomes awaitable | Client / Worker / Step stay sync |
+| New types | Widen handler return types | Add `AsyncClient` / `AsyncWorker` |
+| Examples | Remove dual-Worker bridge after SDK change | No forced rewrite |
+
+These are independent workstreams; no doc cross-links required.
+
+## Tests
+
+Integration tests against a running Dex (`sdk-python` integ suite). Do not add unit tests unless an edge cannot be reached through integ.
+
+### Phase 1
+
+1. `AsyncClient.start_flow` + `wait_for_flow` happy path.
+2. `AsyncClient.invoke_rpc` / `publish` parity with sync `Client`.
+3. Concurrent awaits on one `AsyncClient` (multiple in-flight RPCs) without deadlock.
+4. Existing sync `Client` integ suite unchanged (regression).
+
+### Phase 2
+
+5. `AsyncWorker` runs async `execute` that `await`s `AsyncClient.start_flow` for a child on the **same** worker; child completes; parent continues.
+6. Sync `execute` on `AsyncWorker` still works.
+7. Sync `Worker` rejects or fails fast on coroutine `execute` (contract preserved).
+8. Long `wait_for_flow` inside async `execute` with a short timeout does not starve other Worker RPCs on the aio server.
+
+## Documentation
+
+- This plan file — keep until Phase 1 / Phase 2 ship; then trim or fold into release notes.
+- When implementing: [`sdk-python/README.md`](../../sdk-python/README.md) — separate sync vs asyncio sections; state mixing rules explicitly.
+- Changelog / release notes for the `dex-python-sdk` version(s) that ship Phase 1 and Phase 2.
+- Do not rewrite `examples/python` to async in Phase 1. Optional later sample (e.g. FastAPI snippet using `AsyncClient`) only after Phase 1 ships.
+
+## UI/UX
+
+N/A: no in-repo web UI.

--- a/docs/design/plan/typescript-sdk-async-step-handlers.md
+++ b/docs/design/plan/typescript-sdk-async-step-handlers.md
@@ -1,0 +1,123 @@
+# TypeScript SDK: async Step / RPC handlers
+
+Status: proposed
+Audience: implement in a separate worktree (SDK change first, then simplify `examples/typescript`)
+
+## Problem
+
+Java examples call blocking `Client` APIs inside `Step.execute` (start child, wait for child, invoke RPC). That works because the Java Worker is multithreaded: one blocked execute thread does not stop other WorkerService RPCs.
+
+TypeScript today:
+
+1. `Step.execute` / `waitFor` / RPC methods must return synchronously (`StepDecision`, not `Promise`).
+2. `Client` is fully async (`Promise`-based).
+3. Examples bridge with `worker_threads` + `Atomics.wait` (`examples/typescript/src/patterns/client-sync.ts`) and a **second** gRPC Worker as sync `workerTarget` (`syncWorker` in `examples/typescript/src/main.ts`).
+
+`Atomics.wait` freezes the Node event loop of the primary Worker. Child / RPC work started via the sync Client must target the sidecar Worker or the process deadlocks. That topology must not become the recommended app pattern.
+
+## Goal
+
+Let application code write idiomatic async Steps:
+
+```ts
+async execute(context: Context, uuid: number): Promise<StepDecision> {
+  await client.startFlow(childFlow, childId, input, options);
+  return goTo(this.awaitChildStep, { childWFId: childId, timerSeconds: 1 });
+}
+```
+
+Same process, one Worker. No `Atomics.wait`, no sync sidecar Worker, no example-local `client-sync` bridge.
+
+## Non-goals (this change)
+
+- Durable “wait for child completion” as a first-class `Wait` condition (follow-up; see “Later”).
+- Changing Java / Go / Python Step signatures.
+- Shipping a public sync Client API based on `Atomics.wait`.
+
+## Proposed SDK change
+
+### API
+
+Allow handlers to return a value or a Promise of that value:
+
+| Handler | Today | Proposed |
+|---------|--------|----------|
+| `Step.execute` | `StepDecision` | `StepDecision \| Promise<StepDecision>` |
+| `Step.waitFor` | `Wait` | `Wait \| Promise<Wait>` |
+| RPC method body | sync result / `RPCResult` | same, or `Promise` of same |
+
+Keep existing sync handlers valid (no migration required).
+
+### Runtime
+
+`WorkerDispatcher` already uses `async invokeExecute` / `invokeWaitFor` / `invokeRPC`. Await handler results:
+
+```ts
+const decision = await Promise.resolve(step.step.execute(context, input));
+```
+
+Same for `waitFor` and RPC invocation.
+
+Because the handler is truly async (not `Atomics.wait`), the event loop stays free while `await client.*` is in flight. The same Worker can still serve child `invokeExecute` / RPCs. **One Worker is enough.**
+
+### Caveats to document
+
+- Long `await client.waitForFlow(...)` inside `execute` holds that WorkerService call until the poll finishes or times out. Prefer short timeouts + step retry (as parent–child examples already do with timer backoff), or later a durable Wait API.
+- Do not use `Atomics.wait` / `child_process.spawnSync` inside Steps; they block the event loop and recreate the deadlock.
+- Timeouts / retries on `executeMethodTimeoutMs` must still apply to the full async duration (confirm clocking in dispatcher / server options).
+
+## Examples follow-up (after SDK release)
+
+In `examples/typescript`:
+
+1. Delete `src/patterns/client-sync.ts`, `src/patterns/dex-sync-worker.ts`.
+2. Remove `syncWorker` / `syncBlobCache` / `DEX_SYNC_WORKER_BIND_ADDRESS` from `main.ts`, `config/env.ts`, `client-holder.ts`, README.
+3. Replace `startFlowSync` / `waitForFlowSync` / `invokeRpcSync` / `isOptedInSync` with `await client.*` in async Steps:
+   - `patterns/workflow/parentchild/parent-flow-v2.ts`
+   - `patterns/workflow/scalableparallel/{parent-flow,request-receiver-flow}.ts`
+   - `workflow/shortlistcandidates/{shortlist-flow,workflow-ids,is-opted-in-worker}.ts` (drop dedicated opt-in worker thread)
+4. Keep `npm run smoke` green with a **single** Worker bind address.
+
+Depend on a published or workspace `@superdurable/dex` that includes async handlers (bump examples package accordingly).
+
+## Later (optional product improvement)
+
+Even with async `execute`, polling `waitForFlow` from a Step is “Client as orchestrator”. A better Dex-shaped API:
+
+- Wait condition for “flow X completed” (or child-complete channel helpers), similar to scalable-parallel’s completion channels.
+
+Do not block the async-handler work on that.
+
+## Reference: current workaround (to remove)
+
+- Sync bridge: `examples/typescript/src/patterns/client-sync.ts` (`Atomics.wait` + `worker_threads`)
+- Async Client thread: `examples/typescript/src/patterns/dex-sync-worker.ts`
+- Sidecar Worker wiring: `examples/typescript/src/main.ts` (`syncWorker` + `setClient(client, syncWorker.workerTarget)`)
+- Call sites: parent–child, scalable parallel, shortlist `isOptedInSync`
+
+## Tests
+
+SDK integ (`sdk-typescript/test/integ/`), against a running Dex:
+
+1. **Step execute awaits Client.startFlow** — parent Step starts a child on the same Worker; child runs to completion; parent continues. Proves no dual-Worker requirement.
+2. **Step execute awaits Client.waitForFlow** — parent waits for child with a short timeout then completes; covers Promise-returning `execute` + long poll without deadlock.
+3. **Step execute awaits Client.invokeRPC** — flow A Step invokes RPC on flow B registered on the same Worker.
+4. **Sync handlers still work** — existing integ suite unchanged (regression).
+5. **waitFor returning Promise\<Wait\>** — if implemented in the same change; otherwise defer with a tracked follow-up test.
+
+Examples (after cleanup):
+
+6. **Smoke / integ** — `npm run test:integ` and `npm run smoke` with one Worker; parentchild + scalableparallel + shortlist paths must pass.
+
+Do not add unit tests unless an edge case cannot be hit via integ.
+
+## Documentation
+
+- `sdk-typescript/README.md` — document that `execute` / `waitFor` / RPC may be `async` and may `await` `Client` on the same Worker; warn against blocking the event loop.
+- This plan file — keep until shipped, then trim or move to changelog notes.
+- `examples/typescript/README.md` — remove dual-Worker / `DEX_SYNC_WORKER_BIND_ADDRESS` once examples are simplified.
+- Update any public TS API notes if `Step` / RPC typedefs are listed outside the README.
+
+## UI/UX
+
+N/A: no in-repo web UI.

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -89,8 +89,10 @@ Applications implement two generic interfaces from [`dex`](dex/):
   `.other_steps(...)`, from one `get_steps()` method. The `StepList` generic
   binds the Flow input to the starting Step input. Use `StepList.empty()` when
   a Flow has no Steps.
-- `Step[INPUT]` implements synchronous `execute` and optionally synchronous
-  `wait_for`.
+- `Step[INPUT]` implements `execute` and optionally `wait_for`. The default
+  Worker path requires synchronous handlers. With `AsyncWorker` and
+  `Registry(..., allow_async_handlers=True)`, handlers may be `async def` and
+  `await` an `AsyncClient`.
 
 `StepOptions.wait_for_method_timeout` and `execute_method_timeout` bound the
 two handler calls. Timer and channel conditions determine how long a Step waits.
@@ -99,6 +101,18 @@ two handler calls. Timer and channel conditions determine how long a Step waits.
 codec before Client or Worker startup. `Client` methods use these typed objects
 instead of raw Flow, Step, or RPC strings.
 
+### Sync vs asyncio
+
+- **Sync (default):** `Client` and `Worker` use blocking gRPC and a thread-pool
+  Worker. Blocking `Client` calls inside `Step.execute` are safe (one pool
+  thread is occupied; other RPCs still run).
+- **Asyncio:** `AsyncClient` and `AsyncWorker` use `grpc.aio`. Use
+  `Registry(..., allow_async_handlers=True)` when Steps/RPCs are coroutines.
+  Inside async `execute`, inject `AsyncClient` — do not call sync `Client` on
+  the Worker event loop. Sync `Worker` still rejects coroutine handlers at
+  registry construction unless `allow_async_handlers=True` (and even then the
+  sync Worker dispatcher rejects awaitable return values).
+
 Integration scenarios live under
 [`tests/integ`](tests/integ/README.md). They exercise the same workflows,
 client operations, and assertions as the Java suite against an isolated
@@ -106,9 +120,11 @@ client operations, and assertions as the Java suite against an isolated
 
 ## Implementation status
 
-The strongly typed contracts, registry, synchronous Client, Worker gRPC
-service, and Rust-backed BlobCache are implemented. Python owns its gRPC
-transport; the native bridge is limited to the shared BlobCache.
+The strongly typed contracts, registry, synchronous Client/Worker, optional
+`AsyncClient`/`AsyncWorker` (`grpc.aio`), and Rust-backed BlobCache are
+implemented. Python owns its gRPC transport; the native bridge is limited to
+the shared BlobCache. Design notes:
+[`docs/design/plan/python-sdk-async-apis.md`](../docs/design/plan/python-sdk-async-apis.md).
 
 ## Running dex-server locally
 

--- a/sdk-python/dex/__init__.py
+++ b/sdk-python/dex/__init__.py
@@ -17,6 +17,8 @@ from dex.attribute import (
 )
 from dex.blob_cache import BlobCache, BlobCacheConfig, open_blob_cache
 from dex.channel import Channel, ChannelMap
+from dex.async_client import AsyncClient
+from dex.async_worker import AsyncWorker
 from dex.client import Client
 from dex.client_options import ClientOptions
 from dex.codec import (
@@ -91,6 +93,8 @@ __all__ = [
     "AttributeIndex",
     "AttributeLock",
     "AttributeMap",
+    "AsyncClient",
+    "AsyncWorker",
     "BlobCache",
     "BlobCacheConfig",
     "Channel",

--- a/sdk-python/dex/_async_value_hydrator.py
+++ b/sdk-python/dex/_async_value_hydrator.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Super Durable Source License 1.0.
+# You may not use this file except in compliance with the License.
+# See the LICENSE file in the repository root.
+#
+# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from dex.blob_cache import BlobCache
+from dex.dexpb import dex_pb2 as pb
+from dex.dexpb import dex_pb2_grpc
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class _PendingBlob:
+    blob_id: str
+    is_object: bool
+    request: pb.Value
+    indexes: list[int] = field(default_factory=list)
+    hydrated: pb.Value | None = None
+
+
+class AsyncValueHydrator:
+    def __init__(
+        self,
+        service: dex_pb2_grpc.FlowServiceStub,
+        cache: BlobCache,
+    ) -> None:
+        self._service = service
+        self._cache = cache
+
+    async def hydrate(self, value: pb.Value) -> pb.Value:
+        return (await self.hydrate_all([value]))[0]
+
+    async def hydrate_all(self, values: list[pb.Value]) -> list[pb.Value]:
+        hydrated = list(values)
+        pending: dict[tuple[str, bool], _PendingBlob] = {}
+        for index, value in enumerate(values):
+            key = self._blob_key(value)
+            if key is None:
+                self._validate_concrete(value)
+                continue
+            blob = pending.get(key)
+            if blob is None:
+                blob = _PendingBlob(key[0], key[1], value)
+                pending[key] = blob
+            blob.indexes.append(index)
+
+        misses: list[_PendingBlob] = []
+        for blob in pending.values():
+            concrete = self._read_cache(blob)
+            if concrete is None:
+                misses.append(blob)
+            else:
+                blob.hydrated = concrete
+        await self._load_misses(misses)
+
+        for blob in pending.values():
+            if blob.hydrated is None:
+                raise RuntimeError(f"blob was not hydrated: {blob.blob_id}")
+            for index in blob.indexes:
+                hydrated[index] = blob.hydrated
+        return hydrated
+
+    async def wait_for_request(
+        self,
+        request: pb.InvokeWaitForMethodRequest,
+    ) -> pb.InvokeWaitForMethodRequest:
+        result = pb.InvokeWaitForMethodRequest()
+        result.CopyFrom(request)
+        values = [request.step_input, *(entry.value for entry in request.attributes)]
+        hydrated = await self.hydrate_all(values)
+        result.step_input.CopyFrom(hydrated[0])
+        for entry, value in zip(result.attributes, hydrated[1:]):
+            entry.value.CopyFrom(value)
+        return result
+
+    async def execute_request(
+        self,
+        request: pb.InvokeExecuteMethodRequest,
+    ) -> pb.InvokeExecuteMethodRequest:
+        result = pb.InvokeExecuteMethodRequest()
+        result.CopyFrom(request)
+        values = [request.step_input]
+        values.extend(entry.value for entry in request.attributes)
+        values.extend(entry.value for entry in request.step_exe_locals)
+        for channel_result in request.condition_results.channel_results:
+            values.extend(channel_result.values)
+        hydrated = iter(await self.hydrate_all(values))
+        result.step_input.CopyFrom(next(hydrated))
+        for entry in result.attributes:
+            entry.value.CopyFrom(next(hydrated))
+        for entry in result.step_exe_locals:
+            entry.value.CopyFrom(next(hydrated))
+        for channel_result in result.condition_results.channel_results:
+            for value in channel_result.values:
+                value.CopyFrom(next(hydrated))
+        return result
+
+    async def rpc_request(
+        self,
+        request: pb.InvokeWorkerRPCRequest,
+    ) -> pb.InvokeWorkerRPCRequest:
+        result = pb.InvokeWorkerRPCRequest()
+        result.CopyFrom(request)
+        values = [request.input, *(entry.value for entry in request.attributes)]
+        hydrated = await self.hydrate_all(values)
+        result.input.CopyFrom(hydrated[0])
+        for entry, value in zip(result.attributes, hydrated[1:]):
+            entry.value.CopyFrom(value)
+        return result
+
+    async def step_outputs(
+        self,
+        outputs: list[pb.StepCompletionOutput],
+    ) -> list[pb.StepCompletionOutput]:
+        values = [output.completed_step_output for output in outputs]
+        hydrated = await self.hydrate_all(values)
+        results: list[pb.StepCompletionOutput] = []
+        for output, value in zip(outputs, hydrated):
+            result = pb.StepCompletionOutput()
+            result.CopyFrom(output)
+            result.completed_step_output.CopyFrom(value)
+            results.append(result)
+        return results
+
+    async def _load_misses(self, misses: list[_PendingBlob]) -> None:
+        if not misses:
+            return
+        response = await self._service.LoadBlobs(
+            pb.LoadBlobsRequest(values=[miss.request for miss in misses])
+        )
+        for miss in misses:
+            concrete = response.values.get(miss.blob_id)
+            if concrete is None:
+                raise RuntimeError(f"LoadBlobs omitted blob {miss.blob_id}")
+            self._validate_hydrated(miss, concrete)
+            miss.hydrated = concrete
+            self._write_cache(miss, concrete)
+
+    def _read_cache(self, blob: _PendingBlob) -> pb.Value | None:
+        try:
+            payload = self._cache.get(blob.blob_id)
+            if payload is None:
+                return None
+            if blob.is_object:
+                concrete = pb.Value(obj_value=pb.EncodedObject.FromString(payload))
+            else:
+                concrete = pb.Value(string_value=payload.decode("utf-8"))
+            self._validate_hydrated(blob, concrete)
+            return concrete
+        except Exception:
+            _LOGGER.warning("cannot read cached blob %s", blob.blob_id, exc_info=True)
+            try:
+                self._cache.delete(blob.blob_id)
+            except Exception:
+                _LOGGER.warning(
+                    "cannot delete cached blob %s",
+                    blob.blob_id,
+                    exc_info=True,
+                )
+            return None
+
+    def _write_cache(self, blob: _PendingBlob, concrete: pb.Value) -> None:
+        try:
+            payload = (
+                concrete.obj_value.SerializeToString()
+                if blob.is_object
+                else concrete.string_value.encode("utf-8")
+            )
+            self._cache.put(blob.blob_id, payload)
+        except Exception:
+            _LOGGER.warning("cannot cache blob %s", blob.blob_id, exc_info=True)
+
+    @staticmethod
+    def _blob_key(value: pb.Value) -> tuple[str, bool] | None:
+        kind = value.WhichOneof("kind")
+        if kind == "internal_blob_id_for_string_value":
+            blob_id = value.internal_blob_id_for_string_value
+            if not blob_id:
+                raise ValueError("blob ID is required")
+            return blob_id, False
+        if kind == "internal_blob_id_for_obj_value":
+            blob_id = value.internal_blob_id_for_obj_value
+            if not blob_id:
+                raise ValueError("blob ID is required")
+            return blob_id, True
+        return None
+
+    @staticmethod
+    def _validate_hydrated(blob: _PendingBlob, value: pb.Value) -> None:
+        expected = "obj_value" if blob.is_object else "string_value"
+        if value.WhichOneof("kind") != expected:
+            raise RuntimeError(
+                f"blob {blob.blob_id} hydrated to {value.WhichOneof('kind')}"
+            )
+        AsyncValueHydrator._validate_concrete(value)
+
+    @staticmethod
+    def _validate_concrete(value: pb.Value) -> None:
+        kind = value.WhichOneof("kind")
+        if kind in ("string_value", "int_value", "bool_value", "null_value"):
+            return
+        if kind == "double_value":
+            import math
+
+            if not math.isfinite(value.double_value):
+                raise ValueError("non-finite numbers are unsupported")
+            return
+        if kind == "obj_value":
+            if value.obj_value.encoding not in ("json", "rawbytes"):
+                raise ValueError(
+                    f"unsupported object encoding {value.obj_value.encoding}"
+                )
+            return
+        raise ValueError("Value has no concrete kind")

--- a/sdk-python/dex/_async_worker_dispatcher.py
+++ b/sdk-python/dex/_async_worker_dispatcher.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Super Durable Source License 1.0.
+# You may not use this file except in compliance with the License.
+# See the LICENSE file in the repository root.
+#
+# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+from __future__ import annotations
+
+from inspect import isawaitable
+from typing import Any
+
+from dex._async_value_hydrator import AsyncValueHydrator
+from dex._invocation_context import InvocationContext, InvocationMethod
+from dex._value_mapper import ValueMapper
+from dex._worker_dispatcher import WorkerDispatcher
+from dex.dexpb import dex_pb2 as pb
+from dex.flow import RPCResult, Registry
+from dex.step import StepDecision
+from dex.wait import Wait
+
+
+class AsyncWorkerDispatcher(WorkerDispatcher):
+    def __init__(
+        self,
+        registry: Registry,
+        values: ValueMapper,
+        hydrator: AsyncValueHydrator,
+    ) -> None:
+        self._registry = registry
+        self._values = values
+        self._hydrator = hydrator  # type: ignore[assignment]
+
+    async def invoke_wait_for(  # type: ignore[override]
+        self,
+        original: pb.InvokeWaitForMethodRequest,
+    ) -> pb.InvokeWaitForMethodResponse:
+        request = await self._hydrator.wait_for_request(original)
+        flow = self._registry._flow_by_type(request.flow_type)
+        step = flow.step(request.step_type)
+        context = InvocationContext(
+            InvocationMethod.WAIT_FOR,
+            flow,
+            request.context,
+            self._values,
+            request.attributes,
+        )
+        input = self._values.decode(request.step_input, step.input_codec)
+        wait = step.step.wait_for(context, input)
+        if isawaitable(wait):
+            wait = await wait
+        if not isinstance(wait, Wait):
+            raise TypeError("wait_for must return Wait")
+        response = pb.InvokeWaitForMethodResponse(
+            upsert_attributes=list(context.attribute_writes.values()),
+            upsert_step_exe_locals=list(context.local_writes.values()),
+            record_events=context.events,
+            publish_to_channel=context.publications,
+        )
+        waiting = self._map_wait(flow, wait)
+        if waiting is not None:
+            response.waiting_condition.CopyFrom(waiting)
+        return response
+
+    async def invoke_execute(  # type: ignore[override]
+        self,
+        original: pb.InvokeExecuteMethodRequest,
+    ) -> pb.InvokeExecuteMethodResponse:
+        request = await self._hydrator.execute_request(original)
+        flow = self._registry._flow_by_type(request.flow_type)
+        step = flow.step(request.step_type)
+        condition_results = (
+            request.condition_results if request.HasField("condition_results") else None
+        )
+        context = InvocationContext(
+            InvocationMethod.EXECUTE,
+            flow,
+            request.context,
+            self._values,
+            request.attributes,
+            request.step_exe_locals,
+            condition_results,
+        )
+        input = self._values.decode(request.step_input, step.input_codec)
+        decision: Any = step.step.execute(context, input)
+        if isawaitable(decision):
+            decision = await decision
+        if not isinstance(decision, StepDecision):
+            raise TypeError("execute must return StepDecision")
+        return pb.InvokeExecuteMethodResponse(
+            step_decision=self._map_decision(flow, decision),
+            upsert_attributes=list(context.attribute_writes.values()),
+            record_events=context.events,
+            upsert_step_exe_locals=list(context.local_writes.values()),
+            publish_to_channel=context.publications,
+        )
+
+    async def invoke_rpc(  # type: ignore[override]
+        self,
+        original: pb.InvokeWorkerRPCRequest,
+    ) -> pb.InvokeWorkerRPCResponse:
+        request = await self._hydrator.rpc_request(original)
+        flow = self._registry._flow_by_type(request.flow_type)
+        rpc = flow.rpc(request.rpc_name)
+        context = InvocationContext(
+            InvocationMethod.RPC,
+            flow,
+            request.context,
+            self._values,
+            request.attributes,
+            channel_infos=dict(request.channel_infos),
+        )
+        arguments: list[object] = [context]
+        if rpc.input_codec is not None:
+            arguments.append(self._values.decode(request.input, rpc.input_codec))
+        returned: Any = rpc.method(*arguments)
+        if isawaitable(returned):
+            returned = await returned
+        response = pb.InvokeWorkerRPCResponse(
+            upsert_attributes=list(context.attribute_writes.values()),
+            record_events=context.events,
+            publish_to_channel=context.publications,
+        )
+        if isinstance(returned, RPCResult):
+            if rpc.output_codec is None:
+                raise TypeError("RPCResult requires an output type")
+            response.output.CopyFrom(
+                self._values.encode(returned.output, rpc.output_codec)
+            )
+            if returned.next_steps:
+                response.step_decision.next_steps.extend(
+                    self._map_movements(flow, returned.next_steps)
+                )
+        elif returned is None and rpc.output_codec is None:
+            response.output.CopyFrom(self._values.encode_dynamic(None))
+        else:
+            raise TypeError("RPC must return RPCResult or None")
+        return response

--- a/sdk-python/dex/_async_worker_service.py
+++ b/sdk-python/dex/_async_worker_service.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Super Durable Source License 1.0.
+# You may not use this file except in compliance with the License.
+# See the LICENSE file in the repository root.
+#
+# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+import grpc
+
+from dex._async_worker_dispatcher import AsyncWorkerDispatcher
+from dex._grpc_errors import abort_worker_error
+from dex.dexpb import dex_pb2 as pb
+from dex.dexpb import dex_pb2_grpc
+
+_LOGGER = logging.getLogger(__name__)
+ResponseT = TypeVar("ResponseT")
+
+
+class AsyncWorkerService(dex_pb2_grpc.WorkerServiceServicer):
+    def __init__(self, dispatcher: AsyncWorkerDispatcher) -> None:
+        self._dispatcher = dispatcher
+
+    async def InvokeWaitForMethod(  # type: ignore[override]
+        self,
+        request: pb.InvokeWaitForMethodRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> pb.InvokeWaitForMethodResponse:
+        return await self._invoke(
+            context, lambda: self._dispatcher.invoke_wait_for(request)
+        )
+
+    async def InvokeExecuteMethod(  # type: ignore[override]
+        self,
+        request: pb.InvokeExecuteMethodRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> pb.InvokeExecuteMethodResponse:
+        return await self._invoke(
+            context, lambda: self._dispatcher.invoke_execute(request)
+        )
+
+    async def InvokeWorkerRPC(  # type: ignore[override]
+        self,
+        request: pb.InvokeWorkerRPCRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> pb.InvokeWorkerRPCResponse:
+        return await self._invoke(context, lambda: self._dispatcher.invoke_rpc(request))
+
+    @staticmethod
+    async def _invoke(
+        context: grpc.aio.ServicerContext,
+        invocation: Callable[[], Awaitable[ResponseT]],
+    ) -> ResponseT:
+        try:
+            return await invocation()
+        except BaseException as error:
+            _LOGGER.exception("Python AsyncWorker invocation failed")
+            abort_worker_error(context, error)
+            raise RuntimeError("gRPC abort returned unexpectedly") from error

--- a/sdk-python/dex/_async_worker_service.py
+++ b/sdk-python/dex/_async_worker_service.py
@@ -15,7 +15,7 @@ from typing import TypeVar
 import grpc
 
 from dex._async_worker_dispatcher import AsyncWorkerDispatcher
-from dex._grpc_errors import abort_worker_error
+from dex._grpc_errors import async_abort_worker_error
 from dex.dexpb import dex_pb2 as pb
 from dex.dexpb import dex_pb2_grpc
 
@@ -61,5 +61,5 @@ class AsyncWorkerService(dex_pb2_grpc.WorkerServiceServicer):
             return await invocation()
         except BaseException as error:
             _LOGGER.exception("Python AsyncWorker invocation failed")
-            abort_worker_error(context, error)
+            await async_abort_worker_error(context, error)
             raise RuntimeError("gRPC abort returned unexpectedly") from error

--- a/sdk-python/dex/_grpc_errors.py
+++ b/sdk-python/dex/_grpc_errors.py
@@ -45,6 +45,17 @@ def abort_worker_error(
     context: grpc.ServicerContext,
     error: BaseException,
 ) -> None:
+    context.abort_with_status(rpc_status.to_status(_worker_error_status(error)))
+
+
+async def async_abort_worker_error(
+    context: grpc.aio.ServicerContext,
+    error: BaseException,
+) -> None:
+    await context.abort_with_status(rpc_status.to_status(_worker_error_status(error)))
+
+
+def _worker_error_status(error: BaseException) -> status_pb2.Status:
     message = str(error) or type(error).__name__
     worker_error = pb.WorkerErrorResponse(
         detail=message,
@@ -52,12 +63,11 @@ def abort_worker_error(
     )
     packed = any_pb2.Any()
     packed.Pack(worker_error)
-    status = status_pb2.Status(
+    return status_pb2.Status(
         code=grpc.StatusCode.UNKNOWN.value[0],
         message=message,
         details=[packed],
     )
-    context.abort_with_status(rpc_status.to_status(status))
 
 
 def _map_sub_status(value: int) -> ErrorSubStatus | None:

--- a/sdk-python/dex/_grpc_errors.py
+++ b/sdk-python/dex/_grpc_errors.py
@@ -52,7 +52,10 @@ async def async_abort_worker_error(
     context: grpc.aio.ServicerContext[Any, Any],
     error: BaseException,
 ) -> None:
-    await context.abort_with_status(rpc_status.to_status(_worker_error_status(error)))
+    # types-grpcio on 3.11 omits aio abort_with_status; runtime provides it.
+    await cast(Any, context).abort_with_status(
+        rpc_status.to_status(_worker_error_status(error))
+    )
 
 
 def _worker_error_status(error: BaseException) -> status_pb2.Status:

--- a/sdk-python/dex/_grpc_errors.py
+++ b/sdk-python/dex/_grpc_errors.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 import grpc
 from google.protobuf import any_pb2
@@ -49,7 +49,7 @@ def abort_worker_error(
 
 
 async def async_abort_worker_error(
-    context: grpc.aio.ServicerContext,
+    context: grpc.aio.ServicerContext[Any, Any],
     error: BaseException,
 ) -> None:
     await context.abort_with_status(rpc_status.to_status(_worker_error_status(error)))

--- a/sdk-python/dex/_worker_dispatcher.py
+++ b/sdk-python/dex/_worker_dispatcher.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from inspect import isawaitable
 from typing import Any, cast
 
 from dex._invocation_context import InvocationContext, InvocationMethod
@@ -60,6 +61,10 @@ class WorkerDispatcher:
         )
         input = self._values.decode(request.step_input, step.input_codec)
         wait = step.step.wait_for(context, input)
+        if isawaitable(wait):
+            raise TypeError(
+                "wait_for returned an awaitable; use AsyncWorker for async handlers"
+            )
         if not isinstance(wait, Wait):
             raise TypeError("wait_for must return Wait")
         response = pb.InvokeWaitForMethodResponse(
@@ -94,6 +99,10 @@ class WorkerDispatcher:
         )
         input = self._values.decode(request.step_input, step.input_codec)
         decision = step.step.execute(context, input)
+        if isawaitable(decision):
+            raise TypeError(
+                "execute returned an awaitable; use AsyncWorker for async handlers"
+            )
         if not isinstance(decision, StepDecision):
             raise TypeError("execute must return StepDecision")
         return pb.InvokeExecuteMethodResponse(
@@ -123,6 +132,10 @@ class WorkerDispatcher:
         if rpc.input_codec is not None:
             arguments.append(self._values.decode(request.input, rpc.input_codec))
         returned = rpc.method(*arguments)
+        if isawaitable(returned):
+            raise TypeError(
+                "RPC returned an awaitable; use AsyncWorker for async handlers"
+            )
         response = pb.InvokeWorkerRPCResponse(
             upsert_attributes=list(context.attribute_writes.values()),
             record_events=context.events,

--- a/sdk-python/dex/async_client.py
+++ b/sdk-python/dex/async_client.py
@@ -1,0 +1,757 @@
+# Legacy Materials in this file remain under their original licenses.
+# See LEGACY_NOTICES.md.
+
+# Modifications Copyright (c) 2026 Super Durable, Inc.
+#
+# Modifications after the Legacy Cutoff are licensed under the
+# Super Durable Source License 1.0.
+# Legacy Materials remain under their original licenses.
+# See LICENSE and LEGACY_NOTICES.md.
+
+from __future__ import annotations
+
+from datetime import timedelta, timezone
+from types import TracebackType
+from typing import Any, Callable, TypeVar, cast, overload
+from uuid import uuid4
+
+import grpc
+
+from dex._grpc_errors import translate_rpc_error
+from dex._utils import require_name
+from dex._async_value_hydrator import AsyncValueHydrator
+from dex._value_mapper import ValueMapper
+from dex._worker_dispatcher import WorkerDispatcher
+from dex.attribute import Attribute, AttributeMap
+from dex.blob_cache import BlobCache
+from dex.channel import Channel, ChannelMap
+from dex.client_options import ClientOptions
+from dex.context import Context
+from dex.dexpb import dex_pb2 as pb
+from dex.dexpb import dex_pb2_grpc
+from dex.flow import Flow, Registry, RPCResult
+from dex.flow_config import ActiveStepSearchMode, FlowConfig
+from dex.flow_info import FlowInfo, FlowStatus, SearchFlowEntry, SearchFlowsPage
+from dex.flow_options import (
+    IdReusePolicy,
+    ResetFlowOptions,
+    ResetType,
+    StartFlowOptions,
+    StopFlowOptions,
+    StopType,
+)
+from dex.runtime_errors import (
+    FlowErrorType,
+    FlowUncompletedError,
+    LongPollTimeoutError,
+)
+from dex.step import RetryPolicy, StepDurability
+from dex.step_execution import StepExecutionId, TimerId
+
+InputT = TypeVar("InputT")
+OutputT = TypeVar("OutputT")
+ValueT = TypeVar("ValueT")
+
+
+class AsyncClient:
+    def __init__(
+        self,
+        registry: Registry,
+        blob_cache: BlobCache,
+        options: ClientOptions | None = None,
+    ) -> None:
+        self.registry = registry
+        self.blob_cache = blob_cache
+        self.options = options or ClientOptions()
+        self._channel = grpc.aio.insecure_channel(self.options.server_address)
+        self._service = dex_pb2_grpc.FlowServiceStub(  # type: ignore[no-untyped-call]
+            self._channel
+        )
+        self._values = ValueMapper(registry.codec_registry)
+        self._hydrator = AsyncValueHydrator(self._service, blob_cache)
+        self._mappings = WorkerDispatcher(
+            registry,
+            self._values,
+            self._hydrator,
+        )
+        self._closed = False
+
+    async def __aenter__(self) -> AsyncClient:
+        return self
+
+    async def __aexit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    async def start_flow(
+        self,
+        flow: Flow[InputT],
+        flow_id: str,
+        input: InputT,
+        options: StartFlowOptions = StartFlowOptions(),
+    ) -> str:
+        registered = self.registry._flow_for_instance(flow)
+        request = pb.StartFlowRequest(
+            flow_id=require_name(flow_id),
+            flow_type=registered.name,
+            request_id=options.request_id or str(uuid4()),
+            flow_start_options=self._map_start_options(options),
+        )
+        if registered.start_step is not None:
+            start = registered.start_step
+            request.start_step_type = start.name
+            request.step_input.CopyFrom(self._values.encode(input, start.input_codec))
+            step_options = self._mappings.map_step_options(
+                registered,
+                start.step.get_step_options(),
+            )
+            if step_options is not None:
+                request.step_options.CopyFrom(step_options)
+            request.step_options.skip_wait_for = start.skips_wait_for
+        elif input is not None:
+            raise ValueError("Flow without a start Step requires None input")
+        if options.timeout is not None:
+            request.flow_timeout_seconds = self._seconds32(options.timeout)
+        response = cast(
+            pb.StartFlowResponse, await self._call(self._service.StartFlow, request)
+        )
+        return response.run_id
+
+    @overload
+    async def invoke_rpc(
+        self,
+        rpc_method: Callable[[Context, InputT], RPCResult[OutputT]],
+        flow_id: str,
+        input: InputT,
+        *,
+        run_id: str = "",
+    ) -> OutputT: ...
+
+    @overload
+    async def invoke_rpc(
+        self,
+        rpc_method: Callable[[Context], RPCResult[OutputT]],
+        flow_id: str,
+        *,
+        run_id: str = "",
+    ) -> OutputT: ...
+
+    @overload
+    async def invoke_rpc(
+        self,
+        rpc_method: Callable[[Context, InputT], None],
+        flow_id: str,
+        input: InputT,
+        *,
+        run_id: str = "",
+    ) -> None: ...
+
+    @overload
+    async def invoke_rpc(
+        self,
+        rpc_method: Callable[[Context], None],
+        flow_id: str,
+        *,
+        run_id: str = "",
+    ) -> None: ...
+
+    async def invoke_rpc(
+        self,
+        rpc_method: Callable[..., Any],
+        flow_id: str,
+        input: object = None,
+        *,
+        run_id: str = "",
+    ) -> Any:
+        _, rpc = self.registry._rpc_for_method(rpc_method)
+        encoded_input = (
+            self._values.encode(input, rpc.input_codec)
+            if rpc.input_codec is not None
+            else self._values.encode_dynamic(None)
+        )
+        timeout = (
+            self._seconds32(rpc.options.timeout)
+            if rpc.options.timeout is not None
+            else 0
+        )
+        response = cast(
+            pb.InvokeRPCResponse,
+            await self._call(
+                self._service.InvokeRPC,
+                pb.InvokeRPCRequest(
+                    flow_id=require_name(flow_id),
+                    run_id=run_id,
+                    rpc_name=rpc.name,
+                    input=encoded_input,
+                    timeout_seconds=timeout,
+                    lock_attribute_keys=rpc.locks,
+                    request_id=str(uuid4()),
+                ),
+            ),
+        )
+        if rpc.output_codec is None:
+            return None
+        return self._values.decode(
+            await self._hydrator.hydrate(response.output),
+            rpc.output_codec,
+        )
+
+    @overload
+    async def get_attribute(
+        self,
+        flow_id: str,
+        attribute: Attribute[ValueT],
+        *,
+        run_id: str = "",
+    ) -> ValueT: ...
+
+    @overload
+    async def get_attribute(
+        self,
+        flow_id: str,
+        attribute: AttributeMap[ValueT],
+        instance: str,
+        *,
+        run_id: str = "",
+    ) -> ValueT: ...
+
+    async def get_attribute(
+        self,
+        flow_id: str,
+        attribute: Attribute[Any] | AttributeMap[Any],
+        instance: str | None = None,
+        *,
+        run_id: str = "",
+    ) -> Any:
+        key = self._definition_name(attribute, instance)
+        response = cast(
+            pb.GetAttributesResponse,
+            await self._call(
+                self._service.GetAttributes,
+                pb.GetAttributesRequest(
+                    flow_id=require_name(flow_id),
+                    run_id=run_id,
+                    keys=[key],
+                ),
+            ),
+        )
+        if not response.attributes:
+            return None
+        value = await self._hydrator.hydrate(response.attributes[0].value)
+        return self._values.decode(value, self._values.codec(attribute.value_type))
+
+    @overload
+    async def set_attribute(
+        self,
+        flow_id: str,
+        attribute: Attribute[ValueT],
+        value: ValueT,
+        /,
+        *,
+        run_id: str = "",
+    ) -> None: ...
+
+    @overload
+    async def set_attribute(
+        self,
+        flow_id: str,
+        attribute: AttributeMap[ValueT],
+        instance: str,
+        value: ValueT,
+        /,
+        *,
+        run_id: str = "",
+    ) -> None: ...
+
+    async def set_attribute(
+        self,
+        flow_id: str,
+        attribute: Attribute[Any] | AttributeMap[Any],
+        /,
+        *args: object,
+        run_id: str = "",
+    ) -> None:
+        instance, value = self._definition_value(attribute, args)
+        write = pb.AttributeWrite(
+            key=self._definition_name(attribute, instance),
+            value=self._values.encode(
+                value,
+                self._values.codec(attribute.value_type),
+            ),
+        )
+        index = self._values.index_config(
+            attribute.index,
+            isinstance(attribute, AttributeMap),
+        )
+        if index is not None:
+            write.index_config.CopyFrom(index)
+        await self._call(
+            self._service.SetAttributes,
+            pb.SetAttributesRequest(
+                flow_id=require_name(flow_id),
+                run_id=run_id,
+                attributes=[write],
+                request_id=str(uuid4()),
+            ),
+        )
+
+    @overload
+    async def publish(
+        self,
+        flow_id: str,
+        channel: Channel[ValueT],
+        /,
+        *values: ValueT,
+        run_id: str = "",
+    ) -> None: ...
+
+    @overload
+    async def publish(
+        self,
+        flow_id: str,
+        channel: ChannelMap[ValueT],
+        instance: str,
+        /,
+        *values: ValueT,
+        run_id: str = "",
+    ) -> None: ...
+
+    async def publish(
+        self,
+        flow_id: str,
+        channel: Channel[Any] | ChannelMap[Any],
+        /,
+        *args: object,
+        run_id: str = "",
+    ) -> None:
+        if isinstance(channel, ChannelMap):
+            if len(args) < 2 or not isinstance(args[0], str):
+                raise TypeError("ChannelMap publish requires instance and values")
+            instance = args[0]
+            values = args[1:]
+        else:
+            instance = None
+            values = args
+        if not values:
+            raise ValueError("publish requires at least one value")
+        name = self._definition_name(channel, instance)
+        codec = self._values.codec(channel.value_type)
+        await self._call(
+            self._service.PublishToChannel,
+            pb.PublishToChannelRequest(
+                flow_id=require_name(flow_id),
+                run_id=run_id,
+                messages=[
+                    pb.ChannelMessage(
+                        channel_name=name,
+                        value=self._values.encode(value, codec),
+                    )
+                    for value in values
+                ],
+            ),
+        )
+
+    @overload
+    async def wait_for_flow(self, flow_id: str) -> None: ...
+
+    @overload
+    async def wait_for_flow(
+        self,
+        flow_id: str,
+        output_type: type[OutputT],
+        timeout: timedelta | None = None,
+    ) -> OutputT: ...
+
+    async def wait_for_flow(
+        self,
+        flow_id: str,
+        output_type: type[Any] | None = None,
+        timeout: timedelta | None = None,
+    ) -> Any:
+        response = await self._wait_for_flow_response(flow_id, timeout)
+        if output_type is None:
+            return None
+        codec = self._values.codec(output_type)
+        for result in reversed(response.results):
+            if result.HasField("completed_step_output"):
+                return self._values.decode(
+                    await self._hydrator.hydrate(result.completed_step_output),
+                    codec,
+                )
+        return None
+
+    async def stop_flow(
+        self,
+        flow_id: str,
+        options: StopFlowOptions = StopFlowOptions(),
+    ) -> None:
+        await self._call(
+            self._service.StopFlow,
+            pb.StopFlowRequest(
+                flow_id=require_name(flow_id),
+                reason=options.reason or "",
+                stop_type={
+                    StopType.CANCEL: pb.STOP_TYPE_CANCEL,
+                    StopType.TERMINATE: pb.STOP_TYPE_TERMINATE,
+                    StopType.FAIL: pb.STOP_TYPE_FAIL,
+                }[options.type],
+            ),
+        )
+
+    async def describe_flow(self, flow_id: str) -> FlowInfo:
+        response = cast(
+            pb.GetFlowSummaryResponse,
+            await self._call(
+                self._service.GetFlowSummary,
+                pb.GetFlowSummaryRequest(flow_id=require_name(flow_id)),
+            ),
+        )
+        return FlowInfo(
+            response.flow_execution_id.flow_id,
+            response.flow_execution_id.run_id,
+            response.flow_type,
+            self._map_flow_status(response.flow_status),
+            response.start_time.ToDatetime(tzinfo=timezone.utc),
+        )
+
+    async def search_flows(
+        self,
+        query: str,
+        page_size: int,
+        next_page_token: str = "",
+    ) -> SearchFlowsPage:
+        if page_size < 0:
+            raise ValueError("search page size must not be negative")
+        response = cast(
+            pb.SearchFlowsResponse,
+            await self._call(
+                self._service.SearchFlows,
+                pb.SearchFlowsRequest(
+                    query=query,
+                    page_size=page_size,
+                    next_page_token=next_page_token,
+                ),
+            ),
+        )
+        flows = [await self._map_search_entry(entry) for entry in response.flow_runs]
+        return SearchFlowsPage(flows, response.next_page_token)
+
+    async def _map_search_entry(self, entry: pb.SearchFlowsResponseEntry) -> SearchFlowEntry:
+        attributes = {
+            kv.key: self._values.to_value(await self._hydrator.hydrate(kv.value))
+            for kv in entry.search_attributes
+        }
+        closed_at = (
+            entry.close_time.ToDatetime(tzinfo=timezone.utc)
+            if entry.HasField("close_time")
+            else None
+        )
+        return SearchFlowEntry(
+            entry.flow_id,
+            entry.run_id,
+            entry.flow_type,
+            self._map_flow_status(entry.flow_status),
+            entry.start_time.ToDatetime(tzinfo=timezone.utc),
+            closed_at,
+            attributes,
+        )
+
+    async def reset_flow(self, flow_id: str, options: ResetFlowOptions) -> str:
+        request = pb.ResetFlowRequest(
+            flow_id=require_name(flow_id),
+            reset_type={
+                ResetType.BEGINNING: pb.FLOW_RESET_TYPE_BEGINNING,
+                ResetType.HISTORY_EVENT_ID: pb.FLOW_RESET_TYPE_HISTORY_EVENT_ID,
+                ResetType.HISTORY_EVENT_TIME: pb.FLOW_RESET_TYPE_HISTORY_EVENT_TIME,
+                ResetType.STEP_TYPE: pb.FLOW_RESET_TYPE_STEP_TYPE,
+                ResetType.STEP_EXECUTION_ID: pb.FLOW_RESET_TYPE_STEP_EXECUTION_ID,
+            }[options.type],
+            reason=options.reason or "",
+            skip_channel_messages_reapply=options.skip_channel_messages_reapply,
+            skip_locking_rpc_reapply=options.skip_locking_rpc_reapply,
+        )
+        if options.history_event_id is not None:
+            request.history_event_id = options.history_event_id
+        if options.history_event_time is not None:
+            request.history_event_time = options.history_event_time.isoformat()
+        if options.step_type is not None:
+            request.step_type = options.step_type
+        if options.step_execution_id is not None:
+            request.step_execution_id = options.step_execution_id
+        response = cast(
+            pb.ResetFlowResponse,
+            await self._call(self._service.ResetFlow, request),
+        )
+        return response.run_id
+
+    async def skip_timer(
+        self,
+        flow_id: str,
+        step_execution_id: StepExecutionId,
+        timer_id: TimerId,
+    ) -> None:
+        request = pb.SkipTimerRequest(
+            flow_id=require_name(flow_id),
+            step_execution_id=(
+                f"{step_execution_id.step_type}-{step_execution_id.number}"
+            ),
+        )
+        if timer_id.condition_id is not None:
+            request.timer_condition_id = timer_id.condition_id
+        if timer_id.condition_index is not None:
+            request.timer_condition_index = timer_id.condition_index
+        await self._call(self._service.SkipTimer, request)
+
+    async def wait_for_step_completion(
+        self,
+        flow_id: str,
+        step_execution_id: StepExecutionId,
+        timeout: timedelta,
+    ) -> None:
+        await self._call(
+            self._service.WaitForStepCompletion,
+            pb.WaitForStepCompletionRequest(
+                flow_id=require_name(flow_id),
+                step_type=step_execution_id.step_type,
+                step_execution_number=str(step_execution_id.number),
+                wait_time_seconds=self._seconds32(timeout),
+                request_id=str(uuid4()),
+            ),
+        )
+
+    async def update_flow_config(self, flow_id: str, config: FlowConfig) -> None:
+        await self._call(
+            self._service.UpdateFlowConfig,
+            pb.UpdateFlowConfigRequest(
+                flow_id=require_name(flow_id),
+                flow_config=self._map_flow_config(config),
+            ),
+        )
+
+    async def trigger_continue_as_new(self, flow_id: str) -> None:
+        await self._call(
+            self._service.TriggerContinueAsNew,
+            pb.TriggerContinueAsNewRequest(flow_id=require_name(flow_id)),
+        )
+
+    async def health_check(self) -> bool:
+        from google.protobuf import empty_pb2
+
+        await self._call(self._service.HealthCheck, empty_pb2.Empty())
+        return True
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._channel.close()
+
+    async def _wait_for_flow_response(
+        self,
+        flow_id: str,
+        timeout: timedelta | None,
+    ) -> pb.WaitForFlowResponse:
+        request = pb.WaitForFlowRequest(
+            flow_id=require_name(flow_id),
+            needs_results=True,
+        )
+        if timeout is not None:
+            request.wait_time_seconds = self._seconds32(timeout)
+        try:
+            response = cast(pb.WaitForFlowResponse, await self._service.WaitForFlow(request))
+        except grpc.RpcError as error:
+            if error.code() is grpc.StatusCode.DEADLINE_EXCEEDED:
+                raise LongPollTimeoutError(flow_id) from error
+            raise translate_rpc_error(error) from error
+        if response.flow_status != pb.FLOW_STATUS_COMPLETED:
+            info = await self.describe_flow(flow_id)
+            results = await self._hydrator.step_outputs(list(response.results))
+            raise FlowUncompletedError(
+                info.run_id,
+                self._map_flow_status(response.flow_status),
+                self._map_flow_error_type(response.error_type),
+                response.error_message or None,
+                results,
+                self._values,
+            )
+        return response
+
+    def _map_start_options(self, options: StartFlowOptions) -> pb.FlowStartOptions:
+        mapped = pb.FlowStartOptions(
+            id_reuse_policy={
+                IdReusePolicy.DEFAULT: pb.ID_REUSE_POLICY_UNSPECIFIED,
+                IdReusePolicy.ALLOW_IF_PREVIOUS_FAILED: (
+                    pb.ID_REUSE_POLICY_ALLOW_IF_PREVIOUS_EXISTS_ABNORMALLY
+                ),
+                IdReusePolicy.ALLOW_IF_NOT_RUNNING: (
+                    pb.ID_REUSE_POLICY_ALLOW_IF_NO_RUNNING
+                ),
+                IdReusePolicy.ALLOW_TERMINATE_IF_RUNNING: (
+                    pb.ID_REUSE_POLICY_ALLOW_TERMINATE_IF_RUNNING
+                ),
+                IdReusePolicy.DISALLOW: pb.ID_REUSE_POLICY_DISALLOW_REUSE,
+            }[options.id_reuse_policy],
+            cron_schedule=options.cron_schedule or "",
+            flow_already_started_options=pb.FlowAlreadyStartedOptions(
+                ignore_already_started_error=options.ignore_already_started
+            ),
+        )
+        if options.start_delay is not None:
+            mapped.flow_start_delay_seconds = self._seconds32(options.start_delay)
+        if options.retry_policy is not None:
+            mapped.retry_policy.CopyFrom(self._map_flow_retry(options.retry_policy))
+        for initialization in options._attribute_initializations:
+            definition = initialization.definition
+            key = self._definition_name(definition, initialization.instance)
+            mapped.attributes.append(
+                pb.AttributeWrite(
+                    key=key,
+                    value=self._values.encode(
+                        initialization.value,
+                        self._values.codec(definition.value_type),
+                    ),
+                )
+            )
+        if (
+            options.config_override is not None
+            or self.options.worker_target is not None
+        ):
+            mapped.flow_config_override.CopyFrom(
+                self._map_flow_config(options.config_override)
+            )
+        return mapped
+
+    def _map_flow_config(self, config: FlowConfig | None) -> pb.FlowConfig:
+        mapped = pb.FlowConfig()
+        if config is not None:
+            if config.active_step_search_mode is not None:
+                mapped.active_step_search_mode = {
+                    ActiveStepSearchMode.DEFAULT: (
+                        pb.ACTIVE_STEP_SEARCH_MODE_UNSPECIFIED
+                    ),
+                    ActiveStepSearchMode.ALL: (
+                        pb.ACTIVE_STEP_SEARCH_MODE_ENABLED_FOR_ALL
+                    ),
+                    ActiveStepSearchMode.WITH_WAIT_FOR: (
+                        pb.ACTIVE_STEP_SEARCH_MODE_ENABLED_FOR_STEPS_WITH_WAIT_FOR
+                    ),
+                    ActiveStepSearchMode.DISABLED: (
+                        pb.ACTIVE_STEP_SEARCH_MODE_DISABLED
+                    ),
+                }[config.active_step_search_mode]
+            if config.continue_as_new_threshold is not None:
+                mapped.continue_as_new_threshold = config.continue_as_new_threshold
+            if config.continue_as_new_page_size_bytes is not None:
+                mapped.continue_as_new_page_size_in_bytes = (
+                    config.continue_as_new_page_size_bytes
+                )
+            if config.step_durability is not None:
+                mapped.step_durability = {
+                    StepDurability.DEFAULT: pb.STEP_DURABILITY_UNSPECIFIED,
+                    StepDurability.SYNC: pb.STEP_DURABILITY_SYNC,
+                    StepDurability.ASYNC: pb.STEP_DURABILITY_ASYNC,
+                }[config.step_durability]
+        target = (
+            config.worker_target
+            if config is not None and config.worker_target is not None
+            else self.options.worker_target
+        )
+        if target is not None:
+            mapped.worker_target.CopyFrom(
+                pb.WorkerTarget(
+                    address=target.address,
+                    is_headless_address=target.headless,
+                )
+            )
+        return mapped
+
+    @staticmethod
+    def _map_flow_retry(retry: RetryPolicy) -> pb.FlowRetryPolicy:
+        mapped = pb.FlowRetryPolicy(
+            backoff_coefficient=retry.backoff_coefficient,
+            maximum_attempts=retry.maximum_attempts,
+        )
+        if retry.initial_interval is not None:
+            mapped.initial_interval_seconds = AsyncClient._seconds32(retry.initial_interval)
+        if retry.maximum_interval is not None:
+            mapped.maximum_interval_seconds = AsyncClient._seconds32(retry.maximum_interval)
+        return mapped
+
+    @staticmethod
+    def _definition_name(
+        definition: Attribute[Any] | AttributeMap[Any] | Channel[Any] | ChannelMap[Any],
+        instance: str | None,
+    ) -> str:
+        if isinstance(definition, (AttributeMap, ChannelMap)):
+            if instance is None:
+                raise ValueError("dynamic definition requires an instance")
+            return Registry.physical_name(definition.name, instance)
+        if instance is not None:
+            raise ValueError("static definition cannot use an instance")
+        return definition.name
+
+    @staticmethod
+    def _definition_value(
+        definition: Attribute[Any] | AttributeMap[Any],
+        args: tuple[object, ...],
+    ) -> tuple[str | None, object]:
+        if isinstance(definition, Attribute) and len(args) == 1:
+            return None, args[0]
+        if (
+            isinstance(definition, AttributeMap)
+            and len(args) == 2
+            and isinstance(args[0], str)
+        ):
+            return args[0], args[1]
+        raise TypeError("set_attribute received invalid arguments")
+
+    @staticmethod
+    def _seconds32(duration: timedelta) -> int:
+        seconds = duration.total_seconds()
+        if seconds < 0 or not seconds.is_integer() or seconds > 2**31 - 1:
+            raise ValueError("duration must be whole seconds within int32")
+        return int(seconds)
+
+    @staticmethod
+    def _map_flow_status(status: int) -> FlowStatus:
+        statuses: dict[int, FlowStatus] = {
+            int(pb.FLOW_STATUS_RUNNING): FlowStatus.RUNNING,
+            int(pb.FLOW_STATUS_COMPLETED): FlowStatus.COMPLETED,
+            int(pb.FLOW_STATUS_FAILED): FlowStatus.FAILED,
+            int(pb.FLOW_STATUS_TIMEOUT): FlowStatus.TIMED_OUT,
+            int(pb.FLOW_STATUS_TERMINATED): FlowStatus.TERMINATED,
+            int(pb.FLOW_STATUS_CANCELED): FlowStatus.CANCELED,
+            int(pb.FLOW_STATUS_CONTINUED_AS_NEW): FlowStatus.CONTINUED_AS_NEW,
+        }
+        try:
+            return statuses[status]
+        except KeyError as error:
+            raise ValueError(f"unknown Flow status {status}") from error
+
+    @staticmethod
+    def _map_flow_error_type(error_type: int) -> FlowErrorType | None:
+        error_types: dict[int, FlowErrorType] = {
+            int(pb.FLOW_ERROR_TYPE_STEP_DECISION_FAILING_FLOW): (
+                FlowErrorType.STEP_DECISION_FAILED
+            ),
+            int(
+                pb.FLOW_ERROR_TYPE_CLIENT_API_FAILING_FLOW
+            ): FlowErrorType.CLIENT_API_FAILED,
+            int(pb.FLOW_ERROR_TYPE_WORKER_API_FAIL): FlowErrorType.WORKER_API_FAILED,
+            int(pb.FLOW_ERROR_TYPE_INVALID_USER_FLOW_CODE): (
+                FlowErrorType.INVALID_USER_FLOW_CODE
+            ),
+            int(pb.FLOW_ERROR_TYPE_INTERNAL): FlowErrorType.INTERNAL,
+        }
+        return error_types.get(error_type)
+
+    @staticmethod
+    async def _call(method: Callable[[Any], Any], request: Any) -> Any:
+        try:
+            return await method(request)
+        except grpc.RpcError as error:
+            raise translate_rpc_error(error) from error

--- a/sdk-python/dex/async_worker.py
+++ b/sdk-python/dex/async_worker.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Super Durable Source License 1.0.
+# You may not use this file except in compliance with the License.
+# See the LICENSE file in the repository root.
+#
+# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+from __future__ import annotations
+
+import asyncio
+from types import TracebackType
+
+import grpc
+
+from dex._async_value_hydrator import AsyncValueHydrator
+from dex._async_worker_dispatcher import AsyncWorkerDispatcher
+from dex._async_worker_service import AsyncWorkerService
+from dex._value_mapper import ValueMapper
+from dex.blob_cache import BlobCache
+from dex.dexpb import dex_pb2_grpc
+from dex.flow import Registry
+from dex.worker_options import WorkerOptions, WorkerTarget
+
+
+class AsyncWorker:
+    def __init__(
+        self,
+        registry: Registry,
+        blob_cache: BlobCache,
+        options: WorkerOptions | None = None,
+    ) -> None:
+        self.registry = registry
+        self.blob_cache = blob_cache
+        self.options = options or WorkerOptions()
+        self._state = "created"
+        self._flow_channel = grpc.aio.insecure_channel(self.options.server_address)
+        flow_service = dex_pb2_grpc.FlowServiceStub(  # type: ignore[no-untyped-call]
+            self._flow_channel
+        )
+        values = ValueMapper(registry.codec_registry)
+        dispatcher = AsyncWorkerDispatcher(
+            registry,
+            values,
+            AsyncValueHydrator(flow_service, blob_cache),
+        )
+        self._server = grpc.aio.server()
+        dex_pb2_grpc.add_WorkerServiceServicer_to_server(  # type: ignore[no-untyped-call]
+            AsyncWorkerService(dispatcher),
+            self._server,
+        )
+        self._bound_port = self._server.add_insecure_port(self.options.bind_address)
+        if self._bound_port == 0:
+            raise ValueError(
+                f"cannot bind Python AsyncWorker to {self.options.bind_address}"
+            )
+        self._worker_target = self.options.worker_target or WorkerTarget(
+            self._target_address(self.options.bind_address, self._bound_port)
+        )
+        self._stopped = asyncio.Event()
+
+    @property
+    def worker_target(self) -> WorkerTarget:
+        return self._worker_target
+
+    async def __aenter__(self) -> AsyncWorker:
+        return self
+
+    async def __aexit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    async def start(self) -> None:
+        if self._state != "created":
+            raise RuntimeError(f"AsyncWorker cannot start from state {self._state}")
+        self._state = "running"
+        await self._server.start()
+        await self._server.wait_for_termination()
+        self._stopped.set()
+
+    async def stop(self) -> None:
+        if self._state in ("stopped", "closed"):
+            return
+        self._state = "stopping"
+        await self._server.stop(grace=5)
+        await self._flow_channel.close()
+        if self._state != "closed":
+            self._state = "stopped"
+        self._stopped.set()
+
+    async def close(self) -> None:
+        await self.stop()
+        self._state = "closed"
+
+    @staticmethod
+    def _target_address(bind_address: str, bound_port: int) -> str:
+        host, separator, port = bind_address.rpartition(":")
+        if not separator or not port:
+            raise ValueError("Worker bind address requires a port")
+        if host in ("", "0.0.0.0", "::", "[::]"):
+            host = "localhost"
+        return f"{host}:{bound_port}"

--- a/sdk-python/dex/flow.py
+++ b/sdk-python/dex/flow.py
@@ -178,10 +178,16 @@ class Registry:
         self,
         flows: Sequence[Flow[Any]],
         codec_registry: CodecRegistry | None = None,
+        *,
+        allow_async_handlers: bool = False,
     ) -> None:
         immutable_flows = tuple(flows)
         resolved_codecs = codec_registry or CodecRegistry()
-        registered_flows = self._assemble(immutable_flows, resolved_codecs)
+        registered_flows = self._assemble(
+            immutable_flows,
+            resolved_codecs,
+            allow_async_handlers=allow_async_handlers,
+        )
         registered_steps = tuple(
             step
             for registered_flow in registered_flows.values()
@@ -204,7 +210,10 @@ class Registry:
 
     @staticmethod
     def _assemble(
-        flows: tuple[Flow[Any], ...], codec_registry: CodecRegistry
+        flows: tuple[Flow[Any], ...],
+        codec_registry: CodecRegistry,
+        *,
+        allow_async_handlers: bool,
     ) -> dict[str, _RegisteredFlow]:
         registered_flows: dict[str, _RegisteredFlow] = {}
         for flow in flows:
@@ -218,6 +227,7 @@ class Registry:
                 flow_name,
                 flow,
                 codec_registry,
+                allow_async_handlers=allow_async_handlers,
             )
         return registered_flows
 
@@ -226,6 +236,8 @@ class Registry:
         flow_name: str,
         flow: Flow[Any],
         codec_registry: CodecRegistry,
+        *,
+        allow_async_handlers: bool,
     ) -> _RegisteredFlow:
         definitions = flow.get_steps()
         if not isinstance(definitions, StepList):
@@ -246,7 +258,11 @@ class Registry:
             registered_step = _RegisteredStep(
                 step_name,
                 step,
-                Registry._step_input_codec(step, codec_registry),
+                Registry._step_input_codec(
+                    step,
+                    codec_registry,
+                    allow_async_handlers=allow_async_handlers,
+                ),
                 definition.is_start_step,
                 type(step).wait_for is Step.wait_for,
             )
@@ -270,7 +286,11 @@ class Registry:
             if rpc_name in registered_rpcs:
                 raise ValueError(f"duplicate RPC {rpc_name}")
             Registry._validate_rpc_locks(rpc_name, options, schema)
-            input_codec, output_codec = Registry._rpc_codecs(method, codec_registry)
+            input_codec, output_codec = Registry._rpc_codecs(
+                method,
+                codec_registry,
+                allow_async_handlers=allow_async_handlers,
+            )
             registered_rpcs[rpc_name] = _RegisteredRPC(
                 rpc_name,
                 method,
@@ -329,12 +349,18 @@ class Registry:
             lock_identities.add(identity)
 
     @staticmethod
-    def _step_input_codec(step: Step[Any], codec_registry: CodecRegistry) -> Codec[Any]:
+    def _step_input_codec(
+        step: Step[Any],
+        codec_registry: CodecRegistry,
+        *,
+        allow_async_handlers: bool,
+    ) -> Codec[Any]:
         input_type = Registry._step_handler_input_type(
             step,
             "execute",
             step.execute,
             StepDecision,
+            allow_async_handlers=allow_async_handlers,
         )
         if type(step).wait_for is not Step.wait_for:
             wait_input_type = Registry._step_handler_input_type(
@@ -342,6 +368,7 @@ class Registry:
                 "wait_for",
                 step.wait_for,
                 Wait,
+                allow_async_handlers=allow_async_handlers,
             )
             if wait_input_type != input_type:
                 raise TypeError(
@@ -355,8 +382,10 @@ class Registry:
         handler_name: str,
         handler: Callable[..., Any],
         return_type: type[Any],
+        *,
+        allow_async_handlers: bool,
     ) -> Any:
-        if iscoroutinefunction(handler):
+        if iscoroutinefunction(handler) and not allow_async_handlers:
             raise TypeError(
                 f"Step {step.get_step_type()} {handler_name} must be synchronous"
             )
@@ -385,9 +414,12 @@ class Registry:
 
     @staticmethod
     def _rpc_codecs(
-        method: Callable[..., Any], codec_registry: CodecRegistry
+        method: Callable[..., Any],
+        codec_registry: CodecRegistry,
+        *,
+        allow_async_handlers: bool,
     ) -> tuple[Codec[Any] | None, Codec[Any] | None]:
-        if iscoroutinefunction(method):
+        if iscoroutinefunction(method) and not allow_async_handlers:
             raise TypeError("RPC must be synchronous")
         parameters = tuple(signature(method).parameters.values())
         hints = get_type_hints(method)

--- a/sdk-python/tests/integ/async_environment.py
+++ b/sdk-python/tests/integ/async_environment.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Super Durable Source License 1.0.
+# You may not use this file except in compliance with the License.
+# See the LICENSE file in the repository root.
+#
+# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import time
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from dex import (
+    AsyncClient,
+    AsyncWorker,
+    BlobCacheConfig,
+    ClientOptions,
+    Flow,
+    Registry,
+    WorkerOptions,
+    open_blob_cache,
+)
+
+
+class AsyncDexDevTestEnvironment:
+    def __init__(self, *flows: Flow[Any], allow_async_handlers: bool = False) -> None:
+        self._server_address = os.environ.get("DEX_SERVER_ADDRESS", "127.0.0.1:8801")
+        self._worker_port = _available_port()
+        self._worker_address = f"127.0.0.1:{self._worker_port}"
+        self._registry = Registry(flows, allow_async_handlers=allow_async_handlers)
+        self._cache_directory = TemporaryDirectory(
+            prefix="dex-python-async-integration-cache-"
+        )
+        self._cache = open_blob_cache(
+            BlobCacheConfig(
+                self._cache_directory.name,
+                64 * 1024 * 1024,
+            )
+        )
+        self._worker = AsyncWorker(
+            self._registry,
+            self._cache,
+            WorkerOptions(
+                bind_address=self._worker_address,
+                server_address=self._server_address,
+            ),
+        )
+        self._worker_task: asyncio.Task[None] | None = None
+        self.client: AsyncClient | None = None
+
+    async def __aenter__(self) -> AsyncDexDevTestEnvironment:
+        self._worker_task = asyncio.create_task(self._worker.start())
+        await _await_worker(self._worker_port, self._worker_task)
+        self.client = AsyncClient(
+            self._registry,
+            self._cache,
+            ClientOptions(self._server_address, self._worker.worker_target),
+        )
+        return self
+
+    async def __aexit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: object,
+    ) -> None:
+        if self.client is not None:
+            await self.client.close()
+        await self._worker.close()
+        if self._worker_task is not None:
+            try:
+                await asyncio.wait_for(self._worker_task, timeout=10)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                self._worker_task.cancel()
+        self._cache.close()
+        self._cache_directory.cleanup()
+
+
+async def _await_worker(port: int, worker_task: asyncio.Task[None]) -> None:
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if worker_task.done():
+            error = worker_task.exception()
+            if error is not None:
+                raise RuntimeError("Python AsyncWorker failed") from error
+            raise RuntimeError("Python AsyncWorker stopped before becoming ready")
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                return
+        except OSError:
+            await asyncio.sleep(0.01)
+    raise RuntimeError("Python AsyncWorker did not become ready")
+
+
+def _available_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])

--- a/sdk-python/tests/integ/async_environment.py
+++ b/sdk-python/tests/integ/async_environment.py
@@ -51,12 +51,18 @@ class AsyncDexDevTestEnvironment:
             ),
         )
         self._worker_task: asyncio.Task[None] | None = None
-        self.client: AsyncClient | None = None
+        self._client: AsyncClient | None = None
+
+    @property
+    def client(self) -> AsyncClient:
+        if self._client is None:
+            raise RuntimeError("AsyncDexDevTestEnvironment is not entered")
+        return self._client
 
     async def __aenter__(self) -> AsyncDexDevTestEnvironment:
         self._worker_task = asyncio.create_task(self._worker.start())
         await _await_worker(self._worker_port, self._worker_task)
-        self.client = AsyncClient(
+        self._client = AsyncClient(
             self._registry,
             self._cache,
             ClientOptions(self._server_address, self._worker.worker_target),
@@ -69,8 +75,9 @@ class AsyncDexDevTestEnvironment:
         exception: BaseException | None,
         traceback: object,
     ) -> None:
-        if self.client is not None:
-            await self.client.close()
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
         await self._worker.close()
         if self._worker_task is not None:
             try:

--- a/sdk-python/tests/integ/async_environment.py
+++ b/sdk-python/tests/integ/async_environment.py
@@ -1,10 +1,12 @@
-# Copyright (c) 2026 Super Durable, Inc.
+# Portions of this file are derived from indeedeng/iwf-java-sdk.
+# Those portions are licensed under the Apache License, Version 2.0.
+# See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
 #
-# Licensed under the Super Durable Source License 1.0.
-# You may not use this file except in compliance with the License.
-# See the LICENSE file in the repository root.
+# Modifications Copyright (c) 2026 Super Durable, Inc.
 #
-# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+# Modifications are licensed under the Super Durable Source License 1.0.
+# Third-Party Materials remain under the Apache License, Version 2.0.
+# See LICENSE and LEGACY_NOTICES.md.
 
 from __future__ import annotations
 

--- a/sdk-python/tests/integ/shared.py
+++ b/sdk-python/tests/integ/shared.py
@@ -9,6 +9,7 @@
 # See LICENSE and LEGACY_NOTICES.md.
 
 from dataclasses import dataclass
+from uuid import uuid4
 
 from dex import Context, Step, StepDecision, graceful_complete
 
@@ -22,3 +23,7 @@ class CompleteStringStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
         del context
         return graceful_complete(input)
+
+
+def unique_id(prefix: str) -> str:
+    return f"{prefix}-{uuid4()}"

--- a/sdk-python/tests/integ/test_any_command_combination_runtime.py
+++ b/sdk-python/tests/integ/test_any_command_combination_runtime.py
@@ -16,7 +16,7 @@ from dex import FlowErrorType, FlowStatus, FlowUncompletedError
 
 from .any_combination_fail_flow import AnyCombinationFailFlow
 from .environment import DexDevTestEnvironment
-from .test_basic_runtime import unique_id
+from .shared import unique_id
 
 
 def test_unknown_condition_id_fails_flow() -> None:

--- a/sdk-python/tests/integ/test_async_runtime.py
+++ b/sdk-python/tests/integ/test_async_runtime.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 from typing import Callable
 
 from dex import (
+    AsyncClient,
     Context,
     Flow,
     PersistenceSchema,
@@ -39,9 +40,7 @@ async def _async_client_basic_workflow() -> None:
     async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("async-basic")
         await environment.client.start_flow(flow, flow_id, 0)
-        assert (
-            await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
-        )
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
 
 
 def test_async_client_concurrent_start_and_wait() -> None:
@@ -79,18 +78,16 @@ async def _async_worker_async_execute_starts_child() -> None:
         client_holder["client"] = environment.client
         flow_id = unique_id("async-parent")
         await environment.client.start_flow(parent, flow_id, 1)
-        assert (
-            await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 1
-        )
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 1
 
 
-client_holder: dict[str, object] = {}
+client_holder: dict[str, AsyncClient] = {}
 
 
 class StartChild(Step[int]):
     def __init__(
         self,
-        client_provider: Callable[[], object],
+        client_provider: Callable[[], AsyncClient],
         child: BasicFlow,
         finish: Finish,
     ) -> None:
@@ -98,12 +95,14 @@ class StartChild(Step[int]):
         self._child = child
         self._finish = finish
 
-    async def execute(self, context: Context, input: int) -> StepDecision:
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: int
+    ) -> StepDecision:
         del context
         client = self._client_provider()
         child_id = unique_id("async-child")
-        await client.start_flow(self._child, child_id, 0)  # type: ignore[union-attr]
-        await client.wait_for_flow(child_id, int, WAIT_TIMEOUT)  # type: ignore[union-attr]
+        await client.start_flow(self._child, child_id, 0)
+        await client.wait_for_flow(child_id, int, WAIT_TIMEOUT)
         return go_to(self._finish, input)
 
 
@@ -116,7 +115,7 @@ class Finish(Step[int]):
 class ParentStartsChildFlow(Flow[int]):
     def __init__(
         self,
-        client_provider: Callable[[], object],
+        client_provider: Callable[[], AsyncClient],
         child: BasicFlow,
     ) -> None:
         self.finish = Finish()

--- a/sdk-python/tests/integ/test_async_runtime.py
+++ b/sdk-python/tests/integ/test_async_runtime.py
@@ -41,7 +41,6 @@ def test_async_client_basic_workflow() -> None:
 async def _async_client_basic_workflow() -> None:
     flow = BasicFlow()
     async with AsyncDexDevTestEnvironment(flow) as environment:
-        assert environment.client is not None
         flow_id = unique_id("async-basic")
         await environment.client.start_flow(flow, flow_id, 0)
         assert (
@@ -56,7 +55,6 @@ def test_async_client_concurrent_start_and_wait() -> None:
 async def _async_client_concurrent_start_and_wait() -> None:
     flow = BasicFlow()
     async with AsyncDexDevTestEnvironment(flow) as environment:
-        assert environment.client is not None
         client = environment.client
 
         async def one(index: int) -> int:
@@ -82,7 +80,6 @@ async def _async_worker_async_execute_starts_child() -> None:
         child,
         allow_async_handlers=True,
     ) as environment:
-        assert environment.client is not None
         client_holder["client"] = environment.client
         flow_id = unique_id("async-parent")
         await environment.client.start_flow(parent, flow_id, 1)

--- a/sdk-python/tests/integ/test_async_runtime.py
+++ b/sdk-python/tests/integ/test_async_runtime.py
@@ -1,10 +1,12 @@
-# Copyright (c) 2026 Super Durable, Inc.
+# Portions of this file are derived from indeedeng/iwf-java-sdk.
+# Those portions are licensed under the Apache License, Version 2.0.
+# See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
 #
-# Licensed under the Super Durable Source License 1.0.
-# You may not use this file except in compliance with the License.
-# See the LICENSE file in the repository root.
+# Modifications Copyright (c) 2026 Super Durable, Inc.
 #
-# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+# Modifications are licensed under the Super Durable Source License 1.0.
+# Third-Party Materials remain under the Apache License, Version 2.0.
+# See LICENSE and LEGACY_NOTICES.md.
 
 from __future__ import annotations
 

--- a/sdk-python/tests/integ/test_async_runtime.py
+++ b/sdk-python/tests/integ/test_async_runtime.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Super Durable Source License 1.0.
+# You may not use this file except in compliance with the License.
+# See the LICENSE file in the repository root.
+#
+# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from typing import Callable
+from uuid import uuid4
+
+from dex import (
+    Context,
+    Flow,
+    PersistenceSchema,
+    Step,
+    StepDecision,
+    StepList,
+    graceful_complete,
+    go_to,
+)
+
+from .async_environment import AsyncDexDevTestEnvironment
+from .basic_flow import BasicFlow
+
+WAIT_TIMEOUT = timedelta(seconds=30)
+
+
+def unique_id(prefix: str) -> str:
+    return f"{prefix}-{uuid4()}"
+
+
+def test_async_client_basic_workflow() -> None:
+    asyncio.run(_async_client_basic_workflow())
+
+
+async def _async_client_basic_workflow() -> None:
+    flow = BasicFlow()
+    async with AsyncDexDevTestEnvironment(flow) as environment:
+        assert environment.client is not None
+        flow_id = unique_id("async-basic")
+        await environment.client.start_flow(flow, flow_id, 0)
+        assert (
+            await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+        )
+
+
+def test_async_client_concurrent_start_and_wait() -> None:
+    asyncio.run(_async_client_concurrent_start_and_wait())
+
+
+async def _async_client_concurrent_start_and_wait() -> None:
+    flow = BasicFlow()
+    async with AsyncDexDevTestEnvironment(flow) as environment:
+        assert environment.client is not None
+        client = environment.client
+
+        async def one(index: int) -> int:
+            flow_id = unique_id(f"async-concurrent-{index}")
+            await client.start_flow(flow, flow_id, 0)
+            result = await client.wait_for_flow(flow_id, int, WAIT_TIMEOUT)
+            assert result == 2
+            return result
+
+        results = await asyncio.gather(*(one(index) for index in range(3)))
+        assert results == [2, 2, 2]
+
+
+def test_async_worker_async_execute_starts_child() -> None:
+    asyncio.run(_async_worker_async_execute_starts_child())
+
+
+async def _async_worker_async_execute_starts_child() -> None:
+    child = BasicFlow()
+    parent = ParentStartsChildFlow(lambda: client_holder["client"], child)
+    async with AsyncDexDevTestEnvironment(
+        parent,
+        child,
+        allow_async_handlers=True,
+    ) as environment:
+        assert environment.client is not None
+        client_holder["client"] = environment.client
+        flow_id = unique_id("async-parent")
+        await environment.client.start_flow(parent, flow_id, 1)
+        assert (
+            await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 1
+        )
+
+
+client_holder: dict[str, object] = {}
+
+
+class StartChild(Step[int]):
+    def __init__(
+        self,
+        client_provider: Callable[[], object],
+        child: BasicFlow,
+        finish: Finish,
+    ) -> None:
+        self._client_provider = client_provider
+        self._child = child
+        self._finish = finish
+
+    async def execute(self, context: Context, input: int) -> StepDecision:
+        del context
+        client = self._client_provider()
+        child_id = unique_id("async-child")
+        await client.start_flow(self._child, child_id, 0)  # type: ignore[union-attr]
+        await client.wait_for_flow(child_id, int, WAIT_TIMEOUT)  # type: ignore[union-attr]
+        return go_to(self._finish, input)
+
+
+class Finish(Step[int]):
+    def execute(self, context: Context, input: int) -> StepDecision:
+        del context
+        return graceful_complete(input)
+
+
+class ParentStartsChildFlow(Flow[int]):
+    def __init__(
+        self,
+        client_provider: Callable[[], object],
+        child: BasicFlow,
+    ) -> None:
+        self.finish = Finish()
+        self.start = StartChild(client_provider, child, self.finish)
+
+    def get_flow_type(self) -> str:
+        return "AsyncParentStartsChild"
+
+    def get_steps(self) -> StepList[int]:
+        return StepList.start_step(self.start).other_steps(self.finish)
+
+    def get_persistence_schema(self) -> PersistenceSchema:
+        return PersistenceSchema.of()

--- a/sdk-python/tests/integ/test_async_runtime.py
+++ b/sdk-python/tests/integ/test_async_runtime.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta
 from typing import Callable
-from uuid import uuid4
 
 from dex import (
     Context,
@@ -26,12 +25,9 @@ from dex import (
 
 from .async_environment import AsyncDexDevTestEnvironment
 from .basic_flow import BasicFlow
+from .shared import unique_id
 
 WAIT_TIMEOUT = timedelta(seconds=30)
-
-
-def unique_id(prefix: str) -> str:
-    return f"{prefix}-{uuid4()}"
 
 
 def test_async_client_basic_workflow() -> None:

--- a/sdk-python/tests/integ/test_basic_runtime.py
+++ b/sdk-python/tests/integ/test_basic_runtime.py
@@ -8,6 +8,7 @@
 # Third-Party Materials remain under the Apache License, Version 2.0.
 # See LICENSE and LEGACY_NOTICES.md.
 
+import asyncio
 from datetime import timedelta
 from typing import cast
 from uuid import uuid4
@@ -27,9 +28,9 @@ from dex import (
 )
 
 from .abnormal_exit_flow import AbnormalExitFlow
+from .async_environment import AsyncDexDevTestEnvironment
 from .basic_flow import BasicFlow
 from .empty_input_flow import EmptyInputFlow
-from .environment import DexDevTestEnvironment
 from .immutable_step_options_flow import ImmutableStepOptionsFlow
 from .mixed_wait_flow import MixedWaitFlow
 from .model_input_flow import ModelInputFlow
@@ -41,70 +42,93 @@ WAIT_TIMEOUT = timedelta(seconds=30)
 
 
 def test_basic_workflow() -> None:
+    asyncio.run(_basic_workflow())
+
+
+async def _basic_workflow() -> None:
     flow = BasicFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("basic")
         options = StartFlowOptions(id_reuse_policy=IdReusePolicy.DISALLOW)
-        environment.client.start_flow(flow, flow_id, 0, options)
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+        await environment.client.start_flow(flow, flow_id, 0, options)
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
         with pytest.raises(DexException) as captured:
-            environment.client.start_flow(flow, flow_id, 0, options)
+            await environment.client.start_flow(flow, flow_id, 0, options)
         assert captured.value.sub_status is ErrorSubStatus.FLOW_ALREADY_STARTED
 
 
 def test_basic_workflow_abnormal_exit_reuse() -> None:
+    asyncio.run(_basic_workflow_abnormal_exit_reuse())
+
+
+async def _basic_workflow_abnormal_exit_reuse() -> None:
     abnormal = AbnormalExitFlow()
     basic = BasicFlow()
-    with DexDevTestEnvironment(abnormal, basic) as environment:
+    async with AsyncDexDevTestEnvironment(abnormal, basic) as environment:
         flow_id = unique_id("abnormal-exit-reuse")
         options = StartFlowOptions(
             id_reuse_policy=IdReusePolicy.ALLOW_IF_PREVIOUS_FAILED
         )
-        failed_run = environment.client.start_flow(abnormal, flow_id, 0, options)
+        failed_run = await environment.client.start_flow(
+            abnormal, flow_id, 0, options
+        )
         with pytest.raises(FlowUncompletedError) as captured:
-            environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT)
+            await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT)
         assert captured.value.run_id == failed_run
         assert captured.value.status is FlowStatus.FAILED
-        environment.client.start_flow(basic, flow_id, 0, options)
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+        await environment.client.start_flow(basic, flow_id, 0, options)
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
 
 
 def test_empty_input_workflow() -> None:
+    asyncio.run(_empty_input_workflow())
+
+
+async def _empty_input_workflow() -> None:
     flow = EmptyInputFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("empty-input")
-        environment.client.start_flow(flow, flow_id, None)
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) is None
+        await environment.client.start_flow(flow, flow_id, None)
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) is None
         with pytest.raises(DexException) as captured:
-            environment.client.wait_for_flow(
+            await environment.client.wait_for_flow(
                 unique_id("missing"), int, timedelta(seconds=1)
             )
         assert captured.value.sub_status is ErrorSubStatus.FLOW_NOT_EXISTS
 
 
 def test_custom_flow_type() -> None:
+    asyncio.run(_custom_flow_type())
+
+
+async def _custom_flow_type() -> None:
     flow = EmptyInputFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("type-specified")
         assert flow.get_flow_type() == "test-customized-flow-type"
-        environment.client.start_flow(flow, flow_id, None)
+        await environment.client.start_flow(flow, flow_id, None)
         assert (
-            environment.client.wait_for_flow(flow_id, type(None), WAIT_TIMEOUT) is None
+            await environment.client.wait_for_flow(flow_id, type(None), WAIT_TIMEOUT)
+            is None
         )
         with pytest.raises(ValueError, match="Flow instance is not registered"):
-            environment.client.start_flow(
+            await environment.client.start_flow(
                 EmptyInputFlow(), unique_id("unregistered"), None
             )
 
 
 def test_model_input_workflow() -> None:
+    asyncio.run(_model_input_workflow())
+
+
+async def _model_input_workflow() -> None:
     flow = ModelInputFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("model-input")
-        environment.client.start_flow(flow, flow_id, ModelInput(value=10))
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 10
+        await environment.client.start_flow(flow, flow_id, ModelInput(value=10))
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 10
         with pytest.raises(TypeError):
-            environment.client.start_flow(
+            await environment.client.start_flow(
                 flow,
                 unique_id("wrong-input"),
                 cast(ModelInput, "wrong"),
@@ -112,72 +136,102 @@ def test_model_input_workflow() -> None:
 
 
 def test_flow_config_override() -> None:
+    asyncio.run(_flow_config_override())
+
+
+async def _flow_config_override() -> None:
     flow = BasicFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("config-override")
         options = StartFlowOptions(
             config_override=FlowConfig(continue_as_new_threshold=1)
         )
-        environment.client.start_flow(flow, flow_id, 0, options)
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+        await environment.client.start_flow(flow, flow_id, 0, options)
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
 
 
 def test_describe_missing_flow() -> None:
+    asyncio.run(_describe_missing_flow())
+
+
+async def _describe_missing_flow() -> None:
     flow = BasicFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         with pytest.raises(DexException) as captured:
-            environment.client.describe_flow(unique_id("missing"))
+            await environment.client.describe_flow(unique_id("missing"))
         assert captured.value.sub_status is ErrorSubStatus.FLOW_NOT_EXISTS
 
 
 def test_describe_running_flow() -> None:
+    asyncio.run(_describe_running_flow())
+
+
+async def _describe_running_flow() -> None:
     flow = SignalFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("running")
-        environment.client.start_flow(flow, flow_id, 0)
-        assert environment.client.describe_flow(flow_id).status is FlowStatus.RUNNING
-        environment.client.stop_flow(flow_id)
+        await environment.client.start_flow(flow, flow_id, 0)
+        assert (
+            await environment.client.describe_flow(flow_id)
+        ).status is FlowStatus.RUNNING
+        await environment.client.stop_flow(flow_id)
 
 
 def test_wait_for_step_completion() -> None:
+    asyncio.run(_wait_for_step_completion())
+
+
+async def _wait_for_step_completion() -> None:
     flow = BasicFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("wait-step")
-        environment.client.start_flow(flow, flow_id, 5)
-        environment.client.wait_for_step_completion(
+        await environment.client.start_flow(flow, flow_id, 5)
+        await environment.client.wait_for_step_completion(
             flow_id,
             StepExecutionId("BasicSecondStep"),
             WAIT_TIMEOUT,
         )
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 7
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 7
 
 
 def test_proceed_on_wait_failure() -> None:
+    asyncio.run(_proceed_on_wait_failure())
+
+
+async def _proceed_on_wait_failure() -> None:
     flow = ProceedOnWaitFailureFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("proceed-on-wait-failure")
-        environment.client.start_flow(flow, flow_id, "input")
+        await environment.client.start_flow(flow, flow_id, "input")
         assert (
-            environment.client.wait_for_flow(flow_id, str, WAIT_TIMEOUT)
+            await environment.client.wait_for_flow(flow_id, str, WAIT_TIMEOUT)
             == "input-recovered"
         )
 
 
 def test_mixed_wait_styles() -> None:
+    asyncio.run(_mixed_wait_styles())
+
+
+async def _mixed_wait_styles() -> None:
     flow = MixedWaitFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("mixed-wait")
-        environment.client.start_flow(flow, flow_id, 0)
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+        await environment.client.start_flow(flow, flow_id, 0)
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
 
 
 def test_movement_options_do_not_mutate_step_defaults() -> None:
+    asyncio.run(_movement_options_do_not_mutate_step_defaults())
+
+
+async def _movement_options_do_not_mutate_step_defaults() -> None:
     flow = ImmutableStepOptionsFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("immutable-options")
-        environment.client.start_flow(flow, flow_id, 0)
+        await environment.client.start_flow(flow, flow_id, 0)
         with pytest.raises(FlowUncompletedError) as captured:
-            environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT)
+            await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT)
         assert captured.value.status is FlowStatus.FAILED
         assert captured.value.error_type is FlowErrorType.WORKER_API_FAILED
         assert str(captured.value) == "expected wait failure 2"

--- a/sdk-python/tests/integ/test_basic_runtime_async.py
+++ b/sdk-python/tests/integ/test_basic_runtime_async.py
@@ -10,7 +10,7 @@
 
 import asyncio
 from datetime import timedelta
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -68,9 +68,7 @@ async def _basic_workflow_abnormal_exit_reuse() -> None:
         options = StartFlowOptions(
             id_reuse_policy=IdReusePolicy.ALLOW_IF_PREVIOUS_FAILED
         )
-        failed_run = await environment.client.start_flow(
-            abnormal, flow_id, 0, options
-        )
+        failed_run = await environment.client.start_flow(abnormal, flow_id, 0, options)
         with pytest.raises(FlowUncompletedError) as captured:
             await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT)
         assert captured.value.run_id == failed_run
@@ -88,7 +86,9 @@ async def _empty_input_workflow() -> None:
     async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("empty-input")
         await environment.client.start_flow(flow, flow_id, None)
-        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) is None
+        assert (
+            await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) is None
+        )
         with pytest.raises(DexException) as captured:
             await environment.client.wait_for_flow(
                 unique_id("missing"), int, timedelta(seconds=1)
@@ -106,10 +106,12 @@ async def _custom_flow_type() -> None:
         flow_id = unique_id("type-specified")
         assert flow.get_flow_type() == "test-customized-flow-type"
         await environment.client.start_flow(flow, flow_id, None)
-        assert (
-            await environment.client.wait_for_flow(flow_id, type(None), WAIT_TIMEOUT)
-            is None
+        completed = await environment.client.wait_for_flow(
+            flow_id,
+            cast(type[Any], type(None)),
+            WAIT_TIMEOUT,
         )
+        assert completed is None
         with pytest.raises(ValueError, match="Flow instance is not registered"):
             await environment.client.start_flow(
                 EmptyInputFlow(), unique_id("unregistered"), None

--- a/sdk-python/tests/integ/test_basic_runtime_async.py
+++ b/sdk-python/tests/integ/test_basic_runtime_async.py
@@ -11,7 +11,6 @@
 import asyncio
 from datetime import timedelta
 from typing import cast
-from uuid import uuid4
 
 import pytest
 
@@ -35,7 +34,7 @@ from .immutable_step_options_flow import ImmutableStepOptionsFlow
 from .mixed_wait_flow import MixedWaitFlow
 from .model_input_flow import ModelInputFlow
 from .proceed_on_wait_failure_flow import ProceedOnWaitFailureFlow
-from .shared import ModelInput
+from .shared import ModelInput, unique_id
 from .signal_flow import SignalFlow
 
 WAIT_TIMEOUT = timedelta(seconds=30)
@@ -235,7 +234,3 @@ async def _movement_options_do_not_mutate_step_defaults() -> None:
         assert captured.value.status is FlowStatus.FAILED
         assert captured.value.error_type is FlowErrorType.WORKER_API_FAILED
         assert str(captured.value) == "expected wait failure 2"
-
-
-def unique_id(prefix: str) -> str:
-    return f"{prefix}-{uuid4()}"

--- a/sdk-python/tests/integ/test_basic_runtime_sync.py
+++ b/sdk-python/tests/integ/test_basic_runtime_sync.py
@@ -1,0 +1,182 @@
+# Portions of this file are derived from indeedeng/iwf-java-sdk.
+# Those portions are licensed under the Apache License, Version 2.0.
+# See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+#
+# Modifications Copyright (c) 2026 Super Durable, Inc.
+#
+# Modifications are licensed under the Super Durable Source License 1.0.
+# Third-Party Materials remain under the Apache License, Version 2.0.
+# See LICENSE and LEGACY_NOTICES.md.
+
+from datetime import timedelta
+from typing import cast
+
+import pytest
+
+from dex import (
+    DexException,
+    ErrorSubStatus,
+    FlowConfig,
+    FlowErrorType,
+    FlowStatus,
+    FlowUncompletedError,
+    IdReusePolicy,
+    StartFlowOptions,
+    StepExecutionId,
+)
+
+from .abnormal_exit_flow import AbnormalExitFlow
+from .basic_flow import BasicFlow
+from .empty_input_flow import EmptyInputFlow
+from .environment import DexDevTestEnvironment
+from .immutable_step_options_flow import ImmutableStepOptionsFlow
+from .mixed_wait_flow import MixedWaitFlow
+from .model_input_flow import ModelInputFlow
+from .proceed_on_wait_failure_flow import ProceedOnWaitFailureFlow
+from .shared import ModelInput, unique_id
+from .signal_flow import SignalFlow
+
+WAIT_TIMEOUT = timedelta(seconds=30)
+
+
+def test_basic_workflow() -> None:
+    flow = BasicFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("basic")
+        options = StartFlowOptions(id_reuse_policy=IdReusePolicy.DISALLOW)
+        environment.client.start_flow(flow, flow_id, 0, options)
+        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+        with pytest.raises(DexException) as captured:
+            environment.client.start_flow(flow, flow_id, 0, options)
+        assert captured.value.sub_status is ErrorSubStatus.FLOW_ALREADY_STARTED
+
+
+def test_basic_workflow_abnormal_exit_reuse() -> None:
+    abnormal = AbnormalExitFlow()
+    basic = BasicFlow()
+    with DexDevTestEnvironment(abnormal, basic) as environment:
+        flow_id = unique_id("abnormal-exit-reuse")
+        options = StartFlowOptions(
+            id_reuse_policy=IdReusePolicy.ALLOW_IF_PREVIOUS_FAILED
+        )
+        failed_run = environment.client.start_flow(abnormal, flow_id, 0, options)
+        with pytest.raises(FlowUncompletedError) as captured:
+            environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT)
+        assert captured.value.run_id == failed_run
+        assert captured.value.status is FlowStatus.FAILED
+        environment.client.start_flow(basic, flow_id, 0, options)
+        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+
+
+def test_empty_input_workflow() -> None:
+    flow = EmptyInputFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("empty-input")
+        environment.client.start_flow(flow, flow_id, None)
+        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) is None
+        with pytest.raises(DexException) as captured:
+            environment.client.wait_for_flow(
+                unique_id("missing"), int, timedelta(seconds=1)
+            )
+        assert captured.value.sub_status is ErrorSubStatus.FLOW_NOT_EXISTS
+
+
+def test_custom_flow_type() -> None:
+    flow = EmptyInputFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("type-specified")
+        assert flow.get_flow_type() == "test-customized-flow-type"
+        environment.client.start_flow(flow, flow_id, None)
+        assert (
+            environment.client.wait_for_flow(flow_id, type(None), WAIT_TIMEOUT) is None
+        )
+        with pytest.raises(ValueError, match="Flow instance is not registered"):
+            environment.client.start_flow(
+                EmptyInputFlow(), unique_id("unregistered"), None
+            )
+
+
+def test_model_input_workflow() -> None:
+    flow = ModelInputFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("model-input")
+        environment.client.start_flow(flow, flow_id, ModelInput(value=10))
+        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 10
+        with pytest.raises(TypeError):
+            environment.client.start_flow(
+                flow,
+                unique_id("wrong-input"),
+                cast(ModelInput, "wrong"),
+            )
+
+
+def test_flow_config_override() -> None:
+    flow = BasicFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("config-override")
+        options = StartFlowOptions(
+            config_override=FlowConfig(continue_as_new_threshold=1)
+        )
+        environment.client.start_flow(flow, flow_id, 0, options)
+        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+
+
+def test_describe_missing_flow() -> None:
+    flow = BasicFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        with pytest.raises(DexException) as captured:
+            environment.client.describe_flow(unique_id("missing"))
+        assert captured.value.sub_status is ErrorSubStatus.FLOW_NOT_EXISTS
+
+
+def test_describe_running_flow() -> None:
+    flow = SignalFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("running")
+        environment.client.start_flow(flow, flow_id, 0)
+        assert environment.client.describe_flow(flow_id).status is FlowStatus.RUNNING
+        environment.client.stop_flow(flow_id)
+
+
+def test_wait_for_step_completion() -> None:
+    flow = BasicFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("wait-step")
+        environment.client.start_flow(flow, flow_id, 5)
+        environment.client.wait_for_step_completion(
+            flow_id,
+            StepExecutionId("BasicSecondStep"),
+            WAIT_TIMEOUT,
+        )
+        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 7
+
+
+def test_proceed_on_wait_failure() -> None:
+    flow = ProceedOnWaitFailureFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("proceed-on-wait-failure")
+        environment.client.start_flow(flow, flow_id, "input")
+        assert (
+            environment.client.wait_for_flow(flow_id, str, WAIT_TIMEOUT)
+            == "input-recovered"
+        )
+
+
+def test_mixed_wait_styles() -> None:
+    flow = MixedWaitFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("mixed-wait")
+        environment.client.start_flow(flow, flow_id, 0)
+        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+
+
+def test_movement_options_do_not_mutate_step_defaults() -> None:
+    flow = ImmutableStepOptionsFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("immutable-options")
+        environment.client.start_flow(flow, flow_id, 0)
+        with pytest.raises(FlowUncompletedError) as captured:
+            environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT)
+        assert captured.value.status is FlowStatus.FAILED
+        assert captured.value.error_type is FlowErrorType.WORKER_API_FAILED
+        assert str(captured.value) == "expected wait failure 2"

--- a/sdk-python/tests/integ/test_channels_runtime.py
+++ b/sdk-python/tests/integ/test_channels_runtime.py
@@ -8,13 +8,14 @@
 # Third-Party Materials remain under the Apache License, Version 2.0.
 # See LICENSE and LEGACY_NOTICES.md.
 
+import asyncio
 from datetime import timedelta
 
 from dex import StepExecutionId, TimerId
 
+from .async_environment import AsyncDexDevTestEnvironment
 from .basic_internal_channel_flow import BasicInternalChannelFlow
 from .conditional_complete_flow import ConditionalCompleteFlow
-from .environment import DexDevTestEnvironment
 from .signal_flow import SignalFlow
 from .test_basic_runtime import unique_id
 from .waiting_internal_channel_flow import WaitingInternalChannelFlow
@@ -23,51 +24,71 @@ WAIT_TIMEOUT = timedelta(seconds=30)
 
 
 def test_conditional_complete_with_signal_channel() -> None:
+    asyncio.run(_conditional_complete_with_signal_channel())
+
+
+async def _conditional_complete_with_signal_channel() -> None:
     flow = ConditionalCompleteFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("conditional-signal")
-        environment.client.start_flow(flow, flow_id, True)
-        environment.client.publish(flow_id, flow.signal, None)
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 1
+        await environment.client.start_flow(flow, flow_id, True)
+        await environment.client.publish(flow_id, flow.signal, None)
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 1
 
 
 def test_conditional_complete_with_internal_channel() -> None:
+    asyncio.run(_conditional_complete_with_internal_channel())
+
+
+async def _conditional_complete_with_internal_channel() -> None:
     flow = ConditionalCompleteFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("conditional-internal")
-        environment.client.start_flow(flow, flow_id, False)
-        environment.client.invoke_rpc(flow.publish_to_internal_channel, flow_id)
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 1
+        await environment.client.start_flow(flow, flow_id, False)
+        await environment.client.invoke_rpc(flow.publish_to_internal_channel, flow_id)
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 1
 
 
 def test_basic_internal_channel() -> None:
+    asyncio.run(_basic_internal_channel())
+
+
+async def _basic_internal_channel() -> None:
     flow = BasicInternalChannelFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("basic-internal")
-        environment.client.start_flow(flow, flow_id, 1)
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+        await environment.client.start_flow(flow, flow_id, 1)
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
 
 
 def test_waiting_internal_channel() -> None:
+    asyncio.run(_waiting_internal_channel())
+
+
+async def _waiting_internal_channel() -> None:
     flow = WaitingInternalChannelFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("waiting-internal")
-        environment.client.start_flow(flow, flow_id, 1)
-        environment.client.publish(flow_id, flow.channel, 2, 3)
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 6
+        await environment.client.start_flow(flow, flow_id, 1)
+        await environment.client.publish(flow_id, flow.channel, 2, 3)
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 6
 
 
 def test_signal_conditions_and_timer_skip() -> None:
+    asyncio.run(_signal_conditions_and_timer_skip())
+
+
+async def _signal_conditions_and_timer_skip() -> None:
     flow = SignalFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("basic-signal")
-        environment.client.start_flow(flow, flow_id, 1)
-        environment.client.publish(flow_id, flow.first, 2, 3, 5)
-        environment.client.publish(flow_id, flow.third, None)
-        environment.client.publish(flow_id, flow.signal_map, "one", 4)
-        environment.client.skip_timer(
+        await environment.client.start_flow(flow, flow_id, 1)
+        await environment.client.publish(flow_id, flow.first, 2, 3, 5)
+        await environment.client.publish(flow_id, flow.third, None)
+        await environment.client.publish(flow_id, flow.signal_map, "one", 4)
+        await environment.client.skip_timer(
             flow_id,
             StepExecutionId("SignalCombinationStep"),
             TimerId.by_condition_id("test-timer-id"),
         )
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 6
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 6

--- a/sdk-python/tests/integ/test_channels_runtime.py
+++ b/sdk-python/tests/integ/test_channels_runtime.py
@@ -17,7 +17,7 @@ from .async_environment import AsyncDexDevTestEnvironment
 from .basic_internal_channel_flow import BasicInternalChannelFlow
 from .conditional_complete_flow import ConditionalCompleteFlow
 from .signal_flow import SignalFlow
-from .test_basic_runtime import unique_id
+from .shared import unique_id
 from .waiting_internal_channel_flow import WaitingInternalChannelFlow
 
 WAIT_TIMEOUT = timedelta(seconds=30)

--- a/sdk-python/tests/integ/test_persistence_runtime.py
+++ b/sdk-python/tests/integ/test_persistence_runtime.py
@@ -16,7 +16,7 @@ from .basic_persistence_flow import BasicPersistenceFlow
 from .environment import DexDevTestEnvironment
 from .set_attributes_flow import SetAttributesFlow
 from .shared import ModelInput
-from .test_basic_runtime import unique_id
+from .shared import unique_id
 
 WAIT_TIMEOUT = timedelta(seconds=30)
 

--- a/sdk-python/tests/integ/test_reset_runtime.py
+++ b/sdk-python/tests/integ/test_reset_runtime.py
@@ -22,7 +22,7 @@ from dex import (
 
 from .environment import DexDevTestEnvironment
 from .reset_flow import ResetFlow
-from .test_basic_runtime import unique_id
+from .shared import unique_id
 
 
 @pytest.mark.parametrize("locking", (True, False))

--- a/sdk-python/tests/integ/test_rpc_runtime.py
+++ b/sdk-python/tests/integ/test_rpc_runtime.py
@@ -22,7 +22,7 @@ from .dead_end_flow import DeadEndFlow
 from .no_start_flow import NoStartFlow
 from .no_state_flow import NoStateFlow
 from .rpc_flow import RpcFlow
-from .test_basic_runtime import unique_id
+from .shared import unique_id
 
 WAIT_TIMEOUT = timedelta(seconds=30)
 

--- a/sdk-python/tests/integ/test_rpc_runtime.py
+++ b/sdk-python/tests/integ/test_rpc_runtime.py
@@ -8,7 +8,7 @@
 # Third-Party Materials remain under the Apache License, Version 2.0.
 # See LICENSE and LEGACY_NOTICES.md.
 
-from concurrent.futures import ThreadPoolExecutor
+import asyncio
 from datetime import timedelta
 from typing import cast
 
@@ -17,8 +17,8 @@ import pytest
 
 from dex import DexException, ErrorSubStatus, StopFlowOptions, StopType
 
+from .async_environment import AsyncDexDevTestEnvironment
 from .dead_end_flow import DeadEndFlow
-from .environment import DexDevTestEnvironment
 from .no_start_flow import NoStartFlow
 from .no_state_flow import NoStateFlow
 from .rpc_flow import RpcFlow
@@ -28,63 +28,93 @@ WAIT_TIMEOUT = timedelta(seconds=30)
 
 
 def test_flow_without_start_step_can_start_from_rpc() -> None:
+    asyncio.run(_flow_without_start_step_can_start_from_rpc())
+
+
+async def _flow_without_start_step_can_start_from_rpc() -> None:
     flow = NoStartFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("no-start")
-        environment.client.start_flow(flow, flow_id, None)
-        assert environment.client.invoke_rpc(flow.invoke, flow_id, "rpc-input") == 100
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 1
+        await environment.client.start_flow(flow, flow_id, None)
+        assert (
+            await environment.client.invoke_rpc(flow.invoke, flow_id, "rpc-input")
+            == 100
+        )
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 1
 
 
 def test_flow_without_steps_can_serve_rpc() -> None:
+    asyncio.run(_flow_without_steps_can_serve_rpc())
+
+
+async def _flow_without_steps_can_serve_rpc() -> None:
     flow = NoStateFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("no-state")
-        environment.client.start_flow(flow, flow_id, None)
-        assert environment.client.invoke_rpc(flow.invoke, flow_id, "rpc-input") == 100
-        environment.client.stop_flow(flow_id)
+        await environment.client.start_flow(flow, flow_id, None)
+        assert (
+            await environment.client.invoke_rpc(flow.invoke, flow_id, "rpc-input")
+            == 100
+        )
+        await environment.client.stop_flow(flow_id)
 
 
 def test_dead_end_flow_can_be_completed_from_rpc() -> None:
+    asyncio.run(_dead_end_flow_can_be_completed_from_rpc())
+
+
+async def _dead_end_flow_can_be_completed_from_rpc() -> None:
     flow = DeadEndFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("dead-end")
-        environment.client.start_flow(flow, flow_id, None)
-        assert environment.client.invoke_rpc(flow.invoke, flow_id, "rpc-input") == 100
+        await environment.client.start_flow(flow, flow_id, None)
         assert (
-            environment.client.wait_for_flow(flow_id, type(None), WAIT_TIMEOUT) is None
+            await environment.client.invoke_rpc(flow.invoke, flow_id, "rpc-input")
+            == 100
+        )
+        assert (
+            await environment.client.wait_for_flow(flow_id, type(None), WAIT_TIMEOUT)
+            is None
         )
 
 
 def test_locking_rpc_serializes_successful_updates() -> None:
-    flow = NoStateFlow()
-    with DexDevTestEnvironment(flow) as environment:
-        flow_id = unique_id("rpc-lock")
-        environment.client.start_flow(flow, flow_id, None)
+    asyncio.run(_locking_rpc_serializes_successful_updates())
 
-        def increase() -> bool:
+
+async def _locking_rpc_serializes_successful_updates() -> None:
+    flow = NoStateFlow()
+    async with AsyncDexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("rpc-lock")
+        await environment.client.start_flow(flow, flow_id, None)
+
+        async def increase() -> bool:
             try:
-                environment.client.invoke_rpc(flow.increase_counter, flow_id)
+                await environment.client.invoke_rpc(flow.increase_counter, flow_id)
                 return True
             except DexException as conflict:
                 if conflict.code is grpc.StatusCode.ABORTED:
                     return False
                 raise
 
-        with ThreadPoolExecutor(max_workers=10) as executor:
-            succeeded = sum(executor.map(lambda _: increase(), range(100)))
+        results = await asyncio.gather(*(increase() for _ in range(100)))
+        succeeded = sum(results)
         assert succeeded > 0
-        assert environment.client.invoke_rpc(flow.get_counter, flow_id) == succeeded
-        environment.client.stop_flow(flow_id)
+        assert await environment.client.invoke_rpc(flow.get_counter, flow_id) == succeeded
+        await environment.client.stop_flow(flow_id)
 
 
 def test_rpc_without_persistence_unblocks_flow() -> None:
+    asyncio.run(_rpc_without_persistence_unblocks_flow())
+
+
+async def _rpc_without_persistence_unblocks_flow() -> None:
     flow = RpcFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("rpc-no-persistence")
-        environment.client.start_flow(flow, flow_id, 999)
-        environment.client.invoke_rpc(flow.no_persistence, flow_id)
-        assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+        await environment.client.start_flow(flow, flow_id, 999)
+        await environment.client.invoke_rpc(flow.no_persistence, flow_id)
+        assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
 
 
 @pytest.mark.parametrize(
@@ -101,79 +131,109 @@ def test_rpc_functions_and_procedures(
     argument: str | None,
     expected_value: str,
 ) -> None:
+    asyncio.run(
+        _rpc_functions_and_procedures(method_name, argument, expected_value)
+    )
+
+
+async def _rpc_functions_and_procedures(
+    method_name: str,
+    argument: str | None,
+    expected_value: str,
+) -> None:
     flow = RpcFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id(f"rpc-{method_name}")
-        environment.client.start_flow(flow, flow_id, 999)
+        await environment.client.start_flow(flow, flow_id, 999)
         method = getattr(flow, method_name)
         if argument is None:
-            output = environment.client.invoke_rpc(method, flow_id)
+            output = await environment.client.invoke_rpc(method, flow_id)
         else:
-            output = environment.client.invoke_rpc(method, flow_id, argument)
+            output = await environment.client.invoke_rpc(method, flow_id, argument)
         if method_name.startswith("function"):
             assert output == RpcFlow.RPC_OUTPUT
         else:
             assert output is None
-        assert_rpc_completion(environment, flow, flow_id, expected_value)
+        await assert_rpc_completion(environment, flow, flow_id, expected_value)
 
 
 def test_rpc_attribute_round_trip_and_read_only_call() -> None:
+    asyncio.run(_rpc_attribute_round_trip_and_read_only_call())
+
+
+async def _rpc_attribute_round_trip_and_read_only_call() -> None:
     flow = RpcFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("rpc-read-only")
-        environment.client.start_flow(flow, flow_id, 999)
-        environment.client.invoke_rpc(flow.set_data, flow_id, "test-value")
-        assert environment.client.invoke_rpc(flow.get_data, flow_id) == "test-value"
-        environment.client.invoke_rpc(flow.set_data, flow_id, cast(str, None))
-        assert environment.client.invoke_rpc(flow.get_data, flow_id) is None
-        environment.client.invoke_rpc(flow.set_keyword, flow_id, "test-value")
-        assert environment.client.invoke_rpc(flow.get_keyword, flow_id) == "test-value"
-        environment.client.invoke_rpc(flow.set_keyword, flow_id, cast(str, None))
-        assert environment.client.invoke_rpc(flow.get_keyword, flow_id) is None
+        await environment.client.start_flow(flow, flow_id, 999)
+        await environment.client.invoke_rpc(flow.set_data, flow_id, "test-value")
+        assert await environment.client.invoke_rpc(flow.get_data, flow_id) == "test-value"
+        await environment.client.invoke_rpc(flow.set_data, flow_id, cast(str, None))
+        assert await environment.client.invoke_rpc(flow.get_data, flow_id) is None
+        await environment.client.invoke_rpc(flow.set_keyword, flow_id, "test-value")
         assert (
-            environment.client.invoke_rpc(flow.read_only, flow_id, "rpc-input")
+            await environment.client.invoke_rpc(flow.get_keyword, flow_id)
+            == "test-value"
+        )
+        await environment.client.invoke_rpc(flow.set_keyword, flow_id, cast(str, None))
+        assert await environment.client.invoke_rpc(flow.get_keyword, flow_id) is None
+        assert (
+            await environment.client.invoke_rpc(flow.read_only, flow_id, "rpc-input")
             == RpcFlow.RPC_OUTPUT
         )
-        environment.client.stop_flow(
+        await environment.client.stop_flow(
             flow_id,
             StopFlowOptions(StopType.FAIL, RpcFlow.HARDCODED_VALUE),
         )
 
 
 def test_rpc_user_error_preserves_worker_details() -> None:
+    asyncio.run(_rpc_user_error_preserves_worker_details())
+
+
+async def _rpc_user_error_preserves_worker_details() -> None:
     flow = NoStateFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("rpc-error")
-        environment.client.start_flow(flow, flow_id, None)
+        await environment.client.start_flow(flow, flow_id, None)
         with pytest.raises(DexException) as captured:
-            environment.client.invoke_rpc(flow.fail, flow_id, "this is an error")
+            await environment.client.invoke_rpc(flow.fail, flow_id, "this is an error")
         failure = captured.value
         assert failure.code is grpc.StatusCode.FAILED_PRECONDITION
         assert failure.sub_status is ErrorSubStatus.WORKER_API_ERROR
         assert "ValueError" in failure.worker_error_type
         assert "this is an error" in failure.worker_error_detail
-        environment.client.stop_flow(flow_id)
+        await environment.client.stop_flow(flow_id)
 
 
 def test_rpc_channel_size_info() -> None:
+    asyncio.run(_rpc_channel_size_info())
+
+
+async def _rpc_channel_size_info() -> None:
     flow = DeadEndFlow()
-    with DexDevTestEnvironment(flow) as environment:
+    async with AsyncDexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("channel-size")
-        environment.client.start_flow(flow, flow_id, None)
-        environment.client.invoke_rpc(flow.publish_internal, flow_id)
-        assert environment.client.invoke_rpc(flow.publish_internal, flow_id) == 2
-        environment.client.publish(flow_id, flow.idle_signal, None, None, None)
-        assert environment.client.invoke_rpc(flow.signal_size, flow_id) == 3
-        environment.client.stop_flow(flow_id)
+        await environment.client.start_flow(flow, flow_id, None)
+        await environment.client.invoke_rpc(flow.publish_internal, flow_id)
+        assert await environment.client.invoke_rpc(flow.publish_internal, flow_id) == 2
+        await environment.client.publish(flow_id, flow.idle_signal, None, None, None)
+        assert await environment.client.invoke_rpc(flow.signal_size, flow_id) == 3
+        await environment.client.stop_flow(flow_id)
 
 
-def assert_rpc_completion(
-    environment: DexDevTestEnvironment,
+async def assert_rpc_completion(
+    environment: AsyncDexDevTestEnvironment,
     flow: RpcFlow,
     flow_id: str,
     expected_value: str,
 ) -> None:
-    assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
-    assert environment.client.get_attribute(flow_id, flow.data) == expected_value
-    assert environment.client.get_attribute(flow_id, flow.keyword) == expected_value
-    assert environment.client.get_attribute(flow_id, flow.integer) == RpcFlow.RPC_OUTPUT
+    assert await environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+    assert await environment.client.get_attribute(flow_id, flow.data) == expected_value
+    assert (
+        await environment.client.get_attribute(flow_id, flow.keyword) == expected_value
+    )
+    assert (
+        await environment.client.get_attribute(flow_id, flow.integer)
+        == RpcFlow.RPC_OUTPUT
+    )

--- a/sdk-python/tests/integ/test_rpc_runtime.py
+++ b/sdk-python/tests/integ/test_rpc_runtime.py
@@ -10,7 +10,7 @@
 
 import asyncio
 from datetime import timedelta
-from typing import cast
+from typing import Any, cast
 
 import grpc
 import pytest
@@ -72,10 +72,12 @@ async def _dead_end_flow_can_be_completed_from_rpc() -> None:
             await environment.client.invoke_rpc(flow.invoke, flow_id, "rpc-input")
             == 100
         )
-        assert (
-            await environment.client.wait_for_flow(flow_id, type(None), WAIT_TIMEOUT)
-            is None
+        completed = await environment.client.wait_for_flow(
+            flow_id,
+            cast(type[Any], type(None)),
+            WAIT_TIMEOUT,
         )
+        assert completed is None
 
 
 def test_locking_rpc_serializes_successful_updates() -> None:
@@ -100,7 +102,9 @@ async def _locking_rpc_serializes_successful_updates() -> None:
         results = await asyncio.gather(*(increase() for _ in range(100)))
         succeeded = sum(results)
         assert succeeded > 0
-        assert await environment.client.invoke_rpc(flow.get_counter, flow_id) == succeeded
+        assert (
+            await environment.client.invoke_rpc(flow.get_counter, flow_id) == succeeded
+        )
         await environment.client.stop_flow(flow_id)
 
 
@@ -131,9 +135,7 @@ def test_rpc_functions_and_procedures(
     argument: str | None,
     expected_value: str,
 ) -> None:
-    asyncio.run(
-        _rpc_functions_and_procedures(method_name, argument, expected_value)
-    )
+    asyncio.run(_rpc_functions_and_procedures(method_name, argument, expected_value))
 
 
 async def _rpc_functions_and_procedures(
@@ -154,7 +156,7 @@ async def _rpc_functions_and_procedures(
             assert output == RpcFlow.RPC_OUTPUT
         else:
             assert output is None
-        await assert_rpc_completion(environment, flow, flow_id, expected_value)
+        await assert_async_rpc_completion(environment, flow, flow_id, expected_value)
 
 
 def test_rpc_attribute_round_trip_and_read_only_call() -> None:
@@ -167,7 +169,9 @@ async def _rpc_attribute_round_trip_and_read_only_call() -> None:
         flow_id = unique_id("rpc-read-only")
         await environment.client.start_flow(flow, flow_id, 999)
         await environment.client.invoke_rpc(flow.set_data, flow_id, "test-value")
-        assert await environment.client.invoke_rpc(flow.get_data, flow_id) == "test-value"
+        assert (
+            await environment.client.invoke_rpc(flow.get_data, flow_id) == "test-value"
+        )
         await environment.client.invoke_rpc(flow.set_data, flow_id, cast(str, None))
         assert await environment.client.invoke_rpc(flow.get_data, flow_id) is None
         await environment.client.invoke_rpc(flow.set_keyword, flow_id, "test-value")
@@ -222,7 +226,7 @@ async def _rpc_channel_size_info() -> None:
         await environment.client.stop_flow(flow_id)
 
 
-async def assert_rpc_completion(
+async def assert_async_rpc_completion(
     environment: AsyncDexDevTestEnvironment,
     flow: RpcFlow,
     flow_id: str,

--- a/sdk-python/tests/integ/test_rpc_with_memo_runtime.py
+++ b/sdk-python/tests/integ/test_rpc_with_memo_runtime.py
@@ -14,7 +14,7 @@ from dex import StopFlowOptions, StopType
 
 from .environment import DexDevTestEnvironment
 from .rpc_flow import RpcFlow
-from .test_basic_runtime import unique_id
+from .shared import unique_id
 from .test_rpc_runtime import assert_rpc_completion
 
 

--- a/sdk-python/tests/integ/test_rpc_with_memo_runtime.py
+++ b/sdk-python/tests/integ/test_rpc_with_memo_runtime.py
@@ -8,6 +8,7 @@
 # Third-Party Materials remain under the Apache License, Version 2.0.
 # See LICENSE and LEGACY_NOTICES.md.
 
+from datetime import timedelta
 from typing import cast
 
 from dex import StopFlowOptions, StopType
@@ -15,7 +16,8 @@ from dex import StopFlowOptions, StopType
 from .environment import DexDevTestEnvironment
 from .rpc_flow import RpcFlow
 from .shared import unique_id
-from .test_rpc_runtime import assert_rpc_completion
+
+WAIT_TIMEOUT = timedelta(seconds=30)
 
 
 def test_rpc_memo_function_one() -> None:
@@ -86,3 +88,15 @@ def start_flow(
     flow_id = unique_id(prefix)
     environment.client.start_flow(flow, flow_id, 999)
     return flow_id
+
+
+def assert_rpc_completion(
+    environment: DexDevTestEnvironment,
+    flow: RpcFlow,
+    flow_id: str,
+    expected_value: str,
+) -> None:
+    assert environment.client.wait_for_flow(flow_id, int, WAIT_TIMEOUT) == 2
+    assert environment.client.get_attribute(flow_id, flow.data) == expected_value
+    assert environment.client.get_attribute(flow_id, flow.keyword) == expected_value
+    assert environment.client.get_attribute(flow_id, flow.integer) == RpcFlow.RPC_OUTPUT

--- a/sdk-python/tests/integ/test_search_flows_runtime.py
+++ b/sdk-python/tests/integ/test_search_flows_runtime.py
@@ -21,7 +21,7 @@ from dex.flow_info import SearchFlowEntry
 
 from .environment import DexDevTestEnvironment
 from .search_flows_flow import KEYWORD_KEY, SearchFlowsFlow
-from .test_basic_runtime import unique_id
+from .shared import unique_id
 
 WAIT_TIMEOUT = timedelta(seconds=30)
 

--- a/sdk-python/tests/integ/test_step_options_runtime.py
+++ b/sdk-python/tests/integ/test_step_options_runtime.py
@@ -19,7 +19,7 @@ from .state_options_flow import StateOptionsFlow
 from .state_options_override_flow import StateOptionsOverrideFlow
 from .state_recovery_flow import StateRecoveryFlow
 from .state_recovery_no_wait_flow import StateRecoveryNoWaitFlow
-from .test_basic_runtime import unique_id
+from .shared import unique_id
 from .timer_flow import TimerFlow
 
 WAIT_TIMEOUT = timedelta(seconds=30)

--- a/sdk-python/tests/integ/test_workflow_uncompleted_runtime.py
+++ b/sdk-python/tests/integ/test_workflow_uncompleted_runtime.py
@@ -28,7 +28,7 @@ from .force_fail_flow import ForceFailFlow
 from .signal_flow import SignalFlow
 from .state_failure_flow import StateFailureFlow
 from .state_timeout_flow import StateTimeoutFlow
-from .test_basic_runtime import unique_id
+from .shared import unique_id
 
 
 def test_flow_wait_timeout() -> None:

--- a/sdk-python/tests/test_contracts.py
+++ b/sdk-python/tests/test_contracts.py
@@ -194,6 +194,11 @@ def test_registry_rejects_async_step_and_rpc_handlers() -> None:
         Registry((AsyncOrderFlow(),))
 
 
+def test_registry_allows_async_handlers_when_enabled() -> None:
+    registry = Registry((AsyncOrderFlow(),), allow_async_handlers=True)
+    assert registry.flows[0].get_flow_type() == AsyncOrderFlow().get_flow_type()
+
+
 def test_registry_rejects_duplicate_interfaces() -> None:
     with pytest.raises(ValueError, match="duplicate Flow Orders"):
         Registry((ORDERS, ORDERS))


### PR DESCRIPTION
## Summary
- Add `AsyncClient` / `AsyncWorker` (`grpc.aio`) with optional awaitable Step/RPC handlers via `Registry(..., allow_async_handlers=True)`.
- Cover the async runtime with contract and integration tests; document sync vs asyncio in the Python SDK README.
- Add design plans for Python async APIs and TypeScript async Step/waitFor/RPC handlers.

## Test plan
- [ ] `make -C sdk-python unitTests` (or equivalent contract tests including `allow_async_handlers`)
- [ ] Run `sdk-python/tests/integ/test_async_runtime.py` against a local Dex server
- [ ] Skim `docs/design/plan/python-sdk-async-apis.md` and `typescript-sdk-async-step-handlers.md` for accuracy


Made with [Cursor](https://cursor.com)