### PR TITLE
Stamp Python SDK PyPI version from release tag

### DIFF
--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "sdk-python/pyproject.toml"
       - "sdk-python/uv.lock"
+      - "sdk-python/scripts/stamp_release_version.py"
       - "sdk-rust/Cargo.lock"
       - "sdk-rust/Cargo.toml"
       - "sdk-rust/crates/dex-blob-cache/**"
@@ -51,7 +52,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - name: Resolve and validate release version
+      - name: Resolve release version
         id: release
         shell: bash
         env:
@@ -78,11 +79,6 @@ jobs:
           fi
           if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
             echo "Invalid Python SDK release version: ${version}" >&2
-            exit 1
-          fi
-          project_version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-          if [[ "${version}" != "${project_version}" ]]; then
-            echo "Release version ${version} does not match pyproject.toml ${project_version}" >&2
             exit 1
           fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
@@ -121,6 +117,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+      - name: Stamp package version from release
+        working-directory: sdk-python
+        run: python scripts/stamp_release_version.py '${{ needs.prepare.outputs.version }}'
       - name: Build wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -162,6 +161,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+      - name: Stamp package version from release
+        working-directory: sdk-python
+        run: python scripts/stamp_release_version.py '${{ needs.prepare.outputs.version }}'
       - name: Build source distribution
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,38 @@ Notes:
 - Python, Java, and Docker release workflows also support **workflow_dispatch** for manual runs. Python manual runs build without publishing unless `publish` is selected.
 - TypeScript publishing requires a GitHub Release after its one-time npm bootstrap publish.
 
+### Committed `version` vs release tags (Python / TypeScript)
+
+For the Python and TypeScript SDKs, the **GitHub Release tag** is the source of truth for
+what gets published (`sdk-python/vX.Y.Z` → PyPI, `sdk-typescript/vX.Y.Z` → npm). CI
+temporarily stamps that version into package metadata on the runner and does **not**
+commit the change.
+
+The committed fields still matter; they are not unused:
+
+| Field | Role |
+|-------|------|
+| [`sdk-python/pyproject.toml`](sdk-python/pyproject.toml) `project.version` | Required package metadata. Used for local / editable installs (`pip` / `uv`), metadata queries, and aligning `uv.lock`. Also used when [`.github/workflows/sdk-python-publish.yml`](.github/workflows/sdk-python-publish.yml) runs on a **pull_request** (no tag): that dry-run builds wheels/sdists using the committed version. |
+| [`sdk-typescript/package.json`](sdk-typescript/package.json) `version` | Required package metadata. Used for local installs, `npm pack`, and keeping `package-lock.json` in sync. The TypeScript publish workflow only runs on release tags, so the committed value is not what npm receives unless CI has just rewritten it for that job. |
+
+What the committed value is **not**:
+
+- Not the source of the next PyPI / npm release (the tag / workflow_dispatch version is).
+- Not automatically updated in git when you publish a tag.
+- Not what examples pin when they depend on a registry version.
+
+Practical workflow:
+
+1. Publish with a tag (for example `sdk-python/v0.1.0`) — no need to bump the committed
+   file first.
+2. Optionally open a follow-up PR so `pyproject.toml` / `package.json` (and locks) on
+   `main` match the version you just shipped, if you want the repo tip to self-report
+   the same number.
+
+`package.json` cannot carry comments; the TypeScript SDK README Releases section
+documents the same tag-driven rule. `pyproject.toml` may note that publish stamps from
+the tag.
+
 ## Package-specific guides
 
 - [server/CONTRIBUTING.md](server/CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Each component has its own version and tag prefix. Create a GitHub Release for t
 | Component | Tag format | Example | What it publishes |
 |-----------|------------|---------|-------------------|
 | Server / Docker | `server-vX.Y.Z` | `server-v1.0.0` | Docker Hub `dex-server:v1.0.0` and `dex-server-lite:v1.0.0` |
-| Python SDK | `sdk-python/vX.Y.Z` | `sdk-python/v0.0.2` | PyPI [`dex-python-sdk`](https://pypi.org/project/dex-python-sdk/) (version from `sdk-python/pyproject.toml`) |
+| Python SDK | `sdk-python/vX.Y.Z` | `sdk-python/v0.1.0` | PyPI [`dex-python-sdk`](https://pypi.org/project/dex-python-sdk/) via [`.github/workflows/sdk-python-publish.yml`](.github/workflows/sdk-python-publish.yml) (version from the tag) |
 | Java SDK | `sdk-java/vX.Y.Z` | `sdk-java/v0.0.3` | Maven Central `io.superdurable:dex-sdk` via [`.github/workflows/sdk-java-publish.yml`](.github/workflows/sdk-java-publish.yml) (version from the tag) |
 | Go SDK | `sdk-go/vX.Y.Z` | `sdk-go/v1.2.3` | Go module tag for `github.com/superdurable/dex/sdk-go` |
 | TypeScript SDK | `sdk-typescript/vX.Y.Z` | `sdk-typescript/v0.1.0` | npm [`@superdurable/dex`](https://www.npmjs.com/package/@superdurable/dex) via [`.github/workflows/sdk-typescript-publish.yml`](.github/workflows/sdk-typescript-publish.yml) (version from the tag) |
@@ -150,7 +150,7 @@ Each component has its own version and tag prefix. Create a GitHub Release for t
 
 Notes:
 
-- Bump a component's version file when its release workflow uses it; Java and TypeScript derive versions from tags.
+- Java, TypeScript, and Python derive publish versions from tags (CI stamps the package metadata for the build). Bump committed version files when you want the repo tip to match.
 - Go uses a path-style tag (`sdk-go/v…`) so `go get` resolves the subdirectory module.
 - Python, Java, and Docker release workflows also support **workflow_dispatch** for manual runs. Python manual runs build without publishing unless `publish` is selected.
 - TypeScript publishing requires a GitHub Release after its one-time npm bootstrap publish.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,12 +155,13 @@ Notes:
 - Python, Java, and Docker release workflows also support **workflow_dispatch** for manual runs. Python manual runs build without publishing unless `publish` is selected.
 - TypeScript publishing requires a GitHub Release after its one-time npm bootstrap publish.
 
-### Committed `version` vs release tags (Python / TypeScript)
+### Committed `version` vs release tags (Python / TypeScript / Java)
 
-For the Python and TypeScript SDKs, the **GitHub Release tag** is the source of truth for
-what gets published (`sdk-python/vX.Y.Z` → PyPI, `sdk-typescript/vX.Y.Z` → npm). CI
-temporarily stamps that version into package metadata on the runner and does **not**
-commit the change.
+For the Python, TypeScript, and Java SDKs, the **GitHub Release tag** is the source of
+truth for what gets published (`sdk-python/vX.Y.Z` → PyPI, `sdk-typescript/vX.Y.Z` → npm,
+`sdk-java/vX.Y.Z` → Maven Central). CI applies that version for the release build (Python
+and TypeScript stamp package metadata on the runner; Java passes `-PreleaseVersion`) and
+does **not** commit the change.
 
 The committed fields still matter; they are not unused:
 
@@ -168,10 +169,12 @@ The committed fields still matter; they are not unused:
 |-------|------|
 | [`sdk-python/pyproject.toml`](sdk-python/pyproject.toml) `project.version` | Required package metadata. Used for local / editable installs (`pip` / `uv`), metadata queries, and aligning `uv.lock`. Also used when [`.github/workflows/sdk-python-publish.yml`](.github/workflows/sdk-python-publish.yml) runs on a **pull_request** (no tag): that dry-run builds wheels/sdists using the committed version. |
 | [`sdk-typescript/package.json`](sdk-typescript/package.json) `version` | Required package metadata. Used for local installs, `npm pack`, and keeping `package-lock.json` in sync. The TypeScript publish workflow only runs on release tags, so the committed value is not what npm receives unless CI has just rewritten it for that job. |
+| [`sdk-java/build.gradle`](sdk-java/build.gradle) default `releaseVersion` | Fallback when `-PreleaseVersion` is omitted (local / SNAPSHOT builds). Maven Central publish always supplies the version from the tag (or workflow_dispatch). |
 
 What the committed value is **not**:
 
-- Not the source of the next PyPI / npm release (the tag / workflow_dispatch version is).
+- Not the source of the next PyPI / npm / Maven Central release (the tag /
+  workflow_dispatch version is).
 - Not automatically updated in git when you publish a tag.
 - Not what examples pin when they depend on a registry version.
 
@@ -179,13 +182,14 @@ Practical workflow:
 
 1. Publish with a tag (for example `sdk-python/v0.1.0`) — no need to bump the committed
    file first.
-2. Optionally open a follow-up PR so `pyproject.toml` / `package.json` (and locks) on
-   `main` match the version you just shipped, if you want the repo tip to self-report
-   the same number.
+2. Follow up with a PR so tip versions match what you shipped:
+   - Python: `pyproject.toml` (+ `uv.lock`) and docs install pins
+   - TypeScript: `package.json` (+ `package-lock.json`)
+   - Java: default `…-SNAPSHOT` in `build.gradle` / smoke-test coords, plus README pins
 
 `package.json` cannot carry comments; the TypeScript SDK README Releases section
-documents the same tag-driven rule. `pyproject.toml` may note that publish stamps from
-the tag.
+documents the same tag-driven rule. `pyproject.toml` and `build.gradle` may note that
+publish takes the version from the tag.
 
 ## Package-specific guides
 

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -172,7 +172,7 @@ Javadoc: [javadoc.io](https://www.javadoc.io/doc/io.superdurable/dex-sdk/latest/
 ### Gradle
 
 ```gradle
-implementation 'io.superdurable:dex-sdk:0.0.2'
+implementation 'io.superdurable:dex-sdk:0.0.3'
 ```
 
 ### Maven
@@ -181,7 +181,7 @@ implementation 'io.superdurable:dex-sdk:0.0.2'
 <dependency>
     <groupId>io.superdurable</groupId>
     <artifactId>dex-sdk</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
 </dependency>
 ```
 
@@ -245,7 +245,7 @@ then compiles and runs independent Gradle and Maven consumers. Both consumers
 open the packaged Rust BlobCache library and perform a cache round trip.
 
 ```shell
-./validate-publication.sh 0.0.2-local
+./validate-publication.sh 0.0.3-local
 ```
 
 The command requires JDK 17, Rust 1.88+, and Maven. Published classes still
@@ -270,7 +270,7 @@ use the local publishing command:
 
 1. Run:
   ```
-  ./gradlew publishToMavenLocal -PreleaseVersion=0.0.2-local
+  ./gradlew publishToMavenLocal -PreleaseVersion=0.0.3-local
   ```
 
 2. In the [samples](https://github.com/superdurable/dex/tree/main/examples/java)
@@ -281,7 +281,7 @@ use the local publishing command:
 
 3. Once you're done, to remove the locally published version, run:
   ```
-  ./gradlew unpublishFromMavenLocal -PreleaseVersion=0.0.2-local
+  ./gradlew unpublishFromMavenLocal -PreleaseVersion=0.0.3-local
   ```
 
 ### Repo structure

--- a/sdk-java/build.gradle
+++ b/sdk-java/build.gradle
@@ -16,7 +16,8 @@ plugins {
 }
 
 group = 'io.superdurable'
-version = providers.gradleProperty('releaseVersion').getOrElse('0.0.2-SNAPSHOT')
+// Publish uses tag sdk-java/v*; -PreleaseVersion overrides this for release builds.
+version = providers.gradleProperty('releaseVersion').getOrElse('0.0.3-SNAPSHOT')
 def artifactVersion = version.toString()
 
 java {

--- a/sdk-java/publication-smoke-test/pom.xml
+++ b/sdk-java/publication-smoke-test/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <dexSdkVersion>0.0.2-SNAPSHOT</dexSdkVersion>
+        <dexSdkVersion>0.0.3-SNAPSHOT</dexSdkVersion>
         <maven.compiler.release>8</maven.compiler.release>
         <publicationRepository>file://${project.basedir}/../build/publication-repository</publicationRepository>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -71,7 +71,7 @@ options = (
 ```
 
 ```
-pip install dex-python-sdk==0.0.2
+pip install dex-python-sdk==0.1.0
 ```
 
 See [samples](../examples/python) for use case examples.

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -204,12 +204,17 @@ This project is governed by the [Contributor Covenant v 1.4.1](CODE_OF_CONDUCT.m
 
 ## Publishing to PyPI
 
-1. Bump `version` in `pyproject.toml`, refresh `uv.lock`, and update the `pip install` line above.
-2. Run **Publish Python SDK to PyPI** manually without `publish` to validate all distributions.
-3. Create a GitHub Release with tag `sdk-python/vX.Y.Z` (for example `sdk-python/v0.0.2`).
-4. CI builds and smoke-tests Linux x86_64/ARM64, macOS x86_64/ARM64, and Windows x86_64 wheels, verifies the source distribution, and publishes them with `PYPI_TOKEN`.
+1. Optionally run **Publish Python SDK to PyPI** via workflow_dispatch with a version and
+   `publish=false` to validate all distributions without uploading.
+2. Create a GitHub Release with tag `sdk-python/vX.Y.Z` (for example `sdk-python/v0.1.0`).
+   CI stamps that version into `pyproject.toml` for the build (same idea as the TypeScript
+   SDK release), then builds and smoke-tests Linux x86_64/ARM64, macOS x86_64/ARM64, and
+   Windows x86_64 wheels, verifies the source distribution, and publishes with `PYPI_TOKEN`.
+3. After publishing, bump the committed `pyproject.toml` / docs install line when you want
+   the repo tip to reflect the released version.
 
-A manual run publishes only from `main`, when its version matches `pyproject.toml` and `publish` is explicitly selected.
+A manual run publishes only from `main`, and only when `publish` is explicitly selected.
+The dispatch `version` input is stamped the same way as a release tag.
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md#releases-monorepo-tags) for monorepo tag conventions.
 

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "dex-python-sdk"
+# Publish uses tag sdk-python/v*; CI stamps this for release builds.
 version = "0.0.2"
 description = "Python SDK for the Dex workflow engine"
 authors = [{name = "Super Durable"}]

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dex-python-sdk"
 # Publish uses tag sdk-python/v*; CI stamps this for release builds.
-version = "0.0.2"
+version = "0.1.0"
 description = "Python SDK for the Dex workflow engine"
 authors = [{name = "Super Durable"}]
 readme = "README.md"

--- a/sdk-python/scripts/stamp_release_version.py
+++ b/sdk-python/scripts/stamp_release_version.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Super Durable Source License 1.0.
+# You may not use this file except in compliance with the License.
+# See the LICENSE file in the repository root.
+#
+# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+"""Stamp sdk-python/pyproject.toml project.version for a release build."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+    )
+    arguments = parser.parse_args()
+    text = arguments.pyproject.read_text()
+    updated, count = re.subn(
+        r'(?m)^version = "[^"]*"',
+        f'version = "{arguments.version}"',
+        text,
+        count=1,
+    )
+    if count != 1:
+        print("failed to stamp project.version in pyproject.toml", file=sys.stderr)
+        return 1
+    arguments.pyproject.write_text(updated)
+    project_version = tomllib.loads(arguments.pyproject.read_text())["project"][
+        "version"
+    ]
+    if project_version != arguments.version:
+        print(
+            f"pyproject.toml version {project_version} does not match {arguments.version}",
+            file=sys.stderr,
+        )
+        return 1
+    print(project_version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk-python/uv.lock
+++ b/sdk-python/uv.lock
@@ -240,7 +240,7 @@ wheels = [
 
 [[package]]
 name = "dex-python-sdk"
-version = "0.0.2"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },

--- a/sdk-typescript/package-lock.json
+++ b/sdk-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@superdurable/dex",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@superdurable/dex",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "LicenseRef-Super-Durable-1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.13.0",

--- a/sdk-typescript/package.json
+++ b/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdurable/dex",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "TypeScript SDK for the Dex durable workflow engine",
   "license": "LicenseRef-Super-Durable-1.0",
   "repository": {


### PR DESCRIPTION
## Summary
- Remove the publish check that required `pyproject.toml` to already match the release tag.
- Stamp `project.version` from `sdk-python/vX.Y.Z` (or workflow_dispatch version) before wheel/sdist builds, matching the TypeScript SDK release flow.
- Update Python publish docs in `sdk-python/README.md` and `CONTRIBUTING.md`.

## Test plan
- [ ] Merge, then re-run / re-publish the `sdk-python/v0.1.0` GitHub Release (or workflow_dispatch with `version=0.1.0` and `publish=true` from main)
- [ ] Confirm built artifacts are named `dex_python_sdk-0.1.0-…` / `dex_python_sdk-0.1.0.tar.gz`
- [ ] Confirm PyPI shows `dex-python-sdk==0.1.0`


Made with [Cursor](https://cursor.com)