### PR TITLE
Upgrade Python examples to dex-python-sdk 0.1.1 async APIs

### DIFF
--- a/.github/workflows/examples-python-ci.yml
+++ b/.github/workflows/examples-python-ci.yml
@@ -30,14 +30,14 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.12.2"
-          python-version: "3.9"
+          python-version: "3.11"
           working-directory: examples/python
           enable-cache: true
       - name: Install dependencies (PyPI dex-python-sdk)
         run: uv sync --locked
       - name: Verify published package
         run: |
-          uv run --frozen python -c "import dex, importlib.metadata as m; print(m.version('dex-python-sdk')); assert m.version('dex-python-sdk') == '0.0.1'"
+          uv run --frozen python -c "import dex, importlib.metadata as m; print(m.version('dex-python-sdk')); assert m.version('dex-python-sdk') == '0.1.1'"
       - name: Integ tests with dexcli dev
         run: ./run-integ-tests.sh
       - name: Upload service logs

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,11 +1,11 @@
 # Dex Python examples
 
-These examples target [`dex-python-sdk==0.0.2`](https://pypi.org/project/dex-python-sdk/0.0.2/)
+These examples target [`dex-python-sdk==0.1.1`](https://pypi.org/project/dex-python-sdk/0.1.1/)
 (`import dex`). Requires Python 3.11+.
 
-The sample process hosts one gRPC Worker on `127.0.0.1:8803` and an HTTP
-controller on `127.0.0.1:8080`. One Registry and disk BlobCache are shared by its
-Worker and Client.
+The sample process hosts one asyncio `AsyncWorker` on `127.0.0.1:8803` and a Quart
+HTTP controller on `127.0.0.1:8080`. Controllers and nested parent/child Steps use
+`AsyncClient`. One Registry and disk BlobCache are shared by Worker and Client.
 
 ## Run locally
 

--- a/examples/python/ai-agent-email/README.md
+++ b/examples/python/ai-agent-email/README.md
@@ -12,7 +12,7 @@
 ## What it is
 
 The AI Agent Email is a feature-rich application that leverages AI to streamline email composition
-and management. It combines a React frontend with a Flask backend powered by Dex (Indeed Workflow Framework) to
+and management. It combines a React frontend with a Quart backend powered by Dex to
 provide a durable, scalable email assistant.
 
 ### Why Dex?
@@ -128,7 +128,7 @@ To start the application, execute the following command:
 uv run --frozen python ai-agent-email/main.py
 ```
 
-This will launch the Flask application at http://localhost:8802. Open your browser and navigate to this URL to access
+This will launch the Quart application at http://localhost:8802. Open your browser and navigate to this URL to access
 the AI Agent Email interface.
 
 ## Using the Application

--- a/examples/python/dex_examples/ai_agent_email/http_routes.py
+++ b/examples/python/dex_examples/ai_agent_email/http_routes.py
@@ -19,7 +19,7 @@ from datetime import timedelta
 from pathlib import Path
 
 from dex import StartFlowOptions
-from flask import Blueprint, Response, jsonify, render_template
+from quart import Blueprint, Response, jsonify, render_template
 
 from dex_examples.app import ExampleApp
 from dex_examples.controller.query import optional_query, required_query
@@ -36,12 +36,12 @@ def create_ai_agent_blueprint(app_state: ExampleApp) -> Blueprint:
     blueprint = Blueprint("ai_agent", __name__)
 
     @blueprint.get("/ai-agent")
-    def index() -> str:
-        return render_template("index.html")
+    async def index() -> str:
+        return await render_template("index.html")
 
     @blueprint.get("/api/ai-agent/start")
-    def start() -> str:
-        app_state.client.start_flow(
+    async def start() -> str:
+        await app_state.client.start_flow(
             app_state.email_agent,
             required_query("workflowId"),
             None,
@@ -50,8 +50,8 @@ def create_ai_agent_blueprint(app_state: ExampleApp) -> Blueprint:
         return "workflow started"
 
     @blueprint.get("/api/ai-agent/request")
-    def send_request() -> str:
-        accepted = app_state.client.invoke_rpc(
+    async def send_request() -> str:
+        accepted = await app_state.client.invoke_rpc(
             app_state.email_agent.send_request,
             required_query("workflowId"),
             required_query("request"),
@@ -59,16 +59,16 @@ def create_ai_agent_blueprint(app_state: ExampleApp) -> Blueprint:
         return str(accepted)
 
     @blueprint.get("/api/ai-agent/describe")
-    def describe() -> Response:
-        details = app_state.client.invoke_rpc(
+    async def describe() -> Response:
+        details = await app_state.client.invoke_rpc(
             app_state.email_agent.describe,
             required_query("workflowId"),
         )
         return jsonify(asdict(details))
 
     @blueprint.get("/api/ai-agent/save_draft")
-    def save_draft() -> str:
-        app_state.client.invoke_rpc(
+    async def save_draft() -> str:
+        await app_state.client.invoke_rpc(
             app_state.email_agent.save_draft,
             required_query("workflowId"),
             optional_query("draft", ""),

--- a/examples/python/dex_examples/app.py
+++ b/examples/python/dex_examples/app.py
@@ -14,16 +14,18 @@
 
 from __future__ import annotations
 
-import threading
+import asyncio
+import socket
+import time
 from typing import Any, Callable
 
 from dex import (
+    AsyncClient,
+    AsyncWorker,
     BlobCacheConfig,
-    Client,
     ClientOptions,
     Flow,
     Registry,
-    Worker,
     WorkerOptions,
     WorkerTarget,
     open_blob_cache,
@@ -88,8 +90,8 @@ from dex_examples.workflow.subscription.subscription_flow import SubscriptionFlo
 class ExampleApp:
     def __init__(self, config: ExamplesConfig) -> None:
         self.config = config
-        self._client: Client | None = None
-        client_provider: Callable[[], Client] = self.require_client
+        self._client: AsyncClient | None = None
+        client_provider: Callable[[], AsyncClient] = self.require_client
 
         service = MyDependencyService()
         pattern_service = ServiceDependency()
@@ -168,7 +170,7 @@ class ExampleApp:
             self.processing,
             self.email_agent,
         ]
-        self.registry = Registry(tuple(flows))
+        self.registry = Registry(tuple(flows), allow_async_handlers=True)
         config.blob_cache_dir.mkdir(parents=True, exist_ok=True)
         self.blob_cache = open_blob_cache(
             BlobCacheConfig(str(config.blob_cache_dir), 1 << 30)
@@ -182,8 +184,8 @@ class ExampleApp:
                 else None
             ),
         )
-        self.worker = Worker(self.registry, self.blob_cache, worker_options)
-        self._client = Client(
+        self.worker = AsyncWorker(self.registry, self.blob_cache, worker_options)
+        self._client = AsyncClient(
             self.registry,
             self.blob_cache,
             ClientOptions(
@@ -191,28 +193,50 @@ class ExampleApp:
                 worker_target=self.worker.worker_target,
             ),
         )
-        self._worker_thread: threading.Thread | None = None
+        self._worker_task: asyncio.Task[None] | None = None
 
     @property
-    def client(self) -> Client:
+    def client(self) -> AsyncClient:
         return self.require_client()
 
-    def require_client(self) -> Client:
+    def require_client(self) -> AsyncClient:
         if self._client is None:
             raise RuntimeError("client is not ready")
         return self._client
 
-    def start_worker(self) -> None:
-        if self._worker_thread is not None:
+    async def start_worker(self) -> None:
+        if self._worker_task is not None:
             return
-        self._worker_thread = threading.Thread(
-            target=self.worker.start,
-            name="dex-examples-worker",
-            daemon=True,
-        )
-        self._worker_thread.start()
+        self._worker_task = asyncio.create_task(self.worker.start())
+        await _await_worker(self.worker.worker_target.address, self._worker_task)
 
-    def close(self) -> None:
-        self.worker.close()
-        self.client.close()
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+        await self.worker.close()
+        if self._worker_task is not None:
+            try:
+                await asyncio.wait_for(self._worker_task, timeout=10)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                self._worker_task.cancel()
+            self._worker_task = None
         self.blob_cache.close()
+
+
+async def _await_worker(address: str, worker_task: asyncio.Task[None]) -> None:
+    host, _, port_text = address.rpartition(":")
+    port = int(port_text)
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if worker_task.done():
+            error = worker_task.exception()
+            if error is not None:
+                raise RuntimeError("AsyncWorker failed") from error
+            raise RuntimeError("AsyncWorker stopped before becoming ready")
+        try:
+            with socket.create_connection((host or "127.0.0.1", port), timeout=0.1):
+                return
+        except OSError:
+            await asyncio.sleep(0.01)
+    raise RuntimeError("AsyncWorker did not become ready")

--- a/examples/python/dex_examples/controller/basic_controller.py
+++ b/examples/python/dex_examples/controller/basic_controller.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from flask import Blueprint, Response
+from quart import Blueprint, Response
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -29,9 +29,9 @@ def create_basic_blueprint(app_state: ExampleApp) -> Blueprint:
     blueprint = Blueprint("basic", __name__, url_prefix="/basic")
 
     @blueprint.get("/start")
-    def start() -> Response:
+    async def start() -> Response:
         flow_id = required_query("workflowId")
-        run_id = app_state.client.start_flow(
+        run_id = await app_state.client.start_flow(
             app_state.basic,
             flow_id,
             required_int_query("inputNum"),
@@ -40,16 +40,16 @@ def create_basic_blueprint(app_state: ExampleApp) -> Blueprint:
         return started_flow(flow_id, run_id)
 
     @blueprint.get("/appendString")
-    def append_string() -> str:
-        return app_state.client.invoke_rpc(
+    async def append_string() -> str:
+        return await app_state.client.invoke_rpc(
             app_state.basic.append_string,
             required_query("workflowId"),
             required_query("str"),
         )
 
     @blueprint.get("/approve")
-    def approve() -> str:
-        app_state.client.invoke_rpc(
+    async def approve() -> str:
+        await app_state.client.invoke_rpc(
             app_state.basic.approve,
             required_query("workflowId"),
         )

--- a/examples/python/dex_examples/controller/engagement_controller.py
+++ b/examples/python/dex_examples/controller/engagement_controller.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import asdict
 
-from flask import Blueprint, Response, jsonify
+from quart import Blueprint, Response, jsonify
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -34,9 +34,9 @@ def create_engagement_blueprint(app_state: ExampleApp) -> Blueprint:
     blueprint = Blueprint("engagement", __name__, url_prefix="/engagement")
 
     @blueprint.get("/start")
-    def start() -> Response:
+    async def start() -> Response:
         flow_id = new_flow_id("engagement")
-        run_id = app_state.client.start_flow(
+        run_id = await app_state.client.start_flow(
             app_state.engagement,
             flow_id,
             EngagementInput("test-employer-id", "test-job-seeker-id", "test-notes"),
@@ -45,16 +45,16 @@ def create_engagement_blueprint(app_state: ExampleApp) -> Blueprint:
         return started_flow(flow_id, run_id)
 
     @blueprint.get("/describe")
-    def describe() -> Response:
-        description = app_state.client.invoke_rpc(
+    async def describe() -> Response:
+        description = await app_state.client.invoke_rpc(
             app_state.engagement.describe,
             required_query("workflowId"),
         )
         return jsonify(asdict(description))
 
     @blueprint.get("/optout")
-    def opt_out() -> Response:
-        app_state.client.publish(
+    async def opt_out() -> Response:
+        await app_state.client.publish(
             required_query("workflowId"),
             app_state.engagement.opt_out_reminder,
             None,
@@ -62,8 +62,8 @@ def create_engagement_blueprint(app_state: ExampleApp) -> Blueprint:
         return accepted()
 
     @blueprint.get("/decline")
-    def decline() -> Response:
-        status = app_state.client.invoke_rpc(
+    async def decline() -> Response:
+        status = await app_state.client.invoke_rpc(
             app_state.engagement.decline,
             required_query("workflowId"),
             optional_query("notes", ""),
@@ -71,8 +71,8 @@ def create_engagement_blueprint(app_state: ExampleApp) -> Blueprint:
         return jsonify(status.value)
 
     @blueprint.get("/accept")
-    def accept() -> Response:
-        status = app_state.client.invoke_rpc(
+    async def accept() -> Response:
+        status = await app_state.client.invoke_rpc(
             app_state.engagement.accept,
             required_query("workflowId"),
             optional_query("notes", ""),

--- a/examples/python/dex_examples/controller/job_post_controller.py
+++ b/examples/python/dex_examples/controller/job_post_controller.py
@@ -19,7 +19,7 @@ from dataclasses import asdict
 from datetime import timedelta
 
 from dex import FlowConfig, StartFlowOptions
-from flask import Blueprint, Response, jsonify
+from quart import Blueprint, Response, jsonify
 
 from dex_examples.app import ExampleApp
 from dex_examples.controller.query import optional_query, required_query
@@ -35,7 +35,7 @@ def create_job_post_blueprint(app_state: ExampleApp) -> Blueprint:
     blueprint = Blueprint("job_post", __name__, url_prefix="/jobpost")
 
     @blueprint.get("/create")
-    def create() -> str:
+    async def create() -> str:
         flow = app_state.job_post
         flow_id = f"job_id_{int(time.time())}"
         options = (
@@ -50,25 +50,25 @@ def create_job_post_blueprint(app_state: ExampleApp) -> Blueprint:
             )
             .with_attribute(flow.last_update_time_millis, int(time.time() * 1000))
         )
-        app_state.client.start_flow(flow, flow_id, None, options)
+        await app_state.client.start_flow(flow, flow_id, None, options)
         return f"started workflowId: {flow_id}"
 
     @blueprint.get("/read")
-    def read() -> Response:
-        job_info = app_state.client.invoke_rpc(
+    async def read() -> Response:
+        job_info = await app_state.client.invoke_rpc(
             app_state.job_post.get,
             required_query("workflowId"),
         )
         return jsonify(asdict(job_info))
 
     @blueprint.get("/update")
-    def update() -> str:
+    async def update() -> str:
         job_info = JobInfo(
             unquote(required_query("title")),
             unquote(required_query("description")),
             unquote(optional_query("notes", "test-notes")),
         )
-        app_state.client.invoke_rpc(
+        await app_state.client.invoke_rpc(
             app_state.job_post.update,
             required_query("workflowId"),
             job_info,
@@ -76,8 +76,8 @@ def create_job_post_blueprint(app_state: ExampleApp) -> Blueprint:
         return "updated"
 
     @blueprint.get("/delete")
-    def delete() -> str:
-        app_state.client.stop_flow(required_query("workflowId"))
+    async def delete() -> str:
+        await app_state.client.stop_flow(required_query("workflowId"))
         return "marked as soft deleted, will be delete later after retention"
 
     @blueprint.get("/search")

--- a/examples/python/dex_examples/controller/microservice_controller.py
+++ b/examples/python/dex_examples/controller/microservice_controller.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from flask import Blueprint, Response
+from quart import Blueprint, Response
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -29,9 +29,9 @@ def create_microservice_blueprint(app_state: ExampleApp) -> Blueprint:
     blueprint = Blueprint("microservice", __name__, url_prefix="/microservice")
 
     @blueprint.get("/start")
-    def start() -> Response:
+    async def start() -> Response:
         flow_id = required_query("workflowId")
-        run_id = app_state.client.start_flow(
+        run_id = await app_state.client.start_flow(
             app_state.orchestration,
             flow_id,
             "test initial data",
@@ -40,16 +40,16 @@ def create_microservice_blueprint(app_state: ExampleApp) -> Blueprint:
         return started_flow(flow_id, run_id)
 
     @blueprint.get("/swap")
-    def swap() -> str:
-        return app_state.client.invoke_rpc(
+    async def swap() -> str:
+        return await app_state.client.invoke_rpc(
             app_state.orchestration.swap,
             required_query("workflowId"),
             required_query("data"),
         )
 
     @blueprint.get("/signal")
-    def signal() -> Response:
-        app_state.client.publish(
+    async def signal() -> Response:
+        await app_state.client.publish(
             required_query("workflowId"),
             app_state.orchestration.ready,
             None,

--- a/examples/python/dex_examples/controller/money_transfer_controller.py
+++ b/examples/python/dex_examples/controller/money_transfer_controller.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from flask import Blueprint, Response
+from quart import Blueprint, Response
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -32,7 +32,7 @@ def create_money_transfer_blueprint(app_state: ExampleApp) -> Blueprint:
     blueprint = Blueprint("money_transfer", __name__, url_prefix="/moneytransfer")
 
     @blueprint.get("/start")
-    def start() -> Response:
+    async def start() -> Response:
         request = TransferRequest(
             required_query("fromAccount"),
             required_query("toAccount"),
@@ -40,7 +40,7 @@ def create_money_transfer_blueprint(app_state: ExampleApp) -> Blueprint:
             optional_query("notes", ""),
         )
         flow_id = new_flow_id("money-transfer")
-        run_id = app_state.client.start_flow(
+        run_id = await app_state.client.start_flow(
             app_state.money_transfer,
             flow_id,
             request,

--- a/examples/python/dex_examples/controller/polling_controller.py
+++ b/examples/python/dex_examples/controller/polling_controller.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from flask import Blueprint, Response, jsonify
+from quart import Blueprint, Response, jsonify
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -34,9 +34,9 @@ def create_polling_blueprint(app_state: ExampleApp) -> Blueprint:
     blueprint = Blueprint("polling", __name__, url_prefix="/polling")
 
     @blueprint.get("/start")
-    def start() -> Response:
+    async def start() -> Response:
         flow_id = required_query("workflowId")
-        run_id = app_state.client.start_flow(
+        run_id = await app_state.client.start_flow(
             app_state.polling,
             flow_id,
             required_int_query("pollingCompletionThreshold"),
@@ -45,7 +45,7 @@ def create_polling_blueprint(app_state: ExampleApp) -> Blueprint:
         return started_flow(flow_id, run_id)
 
     @blueprint.get("/complete")
-    def complete() -> Response | tuple[Response, int]:
+    async def complete() -> Response | tuple[Response, int]:
         flow_id = required_query("workflowId")
         channel_name = required_query("channel")
         if channel_name == TASK_A_COMPLETED:
@@ -54,7 +54,7 @@ def create_polling_blueprint(app_state: ExampleApp) -> Blueprint:
             channel = app_state.polling.task_b_completed
         else:
             return jsonify({"error": "channel must identify task A or task B"}), 400
-        app_state.client.publish(flow_id, channel, None)
+        await app_state.client.publish(flow_id, channel, None)
         return accepted()
 
     return blueprint

--- a/examples/python/dex_examples/controller/query.py
+++ b/examples/python/dex_examples/controller/query.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import time
 
-from flask import Response, abort, jsonify, request
+from quart import Response, abort, jsonify, request
 
 
 def required_query(name: str) -> str:
@@ -41,8 +41,8 @@ def required_int_query(name: str) -> int:
         abort(400, description=f"{name} must be an integer")
 
 
-def required_body_field(name: str) -> str:
-    body = request.get_json(silent=True)
+async def required_body_field(name: str) -> str:
+    body = await request.get_json(silent=True)
     value = body.get(name) if isinstance(body, dict) else None
     if not isinstance(value, str) or not value:
         abort(400, description=f"{name} is required in the request body")

--- a/examples/python/dex_examples/controller/resourcecontrol_controller.py
+++ b/examples/python/dex_examples/controller/resourcecontrol_controller.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import random
 
 from dex import DexException, ErrorSubStatus
-from flask import Blueprint
+from quart import Blueprint
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -33,14 +33,14 @@ def create_resource_control_blueprint(app_state: ExampleApp) -> Blueprint:
     blueprint = Blueprint("resource_control", __name__, url_prefix="/controller")
 
     @blueprint.get("/request")
-    def enqueue_request() -> str:
+    async def enqueue_request() -> str:
         request = Request(required_query("id"), optional_query("data", "abcd"))
         # A real deployment would rank instances by usage instead of picking one
         # at random, then check availability before enqueueing.
         instance_id = random.choice(SPOT_INSTANCE_IDS)
         flow_id = f"controller_flow_{instance_id}"
         try:
-            accepted = app_state.client.invoke_rpc(
+            accepted = await app_state.client.invoke_rpc(
                 app_state.controller.enqueue,
                 flow_id,
                 request,
@@ -48,7 +48,7 @@ def create_resource_control_blueprint(app_state: ExampleApp) -> Blueprint:
         except DexException as error:
             if error.sub_status is not ErrorSubStatus.FLOW_NOT_EXISTS:
                 raise
-            app_state.client.start_flow(
+            await app_state.client.start_flow(
                 app_state.controller,
                 flow_id,
                 request,
@@ -63,17 +63,17 @@ def create_resource_control_blueprint(app_state: ExampleApp) -> Blueprint:
         return "request is denied because instance is busy. Please retry later"
 
     @blueprint.get("/shutdown")
-    def shutdown() -> str:
+    async def shutdown() -> str:
         instance_id = required_query("instance_id")
-        app_state.client.invoke_rpc(
+        await app_state.client.invoke_rpc(
             app_state.controller.shutdown,
             f"controller_flow_{instance_id}",
         )
         return "done"
 
     @blueprint.get("/processing/describe")
-    def describe_processing() -> str:
-        return app_state.client.invoke_rpc(
+    async def describe_processing() -> str:
+        return await app_state.client.invoke_rpc(
             app_state.processing.describe,
             f"processing-{required_query('id')}",
         )

--- a/examples/python/dex_examples/controller/shortlist_controller.py
+++ b/examples/python/dex_examples/controller/shortlist_controller.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dex import DexException, ErrorSubStatus
-from flask import Blueprint, Response, jsonify
+from quart import Blueprint, Response, jsonify
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -33,17 +33,24 @@ def create_shortlist_blueprint(app_state: ExampleApp) -> Blueprint:
         __name__,
         url_prefix="/shortlist_candidates",
     )
-    opt_in_checker = workflow_ids.ClientOptInChecker(
-        app_state.require_client,
-        app_state.employer_opt_in,
-    )
+
+    async def check_opted_in(employer_id: str) -> bool:
+        try:
+            return await app_state.client.invoke_rpc(
+                app_state.employer_opt_in.is_opted_in,
+                workflow_ids.employer_opt_in(employer_id),
+            )
+        except DexException as error:
+            if error.sub_status is ErrorSubStatus.FLOW_NOT_EXISTS:
+                return False
+            raise
 
     @blueprint.post("/opt_in")
-    def opt_in() -> str:
-        employer_id = required_body_field("employerId")
+    async def opt_in() -> str:
+        employer_id = await required_body_field("employerId")
         flow_id = workflow_ids.employer_opt_in(employer_id)
         try:
-            app_state.client.start_flow(
+            await app_state.client.start_flow(
                 app_state.employer_opt_in,
                 flow_id,
                 EmployerOptInInput(employer_id),
@@ -56,10 +63,10 @@ def create_shortlist_blueprint(app_state: ExampleApp) -> Blueprint:
         return f"Started workflowId: {flow_id}"
 
     @blueprint.post("/opt_out")
-    def opt_out() -> str:
-        employer_id = required_body_field("employerId")
+    async def opt_out() -> str:
+        employer_id = await required_body_field("employerId")
         try:
-            app_state.client.invoke_rpc(
+            await app_state.client.invoke_rpc(
                 app_state.employer_opt_in.opt_out,
                 workflow_ids.employer_opt_in(employer_id),
             )
@@ -70,21 +77,21 @@ def create_shortlist_blueprint(app_state: ExampleApp) -> Blueprint:
         return f"Employer {employer_id} has opted out"
 
     @blueprint.get("/is_opted_in")
-    def is_opted_in() -> Response:
+    async def is_opted_in() -> Response:
         employer_id = optional_query("employerId", "test-employer")
-        return jsonify(opt_in_checker.is_opted_in(employer_id))
+        return jsonify(await check_opted_in(employer_id))
 
     @blueprint.post("/shortlist")
-    def shortlist() -> str:
-        employer_id = required_body_field("employerId")
-        candidate_id = required_body_field("candidateId")
+    async def shortlist() -> str:
+        employer_id = await required_body_field("employerId")
+        candidate_id = await required_body_field("candidateId")
 
-        if not opt_in_checker.is_opted_in(employer_id):
+        if not await check_opted_in(employer_id):
             return f"Do nothing for {employer_id}-{candidate_id} because of no opt-in"
 
         flow_id = workflow_ids.shortlist(employer_id, candidate_id)
         try:
-            app_state.client.start_flow(
+            await app_state.client.start_flow(
                 app_state.shortlist,
                 flow_id,
                 ShortlistInput(employer_id, candidate_id),
@@ -97,11 +104,11 @@ def create_shortlist_blueprint(app_state: ExampleApp) -> Blueprint:
         return f"Started workflowId: {flow_id}"
 
     @blueprint.post("/revoke_shortlist")
-    def revoke_shortlist() -> str:
-        employer_id = required_body_field("employerId")
-        candidate_id = required_body_field("candidateId")
+    async def revoke_shortlist() -> str:
+        employer_id = await required_body_field("employerId")
+        candidate_id = await required_body_field("candidateId")
         try:
-            app_state.client.publish(
+            await app_state.client.publish(
                 workflow_ids.shortlist(employer_id, candidate_id),
                 app_state.shortlist.revoke_shortlist,
                 None,
@@ -113,11 +120,11 @@ def create_shortlist_blueprint(app_state: ExampleApp) -> Blueprint:
         return f"Revoked shortlist for {employer_id}-{candidate_id}"
 
     @blueprint.get("/email_sent_timestamp")
-    def email_sent_timestamp() -> Response | tuple[Response, int]:
+    async def email_sent_timestamp() -> Response | tuple[Response, int]:
         employer_id = optional_query("employerId", "test-employer")
         candidate_id = optional_query("candidateId", "test-candidate")
         try:
-            timestamp = app_state.client.invoke_rpc(
+            timestamp = await app_state.client.invoke_rpc(
                 app_state.shortlist.get_email_sent_timestamp,
                 workflow_ids.shortlist(employer_id, candidate_id),
             )

--- a/examples/python/dex_examples/controller/signup_controller.py
+++ b/examples/python/dex_examples/controller/signup_controller.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dex import DexException, ErrorSubStatus
-from flask import Blueprint
+from quart import Blueprint
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -27,11 +27,11 @@ def create_signup_blueprint(app_state: ExampleApp) -> Blueprint:
     blueprint = Blueprint("signup", __name__, url_prefix="/signup")
 
     @blueprint.get("/submit")
-    def submit() -> str:
+    async def submit() -> str:
         username = required_query("username")
         form = SignupForm(username, required_query("email"), "Test", "Test")
         try:
-            app_state.client.start_flow(
+            await app_state.client.start_flow(
                 app_state.signup,
                 username,
                 form,
@@ -44,8 +44,8 @@ def create_signup_blueprint(app_state: ExampleApp) -> Blueprint:
         return "success"
 
     @blueprint.get("/verify")
-    def verify() -> str:
-        return app_state.client.invoke_rpc(
+    async def verify() -> str:
+        return await app_state.client.invoke_rpc(
             app_state.signup.verify,
             required_query("username"),
         )

--- a/examples/python/dex_examples/controller/subscription_controller.py
+++ b/examples/python/dex_examples/controller/subscription_controller.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import asdict
 
-from flask import Blueprint, Response, jsonify
+from quart import Blueprint, Response, jsonify
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -35,7 +35,7 @@ def create_subscription_blueprint(app_state: ExampleApp) -> Blueprint:
     blueprint = Blueprint("subscription", __name__, url_prefix="/subscription")
 
     @blueprint.get("/start")
-    def start() -> Response:
+    async def start() -> Response:
         customer = Customer(
             "Quanzheng",
             "Long",
@@ -49,7 +49,7 @@ def create_subscription_blueprint(app_state: ExampleApp) -> Blueprint:
             ),
         )
         flow_id = new_flow_id("subscription")
-        run_id = app_state.client.start_flow(
+        run_id = await app_state.client.start_flow(
             app_state.subscription,
             flow_id,
             customer,
@@ -58,8 +58,8 @@ def create_subscription_blueprint(app_state: ExampleApp) -> Blueprint:
         return started_flow(flow_id, run_id)
 
     @blueprint.get("/cancel")
-    def cancel() -> Response:
-        app_state.client.publish(
+    async def cancel() -> Response:
+        await app_state.client.publish(
             required_query("workflowId"),
             app_state.subscription.cancel_subscription,
             None,
@@ -67,8 +67,8 @@ def create_subscription_blueprint(app_state: ExampleApp) -> Blueprint:
         return accepted()
 
     @blueprint.get("/updateChargeAmount")
-    def update_charge_amount() -> Response:
-        app_state.client.publish(
+    async def update_charge_amount() -> Response:
+        await app_state.client.publish(
             required_query("workflowId"),
             app_state.subscription.update_charge_amount,
             required_int_query("newChargeAmount"),
@@ -76,8 +76,8 @@ def create_subscription_blueprint(app_state: ExampleApp) -> Blueprint:
         return accepted()
 
     @blueprint.get("/describe")
-    def describe() -> Response:
-        subscription = app_state.client.invoke_rpc(
+    async def describe() -> Response:
+        subscription = await app_state.client.invoke_rpc(
             app_state.subscription.describe,
             required_query("workflowId"),
         )

--- a/examples/python/dex_examples/http_app.py
+++ b/examples/python/dex_examples/http_app.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import traceback
 
 from dex import DexException, ErrorSubStatus
-from flask import Flask
+from quart import Quart
 from werkzeug.exceptions import HTTPException
 
 from dex_examples.ai_agent_email.http_routes import (
@@ -51,36 +51,36 @@ SUB_STATUS_HTTP_CODES = {
 }
 
 
-def create_app(app_state: ExampleApp) -> Flask:
-    flask_app = Flask(
+def create_app(app_state: ExampleApp) -> Quart:
+    quart_app = Quart(
         __name__,
         template_folder=str(TEMPLATE_DIR),
         static_folder=str(STATIC_DIR),
         static_url_path="/static",
     )
 
-    flask_app.register_blueprint(create_money_transfer_blueprint(app_state))
-    flask_app.register_blueprint(create_microservice_blueprint(app_state))
-    flask_app.register_blueprint(create_engagement_blueprint(app_state))
-    flask_app.register_blueprint(create_subscription_blueprint(app_state))
-    flask_app.register_blueprint(create_polling_blueprint(app_state))
-    flask_app.register_blueprint(create_signup_blueprint(app_state))
-    flask_app.register_blueprint(create_job_post_blueprint(app_state))
-    flask_app.register_blueprint(create_shortlist_blueprint(app_state))
-    flask_app.register_blueprint(create_basic_blueprint(app_state))
-    flask_app.register_blueprint(create_resource_control_blueprint(app_state))
-    flask_app.register_blueprint(create_design_pattern_blueprint(app_state))
-    flask_app.register_blueprint(create_ai_agent_blueprint(app_state))
+    quart_app.register_blueprint(create_money_transfer_blueprint(app_state))
+    quart_app.register_blueprint(create_microservice_blueprint(app_state))
+    quart_app.register_blueprint(create_engagement_blueprint(app_state))
+    quart_app.register_blueprint(create_subscription_blueprint(app_state))
+    quart_app.register_blueprint(create_polling_blueprint(app_state))
+    quart_app.register_blueprint(create_signup_blueprint(app_state))
+    quart_app.register_blueprint(create_job_post_blueprint(app_state))
+    quart_app.register_blueprint(create_shortlist_blueprint(app_state))
+    quart_app.register_blueprint(create_basic_blueprint(app_state))
+    quart_app.register_blueprint(create_resource_control_blueprint(app_state))
+    quart_app.register_blueprint(create_design_pattern_blueprint(app_state))
+    quart_app.register_blueprint(create_ai_agent_blueprint(app_state))
 
-    flask_app.register_error_handler(HTTPException, handle_http_exception)
-    flask_app.register_error_handler(DexException, handle_dex_exception)
-    flask_app.register_error_handler(Exception, handle_unexpected_exception)
+    quart_app.register_error_handler(HTTPException, handle_http_exception)
+    quart_app.register_error_handler(DexException, handle_dex_exception)
+    quart_app.register_error_handler(Exception, handle_unexpected_exception)
 
-    @flask_app.get("/")
+    @quart_app.get("/")
     def index() -> str:
         return "dex examples home"
 
-    return flask_app
+    return quart_app
 
 
 def handle_http_exception(error: HTTPException) -> tuple[str, int]:

--- a/examples/python/dex_examples/patterns/controller/design_pattern_controller.py
+++ b/examples/python/dex_examples/patterns/controller/design_pattern_controller.py
@@ -18,7 +18,7 @@ import json
 import time
 from dataclasses import asdict
 from datetime import timedelta
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable
 
 from dex import (
     DexException,
@@ -27,7 +27,7 @@ from dex import (
     StartFlowOptions,
     StepExecutionId,
 )
-from flask import Blueprint
+from quart import Blueprint
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -61,8 +61,8 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
     blueprint = Blueprint("design_pattern", __name__, url_prefix="/design-pattern")
 
     @blueprint.get("/polling/start/simple")
-    def start_simple_polling() -> str:
-        return app_state.client.start_flow(
+    async def start_simple_polling() -> str:
+        return await app_state.client.start_flow(
             app_state.simple_polling,
             required_query("workflowId"),
             None,
@@ -70,8 +70,8 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         )
 
     @blueprint.get("/polling/start/backoff")
-    def start_backoff_polling() -> str:
-        return app_state.client.start_flow(
+    async def start_backoff_polling() -> str:
+        return await app_state.client.start_flow(
             app_state.backoff_polling,
             required_query("workflowId"),
             None,
@@ -79,8 +79,8 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         )
 
     @blueprint.get("/interruptible/start")
-    def start_interruptible() -> str:
-        return app_state.client.start_flow(
+    async def start_interruptible() -> str:
+        return await app_state.client.start_flow(
             app_state.interruptible,
             required_query("workflowId"),
             None,
@@ -88,17 +88,17 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         )
 
     @blueprint.get("/interruptible/cancel")
-    def cancel_interruptible() -> str:
-        app_state.client.invoke_rpc(
+    async def cancel_interruptible() -> str:
+        await app_state.client.invoke_rpc(
             app_state.interruptible.interrupt,
             required_query("workflowId"),
         )
         return "done"
 
     @blueprint.get("/workflow-with-reminder/start")
-    def start_reminder() -> str:
+    async def start_reminder() -> str:
         flow_id = f"reminder_test_id_{time.time_ns()}"
-        app_state.client.start_flow(
+        await app_state.client.start_flow(
             app_state.reminder,
             flow_id,
             None,
@@ -107,16 +107,16 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         return f"started workflowId: {flow_id}"
 
     @blueprint.get("/workflow-with-reminder/accept")
-    def accept_reminder() -> str:
-        app_state.client.invoke_rpc(
+    async def accept_reminder() -> str:
+        await app_state.client.invoke_rpc(
             app_state.reminder.accept,
             required_query("workflowId"),
         )
         return "accepted"
 
     @blueprint.get("/workflow-with-reminder/optout")
-    def opt_out_reminder() -> str:
-        app_state.client.publish(
+    async def opt_out_reminder() -> str:
+        await app_state.client.publish(
             required_query("workflowId"),
             app_state.reminder.opt_out_reminder,
             None,
@@ -124,12 +124,12 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         return "done"
 
     @blueprint.post("/storage/add")
-    def add_storage_item() -> str:
+    async def add_storage_item() -> str:
         item = AddStorageItemRequest(
-            required_body_field("key"),
-            required_body_field("value"),
+            await required_body_field("key"),
+            await required_body_field("value"),
         )
-        invoke_storage_rpc(
+        await invoke_storage_rpc(
             app_state,
             lambda: app_state.client.invoke_rpc(
                 app_state.storage.add_item,
@@ -140,9 +140,9 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         return "Added storage item"
 
     @blueprint.get("/storage/get")
-    def get_storage_item() -> str:
+    async def get_storage_item() -> str:
         item_key = required_query("itemKey")
-        item_value = invoke_storage_rpc(
+        item_value = await invoke_storage_rpc(
             app_state,
             lambda: app_state.client.invoke_rpc(
                 app_state.storage.get_item,
@@ -153,9 +153,9 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         return f"Item: {item_value}"
 
     @blueprint.post("/storage/remove")
-    def remove_storage_item() -> str:
+    async def remove_storage_item() -> str:
         item_key = required_query("itemKey")
-        invoke_storage_rpc(
+        await invoke_storage_rpc(
             app_state,
             lambda: app_state.client.invoke_rpc(
                 app_state.storage.remove_item,
@@ -166,8 +166,8 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         return "Removed storage item"
 
     @blueprint.get("/intervention/start")
-    def start_intervention() -> str:
-        return app_state.client.start_flow(
+    async def start_intervention() -> str:
+        return await app_state.client.start_flow(
             app_state.manual_intervention,
             required_query("workflowId"),
             None,
@@ -175,8 +175,8 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         )
 
     @blueprint.get("/resettabletimer/start")
-    def start_resettable_timer() -> str:
-        return app_state.client.start_flow(
+    async def start_resettable_timer() -> str:
+        return await app_state.client.start_flow(
             app_state.resettable_timer,
             required_query("workflowId"),
             None,
@@ -184,16 +184,16 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         )
 
     @blueprint.get("/resettabletimer/reset")
-    def reset_resettable_timer() -> str:
-        app_state.client.invoke_rpc(
+    async def reset_resettable_timer() -> str:
+        await app_state.client.invoke_rpc(
             app_state.resettable_timer.send_reset_message,
             required_query("workflowId"),
         )
         return "reset"
 
     @blueprint.get("/parallel/start/simple")
-    def start_simple_parallel() -> str:
-        return app_state.client.start_flow(
+    async def start_simple_parallel() -> str:
+        return await app_state.client.start_flow(
             app_state.simple_parallel,
             required_query("workflowId"),
             JobSeeker("123", "jobseeker@indeed.com", "0987654321"),
@@ -201,8 +201,8 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         )
 
     @blueprint.get("/parallel/start/withAwait")
-    def start_parallel_with_await() -> str:
-        return app_state.client.start_flow(
+    async def start_parallel_with_await() -> str:
+        return await app_state.client.start_flow(
             app_state.parallel_with_await,
             required_query("workflowId"),
             50,
@@ -210,8 +210,8 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         )
 
     @blueprint.get("/recovery/start")
-    def start_recovery() -> str:
-        app_state.client.start_flow(
+    async def start_recovery() -> str:
+        await app_state.client.start_flow(
             app_state.failure_recovery,
             required_query("workflowId"),
             FailureRecoveryWorkflowInput(
@@ -223,8 +223,8 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         return "recovery workflow started"
 
     @blueprint.get("/scalableparallel/start")
-    def start_scalable_parallel() -> str:
-        app_state.client.start_flow(
+    async def start_scalable_parallel() -> str:
+        await app_state.client.start_flow(
             app_state.request_receiver,
             required_query("workflowId"),
             required_int_query("numOfChildWfs"),
@@ -233,8 +233,8 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         return "success"
 
     @blueprint.get("/parentchild/start")
-    def start_parent_child() -> str:
-        app_state.client.start_flow(
+    async def start_parent_child() -> str:
+        await app_state.client.start_flow(
             app_state.parent_flow_v2,
             required_query("workflowId"),
             required_int_query("numOfChildWfs"),
@@ -243,8 +243,8 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         return "success"
 
     @blueprint.get("/drainchannels/internal/start")
-    def start_drain_internal_channels() -> str:
-        return app_state.client.start_flow(
+    async def start_drain_internal_channels() -> str:
+        return await app_state.client.start_flow(
             app_state.drain_internal,
             required_query("workflowId"),
             "start-input",
@@ -252,10 +252,10 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         )
 
     @blueprint.get("/drainchannels/signal/startorsignal")
-    def start_or_signal_drain_signal_channels() -> str:
+    async def start_or_signal_drain_signal_channels() -> str:
         flow_id = required_query("workflowId")
         try:
-            app_state.client.publish(
+            await app_state.client.publish(
                 flow_id,
                 app_state.drain_signal.queue_signal_channel,
                 "signal from startorsignal endpoint",
@@ -263,7 +263,7 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         except DexException as error:
             if error.sub_status is not ErrorSubStatus.FLOW_NOT_EXISTS:
                 raise
-            run_id = app_state.client.start_flow(
+            run_id = await app_state.client.start_flow(
                 app_state.drain_signal,
                 flow_id,
                 "first message from start",
@@ -273,20 +273,20 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         return "Signaled the workflow"
 
     @blueprint.get("/waitforstatecompletion/start")
-    def start_wait_for_state_completion() -> str:
+    async def start_wait_for_state_completion() -> str:
         flow_id = required_query("workflowId")
-        app_state.client.start_flow(
+        await app_state.client.start_flow(
             app_state.wait_for_state_completion,
             flow_id,
             JobSeekerData(1),
             start_options(),
         )
-        app_state.client.wait_for_step_completion(
+        await app_state.client.wait_for_step_completion(
             flow_id,
             PERSIST_DATA_STEP,
             PERSIST_DATA_TIMEOUT,
         )
-        persisted = app_state.client.invoke_rpc(
+        persisted = await app_state.client.invoke_rpc(
             app_state.wait_for_state_completion.get_job_seeker_data,
             flow_id,
         )
@@ -294,9 +294,9 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
         return f"success for workflow {flow_id} with data {payload}"
 
     @blueprint.get("/timeout/start")
-    def start_timeout() -> str:
+    async def start_timeout() -> str:
         flow_id = required_query("workflowId")
-        app_state.client.start_flow(
+        await app_state.client.start_flow(
             app_state.timeout,
             flow_id,
             optional_query("successfulWorkflow", "true").lower() == "true",
@@ -307,17 +307,19 @@ def create_design_pattern_blueprint(app_state: ExampleApp) -> Blueprint:
     return blueprint
 
 
-def invoke_storage_rpc(app_state: ExampleApp, invoke: Callable[[], Any]) -> Any:
+async def invoke_storage_rpc(
+    app_state: ExampleApp, invoke: Callable[[], Awaitable[Any]]
+) -> Any:
     """Returns the RPC result, starting the singleton storage Flow on first use."""
     try:
-        return invoke()
+        return await invoke()
     except DexException as error:
         if error.sub_status is not ErrorSubStatus.FLOW_NOT_EXISTS:
             raise
-    app_state.client.start_flow(
+    await app_state.client.start_flow(
         app_state.storage,
         STORAGE_FLOW_ID,
         None,
         start_options(),
     )
-    return invoke()
+    return await invoke()

--- a/examples/python/dex_examples/patterns/workflow/drainchannels/signal/drain_signal_channels_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/drainchannels/signal/drain_signal_channels_flow.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-import time
+import asyncio
 
 from dex import (
     Channel,
@@ -42,7 +42,9 @@ class ProcessSignal(Step[str]):
             return Wait.any_of(self.queue_signal_channel.for_one())
         return Wait.skip_immediately()
 
-    def execute(self, context: Context, input: str) -> StepDecision:
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: str
+    ) -> StepDecision:
         if input is not None:
             print(f"DrainSignalChannelsFlow process signal value: {input}")
         else:
@@ -54,8 +56,8 @@ class ProcessSignal(Step[str]):
                 raise RuntimeError("No signal value found")
             print(f"DrainSignalChannelsFlow process signal value: {value}")
 
-        # Stay alive briefly so more signals can arrive before the empty check.
-        time.sleep(DRAIN_WINDOW_SECONDS)
+        # Yield so AsyncWorker can serve other Flows during the drain window.
+        await asyncio.sleep(DRAIN_WINDOW_SECONDS)
 
         return force_complete_when_channels_empty(
             None,

--- a/examples/python/dex_examples/patterns/workflow/interruptible/interruptible_execution_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/interruptible/interruptible_execution_flow.py
@@ -114,8 +114,7 @@ class Init(Step[None]):
         self.interrupt_signal = interrupt_signal
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
-        self.interrupt_signal.set(context, "")
+        del context, input
         parameters = WorkJobParametersInput(15, 1)
         return go_to_multi(
             StepMovement.of(self.work_a_execution, parameters),

--- a/examples/python/dex_examples/patterns/workflow/parallel/parallel_states_with_await_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/parallel/parallel_states_with_await_flow.py
@@ -14,8 +14,8 @@
 
 from __future__ import annotations
 
+import asyncio
 import random
-import time
 from typing import Any
 
 from dex import (
@@ -40,8 +40,10 @@ class NotifyUser(Step[JobSeeker]):
     def __init__(self, notify_channel: Channel[str]) -> None:
         self.notify_channel = notify_channel
 
-    def execute(self, context: Context, input: JobSeeker) -> StepDecision:
-        time.sleep(random.random() * 5)
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: JobSeeker
+    ) -> StepDecision:
+        await asyncio.sleep(random.random() * 5)
 
         message = f"[FAKE] Notifying user of something: {input.id}"
         print(message)

--- a/examples/python/dex_examples/patterns/workflow/parentchild/parent_flow_v2.py
+++ b/examples/python/dex_examples/patterns/workflow/parentchild/parent_flow_v2.py
@@ -17,11 +17,11 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Callable
+from typing import Any, Callable, cast
 
 from dex import (
+    AsyncClient,
     Channel,
-    Client,
     Context,
     DexException,
     ErrorSubStatus,
@@ -51,7 +51,7 @@ MAX_WAIT_SECONDS = 10
 class AwaitChildWorkflowCompletion(Step[WaitForChildInput]):
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         loop_for_next_task_provider: Callable[[], LoopForNextTask],
     ) -> None:
         self.client_provider = client_provider
@@ -61,12 +61,14 @@ class AwaitChildWorkflowCompletion(Step[WaitForChildInput]):
         del context
         return Wait.any_of(Timer.by_duration(timedelta(seconds=input.timer_seconds)))
 
-    def execute(self, context: Context, input: WaitForChildInput) -> StepDecision:
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: WaitForChildInput
+    ) -> StepDecision:
         del context
         try:
-            self.client_provider().wait_for_flow(
+            await self.client_provider().wait_for_flow(
                 input.child_wf_id,
-                type(None),
+                cast(type[Any], type(None)),
                 timedelta(seconds=max(input.timer_seconds, 1)),
             )
         except LongPollTimeoutError:
@@ -83,7 +85,7 @@ class AwaitChildWorkflowCompletion(Step[WaitForChildInput]):
 class StartChildWorkflow(Step[int]):
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         child_flow: ChildFlow,
         await_child_workflow_completion: AwaitChildWorkflowCompletion,
     ) -> None:
@@ -91,11 +93,13 @@ class StartChildWorkflow(Step[int]):
         self.child_flow = child_flow
         self.await_child_workflow_completion = await_child_workflow_completion
 
-    def execute(self, context: Context, input: int) -> StepDecision:
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: int
+    ) -> StepDecision:
         del context
         child_workflow_id = f"child-wf-{input}"
         try:
-            self.client_provider().start_flow(
+            await self.client_provider().start_flow(
                 self.child_flow,
                 child_workflow_id,
                 str(input),
@@ -158,7 +162,7 @@ class ParentFlowV2(Flow[int]):
 
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         child_flow: ChildFlow,
     ) -> None:
         self.await_child_workflow_completion = AwaitChildWorkflowCompletion(

--- a/examples/python/dex_examples/patterns/workflow/scalableparallel/child_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/scalableparallel/child_flow.py
@@ -19,8 +19,8 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Callable
 
 from dex import (
+    AsyncClient,
     Attribute,
-    Client,
     Context,
     DexException,
     ErrorSubStatus,
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 class Processing(Step[str]):
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         parent_flow_provider: Callable[[], ParentFlow],
         parent_workflow_id: Attribute[str],
     ) -> None:
@@ -53,7 +53,9 @@ class Processing(Step[str]):
         del context, input
         return Wait.any_of(Timer.by_duration(timedelta(seconds=random.randint(1, 3))))
 
-    def execute(self, context: Context, input: str) -> StepDecision:
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: str
+    ) -> StepDecision:
         del input
         try:
             parent_id = self.parent_workflow_id.get(context)
@@ -62,7 +64,7 @@ class Processing(Step[str]):
             parent_id = ""
         if parent_id:
             try:
-                self.client_provider().invoke_rpc(
+                await self.client_provider().invoke_rpc(
                     self.parent_flow_provider().complete_child_workflow,
                     parent_id,
                     context.flow_id,
@@ -84,7 +86,7 @@ class ChildFlow(Flow[str]):
 
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         parent_flow_provider: Callable[[], ParentFlow],
     ) -> None:
         self.processing = Processing(

--- a/examples/python/dex_examples/patterns/workflow/scalableparallel/parent_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/scalableparallel/parent_flow.py
@@ -20,10 +20,10 @@ from datetime import timedelta
 from typing import Callable
 
 from dex import (
+    AsyncClient,
     Attribute,
     Channel,
     ChannelMap,
-    Client,
     Context,
     DexException,
     ErrorSubStatus,
@@ -55,7 +55,7 @@ MAX_BUFFERED_TASKS = 10
 class LoopForNextMessage(Step[None]):
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         child_flow: ChildFlow,
         task_queue: Channel[str],
         child_complete: ChannelMap[None],
@@ -78,7 +78,9 @@ class LoopForNextMessage(Step[None]):
             conditions.insert(0, self.task_queue.for_one())
         return Wait.any_of(*conditions)
 
-    def execute(self, context: Context, input: None) -> StepDecision:
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: None
+    ) -> StepDecision:
         del input
         new_wait_list = list(self.current_wait_child_wfs.get(context) or [])
 
@@ -87,7 +89,7 @@ class LoopForNextMessage(Step[None]):
             request = task_results[0]
             child_workflow_id = f"processing-{request}"
             try:
-                self.client_provider().start_flow(
+                await self.client_provider().start_flow(
                     self.child_flow,
                     child_workflow_id,
                     request,
@@ -148,7 +150,7 @@ class ParentFlow(Flow[BatchEnqueueRequest]):
 
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         child_flow: ChildFlow,
     ) -> None:
         self.loop_for_next_message = LoopForNextMessage(

--- a/examples/python/dex_examples/patterns/workflow/scalableparallel/request_receiver_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/scalableparallel/request_receiver_flow.py
@@ -19,19 +19,21 @@ import uuid
 from typing import Callable
 
 from dex import (
-    Client,
+    AsyncClient,
     Context,
     DexException,
     ErrorSubStatus,
     Flow,
+    IdReusePolicy,
     PersistenceSchema,
+    StartFlowOptions,
     Step,
     StepDecision,
     StepList,
     graceful_complete,
 )
 
-from dex_examples.config import start_options
+from dex_examples.config import DEFAULT_TIMEOUT
 from dex_examples.patterns.workflow.scalableparallel.exceptions.enqueue_failed_error import (
     EnqueueFailedError,
 )
@@ -47,29 +49,39 @@ from dex_examples.patterns.workflow.scalableparallel.parent_flow import (
 class Request(Step[int]):
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         parent_flow: ParentFlow,
     ) -> None:
         self.client_provider = client_provider
         self.parent_flow = parent_flow
 
-    def execute(self, context: Context, input: int) -> StepDecision:
-        del context
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: int
+    ) -> StepDecision:
         batch = self._generate_tasks(input)
-        parent_workflow_id = f"parent_workflow_{random.randint(1, NUM_PARENT_WORKFLOWS)}"
+        # Scope parent IDs to this receiver run so completed parents from earlier
+        # runs do not block enqueue / restart.
+        parent_workflow_id = (
+            f"{context.flow_id}-parent-{random.randint(1, NUM_PARENT_WORKFLOWS)}"
+        )
 
         client = self.client_provider()
         try:
-            if not client.invoke_rpc(self.parent_flow.enqueue, parent_workflow_id, batch):
+            if not await client.invoke_rpc(
+                self.parent_flow.enqueue, parent_workflow_id, batch
+            ):
                 raise EnqueueFailedError("Enqueue failed, retry in next attempt")
         except DexException as error:
             if error.sub_status is not ErrorSubStatus.FLOW_NOT_EXISTS:
                 raise
-            client.start_flow(
+            await client.start_flow(
                 self.parent_flow,
                 parent_workflow_id,
                 batch,
-                start_options(),
+                StartFlowOptions(
+                    timeout=DEFAULT_TIMEOUT,
+                    id_reuse_policy=IdReusePolicy.ALLOW_IF_NOT_RUNNING,
+                ),
             )
 
         return graceful_complete()
@@ -84,7 +96,7 @@ class Request(Step[int]):
 class RequestReceiverFlow(Flow[int]):
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         parent_flow: ParentFlow,
     ) -> None:
         self.request = Request(client_provider, parent_flow)

--- a/examples/python/dex_examples/resourcecontrol/controller_flow.py
+++ b/examples/python/dex_examples/resourcecontrol/controller_flow.py
@@ -24,10 +24,10 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Callable
 
 from dex import (
+    AsyncClient,
     Attribute,
     Channel,
     ChannelMap,
-    Client,
     Context,
     DexException,
     ErrorSubStatus,
@@ -71,7 +71,7 @@ class MoveToAnotherInstance(Step[None]):
 class LoopForNextRequest(Step[None]):
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         processing_flow_provider: Callable[[], ProcessingFlow],
         move_to_another_instance: MoveToAnotherInstance,
         request_queue: Channel[Request],
@@ -97,13 +97,15 @@ class LoopForNextRequest(Step[None]):
             conditions.insert(0, self.request_queue.for_one())
         return Wait.any_of(*conditions)
 
-    def execute(self, context: Context, input: None) -> StepDecision:
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: None
+    ) -> StepDecision:
         del input
         waiting = list(self.current_wait_child_wfs.get(context) or [])
 
         requests = self.request_queue.results(context)
         if requests:
-            started = self.start_child_flow(context, requests[0])
+            started = await self.start_child_flow(context, requests[0])
             if started is not None:
                 waiting.append(started)
 
@@ -123,12 +125,12 @@ class LoopForNextRequest(Step[None]):
             )
         return go_to(self, None)
 
-    def start_child_flow(self, context: Context, request: Request) -> str | None:
+    async def start_child_flow(self, context: Context, request: Request) -> str | None:
         """Returns the child Flow ID to wait for, or None when another run owns it."""
         processing_flow = self.processing_flow_provider()
         child_flow_id = f"processing-{request.id}"
         try:
-            self.client_provider().start_flow(
+            await self.client_provider().start_flow(
                 processing_flow,
                 child_flow_id,
                 request,
@@ -184,7 +186,7 @@ class ControllerFlow(Flow[Request]):
 
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         processing_flow_provider: Callable[[], ProcessingFlow],
     ) -> None:
         self.move_to_another_instance = MoveToAnotherInstance()

--- a/examples/python/dex_examples/resourcecontrol/processing_flow.py
+++ b/examples/python/dex_examples/resourcecontrol/processing_flow.py
@@ -20,8 +20,8 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Callable
 
 from dex import (
+    AsyncClient,
     Attribute,
-    Client,
     Context,
     DexException,
     ErrorSubStatus,
@@ -54,7 +54,7 @@ STATUS_PROCESSING_COMPLETED = "gpu processing completed"
 class Complete(Step[None]):
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         controller_flow_provider: Callable[[], ControllerFlow],
         parent_flow_id: Attribute[str],
     ) -> None:
@@ -62,12 +62,14 @@ class Complete(Step[None]):
         self.controller_flow_provider = controller_flow_provider
         self.parent_flow_id = parent_flow_id
 
-    def execute(self, context: Context, input: None) -> StepDecision:
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: None
+    ) -> StepDecision:
         del input
         parent_flow_id = self.parent_flow_id.get(context)
         if parent_flow_id:
             try:
-                self.client_provider().invoke_rpc(
+                await self.client_provider().invoke_rpc(
                     self.controller_flow_provider().complete_child_flow,
                     parent_flow_id,
                     context.flow_id,
@@ -192,7 +194,7 @@ class ProcessingFlow(Flow[Request]):
 
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         controller_flow_provider: Callable[[], ControllerFlow],
     ) -> None:
         self.complete = Complete(

--- a/examples/python/dex_examples/workflow/shortlistcandidates/shortlist_flow.py
+++ b/examples/python/dex_examples/workflow/shortlistcandidates/shortlist_flow.py
@@ -68,7 +68,9 @@ class SendEmail(Step[None]):
             self.revoke_shortlist.for_one(),
         )
 
-    def execute(self, context: Context, input: None) -> StepDecision:
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: None
+    ) -> StepDecision:
         del input
         employer = self.employer_id.get(context)
         candidate = self.candidate_id.get(context)
@@ -77,7 +79,7 @@ class SendEmail(Step[None]):
             print(f"Not sending the email to {employer}-{candidate} because of revoking")
             return force_complete()
 
-        if not self.opt_in_checker.is_opted_in(employer):
+        if not await self.opt_in_checker.is_opted_in(employer):
             print(
                 f"Not sending the email to {employer}-{candidate} "
                 "because of not opted-in"

--- a/examples/python/dex_examples/workflow/shortlistcandidates/workflow_ids.py
+++ b/examples/python/dex_examples/workflow/shortlistcandidates/workflow_ids.py
@@ -14,7 +14,7 @@
 
 from typing import Callable, Protocol
 
-from dex import Client, DexException, ErrorSubStatus
+from dex import AsyncClient, DexException, ErrorSubStatus
 
 from dex_examples.workflow.shortlistcandidates.employer_opt_in_flow import (
     EmployerOptInFlow,
@@ -30,7 +30,7 @@ def shortlist(employer_id: str, candidate_id: str) -> str:
 
 
 class OptInChecker(Protocol):
-    def is_opted_in(self, employer_id: str) -> bool: ...
+    async def is_opted_in(self, employer_id: str) -> bool: ...
 
 
 class ClientOptInChecker:
@@ -38,16 +38,16 @@ class ClientOptInChecker:
 
     def __init__(
         self,
-        client_provider: Callable[[], Client],
+        client_provider: Callable[[], AsyncClient],
         opt_in_flow: EmployerOptInFlow,
     ) -> None:
         # A provider defers Client creation, which needs the Registry of all Flows.
         self.client_provider = client_provider
         self.opt_in_flow = opt_in_flow
 
-    def is_opted_in(self, employer_id: str) -> bool:
+    async def is_opted_in(self, employer_id: str) -> bool:
         try:
-            return self.client_provider().invoke_rpc(
+            return await self.client_provider().invoke_rpc(
                 self.opt_in_flow.is_opted_in,
                 employer_opt_in(employer_id),
             )

--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Runs every Dex Python example behind one Flask app and one Worker."""
+"""Runs every Dex Python example behind one Quart app and one AsyncWorker."""
 
 from __future__ import annotations
+
+import asyncio
 
 from dex import DexException, ErrorSubStatus, StartFlowOptions
 
@@ -26,23 +28,26 @@ CRON_SCHEDULE_FLOW_ID = "cron-schedule-sample"
 CRON_EXPRESSION = "*/1 * * * *"
 
 
-def main() -> None:
+async def main() -> None:
     config = ExamplesConfig.from_env()
     app_state = ExampleApp(config)
-    app_state.start_worker()
-    start_cron_schedule(app_state)
-
-    host, port = parse_http_address(config.http_address)
-    print(
-        f"Dex Python examples listening on http://{config.http_address} "
-        f"(worker {app_state.worker.worker_target.address})"
-    )
-    create_app(app_state).run(host=host, port=port)
-
-
-def start_cron_schedule(app_state: ExampleApp) -> None:
+    await app_state.start_worker()
     try:
-        app_state.client.start_flow(
+        await start_cron_schedule(app_state)
+
+        host, port = parse_http_address(config.http_address)
+        print(
+            f"Dex Python examples listening on http://{config.http_address} "
+            f"(worker {app_state.worker.worker_target.address})"
+        )
+        await create_app(app_state).run_task(host=host, port=port)
+    finally:
+        await app_state.close()
+
+
+async def start_cron_schedule(app_state: ExampleApp) -> None:
+    try:
+        await app_state.client.start_flow(
             app_state.cron_schedule,
             CRON_SCHEDULE_FLOW_ID,
             None,
@@ -62,4 +67,4 @@ def parse_http_address(address: str) -> tuple[str, int]:
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/examples/python/pyproject.toml
+++ b/examples/python/pyproject.toml
@@ -7,17 +7,18 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "dex-python-sdk==0.0.2",
-    "flask>=2.3.3,<3",
+    "dex-python-sdk==0.1.1",
     "openai>=1.66.2,<2",
     "openai-agents>=0.0.4,<0.0.5",
     "pydantic>=2.10.6,<3",
+    "quart>=0.20.0,<0.21",
 ]
 
 [dependency-groups]
 dev = [
     "mypy>=1.5.1,<2",
-    "pytest>=7.4.2,<8",
+    "pytest>=8.2,<9",
+    "pytest-asyncio>=0.26,<2",
     "pytest-cov>=4.1,<5",
     "pytest-env>=1.0.1,<2",
 ]
@@ -29,6 +30,9 @@ required-version = "==0.12.2"
 [tool.pytest.ini_options]
 pythonpath = ["."]
 testpaths = ["tests"]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 markers = [
     "integ: integration tests against a running Dex server",
 ]

--- a/examples/python/tests/integ/conftest.py
+++ b/examples/python/tests/integ/conftest.py
@@ -21,14 +21,16 @@ unreachable the whole package is skipped instead of failing.
 
 from __future__ import annotations
 
+import asyncio
 import os
-import time
+from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import timedelta
-from typing import Any, Callable, Iterator
+from typing import Any
 from uuid import uuid4
 
 import pytest
-from dex import Attribute, Client, DexException, ErrorSubStatus, FlowStatus
+import pytest_asyncio
+from dex import AsyncClient, Attribute, DexException, ErrorSubStatus, FlowStatus
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import ExamplesConfig
@@ -47,8 +49,10 @@ def server_address() -> str:
     return os.environ.get("DEX_FLOW_SERVICE_ADDRESS", DEFAULT_SERVER_ADDRESS)
 
 
-@pytest.fixture(scope="session")
-def example_app(tmp_path_factory: pytest.TempPathFactory) -> Iterator[ExampleApp]:
+@pytest_asyncio.fixture(scope="session")
+async def example_app(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> AsyncIterator[ExampleApp]:
     """Boots one ExampleApp with every Flow on an ephemeral Worker port."""
     config = ExamplesConfig(
         server_address=server_address(),
@@ -60,9 +64,9 @@ def example_app(tmp_path_factory: pytest.TempPathFactory) -> Iterator[ExampleApp
         blob_cache_dir=tmp_path_factory.mktemp("dex-examples-blob-cache"),
     )
     app = ExampleApp(config)
-    app.start_worker()
-    if not server_is_ready(app.client):
-        app.close()
+    await app.start_worker()
+    if not await server_is_ready(app.client):
+        await app.close()
         pytest.skip(
             "no Dex server at "
             f"{config.server_address}; set DEX_FLOW_SERVICE_ADDRESS to a running "
@@ -71,16 +75,16 @@ def example_app(tmp_path_factory: pytest.TempPathFactory) -> Iterator[ExampleApp
     try:
         yield app
     finally:
-        app.close()
+        await app.close()
 
 
-@pytest.fixture(scope="session")
-def app(example_app: ExampleApp) -> ExampleApp:
+@pytest_asyncio.fixture(scope="session")
+async def app(example_app: ExampleApp) -> ExampleApp:
     return example_app
 
 
-@pytest.fixture(scope="session")
-def client(example_app: ExampleApp) -> Client:
+@pytest_asyncio.fixture(scope="session")
+async def client(example_app: ExampleApp) -> AsyncClient:
     return example_app.client
 
 
@@ -94,72 +98,80 @@ def new_flow_id() -> Callable[[str], str]:
     return make
 
 
-def server_is_ready(client: Client) -> bool:
-    deadline = time.monotonic() + SERVER_READY_TIMEOUT.total_seconds()
-    while time.monotonic() < deadline:
+async def server_is_ready(client: AsyncClient) -> bool:
+    deadline = asyncio.get_running_loop().time() + SERVER_READY_TIMEOUT.total_seconds()
+    while asyncio.get_running_loop().time() < deadline:
         try:
-            return client.health_check()
+            return await client.health_check()
         except DexException:
-            time.sleep(POLL_INTERVAL_SECONDS)
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
     return False
 
 
-def wait_until(
+async def wait_until(
     description: str,
-    predicate: Callable[[], Any],
+    predicate: Callable[[], Awaitable[Any]],
     timeout: timedelta = WAIT_TIMEOUT,
 ) -> Any:
     """Returns the first truthy value from predicate, or fails the test."""
-    deadline = time.monotonic() + timeout.total_seconds()
+    deadline = asyncio.get_running_loop().time() + timeout.total_seconds()
     while True:
-        value = predicate()
+        value = await predicate()
         if value:
             return value
-        if time.monotonic() >= deadline:
+        if asyncio.get_running_loop().time() >= deadline:
             raise AssertionError(f"timed out waiting for {description}")
-        time.sleep(POLL_INTERVAL_SECONDS)
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
 
 
-def wait_for_attribute(
-    client: Client,
+async def wait_for_attribute(
+    client: AsyncClient,
     flow_id: str,
     attribute: Attribute[Any],
     timeout: timedelta = WAIT_TIMEOUT,
 ) -> Any:
     """Returns the Attribute value once the Flow has written something to it."""
-    return wait_until(
+    return await wait_until(
         f"attribute {attribute.name} on {flow_id}",
         lambda: attribute_or_none(client, flow_id, attribute),
         timeout,
     )
 
 
-def attribute_or_none(client: Client, flow_id: str, attribute: Attribute[Any]) -> Any:
+async def attribute_or_none(
+    client: AsyncClient, flow_id: str, attribute: Attribute[Any]
+) -> Any:
     try:
-        return client.get_attribute(flow_id, attribute)
+        return await client.get_attribute(flow_id, attribute)
     except DexException as error:
         if error.sub_status is ErrorSubStatus.FLOW_NOT_EXISTS:
             return None
         raise
 
 
-def flow_status_or_none(client: Client, flow_id: str) -> FlowStatus | None:
+async def flow_status_or_none(client: AsyncClient, flow_id: str) -> FlowStatus | None:
     try:
-        return client.describe_flow(flow_id).status
+        return (await client.describe_flow(flow_id)).status
     except DexException as error:
         if error.sub_status is ErrorSubStatus.FLOW_NOT_EXISTS:
             return None
         raise
 
 
-def wait_for_flow_status(
-    client: Client,
+async def wait_for_flow_status(
+    client: AsyncClient,
     flow_id: str,
     status: FlowStatus,
     timeout: timedelta = WAIT_TIMEOUT,
 ) -> None:
-    wait_until(
+    await wait_until(
         f"Flow {flow_id} to reach {status.value}",
-        lambda: flow_status_or_none(client, flow_id) is status,
+        lambda: _status_matches(client, flow_id, status),
         timeout,
     )
+
+
+async def _status_matches(
+    client: AsyncClient, flow_id: str, status: FlowStatus
+) -> bool:
+    return await flow_status_or_none(client, flow_id) is status

--- a/examples/python/tests/integ/test_engagement.py
+++ b/examples/python/tests/integ/test_engagement.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Callable
 
 import pytest
-from dex import Client
+from dex import AsyncClient
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -29,73 +29,73 @@ from tests.integ.conftest import WAIT_TIMEOUT, wait_for_attribute
 pytestmark = pytest.mark.integ
 
 
-def test_engagement_accept_completes_the_flow(
+async def test_engagement_accept_completes_the_flow(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("engagement")
-    client.start_flow(
+    await client.start_flow(
         app.engagement,
         flow_id,
         EngagementInput("test-employer-id", "test-job-seeker-id", "test-notes"),
         start_options(),
     )
 
-    wait_for_attribute(client, flow_id, EngagementFlow.engagement_status)
-    description = client.invoke_rpc(app.engagement.describe, flow_id)
+    await wait_for_attribute(client, flow_id, EngagementFlow.engagement_status)
+    description = await client.invoke_rpc(app.engagement.describe, flow_id)
     assert description.employer_id == "test-employer-id"
     assert description.job_seeker_id == "test-job-seeker-id"
     assert description.current_status == Status.INITIATED
 
-    assert client.invoke_rpc(app.engagement.accept, flow_id, "sounds good") is (
+    assert await client.invoke_rpc(app.engagement.accept, flow_id, "sounds good") is (
         Status.ACCEPTED
     )
-    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "done"
+    assert await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "done"
 
 
-def test_engagement_decline_then_accept(
+async def test_engagement_decline_then_accept(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("engagement")
-    client.start_flow(
+    await client.start_flow(
         app.engagement,
         flow_id,
         EngagementInput("test-employer-id", "test-job-seeker-id", None),
         start_options(),
     )
 
-    wait_for_attribute(client, flow_id, EngagementFlow.engagement_status)
-    assert client.invoke_rpc(app.engagement.decline, flow_id, "not now") is (
+    await wait_for_attribute(client, flow_id, EngagementFlow.engagement_status)
+    assert await client.invoke_rpc(app.engagement.decline, flow_id, "not now") is (
         Status.DECLINED
     )
-    assert client.invoke_rpc(app.engagement.accept, flow_id, "changed my mind") is (
+    assert await client.invoke_rpc(app.engagement.accept, flow_id, "changed my mind") is (
         Status.ACCEPTED
     )
 
-    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "done"
-    description = client.invoke_rpc(app.engagement.describe, flow_id)
+    assert await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "done"
+    description = await client.invoke_rpc(app.engagement.describe, flow_id)
     assert description.notes == ";not now;changed my mind"
 
 
-def test_engagement_opt_out_of_reminders(
+async def test_engagement_opt_out_of_reminders(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("engagement")
-    client.start_flow(
+    await client.start_flow(
         app.engagement,
         flow_id,
         EngagementInput("test-employer-id", "test-job-seeker-id", "test-notes"),
         start_options(),
     )
 
-    wait_for_attribute(client, flow_id, EngagementFlow.engagement_status)
-    client.publish(flow_id, app.engagement.opt_out_reminder, None)
+    await wait_for_attribute(client, flow_id, EngagementFlow.engagement_status)
+    await client.publish(flow_id, app.engagement.opt_out_reminder, None)
 
     # Opting out ends the reminder loop but leaves the engagement open.
-    client.invoke_rpc(app.engagement.accept, flow_id, "")
-    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "done"
+    await client.invoke_rpc(app.engagement.accept, flow_id, "")
+    assert await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "done"

--- a/examples/python/tests/integ/test_microservice.py
+++ b/examples/python/tests/integ/test_microservice.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Callable
 
 import pytest
-from dex import Client
+from dex import AsyncClient
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -29,40 +29,44 @@ pytestmark = pytest.mark.integ
 INITIAL_DATA = "test initial data"
 
 
-def test_orchestration_completes_when_ready_is_published(
+async def test_orchestration_completes_when_ready_is_published(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("microservice")
-    client.start_flow(app.orchestration, flow_id, INITIAL_DATA, start_options())
+    await client.start_flow(app.orchestration, flow_id, INITIAL_DATA, start_options())
 
-    wait_until(
-        "CallAPI1 to publish the shared data attribute",
-        lambda: attribute_or_none(client, flow_id, OrchestrationFlow.data)
-        == INITIAL_DATA,
-    )
-    client.publish(flow_id, app.orchestration.ready, None)
+    async def data_ready() -> bool:
+        return (
+            await attribute_or_none(client, flow_id, OrchestrationFlow.data)
+            == INITIAL_DATA
+        )
 
-    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == INITIAL_DATA
+    await wait_until("CallAPI1 to publish the shared data attribute", data_ready)
+    await client.publish(flow_id, app.orchestration.ready, None)
+
+    assert await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == INITIAL_DATA
 
 
-def test_orchestration_swap_replaces_the_data_before_completion(
+async def test_orchestration_swap_replaces_the_data_before_completion(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("microservice")
-    client.start_flow(app.orchestration, flow_id, INITIAL_DATA, start_options())
+    await client.start_flow(app.orchestration, flow_id, INITIAL_DATA, start_options())
 
-    wait_until(
-        "CallAPI1 to publish the shared data attribute",
-        lambda: attribute_or_none(client, flow_id, OrchestrationFlow.data)
-        == INITIAL_DATA,
-    )
-    assert client.invoke_rpc(app.orchestration.swap, flow_id, "swapped data") == (
+    async def data_ready() -> bool:
+        return (
+            await attribute_or_none(client, flow_id, OrchestrationFlow.data)
+            == INITIAL_DATA
+        )
+
+    await wait_until("CallAPI1 to publish the shared data attribute", data_ready)
+    assert await client.invoke_rpc(app.orchestration.swap, flow_id, "swapped data") == (
         INITIAL_DATA
     )
 
-    client.publish(flow_id, app.orchestration.ready, None)
-    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "swapped data"
+    await client.publish(flow_id, app.orchestration.ready, None)
+    assert await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "swapped data"

--- a/examples/python/tests/integ/test_money_transfer.py
+++ b/examples/python/tests/integ/test_money_transfer.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Callable
 
 import pytest
-from dex import Client
+from dex import AsyncClient
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -27,16 +27,16 @@ from tests.integ.conftest import WAIT_TIMEOUT
 pytestmark = pytest.mark.integ
 
 
-def test_money_transfer_completes_the_saga(
+async def test_money_transfer_completes_the_saga(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("money-transfer")
     request = TransferRequest("from-account", "to-account", 100, "test-notes")
 
-    client.start_flow(app.money_transfer, flow_id, request, start_options())
-    output = client.wait_for_flow(flow_id, str, WAIT_TIMEOUT)
+    await client.start_flow(app.money_transfer, flow_id, request, start_options())
+    output = await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT)
 
     assert "transfer is done" in output
     assert "from from-account to to-account for amount 100" in output

--- a/examples/python/tests/integ/test_patterns.py
+++ b/examples/python/tests/integ/test_patterns.py
@@ -18,7 +18,13 @@ from datetime import timedelta
 from typing import Callable
 
 import pytest
-from dex import Client, IdReusePolicy, StartFlowOptions, StepExecutionId
+from dex import (
+    AsyncClient,
+    FlowStatus,
+    IdReusePolicy,
+    StartFlowOptions,
+    StepExecutionId,
+)
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -43,14 +49,14 @@ from tests.integ.conftest import (
 pytestmark = pytest.mark.integ
 
 
-def test_cron_schedule_starts(
+async def test_cron_schedule_starts(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("cron")
     # Cron schedules may return an empty run ID; success is that start does not raise.
-    client.start_flow(
+    await client.start_flow(
         app.cron_schedule,
         flow_id,
         None,
@@ -58,145 +64,155 @@ def test_cron_schedule_starts(
     )
 
 
-def test_drain_internal_channels(
+async def test_drain_internal_channels(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("drain-internal")
-    client.start_flow(
+    await client.start_flow(
         app.drain_internal,
         flow_id,
         "documentId-0",
         start_options(),
     )
-    client.wait_for_flow(flow_id, timeout=WAIT_TIMEOUT)
+    await client.wait_for_flow(flow_id, timeout=WAIT_TIMEOUT)
 
 
-def test_drain_signal_channels(
+async def test_drain_signal_channels(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("drain-signal")
-    run_id = client.start_flow(
+    run_id = await client.start_flow(
         app.drain_signal,
         flow_id,
         "first message from start",
         start_options(),
     )
     assert run_id
-    client.publish(
+    await client.publish(
         flow_id,
         app.drain_signal.queue_signal_channel,
         "signal from test",
     )
 
 
-def test_interruptible_start_and_cancel(
+async def test_interruptible_start_and_cancel(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("interruptible")
-    client.start_flow(app.interruptible, flow_id, None, start_options())
-    client.invoke_rpc(app.interruptible.interrupt, flow_id)
-    client.wait_for_flow(flow_id, timeout=WAIT_TIMEOUT)
+    await client.start_flow(app.interruptible, flow_id, None, start_options())
+    await wait_until(
+        "interruptible flow running",
+        lambda: _status_is(client, flow_id, FlowStatus.RUNNING),
+    )
+    await client.invoke_rpc(app.interruptible.interrupt, flow_id)
+    await client.wait_for_flow(flow_id, timeout=WAIT_TIMEOUT)
 
 
-def test_manual_intervention_completes(
+async def _status_is(
+    client: AsyncClient, flow_id: str, status: FlowStatus
+) -> bool:
+    return await flow_status_or_none(client, flow_id) is status
+
+
+async def test_manual_intervention_completes(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("intervention")
-    client.start_flow(app.manual_intervention, flow_id, None, start_options())
-    client.publish(flow_id, app.manual_intervention.data_channel, "success")
-    output = client.wait_for_flow(flow_id, str, WAIT_TIMEOUT)
+    await client.start_flow(app.manual_intervention, flow_id, None, start_options())
+    await client.publish(flow_id, app.manual_intervention.data_channel, "success")
+    output = await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT)
     assert "Workflow Completed" in output
 
 
-def test_parallel_simple_and_with_await(
+async def test_parallel_simple_and_with_await(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     simple_id = new_flow_id("parallel-simple")
-    client.start_flow(
+    await client.start_flow(
         app.simple_parallel,
         simple_id,
         JobSeeker("123", "jobseeker@example.com", "0987654321"),
         start_options(),
     )
-    client.wait_for_flow(simple_id, timeout=WAIT_TIMEOUT)
+    await client.wait_for_flow(simple_id, timeout=WAIT_TIMEOUT)
 
     await_id = new_flow_id("parallel-await")
-    client.start_flow(app.parallel_with_await, await_id, 5, start_options())
-    client.wait_for_flow(await_id, timeout=WAIT_TIMEOUT)
+    await client.start_flow(app.parallel_with_await, await_id, 5, start_options())
+    await client.wait_for_flow(await_id, timeout=WAIT_TIMEOUT)
 
 
-def test_pattern_polling_simple_and_backoff(
+async def test_pattern_polling_simple_and_backoff(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     simple_id = new_flow_id("pattern-poll-simple")
-    client.start_flow(app.simple_polling, simple_id, None, start_options())
-    client.wait_for_flow(simple_id, timeout=WAIT_TIMEOUT)
+    await client.start_flow(app.simple_polling, simple_id, None, start_options())
+    await client.wait_for_flow(simple_id, timeout=WAIT_TIMEOUT)
 
     backoff_id = new_flow_id("pattern-poll-backoff")
-    client.start_flow(app.backoff_polling, backoff_id, None, start_options())
-    client.wait_for_flow(backoff_id, timeout=WAIT_TIMEOUT)
+    await client.start_flow(app.backoff_polling, backoff_id, None, start_options())
+    await client.wait_for_flow(backoff_id, timeout=WAIT_TIMEOUT)
 
 
-def test_failure_recovery(
+async def test_failure_recovery(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     from dex import FlowStatus, FlowUncompletedError
 
     flow_id = new_flow_id("recovery")
-    client.start_flow(
+    await client.start_flow(
         app.failure_recovery,
         flow_id,
         FailureRecoveryWorkflowInput("widget", 2),
         start_options(),
     )
     with pytest.raises(FlowUncompletedError) as captured:
-        client.wait_for_flow(flow_id, timeout=WAIT_TIMEOUT)
+        await client.wait_for_flow(flow_id, timeout=WAIT_TIMEOUT)
     assert captured.value.status is FlowStatus.FAILED
     assert "Failed to process transaction" in str(captured.value)
 
 
-def test_reminder_accept(
+async def test_reminder_accept(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("reminder")
-    client.start_flow(app.reminder, flow_id, None, start_options())
-    client.invoke_rpc(app.reminder.accept, flow_id)
-    client.wait_for_flow(flow_id, timeout=WAIT_TIMEOUT)
+    await client.start_flow(app.reminder, flow_id, None, start_options())
+    await client.invoke_rpc(app.reminder.accept, flow_id)
+    await client.wait_for_flow(flow_id, timeout=WAIT_TIMEOUT)
 
 
-def test_resettable_timer(
+async def test_resettable_timer(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("resettable-timer")
-    client.start_flow(app.resettable_timer, flow_id, None, start_options())
-    client.invoke_rpc(app.resettable_timer.send_reset_message, flow_id)
+    await client.start_flow(app.resettable_timer, flow_id, None, start_options())
+    await client.invoke_rpc(app.resettable_timer.send_reset_message, flow_id)
 
 
-def test_scalable_parallel(
+async def test_scalable_parallel(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("scalable-parallel")
-    client.start_flow(
+    await client.start_flow(
         app.request_receiver,
         flow_id,
         2,
@@ -205,18 +221,18 @@ def test_scalable_parallel(
             id_reuse_policy=IdReusePolicy.ALLOW_IF_PREVIOUS_FAILED,
         ),
     )
-    client.wait_for_flow(flow_id, timeout=LONG_WAIT_TIMEOUT)
+    await client.wait_for_flow(flow_id, timeout=LONG_WAIT_TIMEOUT)
 
 
-def test_parent_child(
+async def test_parent_child(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("parent-child")
     # ParentFlowV2 keeps CONCURRENCY_PER_PARENT_WORKFLOW loops waiting on the
     # task queue, so it does not complete. Verify start + first child instead.
-    run_id = client.start_flow(
+    run_id = await client.start_flow(
         app.parent_flow_v2,
         flow_id,
         2,
@@ -226,68 +242,59 @@ def test_parent_child(
         ),
     )
     assert run_id
-    wait_until(
+    await wait_until(
         "parent-child started a child flow",
-        lambda: flow_status_or_none(client, "child-wf-0") is not None,
+        lambda: flow_status_or_none(client, "child-wf-0"),
         WAIT_TIMEOUT,
     )
 
 
-def test_storage_add_get_remove(
+async def test_storage_add_get_remove(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
+    new_flow_id: Callable[[str], str],
 ) -> None:
-    from dex import DexException, ErrorSubStatus
-
-    try:
-        client.start_flow(
-            app.storage,
-            STORAGE_FLOW_ID,
-            None,
-            start_options(),
-        )
-    except DexException as error:
-        if error.sub_status is not ErrorSubStatus.FLOW_ALREADY_STARTED:
-            raise
-    key = f"item-{id(app)}"
-    client.invoke_rpc(
+    flow_id = new_flow_id(STORAGE_FLOW_ID)
+    await client.start_flow(app.storage, flow_id, None, start_options())
+    key = "item-1"
+    await client.invoke_rpc(
         app.storage.add_item,
-        STORAGE_FLOW_ID,
+        flow_id,
         AddStorageItemRequest(key, "value-1"),
     )
-    assert client.invoke_rpc(app.storage.get_item, STORAGE_FLOW_ID, key) == "value-1"
-    client.invoke_rpc(app.storage.remove_item, STORAGE_FLOW_ID, key)
+    assert await client.invoke_rpc(app.storage.get_item, flow_id, key) == "value-1"
+    await client.invoke_rpc(app.storage.remove_item, flow_id, key)
 
 
-def test_wait_for_state_completion(
+async def test_wait_for_state_completion(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("wait-state")
-    client.start_flow(
+    await client.start_flow(
         app.wait_for_state_completion,
         flow_id,
         JobSeekerData(1),
         start_options(),
     )
-    client.wait_for_step_completion(
+    await client.wait_for_step_completion(
         flow_id,
         StepExecutionId("PersistData"),
         timedelta(minutes=1),
     )
-    data = client.invoke_rpc(app.wait_for_state_completion.get_job_seeker_data, flow_id)
+    data = await client.invoke_rpc(app.wait_for_state_completion.get_job_seeker_data, flow_id)
     assert data.id == 1
 
 
-def test_graceful_timeout_success(
+async def test_graceful_timeout_success(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("timeout-ok")
-    client.start_flow(app.timeout, flow_id, True, start_options())
+    await client.start_flow(app.timeout, flow_id, True, start_options())
     assert (
-        client.wait_for_flow(flow_id, str, WAIT_TIMEOUT)
+        await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT)
         == "Workflow completed successfully"
     )

--- a/examples/python/tests/integ/test_polling.py
+++ b/examples/python/tests/integ/test_polling.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Callable
 
 import pytest
-from dex import Client
+from dex import AsyncClient
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -28,13 +28,13 @@ pytestmark = pytest.mark.integ
 POLLING_COMPLETION_THRESHOLD = 2
 
 
-def test_polling_completes_after_all_three_tasks(
+async def test_polling_completes_after_all_three_tasks(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("polling")
-    client.start_flow(
+    await client.start_flow(
         app.polling,
         flow_id,
         POLLING_COMPLETION_THRESHOLD,
@@ -42,7 +42,7 @@ def test_polling_completes_after_all_three_tasks(
     )
 
     # Task C completes on its own once Poll reaches the threshold.
-    client.publish(flow_id, app.polling.task_a_completed, None)
-    client.publish(flow_id, app.polling.task_b_completed, None)
+    await client.publish(flow_id, app.polling.task_a_completed, None)
+    await client.publish(flow_id, app.polling.task_b_completed, None)
 
-    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "all tasks completed"
+    assert await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "all tasks completed"

--- a/examples/python/tests/integ/test_python_only.py
+++ b/examples/python/tests/integ/test_python_only.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Callable
 
 import pytest
-from dex import Client
+from dex import AsyncClient
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -29,57 +29,62 @@ from tests.integ.conftest import LONG_WAIT_TIMEOUT, WAIT_TIMEOUT, wait_until
 pytestmark = pytest.mark.integ
 
 
-def test_basic_approve_completes(
+async def test_basic_approve_completes(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("basic")
-    client.start_flow(app.basic, flow_id, 5, start_options())
-    appended = client.invoke_rpc(app.basic.append_string, flow_id, "hello")
+    await client.start_flow(app.basic, flow_id, 5, start_options())
+    appended = await client.invoke_rpc(app.basic.append_string, flow_id, "hello")
     assert "hello" in appended
-    client.invoke_rpc(app.basic.approve, flow_id)
-    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "approved"
+    await client.invoke_rpc(app.basic.approve, flow_id)
+    assert await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "approved"
 
 
-def test_resourcecontrol_enqueue(
+async def test_resourcecontrol_enqueue(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     controller_id = new_flow_id(SPOT_INSTANCE_IDS[0])
-    client.start_flow(
+    await client.start_flow(
         app.controller,
         controller_id,
         Request("bootstrap", "boot"),
         start_options(),
     )
     request = Request(new_flow_id("req"), "payload")
-    assert client.invoke_rpc(app.controller.enqueue, controller_id, request) is True
-    wait_until(
+    assert await client.invoke_rpc(app.controller.enqueue, controller_id, request) is True
+
+    async def controller_running() -> bool:
+        info = await client.describe_flow(controller_id)
+        return info.flow_id == controller_id
+
+    await wait_until(
         "controller still running after enqueue",
-        lambda: client.describe_flow(controller_id).flow_id == controller_id,
+        controller_running,
         LONG_WAIT_TIMEOUT,
     )
 
 
-def test_ai_agent_email_without_openai(
+async def test_ai_agent_email_without_openai(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("ai-agent")
-    client.start_flow(app.email_agent, flow_id, None, start_options())
+    await client.start_flow(app.email_agent, flow_id, None, start_options())
 
-    def waiting() -> bool:
-        details = client.invoke_rpc(app.email_agent.describe, flow_id)
+    async def waiting() -> bool:
+        details = await client.invoke_rpc(app.email_agent.describe, flow_id)
         return details.status == STATUS_WAITING
 
-    wait_until("email agent waiting", waiting, WAIT_TIMEOUT)
-    assert client.invoke_rpc(
+    await wait_until("email agent waiting", waiting, WAIT_TIMEOUT)
+    assert await client.invoke_rpc(
         app.email_agent.send_request,
         flow_id,
         "Draft a short intro email",
     )
-    details = client.invoke_rpc(app.email_agent.describe, flow_id)
+    details = await client.invoke_rpc(app.email_agent.describe, flow_id)
     assert details.current_request

--- a/examples/python/tests/integ/test_remaining_product.py
+++ b/examples/python/tests/integ/test_remaining_product.py
@@ -18,7 +18,7 @@ from datetime import timedelta
 from typing import Callable
 
 import pytest
-from dex import Client, StartFlowOptions
+from dex import AsyncClient, StartFlowOptions
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -33,21 +33,21 @@ from tests.integ.conftest import WAIT_TIMEOUT
 pytestmark = pytest.mark.integ
 
 
-def test_signup_verify_completes(
+async def test_signup_verify_completes(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("signup")
     form = SignupForm(flow_id, f"{flow_id}@example.com", "Test", "User")
-    client.start_flow(app.signup, flow_id, form, start_options())
-    assert client.invoke_rpc(app.signup.verify, flow_id) == "done"
-    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "done"
+    await client.start_flow(app.signup, flow_id, form, start_options())
+    assert await client.invoke_rpc(app.signup.verify, flow_id) == "done"
+    assert await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "done"
 
 
-def test_job_post_create_and_read(
+async def test_job_post_create_and_read(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("jobpost")
@@ -58,16 +58,16 @@ def test_job_post_create_and_read(
         .with_attribute(app.job_post.last_update_time_millis, 1)
         .with_attribute(app.job_post.notes, "initial")
     )
-    client.start_flow(app.job_post, flow_id, None, options)
-    info = client.invoke_rpc(app.job_post.get, flow_id)
+    await client.start_flow(app.job_post, flow_id, None, options)
+    info = await client.invoke_rpc(app.job_post.get, flow_id)
     assert info.title == "Software Engineer"
     assert info.description == "Build durable workflows"
     assert info.notes == "initial"
 
 
-def test_shortlist_opt_in_and_revoke(
+async def test_shortlist_opt_in_and_revoke(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     employer_id = new_flow_id("employer")
@@ -75,19 +75,19 @@ def test_shortlist_opt_in_and_revoke(
     opt_in_id = workflow_ids.employer_opt_in(employer_id)
     shortlist_id = workflow_ids.shortlist(employer_id, candidate_id)
 
-    client.start_flow(
+    await client.start_flow(
         app.employer_opt_in,
         opt_in_id,
         EmployerOptInInput(employer_id),
         start_options(),
     )
-    assert client.invoke_rpc(app.employer_opt_in.is_opted_in, opt_in_id) is True
+    assert await client.invoke_rpc(app.employer_opt_in.is_opted_in, opt_in_id) is True
 
-    client.start_flow(
+    await client.start_flow(
         app.shortlist,
         shortlist_id,
         ShortlistInput(employer_id, candidate_id),
         start_options(),
     )
-    client.publish(shortlist_id, app.shortlist.revoke_shortlist, None)
-    client.wait_for_flow(shortlist_id, timeout=WAIT_TIMEOUT)
+    await client.publish(shortlist_id, app.shortlist.revoke_shortlist, None)
+    await client.wait_for_flow(shortlist_id, timeout=WAIT_TIMEOUT)

--- a/examples/python/tests/integ/test_subscription.py
+++ b/examples/python/tests/integ/test_subscription.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Callable
 
 import pytest
-from dex import Client
+from dex import AsyncClient
 
 from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
@@ -46,68 +46,65 @@ def customer(trial_seconds: int, max_billing_periods: int) -> Customer:
     )
 
 
-def test_subscription_bills_every_period_then_ends(
+async def test_subscription_bills_every_period_then_ends(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("subscription")
-    client.start_flow(app.subscription, flow_id, customer(2, 2), start_options())
+    await client.start_flow(app.subscription, flow_id, customer(2, 2), start_options())
 
-    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "subscription ended"
+    assert await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "subscription ended"
 
 
-def test_subscription_describe_returns_the_stored_plan(
+async def test_subscription_describe_returns_the_stored_plan(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("subscription")
-    client.start_flow(
+    await client.start_flow(
         app.subscription,
         flow_id,
         customer(LONG_TRIAL_SECONDS, 10),
         start_options(),
     )
 
-    subscription = wait_until(
+    subscription = await wait_until(
         "Initialize to store the customer",
         lambda: client.invoke_rpc(app.subscription.describe, flow_id),
     )
     assert subscription.trial_period_seconds == LONG_TRIAL_SECONDS
     assert subscription.billing_period_charge == 100
 
-    client.publish(flow_id, app.subscription.cancel_subscription, None)
-    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "subscription canceled"
+    await client.publish(flow_id, app.subscription.cancel_subscription, None)
+    assert await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "subscription canceled"
 
 
-def test_subscription_update_charge_amount(
+async def test_subscription_update_charge_amount(
     app: ExampleApp,
-    client: Client,
+    client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
     flow_id = new_flow_id("subscription")
-    client.start_flow(
+    await client.start_flow(
         app.subscription,
         flow_id,
         customer(LONG_TRIAL_SECONDS, 10),
         start_options(),
     )
 
-    wait_until(
+    await wait_until(
         "Initialize to store the customer",
         lambda: client.invoke_rpc(app.subscription.describe, flow_id),
     )
-    client.publish(flow_id, app.subscription.update_charge_amount, 250)
+    await client.publish(flow_id, app.subscription.update_charge_amount, 250)
 
-    wait_until(
-        "the new charge amount to be applied",
-        lambda: client.invoke_rpc(
-            app.subscription.describe,
-            flow_id,
-        ).billing_period_charge
-        == 250,
-    )
+    async def charge_updated() -> bool:
+        subscription = await client.invoke_rpc(app.subscription.describe, flow_id)
+        return subscription.billing_period_charge == 250
 
-    client.publish(flow_id, app.subscription.cancel_subscription, None)
-    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "subscription canceled"
+    await wait_until("the new charge amount to be applied", charge_updated)
+
+    await client.publish(flow_id, app.subscription.cancel_subscription, None)
+    assert await client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "subscription canceled"

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -266,54 +275,55 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "dex-python-sdk" },
-    { name = "flask" },
     { name = "openai" },
     { name = "openai-agents" },
     { name = "pydantic" },
+    { name = "quart" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-env" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "dex-python-sdk", specifier = "==0.0.2" },
-    { name = "flask", specifier = ">=2.3.3,<3" },
+    { name = "dex-python-sdk", specifier = "==0.1.1" },
     { name = "openai", specifier = ">=1.66.2,<2" },
     { name = "openai-agents", specifier = ">=0.0.4,<0.0.5" },
     { name = "pydantic", specifier = ">=2.10.6,<3" },
+    { name = "quart", specifier = ">=0.20.0,<0.21" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.5.1,<2" },
-    { name = "pytest", specifier = ">=7.4.2,<8" },
+    { name = "pytest", specifier = ">=8.2,<9" },
+    { name = "pytest-asyncio", specifier = ">=0.26,<2" },
     { name = "pytest-cov", specifier = ">=4.1,<5" },
     { name = "pytest-env", specifier = ">=1.0.1,<2" },
 ]
 
 [[package]]
 name = "dex-python-sdk"
-version = "0.0.2"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "grpcio-status" },
-    { name = "httpx" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/ae/364233fad2087051197944538b6b5b1943a00f02de502b49afcb9d13d1ce/dex_python_sdk-0.0.2.tar.gz", hash = "sha256:3a9dfcf72f21a1a43a4b4c5feaf96224c7bca32a7b5567d347a23968e58da0ee", size = 138418, upload-time = "2026-08-07T17:56:08.276Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/5f/c1e381c8ef2579e33d25e05a1f32bea00a5c4ac64f1898c4de6033b788f5/dex_python_sdk-0.1.1.tar.gz", hash = "sha256:8b47a270492f293bfed6f8ce8f47b68900eef6cde5033ff3255e3f2d6de3596d", size = 104481, upload-time = "2026-08-08T01:34:00.058Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/c2/42fcdcbd2396b9fcef6bc38be5759285ca19fc88ba77cea68a11777390a1/dex_python_sdk-0.0.2-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:fd6654745af30ab078bbaeb047e4a9f14e52ebbc4a06f7590ea8d6e93a7ef45b", size = 680364, upload-time = "2026-08-07T17:56:00.911Z" },
-    { url = "https://files.pythonhosted.org/packages/43/4b/f8e14209c8340cec8247d1c45697f6faf0974bd72cb63cf2686f700fa24a/dex_python_sdk-0.0.2-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9b25baf672de8e3cbdbc86d7f8cc3646287cd2f4531e2b0810a9b0b64a9898b", size = 660906, upload-time = "2026-08-07T17:56:02.619Z" },
-    { url = "https://files.pythonhosted.org/packages/35/7f/e5263a24b82b872bc5306ff175dc75658a5e9d6db43d23cf4939d8192124/dex_python_sdk-0.0.2-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f32f924c0732e912e92063c4e6267655a0bd63b4ac1d34d44dd885a4943ed4d9", size = 717771, upload-time = "2026-08-07T17:56:03.991Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/64/9cbed47c3dd171c8b47705b366a284e185bd0fd519a810504868a36c49fd/dex_python_sdk-0.0.2-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c27244ad42062fe54f5247933c72fd3f12c1d1f2f228c82733b224d51fa72cf3", size = 719895, upload-time = "2026-08-07T17:56:05.519Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a9/9b39f9c8f82f851ee5c88c944876e077b539d24edca4f42d005bffd489e4/dex_python_sdk-0.0.2-cp311-abi3-win_amd64.whl", hash = "sha256:9186a48d2ef3de4789d7d605a0dc38ef7ca138a90d0fb30be0ad0a5d01081991", size = 563356, upload-time = "2026-08-07T17:56:06.993Z" },
+    { url = "https://files.pythonhosted.org/packages/08/73/d341b987ca337157b4897afc6ff9dbb2216df0a9ec415c800f577bbddc43/dex_python_sdk-0.1.1-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a0d9f52d3425475ccb91d5693c069d2f8bda2d8273132e044887e8b62610b109", size = 603856, upload-time = "2026-08-08T01:33:52.859Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/51/c3c7ddee2f310d6cabd79c2c278fefc35705ec0870deb74594148de52973/dex_python_sdk-0.1.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:0940fad25df6f092ac45d51b0e49ea88935e07a15b6a107ac4886ef56f2c2a43", size = 584400, upload-time = "2026-08-08T01:33:54.431Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f1/35a5211acd24b78a7f7cae47eead09e9e8a86373bb7e5adb78aa74caf15e/dex_python_sdk-0.1.1-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54ce80aaafc1fe263bfef664be590f1282b89b907669d693369e48ece8ee0032", size = 641263, upload-time = "2026-08-08T01:33:55.979Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cf/e04f532a85ffd0b42d064ac9a68b986486b8a0d9d497f6190c6c14685e58/dex_python_sdk-0.1.1-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cd3bea0465233db5059f2541943c1a50c07dbf0db3798c7c5f91b48dc430126", size = 643386, upload-time = "2026-08-08T01:33:57.451Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/5aaf6647f7dc0cf9dc63c6df6d2fc6b79f9147cc26e821cf0d049a7f85f7/dex_python_sdk-0.1.1-cp311-abi3-win_amd64.whl", hash = "sha256:24ff39ac3573857bd9aaacd0f14a504a59cc115a8d339e53fcd8c77e9dcb7e65", size = 486210, upload-time = "2026-08-08T01:33:59.003Z" },
 ]
 
 [[package]]
@@ -327,18 +337,19 @@ wheels = [
 
 [[package]]
 name = "flask"
-version = "2.3.3"
+version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
     { name = "click" },
     { name = "itsdangerous" },
     { name = "jinja2" },
+    { name = "markupsafe" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/b7/4ace17e37abd9c21715dea5ee11774a25e404c486a7893fa18e764326ead/flask-2.3.3.tar.gz", hash = "sha256:09c347a92aa7ff4a8e7f3206795f30d826654baf38b873d0744cd571ca609efc", size = 672756, upload-time = "2023-08-21T19:52:35.012Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/56/26f0be8adc2b4257df20c1c4260ddd0aa396cf8e75d90ab2f7ff99bc34f9/flask-2.3.3-py3-none-any.whl", hash = "sha256:f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b", size = 96112, upload-time = "2023-08-21T19:52:33.115Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -440,6 +451,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -465,6 +498,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hypercorn"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "h2" },
+    { name = "priority" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/01/39f41a014b83dd5c795217362f2ca9071cf243e6a75bdcd6cd5b944658cc/hypercorn-0.18.0.tar.gz", hash = "sha256:d63267548939c46b0247dc8e5b45a9947590e35e64ee73a23c074aa3cf88e9da", size = 68420, upload-time = "2025-11-08T13:54:04.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl", hash = "sha256:225e268f2c1c2f28f6d8f6db8f40cb8c992963610c5725e13ccfcddccb24b1cd", size = 61640, upload-time = "2025-11-08T13:54:03.202Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -891,6 +948,15 @@ wheels = [
 ]
 
 [[package]]
+name = "priority"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/3c/eb7c35f4dcede96fca1842dac5f4f5d15511aa4b52f3a961219e68ae9204/priority-2.0.0.tar.gz", hash = "sha256:c965d54f1b8d0d0b19479db3924c7c36cf672dbf2aec92d43fbdaf4492ba18c0", size = 24792, upload-time = "2021-06-27T10:15:05.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/5f/82c8074f7e84978129347c2c6ec8b6c59f3584ff1a20bc3c940a3e061790/priority-2.0.0-py3-none-any.whl", hash = "sha256:6f8eefce5f3ad59baf2c080a664037bb4725cd0a790d53d59ab4059288faf6aa", size = 8946, upload-time = "2021-06-27T10:15:03.856Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.35.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1023,18 +1089,41 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
@@ -1060,6 +1149,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/cc/df6940b2527bfa634c00940dfb6e3ec873bdfb7507b55894c93283fa3178/pytest_env-1.1.3.tar.gz", hash = "sha256:fcd7dc23bb71efd3d35632bde1bbe5ee8c8dc4489d6617fb010674880d96216b", size = 8627, upload-time = "2023-11-28T04:11:27.607Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/b2/bdc663a5647ce2034f7e8420122af340df87c01ba97745fc753b8c917acb/pytest_env-1.1.3-py3-none-any.whl", hash = "sha256:aada77e6d09fcfb04540a6e462c58533c37df35fa853da78707b17ec04d17dfc", size = 6154, upload-time = "2023-11-28T04:11:25.923Z" },
+]
+
+[[package]]
+name = "quart"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "blinker" },
+    { name = "click" },
+    { name = "flask" },
+    { name = "hypercorn" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/9d/12e1143a5bd2ccc05c293a6f5ae1df8fd94a8fc1440ecc6c344b2b30ce13/quart-0.20.0.tar.gz", hash = "sha256:08793c206ff832483586f5ae47018c7e40bdd75d886fee3fabbdaa70c2cf505d", size = 63874, upload-time = "2024-12-23T13:53:05.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/e9/cc28f21f52913adf333f653b9e0a3bf9cb223f5083a26422968ba73edd8d/quart-0.20.0-py3-none-any.whl", hash = "sha256:003c08f551746710acb757de49d9b768986fd431517d0eb127380b656b98b8f1", size = 77960, upload-time = "2024-12-23T13:53:02.842Z" },
 ]
 
 [[package]]
@@ -1204,4 +1313,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]


### PR DESCRIPTION
## Summary
- Pin `examples/python` to `dex-python-sdk==0.1.1` and migrate the sample app to `AsyncClient` / `AsyncWorker` with `allow_async_handlers=True`.
- Replace Flask with Quart and convert controllers, Client-using steps, and integ harnesses to async/`await`.
- Fix AsyncWorker event-loop blockers (`time.sleep` → `asyncio.sleep`) and stabilize pattern integ coverage (unique parent/storage IDs, interruptible startup).

## Rationale
Python SDK 0.1.1 ships async APIs; examples should demonstrate the recommended async host path rather than the sync client/worker.

## User impact
Local and CI example runs now depend on 0.1.1 and use async entrypoints (`asyncio.run` + Quart). Sync step handlers remain valid where they do not call the client.

## Test plan
- [x] `uv sync --locked` in `examples/python`
- [x] `uv run --frozen pytest tests/unit tests/integ` against local Dex (`40 passed`)
- [ ] CI: `.github/workflows/examples-python-ci.yml` (manual dispatch)

