### PR TITLE
Add sync Client/Worker Python examples showcase

### DIFF
--- a/docs/design/plan/python-sdk-async-apis.md
+++ b/docs/design/plan/python-sdk-async-apis.md
@@ -1,7 +1,8 @@
 # Python SDK: optional asyncio APIs
 
 Status: implemented (Phase 1 + Phase 2 in `sdk-python`)
-Audience: SDK consumers; examples remain sync unless a later FastAPI sample is added
+Audience: SDK consumers; primary examples are async (`examples/python`); sync
+showcase under `examples/python/sync-python/`
 
 ## Problem
 
@@ -65,7 +66,9 @@ Exports: `from dex import AsyncClient, AsyncWorker` alongside existing `Client` 
 
 ## Locked design choices
 
-1. **Sync remains default.** Existing `Client` / `Worker` / `Step` / `@rpc` stay unchanged; `examples/python` stays sync.
+1. **Sync remains a first-class surface.** Existing `Client` / `Worker` / `Step` /
+   `@rpc` stay unchanged. Primary examples use `AsyncClient` / `AsyncWorker`;
+   sync showcase lives under `examples/python/sync-python/`.
 2. **Parallel types, not suffixes.** `AsyncClient`, `AsyncWorker`, and coroutine-capable handlers when served by `AsyncWorker`.
 3. **Transport:** `grpc.aio` for both `AsyncClient` and `AsyncWorker` (reuse generated stubs with aio channel/server where possible).
 4. **Mixing rules:**

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -3,9 +3,12 @@
 These examples target [`dex-python-sdk==0.1.1`](https://pypi.org/project/dex-python-sdk/0.1.1/)
 (`import dex`). Requires Python 3.11+.
 
-The sample process hosts one asyncio `AsyncWorker` on `127.0.0.1:8803` and a Quart
-HTTP controller on `127.0.0.1:8080`. Controllers and nested parent/child Steps use
-`AsyncClient`. One Registry and disk BlobCache are shared by Worker and Client.
+The primary sample process hosts one asyncio `AsyncWorker` on `127.0.0.1:8803` and a
+Quart HTTP controller on `127.0.0.1:8080`. Controllers and nested parent/child Steps
+use `AsyncClient`. One Registry and disk BlobCache are shared by Worker and Client.
+
+For the sync `Client` / `Worker` surface (Flask, six Flows), see
+[`sync-python/`](./sync-python/).
 
 ## Run locally
 
@@ -33,7 +36,8 @@ When Dex runs in Docker, set `DEX_WORKER_TARGET=host.docker.internal:8803`.
 ## Verify every example
 
 The E2E suite starts Dex through `dexcli dev` and runs unit + integ tests that
-exercise every product, design-pattern, and Python-only example:
+exercise every product, design-pattern, and Python-only example, plus the
+[`sync-python`](./sync-python/) showcase:
 
 ```bash
 make e2eTests

--- a/examples/python/pyproject.toml
+++ b/examples/python/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "dex-python-sdk==0.1.1",
+    "flask>=3.0,<4",
     "openai>=1.66.2,<2",
     "openai-agents>=0.0.4,<0.0.5",
     "pydantic>=2.10.6,<3",
@@ -28,8 +29,8 @@ package = false
 required-version = "==0.12.2"
 
 [tool.pytest.ini_options]
-pythonpath = ["."]
-testpaths = ["tests"]
+pythonpath = [".", "sync-python"]
+testpaths = ["tests", "sync-python/tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"

--- a/examples/python/run-e2e-tests.sh
+++ b/examples/python/run-e2e-tests.sh
@@ -80,4 +80,4 @@ temporal --address "$temporal_address" operator search-attribute create \
 cd "$script_dir"
 uv sync --locked
 DEX_FLOW_SERVICE_ADDRESS="$dex_address" \
-  uv run --frozen pytest tests/unit tests/integ -v 2>&1 | tee "$test_log"
+  uv run --frozen pytest tests/unit tests/integ sync-python/tests/integ -v 2>&1 | tee "$test_log"

--- a/examples/python/run-integ-tests.sh
+++ b/examples/python/run-integ-tests.sh
@@ -104,4 +104,4 @@ fi
 
 cd "$script_dir"
 DEX_FLOW_SERVICE_ADDRESS="$dex_address" \
-  uv run --frozen pytest -vv tests/
+  uv run --frozen pytest -vv tests/ sync-python/tests/integ

--- a/examples/python/sync-python/README.md
+++ b/examples/python/sync-python/README.md
@@ -1,0 +1,47 @@
+# Sync Python examples
+
+Showcase of the **sync** Dex Python SDK surface (`Client` / `Worker`) next to
+the primary async examples under `examples/python/`.
+
+Targets [`dex-python-sdk==0.1.1`](https://pypi.org/project/dex-python-sdk/0.1.1/).
+Requires Python 3.11+.
+
+Six Flows:
+
+| Demo | Route prefix | Notes |
+|------|--------------|--------|
+| Basic | `/basic` | smallest Flow |
+| Money transfer | `/moneytransfer` | saga |
+| Engagement | `/engagement` | channels + RPC |
+| Subscription | `/subscription` | timers |
+| Parent–child | `/design-pattern/parentchild` | sync `Client` inside `Step.execute` |
+| Interruptible | `/design-pattern/interruptible` | interrupt RPC |
+
+Defaults: Worker `127.0.0.1:8804`, HTTP `127.0.0.1:8081` (does not clash with
+the async app on `8803` / `8080`).
+
+## Run
+
+From `examples/python` (shared `uv` project):
+
+```bash
+dexcli dev --temporal-db-filename /tmp/dex-examples-python.db
+# search attributes — same as the async README
+
+uv sync --locked
+uv run --frozen python sync-python/main.py
+```
+
+Env overrides: `DEX_FLOW_SERVICE_ADDRESS`, `DEX_SYNC_WORKER_BIND_ADDRESS`,
+`DEX_SYNC_WORKER_TARGET`, `DEX_SYNC_EXAMPLES_HTTP_ADDRESS`,
+`DEX_SYNC_BLOB_CACHE_DIR`.
+
+## Verify
+
+```bash
+# from examples/python, with Dex running
+DEX_FLOW_SERVICE_ADDRESS=127.0.0.1:8801 \
+  uv run --frozen pytest sync-python/tests/integ -v
+```
+
+Or run the full e2e suite (`make e2eTests`), which includes these sync integ tests.

--- a/examples/python/sync-python/main.py
+++ b/examples/python/sync-python/main.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runs the sync Client/Worker showcase behind one Flask app."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow `uv run python sync-python/main.py` from examples/python.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from sync_examples.app import SyncExampleApp
+from sync_examples.config import SyncExamplesConfig
+from sync_examples.http_app import create_app
+
+
+def main() -> None:
+    config = SyncExamplesConfig.from_env()
+    app_state = SyncExampleApp(config)
+    app_state.start_worker()
+    try:
+        host, port = parse_http_address(config.http_address)
+        print(
+            f"Dex Python sync examples listening on http://{config.http_address} "
+            f"(Worker {app_state.worker.worker_target.address})"
+        )
+        create_app(app_state).run(host=host, port=port, threaded=True)
+    finally:
+        app_state.close()
+
+
+def parse_http_address(address: str) -> tuple[str, int]:
+    host, _, port_text = address.rpartition(":")
+    if not _ or not port_text:
+        raise ValueError(f"invalid HTTP address: {address}")
+    return host or "127.0.0.1", int(port_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/sync-python/sync_examples/__init__.py
+++ b/examples/python/sync-python/sync_examples/__init__.py
@@ -12,13 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: unitTests e2eTests syncIntegTests
-
-unitTests:
-	uv run --frozen pytest tests/unit -v
-
-syncIntegTests:
-	uv run --frozen pytest sync-python/tests/integ -v
-
-e2eTests:
-	./run-e2e-tests.sh
+"""Sync Client/Worker showcase (six Flows)."""

--- a/examples/python/sync-python/sync_examples/app.py
+++ b/examples/python/sync-python/sync_examples/app.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from typing import Any, Callable
+
+from dex import (
+    BlobCacheConfig,
+    Client,
+    ClientOptions,
+    Flow,
+    Registry,
+    Worker,
+    WorkerOptions,
+    WorkerTarget,
+    open_blob_cache,
+)
+
+from dex_examples.basic.basic_flow import BasicFlow
+from dex_examples.my_dependency_service import MyDependencyService
+from dex_examples.patterns.workflow.interruptible.interruptible_execution_flow import (
+    InterruptibleExecutionFlow,
+)
+from dex_examples.workflow.engagement.engagement_flow import EngagementFlow
+from dex_examples.workflow.money.transfer.money_transfer_flow import MoneyTransferFlow
+from dex_examples.workflow.subscription.subscription_flow import SubscriptionFlow
+from sync_examples.config import SyncExamplesConfig
+from sync_examples.flows.parent_child import ChildFlow, ParentFlowV2
+
+
+class SyncExampleApp:
+    def __init__(self, config: SyncExamplesConfig) -> None:
+        self.config = config
+        self._client: Client | None = None
+        client_provider: Callable[[], Client] = self.require_client
+
+        service = MyDependencyService()
+        self.basic = BasicFlow()
+        self.money_transfer = MoneyTransferFlow(service)
+        self.engagement = EngagementFlow(service)
+        self.subscription = SubscriptionFlow(service)
+        self.interruptible = InterruptibleExecutionFlow()
+        self.child_flow = ChildFlow()
+        self.parent_flow_v2 = ParentFlowV2(client_provider, self.child_flow)
+
+        flows: list[Flow[Any]] = [
+            self.basic,
+            self.money_transfer,
+            self.engagement,
+            self.subscription,
+            self.interruptible,
+            self.child_flow,
+            self.parent_flow_v2,
+        ]
+        self.registry = Registry(tuple(flows))
+        config.blob_cache_dir.mkdir(parents=True, exist_ok=True)
+        self.blob_cache = open_blob_cache(
+            BlobCacheConfig(str(config.blob_cache_dir), 1 << 30)
+        )
+        worker_options = WorkerOptions(
+            bind_address=config.worker_bind_address,
+            server_address=config.server_address,
+            worker_target=(
+                WorkerTarget(config.worker_target)
+                if config.worker_target
+                else None
+            ),
+        )
+        self.worker = Worker(self.registry, self.blob_cache, worker_options)
+        self._client = Client(
+            self.registry,
+            self.blob_cache,
+            ClientOptions(
+                server_address=config.server_address,
+                worker_target=self.worker.worker_target,
+            ),
+        )
+        self._worker_thread: threading.Thread | None = None
+
+    @property
+    def client(self) -> Client:
+        return self.require_client()
+
+    def require_client(self) -> Client:
+        if self._client is None:
+            raise RuntimeError("client is not ready")
+        return self._client
+
+    def start_worker(self) -> None:
+        if self._worker_thread is not None:
+            return
+        self._worker_thread = threading.Thread(
+            target=self.worker.start,
+            name="dex-sync-example-worker",
+            daemon=True,
+        )
+        self._worker_thread.start()
+        _await_worker(self.worker.worker_target.address)
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+        self.worker.close()
+        if self._worker_thread is not None:
+            self._worker_thread.join(timeout=10)
+            self._worker_thread = None
+        self.blob_cache.close()
+
+
+def _await_worker(address: str) -> None:
+    host, _, port_text = address.rpartition(":")
+    port = int(port_text)
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host or "127.0.0.1", port), timeout=0.1):
+                return
+        except OSError:
+            time.sleep(0.01)
+    raise RuntimeError("Worker did not become ready")

--- a/examples/python/sync-python/sync_examples/config.py
+++ b/examples/python/sync-python/sync_examples/config.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+
+from dex import StartFlowOptions
+
+DEFAULT_TIMEOUT = timedelta(hours=1)
+
+
+@dataclass(frozen=True)
+class SyncExamplesConfig:
+    server_address: str
+    worker_bind_address: str
+    worker_target: str | None
+    http_address: str
+    blob_cache_dir: Path
+
+    @staticmethod
+    def from_env() -> SyncExamplesConfig:
+        return SyncExamplesConfig(
+            server_address=os.environ.get(
+                "DEX_FLOW_SERVICE_ADDRESS", "127.0.0.1:8801"
+            ),
+            worker_bind_address=os.environ.get(
+                "DEX_SYNC_WORKER_BIND_ADDRESS", "127.0.0.1:8804"
+            ),
+            worker_target=os.environ.get("DEX_SYNC_WORKER_TARGET") or None,
+            http_address=os.environ.get(
+                "DEX_SYNC_EXAMPLES_HTTP_ADDRESS", "127.0.0.1:8081"
+            ),
+            blob_cache_dir=Path(
+                os.environ.get(
+                    "DEX_SYNC_BLOB_CACHE_DIR",
+                    "/tmp/dex-examples-python-sync-blob-cache",
+                )
+            ),
+        )
+
+
+def start_options() -> StartFlowOptions:
+    return StartFlowOptions(timeout=DEFAULT_TIMEOUT)

--- a/examples/python/sync-python/sync_examples/flows/__init__.py
+++ b/examples/python/sync-python/sync_examples/flows/__init__.py
@@ -11,14 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-.PHONY: unitTests e2eTests syncIntegTests
-
-unitTests:
-	uv run --frozen pytest tests/unit -v
-
-syncIntegTests:
-	uv run --frozen pytest sync-python/tests/integ -v
-
-e2eTests:
-	./run-e2e-tests.sh

--- a/examples/python/sync-python/sync_examples/flows/parent_child.py
+++ b/examples/python/sync-python/sync_examples/flows/parent_child.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parent/child demo using sync Client inside Step.execute."""
+
+from __future__ import annotations
+
+import random
+from datetime import timedelta
+from typing import Any, Callable, cast
+
+from dex import (
+    Channel,
+    Client,
+    Context,
+    DexException,
+    ErrorSubStatus,
+    Flow,
+    LongPollTimeoutError,
+    PersistenceSchema,
+    Step,
+    StepDecision,
+    StepList,
+    StepMovement,
+    Timer,
+    Wait,
+    go_to,
+    go_to_multi,
+    graceful_complete,
+)
+
+from dex_examples.patterns.workflow.parentchild.wait_for_child_input import (
+    WaitForChildInput,
+)
+from sync_examples.config import start_options
+
+CONCURRENCY_PER_PARENT_WORKFLOW = 3
+MAX_WAIT_SECONDS = 10
+
+
+class ChildProcessing(Step[str]):
+    def wait_for(self, context: Context, input: str) -> Wait:
+        del context, input
+        return Wait.any_of(Timer.by_duration(timedelta(seconds=random.randint(1, 3))))
+
+    def execute(self, context: Context, input: str) -> StepDecision:
+        del context, input
+        return graceful_complete()
+
+
+class ChildFlow(Flow[str]):
+    def __init__(self) -> None:
+        self.processing = ChildProcessing()
+
+    def get_steps(self) -> StepList[str]:
+        return StepList.start_step(self.processing)
+
+    def get_persistence_schema(self) -> PersistenceSchema:
+        return PersistenceSchema.of()
+
+
+class AwaitChildWorkflowCompletion(Step[WaitForChildInput]):
+    def __init__(
+        self,
+        client_provider: Callable[[], Client],
+        loop_for_next_task_provider: Callable[[], LoopForNextTask],
+    ) -> None:
+        self.client_provider = client_provider
+        self.loop_for_next_task_provider = loop_for_next_task_provider
+
+    def wait_for(self, context: Context, input: WaitForChildInput) -> Wait:
+        del context
+        return Wait.any_of(Timer.by_duration(timedelta(seconds=input.timer_seconds)))
+
+    def execute(
+        self, context: Context, input: WaitForChildInput
+    ) -> StepDecision:
+        del context
+        try:
+            self.client_provider().wait_for_flow(
+                input.child_wf_id,
+                cast(type[Any], type(None)),
+                timedelta(seconds=max(input.timer_seconds, 1)),
+            )
+        except LongPollTimeoutError:
+            return go_to(
+                self,
+                WaitForChildInput(
+                    input.child_wf_id,
+                    min(input.timer_seconds * 2, MAX_WAIT_SECONDS),
+                ),
+            )
+        return go_to(self.loop_for_next_task_provider(), None)
+
+
+class StartChildWorkflow(Step[int]):
+    def __init__(
+        self,
+        client_provider: Callable[[], Client],
+        child_flow: ChildFlow,
+        await_child_workflow_completion: AwaitChildWorkflowCompletion,
+    ) -> None:
+        self.client_provider = client_provider
+        self.child_flow = child_flow
+        self.await_child_workflow_completion = await_child_workflow_completion
+
+    def execute(self, context: Context, input: int) -> StepDecision:
+        child_workflow_id = f"{context.flow_id}-child-{input}"
+        try:
+            self.client_provider().start_flow(
+                self.child_flow,
+                child_workflow_id,
+                str(input),
+                start_options(),
+            )
+        except DexException as error:
+            if error.sub_status is not ErrorSubStatus.FLOW_ALREADY_STARTED:
+                raise
+        return go_to(
+            self.await_child_workflow_completion,
+            WaitForChildInput(child_workflow_id, 1),
+        )
+
+
+class LoopForNextTask(Step[None]):
+    def __init__(
+        self,
+        start_child_workflow: StartChildWorkflow,
+        task_queue: Channel[int],
+    ) -> None:
+        self.start_child_workflow = start_child_workflow
+        self.task_queue = task_queue
+
+    def wait_for(self, context: Context, input: None) -> Wait:
+        del context, input
+        return Wait.any_of(self.task_queue.for_one())
+
+    def execute(self, context: Context, input: None) -> StepDecision:
+        del input
+        request = self.task_queue.results(context)[0]
+        return go_to(self.start_child_workflow, request)
+
+
+class Init(Step[int]):
+    def __init__(
+        self,
+        loop_for_next_task: LoopForNextTask,
+        task_queue: Channel[int],
+    ) -> None:
+        self.loop_for_next_task = loop_for_next_task
+        self.task_queue = task_queue
+
+    def execute(self, context: Context, input: int) -> StepDecision:
+        for index in range(input):
+            self.task_queue.publish(context, index)
+
+        return go_to_multi(
+            *(
+                StepMovement.of(self.loop_for_next_task, None)
+                for _ in range(CONCURRENCY_PER_PARENT_WORKFLOW)
+            )
+        )
+
+
+class ParentFlowV2(Flow[int]):
+    TASK_QUEUE = "sync_task_queue"
+
+    task_queue = Channel(TASK_QUEUE, int)
+
+    def __init__(
+        self,
+        client_provider: Callable[[], Client],
+        child_flow: ChildFlow,
+    ) -> None:
+        self.await_child_workflow_completion = AwaitChildWorkflowCompletion(
+            client_provider,
+            lambda: self.loop_for_next_task,
+        )
+        self.start_child_workflow = StartChildWorkflow(
+            client_provider,
+            child_flow,
+            self.await_child_workflow_completion,
+        )
+        self.loop_for_next_task = LoopForNextTask(
+            self.start_child_workflow,
+            self.task_queue,
+        )
+        self.init = Init(self.loop_for_next_task, self.task_queue)
+
+    def get_steps(self) -> StepList[int]:
+        return StepList.start_step(self.init).other_steps(
+            self.loop_for_next_task,
+            self.start_child_workflow,
+            self.await_child_workflow_completion,
+        )
+
+    def get_persistence_schema(self) -> PersistenceSchema:
+        return PersistenceSchema.of(self.task_queue)

--- a/examples/python/sync-python/sync_examples/http_app.py
+++ b/examples/python/sync-python/sync_examples/http_app.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from dex import IdReusePolicy, StartFlowOptions
+from flask import Blueprint, Flask, Response, jsonify
+
+from dex_examples.workflow.engagement.engagement_input import EngagementInput
+from dex_examples.workflow.money.transfer.transfer_request import TransferRequest
+from dex_examples.workflow.subscription.customer import Customer
+from dex_examples.workflow.subscription.subscription import Subscription
+from sync_examples.app import SyncExampleApp
+from sync_examples.config import DEFAULT_TIMEOUT, start_options
+from sync_examples.query import (
+    new_flow_id,
+    optional_query,
+    required_int_query,
+    required_query,
+    started_flow,
+)
+
+
+def create_app(app_state: SyncExampleApp) -> Flask:
+    app = Flask(__name__)
+    app.register_blueprint(_basic(app_state))
+    app.register_blueprint(_money_transfer(app_state))
+    app.register_blueprint(_engagement(app_state))
+    app.register_blueprint(_subscription(app_state))
+    app.register_blueprint(_patterns(app_state))
+
+    @app.get("/health")
+    def health() -> Response:
+        return jsonify({"ok": True})
+
+    return app
+
+
+def _basic(app_state: SyncExampleApp) -> Blueprint:
+    blueprint = Blueprint("basic", __name__, url_prefix="/basic")
+
+    @blueprint.get("/start")
+    def start() -> Response:
+        flow_id = required_query("workflowId")
+        run_id = app_state.client.start_flow(
+            app_state.basic,
+            flow_id,
+            required_int_query("inputNum"),
+            start_options(),
+        )
+        return started_flow(flow_id, run_id)
+
+    @blueprint.get("/appendString")
+    def append_string() -> str:
+        return app_state.client.invoke_rpc(
+            app_state.basic.append_string,
+            required_query("workflowId"),
+            required_query("str"),
+        )
+
+    @blueprint.get("/approve")
+    def approve() -> str:
+        app_state.client.invoke_rpc(
+            app_state.basic.approve,
+            required_query("workflowId"),
+        )
+        return "done"
+
+    return blueprint
+
+
+def _money_transfer(app_state: SyncExampleApp) -> Blueprint:
+    blueprint = Blueprint("money_transfer", __name__, url_prefix="/moneytransfer")
+
+    @blueprint.get("/start")
+    def start() -> Response:
+        request = TransferRequest(
+            required_query("fromAccount"),
+            required_query("toAccount"),
+            required_int_query("amount"),
+            optional_query("notes", ""),
+        )
+        flow_id = new_flow_id("money-transfer")
+        run_id = app_state.client.start_flow(
+            app_state.money_transfer,
+            flow_id,
+            request,
+            start_options(),
+        )
+        return started_flow(flow_id, run_id)
+
+    return blueprint
+
+
+def _engagement(app_state: SyncExampleApp) -> Blueprint:
+    blueprint = Blueprint("engagement", __name__, url_prefix="/engagement")
+
+    @blueprint.get("/start")
+    def start() -> Response:
+        flow_id = new_flow_id("engagement")
+        run_id = app_state.client.start_flow(
+            app_state.engagement,
+            flow_id,
+            EngagementInput("test-employer-id", "test-job-seeker-id", "test-notes"),
+            start_options(),
+        )
+        return started_flow(flow_id, run_id)
+
+    @blueprint.get("/describe")
+    def describe() -> Response:
+        description = app_state.client.invoke_rpc(
+            app_state.engagement.describe,
+            required_query("workflowId"),
+        )
+        return jsonify(asdict(description))
+
+    @blueprint.get("/accept")
+    def accept() -> Response:
+        status = app_state.client.invoke_rpc(
+            app_state.engagement.accept,
+            required_query("workflowId"),
+            optional_query("notes", ""),
+        )
+        return jsonify(status.value)
+
+    @blueprint.get("/decline")
+    def decline() -> Response:
+        status = app_state.client.invoke_rpc(
+            app_state.engagement.decline,
+            required_query("workflowId"),
+            optional_query("notes", ""),
+        )
+        return jsonify(status.value)
+
+    return blueprint
+
+
+def _subscription(app_state: SyncExampleApp) -> Blueprint:
+    blueprint = Blueprint("subscription", __name__, url_prefix="/subscription")
+
+    @blueprint.get("/start")
+    def start() -> Response:
+        customer = Customer(
+            "Quanzheng",
+            "Long",
+            "qlong",
+            "qlong@example.com",
+            Subscription(
+                trial_period_seconds=20,
+                billing_period_seconds=10,
+                max_billing_periods=10,
+                billing_period_charge=100,
+            ),
+        )
+        flow_id = new_flow_id("subscription")
+        run_id = app_state.client.start_flow(
+            app_state.subscription,
+            flow_id,
+            customer,
+            start_options(),
+        )
+        return started_flow(flow_id, run_id)
+
+    @blueprint.get("/cancel")
+    def cancel() -> str:
+        app_state.client.publish(
+            required_query("workflowId"),
+            app_state.subscription.cancel_subscription,
+            None,
+        )
+        return "accepted"
+
+    @blueprint.get("/describe")
+    def describe() -> Response:
+        subscription = app_state.client.invoke_rpc(
+            app_state.subscription.describe,
+            required_query("workflowId"),
+        )
+        return jsonify(asdict(subscription))
+
+    return blueprint
+
+
+def _patterns(app_state: SyncExampleApp) -> Blueprint:
+    blueprint = Blueprint("patterns", __name__, url_prefix="/design-pattern")
+
+    @blueprint.get("/parentchild/start")
+    def parent_child_start() -> Response:
+        flow_id = optional_query("workflowId", new_flow_id("parent-child"))
+        num_children = required_int_query("numOfChildWfs")
+        run_id = app_state.client.start_flow(
+            app_state.parent_flow_v2,
+            flow_id,
+            num_children,
+            StartFlowOptions(
+                timeout=DEFAULT_TIMEOUT,
+                id_reuse_policy=IdReusePolicy.ALLOW_IF_PREVIOUS_FAILED,
+            ),
+        )
+        return started_flow(flow_id, run_id)
+
+    @blueprint.get("/interruptible/start")
+    def interruptible_start() -> Response:
+        flow_id = optional_query("workflowId", new_flow_id("interruptible"))
+        run_id = app_state.client.start_flow(
+            app_state.interruptible,
+            flow_id,
+            None,
+            start_options(),
+        )
+        return started_flow(flow_id, run_id)
+
+    @blueprint.get("/interruptible/cancel")
+    def interruptible_cancel() -> str:
+        app_state.client.invoke_rpc(
+            app_state.interruptible.interrupt,
+            required_query("workflowId"),
+        )
+        return "done"
+
+    return blueprint

--- a/examples/python/sync-python/sync_examples/query.py
+++ b/examples/python/sync-python/sync_examples/query.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from flask import Response, jsonify, request
+
+
+def required_query(name: str) -> str:
+    value = request.args.get(name)
+    if value is None or value == "":
+        raise ValueError(f"missing query parameter {name}")
+    return value
+
+
+def optional_query(name: str, default: str) -> str:
+    value = request.args.get(name)
+    if value is None or value == "":
+        return default
+    return value
+
+
+def required_int_query(name: str) -> int:
+    return int(required_query(name))
+
+
+def new_flow_id(prefix: str) -> str:
+    return f"{prefix}-{uuid4().hex}"
+
+
+def started_flow(flow_id: str, run_id: str) -> Response:
+    return jsonify({"workflowId": flow_id, "runId": run_id})

--- a/examples/python/sync-python/sync_examples/wait.py
+++ b/examples/python/sync-python/sync_examples/wait.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from datetime import timedelta
+from typing import Any
+
+from dex import Attribute, Client, DexException, ErrorSubStatus, FlowStatus
+
+WAIT_TIMEOUT = timedelta(seconds=45)
+POLL_INTERVAL_SECONDS = 0.5
+
+
+def wait_until(
+    description: str,
+    predicate: Callable[[], Any],
+    timeout: timedelta = WAIT_TIMEOUT,
+) -> Any:
+    deadline = time.monotonic() + timeout.total_seconds()
+    while True:
+        value = predicate()
+        if value:
+            return value
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"timed out waiting for {description}")
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def wait_for_attribute(
+    client: Client,
+    flow_id: str,
+    attribute: Attribute[Any],
+    timeout: timedelta = WAIT_TIMEOUT,
+) -> Any:
+    return wait_until(
+        f"attribute {attribute.name} on {flow_id}",
+        lambda: attribute_or_none(client, flow_id, attribute),
+        timeout,
+    )
+
+
+def attribute_or_none(
+    client: Client, flow_id: str, attribute: Attribute[Any]
+) -> Any:
+    try:
+        return client.get_attribute(flow_id, attribute)
+    except DexException as error:
+        if error.sub_status is ErrorSubStatus.FLOW_NOT_EXISTS:
+            return None
+        raise
+
+
+def flow_status_or_none(client: Client, flow_id: str) -> FlowStatus | None:
+    try:
+        return client.describe_flow(flow_id).status
+    except DexException as error:
+        if error.sub_status is ErrorSubStatus.FLOW_NOT_EXISTS:
+            return None
+        raise

--- a/examples/python/sync-python/tests/__init__.py
+++ b/examples/python/sync-python/tests/__init__.py
@@ -11,14 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-.PHONY: unitTests e2eTests syncIntegTests
-
-unitTests:
-	uv run --frozen pytest tests/unit -v
-
-syncIntegTests:
-	uv run --frozen pytest sync-python/tests/integ -v
-
-e2eTests:
-	./run-e2e-tests.sh

--- a/examples/python/sync-python/tests/integ/__init__.py
+++ b/examples/python/sync-python/tests/integ/__init__.py
@@ -11,14 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-.PHONY: unitTests e2eTests syncIntegTests
-
-unitTests:
-	uv run --frozen pytest tests/unit -v
-
-syncIntegTests:
-	uv run --frozen pytest sync-python/tests/integ -v
-
-e2eTests:
-	./run-e2e-tests.sh

--- a/examples/python/sync-python/tests/integ/conftest.py
+++ b/examples/python/sync-python/tests/integ/conftest.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sync Client/Worker harness for the sync-python showcase integ tests."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable, Iterator
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+from dex import Client, DexException
+
+from sync_examples.app import SyncExampleApp
+from sync_examples.config import SyncExamplesConfig
+
+DEFAULT_SERVER_ADDRESS = "127.0.0.1:8801"
+SERVER_READY_TIMEOUT = timedelta(seconds=20)
+POLL_INTERVAL_SECONDS = 0.5
+
+
+@pytest.fixture(scope="session")
+def sync_app(tmp_path_factory: pytest.TempPathFactory) -> Iterator[SyncExampleApp]:
+    config = SyncExamplesConfig(
+        server_address=os.environ.get(
+            "DEX_FLOW_SERVICE_ADDRESS", DEFAULT_SERVER_ADDRESS
+        ),
+        worker_bind_address="127.0.0.1:0",
+        worker_target=None,
+        http_address="127.0.0.1:0",
+        blob_cache_dir=tmp_path_factory.mktemp("dex-sync-examples-blob-cache"),
+    )
+    app = SyncExampleApp(config)
+    app.start_worker()
+    if not _server_is_ready(app.client):
+        app.close()
+        pytest.skip(
+            "no Dex server at "
+            f"{config.server_address}; set DEX_FLOW_SERVICE_ADDRESS to run "
+            "sync-python integ tests"
+        )
+    try:
+        yield app
+    finally:
+        app.close()
+
+
+@pytest.fixture(scope="session")
+def app(sync_app: SyncExampleApp) -> SyncExampleApp:
+    return sync_app
+
+
+@pytest.fixture(scope="session")
+def client(sync_app: SyncExampleApp) -> Client:
+    return sync_app.client
+
+
+@pytest.fixture()
+def new_flow_id() -> Callable[[str], str]:
+    def make(prefix: str) -> str:
+        return f"{prefix}-{uuid4().hex}"
+
+    return make
+
+
+def _server_is_ready(client: Client) -> bool:
+    deadline = time.monotonic() + SERVER_READY_TIMEOUT.total_seconds()
+    while time.monotonic() < deadline:
+        try:
+            return client.health_check()
+        except DexException:
+            time.sleep(POLL_INTERVAL_SECONDS)
+    return False

--- a/examples/python/sync-python/tests/integ/test_sync_examples.py
+++ b/examples/python/sync-python/tests/integ/test_sync_examples.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+from dex import Client, FlowStatus, IdReusePolicy, StartFlowOptions
+
+from dex_examples.workflow.engagement.engagement_flow import EngagementFlow
+from dex_examples.workflow.engagement.engagement_input import EngagementInput
+from dex_examples.workflow.engagement.status import Status
+from dex_examples.workflow.money.transfer.transfer_request import TransferRequest
+from dex_examples.workflow.subscription.customer import Customer
+from dex_examples.workflow.subscription.subscription import Subscription
+from sync_examples.app import SyncExampleApp
+from sync_examples.config import DEFAULT_TIMEOUT, start_options
+from sync_examples.wait import (
+    WAIT_TIMEOUT,
+    flow_status_or_none,
+    wait_for_attribute,
+    wait_until,
+)
+
+pytestmark = pytest.mark.integ
+
+
+def test_basic_approve_completes(
+    app: SyncExampleApp,
+    client: Client,
+    new_flow_id: Callable[[str], str],
+) -> None:
+    flow_id = new_flow_id("sync-basic")
+    client.start_flow(app.basic, flow_id, 5, start_options())
+    appended = client.invoke_rpc(app.basic.append_string, flow_id, "hello")
+    assert "hello" in appended
+    client.invoke_rpc(app.basic.approve, flow_id)
+    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "approved"
+
+
+def test_money_transfer_completes_the_saga(
+    app: SyncExampleApp,
+    client: Client,
+    new_flow_id: Callable[[str], str],
+) -> None:
+    flow_id = new_flow_id("sync-money")
+    request = TransferRequest("from-account", "to-account", 100, "test-notes")
+    client.start_flow(app.money_transfer, flow_id, request, start_options())
+    output = client.wait_for_flow(flow_id, str, WAIT_TIMEOUT)
+    assert "transfer is done" in output
+    assert "from from-account to to-account for amount 100" in output
+
+
+def test_engagement_accept_completes(
+    app: SyncExampleApp,
+    client: Client,
+    new_flow_id: Callable[[str], str],
+) -> None:
+    flow_id = new_flow_id("sync-engagement")
+    client.start_flow(
+        app.engagement,
+        flow_id,
+        EngagementInput("test-employer-id", "test-job-seeker-id", "test-notes"),
+        start_options(),
+    )
+    wait_for_attribute(client, flow_id, EngagementFlow.engagement_status)
+    description = client.invoke_rpc(app.engagement.describe, flow_id)
+    assert description.employer_id == "test-employer-id"
+    assert description.current_status == Status.INITIATED
+    assert client.invoke_rpc(app.engagement.accept, flow_id, "sounds good") is (
+        Status.ACCEPTED
+    )
+    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "done"
+
+
+def test_subscription_describe_and_cancel(
+    app: SyncExampleApp,
+    client: Client,
+    new_flow_id: Callable[[str], str],
+) -> None:
+    flow_id = new_flow_id("sync-subscription")
+    customer = Customer(
+        "Quanzheng",
+        "Long",
+        "qlong",
+        "qlong@example.com",
+        Subscription(
+            trial_period_seconds=600,
+            billing_period_seconds=1,
+            max_billing_periods=10,
+            billing_period_charge=100,
+        ),
+    )
+    client.start_flow(app.subscription, flow_id, customer, start_options())
+    subscription = wait_until(
+        "Initialize to store the customer",
+        lambda: client.invoke_rpc(app.subscription.describe, flow_id),
+    )
+    assert subscription.billing_period_charge == 100
+    client.publish(flow_id, app.subscription.cancel_subscription, None)
+    assert client.wait_for_flow(flow_id, str, WAIT_TIMEOUT) == "subscription canceled"
+
+
+def test_parent_child_starts_a_child(
+    app: SyncExampleApp,
+    client: Client,
+    new_flow_id: Callable[[str], str],
+) -> None:
+    flow_id = new_flow_id("sync-parent-child")
+    run_id = client.start_flow(
+        app.parent_flow_v2,
+        flow_id,
+        2,
+        StartFlowOptions(
+            timeout=DEFAULT_TIMEOUT,
+            id_reuse_policy=IdReusePolicy.ALLOW_IF_PREVIOUS_FAILED,
+        ),
+    )
+    assert run_id
+    child_id = f"{flow_id}-child-0"
+    wait_until(
+        "parent-child started a child flow",
+        lambda: flow_status_or_none(client, child_id),
+        WAIT_TIMEOUT,
+    )
+
+
+def test_interruptible_start_and_cancel(
+    app: SyncExampleApp,
+    client: Client,
+    new_flow_id: Callable[[str], str],
+) -> None:
+    flow_id = new_flow_id("sync-interruptible")
+    client.start_flow(app.interruptible, flow_id, None, start_options())
+    wait_until(
+        "interruptible flow running",
+        lambda: flow_status_or_none(client, flow_id) is FlowStatus.RUNNING,
+    )
+    client.invoke_rpc(app.interruptible.interrupt, flow_id)
+    wait_until(
+        "interruptible flow completed",
+        lambda: flow_status_or_none(client, flow_id) is FlowStatus.COMPLETED,
+        WAIT_TIMEOUT,
+    )

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -275,6 +275,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "dex-python-sdk" },
+    { name = "flask" },
     { name = "openai" },
     { name = "openai-agents" },
     { name = "pydantic" },
@@ -293,6 +294,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dex-python-sdk", specifier = "==0.1.1" },
+    { name = "flask", specifier = ">=3.0,<4" },
     { name = "openai", specifier = ">=1.66.2,<2" },
     { name = "openai-agents", specifier = ">=0.0.4,<0.0.5" },
     { name = "pydantic", specifier = ">=2.10.6,<3" },


### PR DESCRIPTION
## Summary
- Add `examples/python/sync-python/`: Flask + sync `Client`/`Worker` showcase with six Flows (basic, money transfer, engagement, subscription, parent–child, interruptible).
- Keep primary examples async; document the split in the examples README and async SDK design plan.
- Wire sync integ tests into e2e / integ scripts (`make syncIntegTests`).

## Stacking
Draft PR stacked on [#217](https://github.com/superdurable/dex/pull/217) (`cursor/python-examples-async`). Retarget to `main` after that merges, or merge via the stack.

## Test plan
- [x] `DEX_FLOW_SERVICE_ADDRESS=127.0.0.1:8801 uv run --frozen pytest sync-python/tests/integ` (`6 passed`)
- [x] `uv run --frozen pytest tests/unit` (`9 passed`)
- [ ] CI / `make e2eTests` after #217 lands

