### PR TITLE
Add async and mixed sync/async TS integ coverage

### DIFF
--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -143,27 +143,30 @@ export class Client {
   }
 
   public invokeRPC<Input, Output>(
-    rpcMethod: (context: Context, input: Input) => RPCResult<Output>,
+    rpcMethod: (
+      context: Context,
+      input: Input,
+    ) => RPCResult<Output> | Promise<RPCResult<Output>>,
     flowId: string,
     input: Input,
     runId?: string,
   ): Promise<Output>;
 
   public invokeRPC<Output>(
-    rpcMethod: (context: Context) => RPCResult<Output>,
+    rpcMethod: (context: Context) => RPCResult<Output> | Promise<RPCResult<Output>>,
     flowId: string,
     runId?: string,
   ): Promise<Output>;
 
   public invokeRPC<Input>(
-    rpcMethod: (context: Context, input: Input) => void,
+    rpcMethod: (context: Context, input: Input) => void | Promise<void>,
     flowId: string,
     input: Input,
     runId?: string,
   ): Promise<void>;
 
   public invokeRPC(
-    rpcMethod: (context: Context) => void,
+    rpcMethod: (context: Context) => void | Promise<void>,
     flowId: string,
     runId?: string,
   ): Promise<void>;

--- a/sdk-typescript/test/integ/README.md
+++ b/sdk-typescript/test/integ/README.md
@@ -31,3 +31,5 @@ Full integration verification:
 - Attribute-map locks retain the instance through
   `items.lock("order-1")`.
 - Client methods return Promise because blocking the Node event loop is unsafe.
+- Step / waitFor / RPC handlers may be sync or async; several ported fixtures and
+  `mixed_sync_async_flow.ts` exercise both styles on one Worker.

--- a/sdk-typescript/test/integ/async-handlers.integration.test.ts
+++ b/sdk-typescript/test/integ/async-handlers.integration.test.ts
@@ -18,6 +18,10 @@ import {
   AsyncWaitForFlow,
 } from "./async_handlers_flows.js";
 import { flowId, withEnvironment } from "./environment.js";
+import {
+  MixedSyncAsyncStepsFlow,
+  MixedSyncStepAsyncRpcFlow,
+} from "./mixed_sync_async_flow.js";
 
 // A synchronous Step could not await the child; that these pass on a single Worker
 // proves the async handler yields the event loop so the same Worker serves the child.
@@ -53,5 +57,27 @@ test("Step waitFor may resolve a Wait asynchronously", async () => {
     const id = flowId("async-waitfor");
     await client.startFlow(flow, id, "done");
     assert.equal(await client.waitForFlow(id, stringCodec, 30_000), "done");
+  });
+});
+
+test("sync and async Step handlers compose across movements", async () => {
+  const flow = new MixedSyncAsyncStepsFlow();
+  await withEnvironment([flow], async ({ client }) => {
+    const id = flowId("mixed-sync-async-steps");
+    await client.startFlow(flow, id, "mix");
+    assert.equal(
+      await client.waitForFlow(id, stringCodec, 30_000),
+      "mix-async-exec-sync-exec-done",
+    );
+  });
+});
+
+test("async RPC wakes a synchronous waiting Step on the same Worker", async () => {
+  const flow = new MixedSyncStepAsyncRpcFlow();
+  await withEnvironment([flow], async ({ client }) => {
+    const id = flowId("mixed-sync-async-rpc");
+    await client.startFlow(flow, id, "payload");
+    assert.equal(await client.invokeRPC(flow.wake, id, "rpc"), "woke:rpc");
+    assert.equal(await client.waitForFlow(id, stringCodec, 30_000), "payload");
   });
 });

--- a/sdk-typescript/test/integ/basic_flow.ts
+++ b/sdk-typescript/test/integ/basic_flow.ts
@@ -27,7 +27,8 @@ class BasicSecondStep implements Step<number> {
     return "BasicSecondStep";
   }
 
-  public execute(_context: Context, input: number): StepDecision {
+  public async execute(_context: Context, input: number): Promise<StepDecision> {
+    await Promise.resolve();
     return gracefulComplete(input + 1);
   }
 }
@@ -41,12 +42,14 @@ class BasicFirstStep implements Step<number> {
     return "BasicFirstStep";
   }
 
-  public waitFor(context: Context, input: number): Wait {
+  public async waitFor(context: Context, input: number): Promise<Wait> {
+    await Promise.resolve();
     context.setStepExecutionLocal("input", input, doubleCodec);
     return Wait.skipImmediately();
   }
 
-  public execute(_context: Context, input: number): StepDecision {
+  public async execute(_context: Context, input: number): Promise<StepDecision> {
+    await Promise.resolve();
     return goTo(this.second, input + 1);
   }
 }

--- a/sdk-typescript/test/integ/empty_input_flow.ts
+++ b/sdk-typescript/test/integ/empty_input_flow.ts
@@ -26,7 +26,8 @@ class EmptySecondStep implements Step<void> {
     return "EmptySecondStep";
   }
 
-  public execute(_context: Context, _input: void): StepDecision {
+  public async execute(_context: Context, _input: void): Promise<StepDecision> {
+    await Promise.resolve();
     return gracefulComplete();
   }
 }
@@ -40,7 +41,8 @@ class EmptyFirstStep implements Step<void> {
     return "EmptyFirstStep";
   }
 
-  public execute(_context: Context, _input: void): StepDecision {
+  public async execute(_context: Context, _input: void): Promise<StepDecision> {
+    await Promise.resolve();
     return goTo(this.second, undefined);
   }
 }

--- a/sdk-typescript/test/integ/mixed_sync_async_flow.ts
+++ b/sdk-typescript/test/integ/mixed_sync_async_flow.ts
@@ -1,0 +1,141 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+import {
+  Channel,
+  StepList,
+  Wait,
+  goTo,
+  gracefulComplete,
+  rpc,
+  stringCodec,
+  voidCodec,
+  type Context,
+  type Flow,
+  type PersistenceSchema,
+  type RPCResult,
+  type Step,
+  type StepDecision,
+} from "../../src/index.js";
+
+// Sync waitFor + async execute, then hands off to an async-wait step.
+class SyncWaitAsyncExecuteStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public constructor(private readonly next: AsyncWaitSyncExecuteStep) {}
+
+  public getStepType(): string {
+    return "SyncWaitAsyncExecuteStep";
+  }
+
+  public waitFor(context: Context, input: string): Wait {
+    context.setStepExecutionLocal("prefix", input, stringCodec);
+    return Wait.skipImmediately();
+  }
+
+  public async execute(context: Context, input: string): Promise<StepDecision> {
+    await Promise.resolve();
+    const prefix = context.getStepExecutionLocal("prefix", stringCodec) ?? input;
+    return goTo(this.next, `${prefix}-async-exec`);
+  }
+}
+
+// Async waitFor + sync execute, then hands off to a fully sync step.
+class AsyncWaitSyncExecuteStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public constructor(private readonly next: SyncCompleteStep) {}
+
+  public getStepType(): string {
+    return "AsyncWaitSyncExecuteStep";
+  }
+
+  public async waitFor(): Promise<Wait> {
+    await Promise.resolve();
+    return Wait.skipImmediately();
+  }
+
+  public execute(_context: Context, input: string): StepDecision {
+    return goTo(this.next, `${input}-sync-exec`);
+  }
+}
+
+class SyncCompleteStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public getStepType(): string {
+    return "SyncCompleteStep";
+  }
+
+  public execute(_context: Context, input: string): StepDecision {
+    return gracefulComplete(`${input}-done`);
+  }
+}
+
+export class MixedSyncAsyncStepsFlow implements Flow<string> {
+  private readonly third = new SyncCompleteStep();
+  private readonly second = new AsyncWaitSyncExecuteStep(this.third);
+  private readonly first = new SyncWaitAsyncExecuteStep(this.second);
+
+  public getFlowType(): string {
+    return "MixedSyncAsyncStepsFlow";
+  }
+
+  public getSteps() {
+    return StepList.startStep(this.first).otherSteps(this.second, this.third);
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return {};
+  }
+}
+
+// Sync Step waits on a channel; async RPC wakes it and returns a value.
+class SyncChannelWaitStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public constructor(private readonly proceed: Channel<void>) {}
+
+  public getStepType(): string {
+    return "SyncChannelWaitStep";
+  }
+
+  public waitFor(): Wait {
+    return Wait.anyOf(this.proceed.forOne());
+  }
+
+  public execute(_context: Context, input: string): StepDecision {
+    return gracefulComplete(input);
+  }
+}
+
+export class MixedSyncStepAsyncRpcFlow implements Flow<string> {
+  public readonly proceed = new Channel("mixed-sync-async-proceed", voidCodec);
+  private readonly start = new SyncChannelWaitStep(this.proceed);
+
+  public getFlowType(): string {
+    return "MixedSyncStepAsyncRpcFlow";
+  }
+
+  public getSteps() {
+    return StepList.startStep(this.start);
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return { channels: [this.proceed] };
+  }
+
+  @rpc({ inputCodec: stringCodec, outputCodec: stringCodec })
+  public async wake(context: Context, input: string): Promise<RPCResult<string>> {
+    await Promise.resolve();
+    this.proceed.publish(context, undefined);
+    return { output: `woke:${input}` };
+  }
+}

--- a/sdk-typescript/test/integ/rpc_flow.ts
+++ b/sdk-typescript/test/integ/rpc_flow.ts
@@ -98,7 +98,8 @@ export class RpcFlow implements Flow<number> {
   }
 
   @rpc({ inputCodec: stringCodec, outputCodec: doubleCodec })
-  public functionOne(context: Context, input: string): RPCResult<number> {
+  public async functionOne(context: Context, input: string): Promise<RPCResult<number>> {
+    await Promise.resolve();
     this.requireContext(context);
     this.data.set(context, undefined);
     this.data.set(context, input);
@@ -109,7 +110,8 @@ export class RpcFlow implements Flow<number> {
   }
 
   @rpc({ outputCodec: doubleCodec })
-  public functionZero(_context: Context): RPCResult<number> {
+  public async functionZero(_context: Context): Promise<RPCResult<number>> {
+    await Promise.resolve();
     this.requireContext(_context);
     this.data.set(_context, RpcFlow.HARDCODED_VALUE);
     this.keyword.set(_context, RpcFlow.HARDCODED_VALUE);

--- a/sdk-typescript/test/integ/timer_flow.ts
+++ b/sdk-typescript/test/integ/timer_flow.ts
@@ -27,11 +27,13 @@ class TimerStep implements Step<number> {
     return "TimerStep";
   }
 
-  public waitFor(_context: Context, input: number): Wait {
+  public async waitFor(_context: Context, input: number): Promise<Wait> {
+    await Promise.resolve();
     return Wait.allOf(Timer.byDuration(input * 1_000, "test-timer-id"));
   }
 
-  public execute(_context: Context, _input: number): StepDecision {
+  public async execute(_context: Context, _input: number): Promise<StepDecision> {
+    await Promise.resolve();
     return gracefulComplete();
   }
 }


### PR DESCRIPTION
## Summary
- Widen `Client.invokeRPC` overloads to accept `Promise` returns so async RPC methods keep typed outputs instead of falling through to `void`.
- Convert several existing TS integ fixtures (`basic`, `empty_input`, `timer`, `rpc` function RPCs) to async handlers as regression coverage for the Promise path.
- Add mixed sync/async Step and async-RPC-wakes-sync-Step integ scenarios.

## Rationale
PR #211 added async handlers but left existing suites sync-only and left `invokeRPC` typing incomplete for async RPCs. This closes that coverage and typing gap without changing product behavior.

## User impact
Async RPC method references now type-check correctly through `Client.invokeRPC`. Existing integ scenarios also exercise async and mixed handler styles on one Worker.

## Test plan
- [x] `npm run typecheck` in `sdk-typescript`
- [x] `npm test` in `sdk-typescript`
- [x] Targeted integ: async-handlers / basic / rpc / core against `dexcli` (`DEX_SERVER_ADDRESS=127.0.0.1:8801`)
- [x] `make copyright-check`

