### PR TITLE
feat(typescript): add dataset deal workflow example

### DIFF
--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -19,6 +19,16 @@ temporal --address 127.0.0.1:7233 operator search-attribute create \
   --name CustomKeywordField --type Keyword
 temporal --address 127.0.0.1:7233 operator search-attribute create \
   --name CustomStringField --type Text
+temporal --address 127.0.0.1:7233 operator search-attribute create \
+  --name ProcessID --type Keyword
+temporal --address 127.0.0.1:7233 operator search-attribute create \
+  --name BuyerID --type Keyword
+temporal --address 127.0.0.1:7233 operator search-attribute create \
+  --name CurrentState --type Keyword
+temporal --address 127.0.0.1:7233 operator search-attribute create \
+  --name PendingPreConditionState --type Keyword
+temporal --address 127.0.0.1:7233 operator search-attribute create \
+  --name PendingPreConditionName --type Keyword
 
 cd examples/typescript
 npm install
@@ -39,6 +49,7 @@ npm run smoke            # every product + design-pattern HTTP route
 
 ## Product examples
 
+- [Dataset deal DSL](./src/workflow/datasetdeal)
 - [Money transfer](./src/workflow/money/transfer)
 - [Microservice orchestration](./src/workflow/microservices)
 - [Engagement](./src/workflow/engagement)

--- a/examples/typescript/src/controller/dataset-deal-controller.ts
+++ b/examples/typescript/src/controller/dataset-deal-controller.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2022-2026 Super Durable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { Router } from "express";
+
+import {
+  DexError,
+  ErrorSubStatus,
+  InitialAttribute,
+  StepExecutionId,
+  type Client,
+} from "@superdurable/dex";
+
+import { startOptions } from "../config/env.js";
+import { datasetDealFlow } from "../workflow/datasetdeal/dataset-deal-flow.js";
+import {
+  decodeDealProcess,
+  decodeStateData,
+  hasCondition,
+  validateDealProcess,
+} from "../workflow/datasetdeal/models.js";
+
+const INITIALIZATION_TIMEOUT_MS = 30_000;
+
+export function createDatasetDealRouter(client: Client): Router {
+  const router = Router();
+
+  router.post("/start", async (request, response) => {
+    try {
+      const body = requireRecord(request.body, "request body");
+      const process = decodeDealProcess(body.process);
+      validateDealProcess(process, datasetDealFlow.actions.availableNames());
+      const buyerId = requireNonEmptyString(body.buyerId, "buyerId");
+      const flowId = `${process.processId}-${randomUUID()}`;
+      const runId = await client.startFlow(
+        datasetDealFlow,
+        flowId,
+        process.processId,
+        startOptions({
+          attributes: [
+            InitialAttribute.of(datasetDealFlow.buyerId, buyerId),
+            InitialAttribute.of(datasetDealFlow.processDefinition, process),
+          ],
+          requestId: flowId,
+        }),
+      );
+      await client.waitForStepCompletion(
+        flowId,
+        StepExecutionId.of(datasetDealFlow.initialize.getStepType()),
+        INITIALIZATION_TIMEOUT_MS,
+      );
+      response.status(201).json({ flowID: flowId, runID: runId });
+    } catch (failure) {
+      if (failure instanceof TypeError) {
+        response.status(400).json({ error: failure.message });
+        return;
+      }
+      throw failure;
+    }
+  });
+
+  router.post("/:flowId/trigger/:conditionName", async (request, response) => {
+    const flowId = request.params.flowId;
+    const conditionName = request.params.conditionName;
+    let process;
+    try {
+      process = await client.getAttribute(flowId, datasetDealFlow.processDefinition);
+    } catch (failure) {
+      if (failure instanceof DexError && failure.subStatus === ErrorSubStatus.FLOW_NOT_EXISTS) {
+        response.status(404).json({ error: `dataset deal ${flowId} was not found` });
+        return;
+      }
+      throw failure;
+    }
+    if (process === undefined) {
+      response.status(404).json({ error: `dataset deal ${flowId} was not found` });
+      return;
+    }
+    if (!hasCondition(process, conditionName)) {
+      response.status(400).json({ error: `condition ${conditionName} is not defined` });
+      return;
+    }
+    try {
+      const body = requireRecord(request.body, "request body");
+      const data = decodeStateData(body.data);
+      await client.publish(flowId, datasetDealFlow.conditionMessages, conditionName, data);
+      response.status(202).json({ flowID: flowId, conditionName });
+    } catch (failure) {
+      if (failure instanceof TypeError) {
+        response.status(400).json({ error: failure.message });
+        return;
+      }
+      throw failure;
+    }
+  });
+
+  return router;
+}
+
+function requireRecord(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError(`${field} is required`);
+  }
+  return value.trim();
+}

--- a/examples/typescript/src/main.ts
+++ b/examples/typescript/src/main.ts
@@ -23,6 +23,7 @@ import { Client, Worker, openBlobCache } from "@superdurable/dex";
 import { setClient } from "./client-holder.js";
 import { startCronSchedule } from "./config/cron-schedule-starter.js";
 import { loadEnv } from "./config/env.js";
+import { createDatasetDealRouter } from "./controller/dataset-deal-controller.js";
 import { createEngagementRouter } from "./controller/engagement-workflow-controller.js";
 import { createJobPostRouter } from "./controller/job-post-controller.js";
 import { createMicroserviceRouter } from "./controller/microservice-workflow-controller.js";
@@ -82,6 +83,7 @@ export async function startSampleServer(): Promise<SampleServer> {
 
   const app = express();
   app.use(express.json());
+  app.use("/dataset-deal", createDatasetDealRouter(client));
   app.use("/moneytransfer", createMoneyTransferRouter(client));
   app.use("/microservice", createMicroserviceRouter(client));
   app.use("/engagement", createEngagementRouter(client));

--- a/examples/typescript/src/registry.ts
+++ b/examples/typescript/src/registry.ts
@@ -35,6 +35,7 @@ import { requestReceiverFlow } from "./patterns/workflow/scalableparallel/reques
 import { storageFlow } from "./patterns/workflow/storage/storage-flow.js";
 import { flowGracefulTimeout } from "./patterns/workflow/timeout/flow-graceful-timeout.js";
 import { waitForStateCompletionFlow } from "./patterns/workflow/waitforstatecompletion/wait-for-state-completion-flow.js";
+import { datasetDealFlow } from "./workflow/datasetdeal/dataset-deal-flow.js";
 import { engagementFlow } from "./workflow/engagement/engagement-flow.js";
 import { jobPostFlow } from "./workflow/jobpost/job-post-flow.js";
 import { orchestrationFlow } from "./workflow/microservices/orchestration-flow.js";
@@ -46,6 +47,7 @@ import { userSignupFlow } from "./workflow/signup/user-signup-flow.js";
 import { subscriptionFlow } from "./workflow/subscription/subscription-flow.js";
 
 export const allExampleFlows: readonly Flow<any>[] = [
+  datasetDealFlow,
   moneyTransferFlow,
   orchestrationFlow,
   engagementFlow,
@@ -81,6 +83,7 @@ export function createExampleRegistry(): Registry {
 }
 
 export {
+  datasetDealFlow,
   moneyTransferFlow,
   orchestrationFlow,
   engagementFlow,

--- a/examples/typescript/src/workflow/datasetdeal/README.md
+++ b/examples/typescript/src/workflow/datasetdeal/README.md
@@ -1,0 +1,82 @@
+# Dataset deal DSL
+
+This is the TypeScript port of the Go dataset-deal workflow. Four fixed Steps
+interpret a seller-defined finite-state process:
+
+```text
+initialize → pre-condition → execute one action → post-condition
+                  ↑                  │                 │
+                  └──────────────────┴──── next state ─┘
+```
+
+Unlike the Go application, this example intentionally has no database or UI.
+The controller accepts the complete process definition when it starts a Flow.
+It passes the definition as an initial durable attribute; the initialize Step
+reads and validates that immutable execution snapshot.
+
+## Controller
+
+The controller exposes only start and trigger operations:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/dataset-deal/start` | Start a deal and wait for initialization |
+| `POST` | `/dataset-deal/:flowId/trigger/:conditionName` | Publish external condition data |
+
+Start request:
+
+```json
+{
+  "buyerId": "buyer-1",
+  "process": {
+    "processId": "dataset-deal-v1",
+    "initialState": "buyer-negotiation",
+    "initialStateData": {},
+    "states": [
+      {
+        "name": "buyer-negotiation",
+        "preActions": [],
+        "postActions": [],
+        "postCondition": {
+          "waitFor": {"name": "buyer-proposal"},
+          "decision": {"key": "", "cases": [], "elseState": "completed"}
+        }
+      },
+      {
+        "name": "completed",
+        "preActions": [],
+        "postActions": []
+      }
+    ]
+  }
+}
+```
+
+Trigger request:
+
+```json
+{
+  "data": {
+    "proposedSamplePrice": "10",
+    "proposedFullPrice": "100"
+  }
+}
+```
+
+The start response is returned only after `DatasetDealInitialize` completes.
+At that point `processDefinition`, `processID`, `buyerID`, and initial
+`stateData` are available to trigger requests.
+
+## Persistence and search
+
+Register these Temporal keyword search attributes before starting the example:
+
+- `ProcessID`
+- `BuyerID`
+- `CurrentState`
+- `PendingPreConditionState`
+- `PendingPreConditionName`
+
+The durable attributes and channel map match the Go workflow's naming contract.
+The built-in actions simulate transfers and deliveries by logging their input
+and merging their results into `stateData`.

--- a/examples/typescript/src/workflow/datasetdeal/actions.ts
+++ b/examples/typescript/src/workflow/datasetdeal/actions.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022-2026 Super Durable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { StateData } from "./models.js";
+
+export const DatasetDealAction = Object.freeze({
+  TRANSFER_MONEY_FROM_BUYER_TO_SELLER: "transferMoneyFromBuyerToSeller",
+  TRANSFER_MONEY_FROM_SELLER_TO_BUYER: "transferMoneyFromSellerToBuyer",
+  TRANSPORT_FULL_DATASET_TO_BUYER: "transportFullDatasetToBuyer",
+  TRANSPORT_SAMPLE_DATASET_TO_BUYER: "transportSampleDatasetToBuyer",
+} as const);
+
+export interface ActionInput {
+  readonly flowId: string;
+  readonly processId: string;
+  readonly buyerId: string;
+  readonly targetState: string;
+  readonly stateData: StateData;
+}
+
+type ActionHandler = (input: ActionInput) => StateData | Promise<StateData>;
+
+export class DatasetDealActions {
+  private readonly handlers: ReadonlyMap<string, ActionHandler>;
+
+  public constructor() {
+    this.handlers = new Map<string, ActionHandler>([
+      [
+        DatasetDealAction.TRANSFER_MONEY_FROM_BUYER_TO_SELLER,
+        transferMoneyFromBuyerToSeller,
+      ],
+      [
+        DatasetDealAction.TRANSFER_MONEY_FROM_SELLER_TO_BUYER,
+        transferMoneyFromSellerToBuyer,
+      ],
+      [DatasetDealAction.TRANSPORT_FULL_DATASET_TO_BUYER, transportFullDatasetToBuyer],
+      [DatasetDealAction.TRANSPORT_SAMPLE_DATASET_TO_BUYER, transportSampleDatasetToBuyer],
+    ]);
+  }
+
+  public availableNames(): readonly string[] {
+    return [...this.handlers.keys()].sort();
+  }
+
+  public async execute(name: string, input: ActionInput): Promise<StateData> {
+    const handler = this.handlers.get(name);
+    if (handler === undefined) {
+      throw new TypeError(`dataset deal action ${name} is not registered`);
+    }
+    return {
+      ...(await handler(input)),
+      lastAction: name,
+      lastActionStatus: "completed",
+    };
+  }
+}
+
+function transferMoneyFromBuyerToSeller(input: ActionInput): StateData {
+  console.info("dataset deal transferred money from buyer to seller", {
+    flowId: input.flowId,
+    buyerId: input.buyerId,
+    targetState: input.targetState,
+    samplePrice: input.stateData.proposedSamplePrice,
+    fullPrice: input.stateData.proposedFullPrice,
+  });
+  return {};
+}
+
+function transferMoneyFromSellerToBuyer(input: ActionInput): StateData {
+  console.info("dataset deal transferred refund from seller to buyer", {
+    flowId: input.flowId,
+    buyerId: input.buyerId,
+    refundPrice: input.stateData.proposedSampleRefundPrice,
+  });
+  return {};
+}
+
+function transportFullDatasetToBuyer(input: ActionInput): StateData {
+  console.info("dataset deal transported full dataset to buyer", {
+    flowId: input.flowId,
+    buyerId: input.buyerId,
+  });
+  return { deliveredDataset: "full" };
+}
+
+function transportSampleDatasetToBuyer(input: ActionInput): StateData {
+  console.info("dataset deal transported sample dataset to buyer", {
+    flowId: input.flowId,
+    buyerId: input.buyerId,
+  });
+  return { deliveredDataset: "sample" };
+}

--- a/examples/typescript/src/workflow/datasetdeal/comprehensive-process.ts
+++ b/examples/typescript/src/workflow/datasetdeal/comprehensive-process.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022-2026 Super Durable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DatasetDealAction } from "./actions.js";
+import type { DealProcess } from "./models.js";
+
+export function comprehensiveDealProcess(processId: string): DealProcess {
+  return {
+    processId,
+    initialState: "buyer-negotiation",
+    initialStateData: {
+      acceptedProposedPrice: "false",
+      proceedToFullDataset: "false",
+      proposedFullPrice: "",
+      proposedSamplePrice: "",
+      proposedSampleRefundPrice: "",
+    },
+    states: [
+      {
+        name: "buyer-negotiation",
+        preActions: [],
+        postActions: [],
+        postCondition: {
+          waitFor: { name: "buyer-proposal" },
+          decision: { key: "", cases: [], elseState: "seller-counteroffer" },
+        },
+      },
+      {
+        name: "seller-counteroffer",
+        preCondition: { name: "seller-price-response" },
+        preActions: [],
+        postActions: [],
+        postCondition: {
+          decision: {
+            key: "acceptedProposedPrice",
+            cases: [{ equals: "true", goToState: "process-sample-order" }],
+            elseState: "buyer-negotiation",
+          },
+        },
+      },
+      {
+        name: "process-sample-order",
+        preActions: [DatasetDealAction.TRANSFER_MONEY_FROM_BUYER_TO_SELLER],
+        postActions: [DatasetDealAction.TRANSPORT_SAMPLE_DATASET_TO_BUYER],
+        postCondition: {
+          decision: { key: "", cases: [], elseState: "wait-sample-feedback" },
+        },
+      },
+      {
+        name: "wait-sample-feedback",
+        preCondition: { name: "sample-feedback" },
+        preActions: [],
+        postActions: [],
+        postCondition: {
+          decision: {
+            key: "proceedToFullDataset",
+            cases: [{ equals: "true", goToState: "process-full-order" }],
+            elseState: "process-refund",
+          },
+        },
+      },
+      {
+        name: "process-full-order",
+        preActions: [DatasetDealAction.TRANSFER_MONEY_FROM_BUYER_TO_SELLER],
+        postActions: [DatasetDealAction.TRANSPORT_FULL_DATASET_TO_BUYER],
+      },
+      {
+        name: "process-refund",
+        preActions: [DatasetDealAction.TRANSFER_MONEY_FROM_SELLER_TO_BUYER],
+        postActions: [],
+      },
+    ],
+  };
+}

--- a/examples/typescript/src/workflow/datasetdeal/dataset-deal-flow.ts
+++ b/examples/typescript/src/workflow/datasetdeal/dataset-deal-flow.ts
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2022-2026 Super Durable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Attribute,
+  ChannelMap,
+  IndexType,
+  StepList,
+  Wait,
+  doubleCodec,
+  goTo,
+  gracefulComplete,
+  jsonCodec,
+  stringCodec,
+  type Context,
+  type Flow,
+  type PersistenceSchema,
+  type Step,
+  type StepDecision,
+} from "@superdurable/dex";
+
+import { DatasetDealActions } from "./actions.js";
+import {
+  decodeDealProcess,
+  decodeStateData,
+  stateByName,
+  validateDealProcess,
+  type ActionPhase,
+  type ActionStepInput,
+  type DealProcess,
+  type DecisionExpression,
+  type StateData,
+  type StateDefinition,
+  type StateStepInput,
+} from "./models.js";
+
+export const PROCESS_ID_SEARCH_KEY = "ProcessID";
+export const BUYER_ID_SEARCH_KEY = "BuyerID";
+export const CURRENT_STATE_SEARCH_KEY = "CurrentState";
+export const PENDING_PRE_CONDITION_STATE_SEARCH_KEY = "PendingPreConditionState";
+export const PENDING_PRE_CONDITION_NAME_SEARCH_KEY = "PendingPreConditionName";
+
+export const stateDataCodec = jsonCodec<StateData>({
+  typeName: "DatasetDealStateData",
+  decode: decodeStateData,
+});
+
+export const dealProcessCodec = jsonCodec<DealProcess>({
+  typeName: "DatasetDealProcess",
+  decode: decodeDealProcess,
+});
+
+const stateStepInputCodec = jsonCodec<StateStepInput>({
+  typeName: "DatasetDealStateStepInput",
+  decode(value) {
+    const input = value as Partial<StateStepInput>;
+    if (typeof input.stateName !== "string") {
+      throw new TypeError("stateName must be a string");
+    }
+    return { stateName: input.stateName };
+  },
+});
+
+const actionStepInputCodec = jsonCodec<ActionStepInput>({
+  typeName: "DatasetDealActionStepInput",
+  decode(value) {
+    const input = value as Partial<ActionStepInput>;
+    if (typeof input.stateName !== "string") {
+      throw new TypeError("stateName must be a string");
+    }
+    if (input.phase !== "pre" && input.phase !== "post") {
+      throw new TypeError("action phase must be pre or post");
+    }
+    return { stateName: input.stateName, phase: input.phase };
+  },
+});
+
+export class DatasetDealFlow implements Flow<string> {
+  public readonly stateData = new Attribute("stateData", stateDataCodec);
+  public readonly processDefinition = new Attribute("processDefinition", dealProcessCodec);
+  public readonly processId = new Attribute("processID", stringCodec, {
+    type: IndexType.KEYWORD,
+    indexKey: PROCESS_ID_SEARCH_KEY,
+  });
+  public readonly buyerId = new Attribute("buyerID", stringCodec, {
+    type: IndexType.KEYWORD,
+    indexKey: BUYER_ID_SEARCH_KEY,
+  });
+  public readonly currentState = new Attribute("currentState", stringCodec, {
+    type: IndexType.KEYWORD,
+    indexKey: CURRENT_STATE_SEARCH_KEY,
+  });
+  public readonly currentActionIndexToExecute = new Attribute(
+    "currentActionIndexToExecute",
+    doubleCodec,
+  );
+  public readonly pendingPreConditionState = new Attribute(
+    "pendingPreConditionState",
+    stringCodec,
+    {
+      type: IndexType.KEYWORD,
+      indexKey: PENDING_PRE_CONDITION_STATE_SEARCH_KEY,
+    },
+  );
+  public readonly pendingPreConditionName = new Attribute(
+    "pendingPreConditionName",
+    stringCodec,
+    {
+      type: IndexType.KEYWORD,
+      indexKey: PENDING_PRE_CONDITION_NAME_SEARCH_KEY,
+    },
+  );
+  public readonly conditionMessages = new ChannelMap("conditionMessages", stateDataCodec);
+
+  public readonly initialize = new Initialize(this);
+  public readonly preCondition = new PreCondition(this);
+  public readonly executeAction = new ExecuteAction(this);
+  public readonly postCondition = new PostConditionStep(this);
+
+  public constructor(public readonly actions: DatasetDealActions = new DatasetDealActions()) {}
+
+  public getFlowType(): string {
+    return "DatasetDealFlow";
+  }
+
+  public getSteps() {
+    return StepList.startStep(this.initialize).otherSteps(
+      this.preCondition,
+      this.executeAction,
+      this.postCondition,
+    );
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return {
+      attributes: [
+        this.stateData,
+        this.processDefinition,
+        this.processId,
+        this.buyerId,
+        this.currentState,
+        this.currentActionIndexToExecute,
+        this.pendingPreConditionState,
+        this.pendingPreConditionName,
+      ],
+      channels: [this.conditionMessages],
+    };
+  }
+}
+
+class Initialize implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public constructor(private readonly flow: DatasetDealFlow) {}
+
+  public getStepType(): string {
+    return "DatasetDealInitialize";
+  }
+
+  public execute(context: Context, processId: string): StepDecision {
+    const process = this.flow.processDefinition.get(context);
+    validateDealProcess(process, this.flow.actions.availableNames());
+    if (process.processId !== processId) {
+      throw new TypeError(
+        `process definition ${process.processId} does not match start input ${processId}`,
+      );
+    }
+    this.flow.buyerId.get(context);
+    this.flow.processId.set(context, processId);
+    this.flow.stateData.set(context, process.initialStateData);
+    this.flow.currentActionIndexToExecute.set(context, 0);
+    return goTo(this.flow.preCondition, { stateName: process.initialState });
+  }
+}
+
+class PreCondition implements Step<StateStepInput> {
+  public readonly inputCodec = stateStepInputCodec;
+
+  public constructor(private readonly flow: DatasetDealFlow) {}
+
+  public getStepType(): string {
+    return "DatasetDealPreCondition";
+  }
+
+  public waitFor(context: Context, input: StateStepInput): Wait {
+    const state = stateByName(this.flow.processDefinition.get(context), input.stateName);
+    if (state.preCondition === undefined) {
+      return Wait.skipImmediately();
+    }
+    this.flow.pendingPreConditionState.set(context, state.name);
+    this.flow.pendingPreConditionName.set(context, state.preCondition.name);
+    return Wait.allOf(this.flow.conditionMessages.forOne(state.preCondition.name));
+  }
+
+  public execute(context: Context, input: StateStepInput): StepDecision {
+    const state = stateByName(this.flow.processDefinition.get(context), input.stateName);
+    if (state.preCondition !== undefined) {
+      mergeStateData(
+        this.flow,
+        context,
+        conditionUpdates(this.flow, context, state.preCondition.name),
+      );
+      this.flow.pendingPreConditionState.delete(context);
+      this.flow.pendingPreConditionName.delete(context);
+    }
+    this.flow.currentActionIndexToExecute.set(context, 0);
+    if (state.preActions.length > 0) {
+      return goTo(this.flow.executeAction, { stateName: state.name, phase: "pre" });
+    }
+    return goToState(this.flow, context, state);
+  }
+}
+
+class ExecuteAction implements Step<ActionStepInput> {
+  public readonly inputCodec = actionStepInputCodec;
+
+  public constructor(private readonly flow: DatasetDealFlow) {}
+
+  public getStepType(): string {
+    return "DatasetDealExecuteAction";
+  }
+
+  public async execute(context: Context, input: ActionStepInput): Promise<StepDecision> {
+    const state = stateByName(this.flow.processDefinition.get(context), input.stateName);
+    const actions = actionsForPhase(state, input.phase);
+    const actionIndex = this.flow.currentActionIndexToExecute.get(context);
+    if (!Number.isInteger(actionIndex) || actionIndex < 0 || actionIndex >= actions.length) {
+      throw new RangeError(
+        `action index ${actionIndex} is invalid for ${input.phase} actions in state ${state.name}`,
+      );
+    }
+
+    const updates = await this.flow.actions.execute(actions[actionIndex]!, {
+      flowId: context.flowId,
+      processId: this.flow.processId.get(context),
+      buyerId: this.flow.buyerId.get(context),
+      targetState: state.name,
+      stateData: this.flow.stateData.get(context),
+    });
+    mergeStateData(this.flow, context, updates);
+
+    const nextActionIndex = actionIndex + 1;
+    this.flow.currentActionIndexToExecute.set(context, nextActionIndex);
+    if (nextActionIndex < actions.length) {
+      return goTo(this.flow.executeAction, input);
+    }
+    this.flow.currentActionIndexToExecute.set(context, 0);
+    if (input.phase === "pre") {
+      return goToState(this.flow, context, state);
+    }
+    return goTo(this.flow.postCondition, { stateName: state.name });
+  }
+}
+
+class PostConditionStep implements Step<StateStepInput> {
+  public readonly inputCodec = stateStepInputCodec;
+
+  public constructor(private readonly flow: DatasetDealFlow) {}
+
+  public getStepType(): string {
+    return "DatasetDealPostCondition";
+  }
+
+  public waitFor(context: Context, input: StateStepInput): Wait {
+    const state = stateByName(this.flow.processDefinition.get(context), input.stateName);
+    if (state.postCondition?.waitFor === undefined) {
+      return Wait.skipImmediately();
+    }
+    return Wait.allOf(this.flow.conditionMessages.forOne(state.postCondition.waitFor.name));
+  }
+
+  public execute(context: Context, input: StateStepInput): StepDecision {
+    const state = stateByName(this.flow.processDefinition.get(context), input.stateName);
+    if (state.postCondition === undefined) {
+      return gracefulComplete(this.flow.stateData.get(context));
+    }
+    if (state.postCondition.waitFor !== undefined) {
+      mergeStateData(
+        this.flow,
+        context,
+        conditionUpdates(this.flow, context, state.postCondition.waitFor.name),
+      );
+    }
+    const nextState = evaluateDecision(
+      state.postCondition.decision,
+      this.flow.stateData.get(context),
+    );
+    return goTo(this.flow.preCondition, { stateName: nextState });
+  }
+}
+
+function goToState(
+  flow: DatasetDealFlow,
+  context: Context,
+  state: StateDefinition,
+): StepDecision {
+  flow.currentState.set(context, state.name);
+  flow.currentActionIndexToExecute.set(context, 0);
+  if (state.postActions.length > 0) {
+    return goTo(flow.executeAction, { stateName: state.name, phase: "post" });
+  }
+  return goTo(flow.postCondition, { stateName: state.name });
+}
+
+function actionsForPhase(state: StateDefinition, phase: ActionPhase): readonly string[] {
+  if (phase === "pre") {
+    return state.preActions;
+  }
+  if (phase === "post") {
+    return state.postActions;
+  }
+  throw new TypeError(`unknown action phase ${phase}`);
+}
+
+function conditionUpdates(
+  flow: DatasetDealFlow,
+  context: Context,
+  conditionName: string,
+): StateData {
+  const results = flow.conditionMessages.results(context, conditionName);
+  if (results.length !== 1) {
+    throw new TypeError(
+      `condition ${conditionName} expected one message, received ${results.length}`,
+    );
+  }
+  return results[0]!;
+}
+
+function mergeStateData(flow: DatasetDealFlow, context: Context, updates: StateData): void {
+  for (const key of Object.keys(updates)) {
+    if (key.trim().length === 0) {
+      throw new TypeError("stateData update key must not be empty");
+    }
+  }
+  flow.stateData.set(context, { ...flow.stateData.get(context), ...updates });
+}
+
+function evaluateDecision(decision: DecisionExpression, stateData: StateData): string {
+  const value = stateData[decision.key];
+  return (
+    decision.cases.find((decisionCase) => decisionCase.equals === value)?.goToState ??
+    decision.elseState
+  );
+}
+
+export const datasetDealFlow = new DatasetDealFlow();

--- a/examples/typescript/src/workflow/datasetdeal/models.ts
+++ b/examples/typescript/src/workflow/datasetdeal/models.ts
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2022-2026 Super Durable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type StateData = Readonly<Record<string, string>>;
+
+export interface DealProcess {
+  readonly processId: string;
+  readonly initialState: string;
+  readonly initialStateData: StateData;
+  readonly states: readonly StateDefinition[];
+}
+
+export interface StateDefinition {
+  readonly name: string;
+  readonly preCondition?: ExternalCondition;
+  readonly preActions: readonly string[];
+  readonly postActions: readonly string[];
+  readonly postCondition?: PostCondition;
+}
+
+export interface ExternalCondition {
+  readonly name: string;
+}
+
+export interface PostCondition {
+  readonly waitFor?: ExternalCondition;
+  readonly decision: DecisionExpression;
+}
+
+export interface DecisionExpression {
+  readonly key: string;
+  readonly cases: readonly EqualCase[];
+  readonly elseState: string;
+}
+
+export interface EqualCase {
+  readonly equals: string;
+  readonly goToState: string;
+}
+
+export interface StateStepInput {
+  readonly stateName: string;
+}
+
+export type ActionPhase = "pre" | "post";
+
+export interface ActionStepInput extends StateStepInput {
+  readonly phase: ActionPhase;
+}
+
+const identifierPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export function decodeDealProcess(value: unknown): DealProcess {
+  const record = requireRecord(value, "deal process");
+  const states = requireArray(record.states, "states").map(decodeStateDefinition);
+  return {
+    processId: requireString(record.processId, "processId"),
+    initialState: requireString(record.initialState, "initialState"),
+    initialStateData: decodeStateData(record.initialStateData ?? {}),
+    states,
+  };
+}
+
+export function decodeStateData(value: unknown): StateData {
+  const record = requireRecord(value, "stateData");
+  return Object.fromEntries(
+    Object.entries(record).map(([key, entry]) => [key, requireString(entry, `stateData.${key}`)]),
+  );
+}
+
+export function validateDealProcess(
+  process: DealProcess,
+  availableActionNames: readonly string[],
+): void {
+  requireIdentifier("processId", process.processId);
+  if (process.states.length === 0) {
+    throw new TypeError("deal process requires at least one state");
+  }
+
+  const states = new Map<string, StateDefinition>();
+  for (const state of process.states) {
+    requireIdentifier("state name", state.name);
+    if (states.has(state.name)) {
+      throw new TypeError(`duplicate state ${state.name}`);
+    }
+    states.set(state.name, state);
+  }
+  if (!states.has(process.initialState)) {
+    throw new TypeError(`initial state ${process.initialState} is not defined`);
+  }
+
+  const conditions = new Map<string, string>();
+  const actions = new Set(availableActionNames);
+  for (const state of process.states) {
+    validateState(state, states, conditions, actions);
+  }
+  for (const key of Object.keys(process.initialStateData)) {
+    if (key.trim().length === 0) {
+      throw new TypeError("initial stateData keys must not be empty");
+    }
+  }
+}
+
+export function stateByName(process: DealProcess, name: string): StateDefinition {
+  const state = process.states.find((candidate) => candidate.name === name);
+  if (state === undefined) {
+    throw new TypeError(`state ${name} is not defined`);
+  }
+  return state;
+}
+
+export function hasCondition(process: DealProcess, name: string): boolean {
+  return process.states.some(
+    (state) => state.preCondition?.name === name || state.postCondition?.waitFor?.name === name,
+  );
+}
+
+function decodeStateDefinition(value: unknown): StateDefinition {
+  const record = requireRecord(value, "state");
+  return {
+    name: requireString(record.name, "state.name"),
+    ...(record.preCondition === undefined
+      ? {}
+      : { preCondition: decodeExternalCondition(record.preCondition) }),
+    preActions: decodeStringArray(record.preActions ?? [], "preActions"),
+    postActions: decodeStringArray(record.postActions ?? [], "postActions"),
+    ...(record.postCondition === undefined
+      ? {}
+      : { postCondition: decodePostCondition(record.postCondition) }),
+  };
+}
+
+function decodeExternalCondition(value: unknown): ExternalCondition {
+  const record = requireRecord(value, "external condition");
+  return { name: requireString(record.name, "condition.name") };
+}
+
+function decodePostCondition(value: unknown): PostCondition {
+  const record = requireRecord(value, "post condition");
+  return {
+    ...(record.waitFor === undefined
+      ? {}
+      : { waitFor: decodeExternalCondition(record.waitFor) }),
+    decision: decodeDecision(record.decision),
+  };
+}
+
+function decodeDecision(value: unknown): DecisionExpression {
+  const record = requireRecord(value, "decision");
+  return {
+    key: requireString(record.key ?? "", "decision.key"),
+    cases: requireArray(record.cases ?? [], "decision.cases").map(decodeEqualCase),
+    elseState: requireString(record.elseState, "decision.elseState"),
+  };
+}
+
+function decodeEqualCase(value: unknown): EqualCase {
+  const record = requireRecord(value, "decision case");
+  return {
+    equals: requireString(record.equals, "case.equals"),
+    goToState: requireString(record.goToState, "case.goToState"),
+  };
+}
+
+function validateState(
+  state: StateDefinition,
+  states: ReadonlyMap<string, StateDefinition>,
+  conditions: Map<string, string>,
+  actions: ReadonlySet<string>,
+): void {
+  if (state.preCondition !== undefined) {
+    validateCondition(state.name, state.preCondition, conditions);
+  }
+  for (const actionName of [...state.preActions, ...state.postActions]) {
+    if (!actions.has(actionName)) {
+      throw new TypeError(`state ${state.name}: action ${actionName} is not available`);
+    }
+  }
+  if (state.postCondition === undefined) {
+    return;
+  }
+  if (state.postCondition.waitFor !== undefined) {
+    validateCondition(state.name, state.postCondition.waitFor, conditions);
+  }
+  validateDecision(state.name, state.postCondition.decision, states);
+}
+
+function validateCondition(
+  stateName: string,
+  condition: ExternalCondition,
+  conditions: Map<string, string>,
+): void {
+  requireIdentifier("condition name", condition.name);
+  const existingState = conditions.get(condition.name);
+  if (existingState !== undefined) {
+    throw new TypeError(`condition ${condition.name} is already used by state ${existingState}`);
+  }
+  conditions.set(condition.name, stateName);
+}
+
+function validateDecision(
+  stateName: string,
+  decision: DecisionExpression,
+  states: ReadonlyMap<string, StateDefinition>,
+): void {
+  if (!states.has(decision.elseState)) {
+    throw new TypeError(`state ${stateName}: else state ${decision.elseState} is not defined`);
+  }
+  if (decision.cases.length === 0) {
+    return;
+  }
+  if (decision.key.trim().length === 0) {
+    throw new TypeError(`state ${stateName}: decision key is required when cases are defined`);
+  }
+  const values = new Set<string>();
+  for (const decisionCase of decision.cases) {
+    if (values.has(decisionCase.equals)) {
+      throw new TypeError(`state ${stateName}: duplicate equals value ${decisionCase.equals}`);
+    }
+    values.add(decisionCase.equals);
+    if (!states.has(decisionCase.goToState)) {
+      throw new TypeError(
+        `state ${stateName}: case state ${decisionCase.goToState} is not defined`,
+      );
+    }
+  }
+}
+
+function requireIdentifier(field: string, value: string): void {
+  if (!identifierPattern.test(value)) {
+    throw new TypeError(`${field} ${value} must match ${identifierPattern}`);
+  }
+}
+
+function requireRecord(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireArray(value: unknown, field: string): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${field} must be an array`);
+  }
+  return value;
+}
+
+function decodeStringArray(value: unknown, field: string): readonly string[] {
+  return requireArray(value, field).map((entry, index) =>
+    requireString(entry, `${field}[${index}]`),
+  );
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError(`${field} must be a string`);
+  }
+  return value;
+}

--- a/examples/typescript/test/e2e/all-routes.test.ts
+++ b/examples/typescript/test/e2e/all-routes.test.ts
@@ -20,6 +20,7 @@ import test from "node:test";
 
 import { loadEnv } from "../../src/config/env.js";
 import { startSampleServer, type SampleServer } from "../../src/main.js";
+import { comprehensiveDealProcess } from "../../src/workflow/datasetdeal/comprehensive-process.js";
 
 let server: SampleServer;
 let baseUrl: string;
@@ -109,6 +110,29 @@ test("product moneytransfer start", async () => {
   });
   requireOk(result, "moneytransfer/start");
   assert.ok((result.json as { flowID: string }).flowID);
+});
+
+test("product dataset deal start waits for initialization and triggers a condition", async () => {
+  const process = comprehensiveDealProcess(id("dataset-deal-process"));
+  const start = await post("/dataset-deal/start", {
+    process,
+    buyerId: id("dataset-deal-buyer"),
+  });
+  requireOk(start, "dataset-deal/start");
+  assert.equal(start.status, 201);
+  const { flowID, runID } = start.json as { flowID: string; runID: string };
+  assert.ok(flowID.length > 0);
+  assert.ok(runID.length > 0);
+
+  const trigger = await post(`/dataset-deal/${flowID}/trigger/buyer-proposal`, {
+    data: {
+      proposedSamplePrice: "10",
+      proposedFullPrice: "100",
+      proposedSampleRefundPrice: "5",
+    },
+  });
+  requireOk(trigger, "dataset-deal/trigger");
+  assert.equal(trigger.status, 202);
 });
 
 test("product microservice start swap signal", async () => {

--- a/examples/typescript/test/integ/dataset-deal.test.ts
+++ b/examples/typescript/test/integ/dataset-deal.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022-2026 Super Durable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { InitialAttribute, StepExecutionId } from "@superdurable/dex";
+
+import { DatasetDealAction } from "../../src/workflow/datasetdeal/actions.js";
+import { comprehensiveDealProcess } from "../../src/workflow/datasetdeal/comprehensive-process.js";
+import { stateDataCodec } from "../../src/workflow/datasetdeal/dataset-deal-flow.js";
+import {
+  acquireIntegEnvironment,
+  awaitCondition,
+  releaseIntegEnvironment,
+} from "./environment.js";
+
+test.before(async () => {
+  await acquireIntegEnvironment();
+});
+
+test.after(async () => {
+  await releaseIntegEnvironment();
+});
+
+test("dataset deal interprets the comprehensive process", async () => {
+  const environment = await acquireIntegEnvironment();
+  const flow = environment.datasetDealFlow;
+  const process = comprehensiveDealProcess(environment.newFlowId("dataset-deal-process"));
+  const flowId = environment.newFlowId(process.processId);
+  const buyerId = environment.newFlowId("dataset-deal-buyer");
+
+  const runId = await environment.client.startFlow(flow, flowId, process.processId, {
+    ...environment.startOptions(),
+    attributes: [
+      InitialAttribute.of(flow.buyerId, buyerId),
+      InitialAttribute.of(flow.processDefinition, process),
+    ],
+  });
+  assert.ok(runId.length > 0);
+  await environment.client.waitForStepCompletion(
+    flowId,
+    StepExecutionId.of(flow.initialize.getStepType()),
+    30_000,
+  );
+  assert.deepEqual(await environment.client.getAttribute(flowId, flow.processDefinition), process);
+  assert.equal(await environment.client.getAttribute(flowId, flow.buyerId), buyerId);
+
+  await waitForAttribute(environment, flowId, flow.currentState, "buyer-negotiation");
+  await environment.client.publish(flowId, flow.conditionMessages, "buyer-proposal", {
+    proposedSamplePrice: "10",
+    proposedFullPrice: "100",
+    proposedSampleRefundPrice: "5",
+  });
+  await waitForAttribute(
+    environment,
+    flowId,
+    flow.pendingPreConditionName,
+    "seller-price-response",
+  );
+  await environment.client.publish(flowId, flow.conditionMessages, "seller-price-response", {
+    acceptedProposedPrice: "false",
+  });
+
+  await waitForAttribute(environment, flowId, flow.currentState, "buyer-negotiation");
+  await environment.client.publish(flowId, flow.conditionMessages, "buyer-proposal", {
+    proposedSamplePrice: "11",
+    proposedFullPrice: "105",
+    proposedSampleRefundPrice: "5",
+  });
+  await waitForAttribute(
+    environment,
+    flowId,
+    flow.pendingPreConditionName,
+    "seller-price-response",
+  );
+  await environment.client.publish(flowId, flow.conditionMessages, "seller-price-response", {
+    acceptedProposedPrice: "true",
+  });
+  await waitForAttribute(environment, flowId, flow.pendingPreConditionName, "sample-feedback");
+  await environment.client.publish(flowId, flow.conditionMessages, "sample-feedback", {
+    proceedToFullDataset: "true",
+  });
+
+  const output = await environment.client.waitForFlow(flowId, stateDataCodec, 45_000);
+  assert.equal(output.deliveredDataset, "full");
+  assert.equal(output.lastAction, DatasetDealAction.TRANSPORT_FULL_DATASET_TO_BUYER);
+  assert.equal(output.lastActionStatus, "completed");
+  assert.equal(
+    await environment.client.getAttribute(flowId, flow.currentState),
+    "process-full-order",
+  );
+});
+
+async function waitForAttribute(
+  environment: Awaited<ReturnType<typeof acquireIntegEnvironment>>,
+  flowId: string,
+  attribute: typeof environment.datasetDealFlow.currentState,
+  expected: string,
+): Promise<void> {
+  await awaitCondition(
+    () => environment.client.getAttribute(flowId, attribute),
+    (value) => value === expected,
+    15_000,
+    `attribute ${attribute.name} did not become ${expected}`,
+  );
+}

--- a/examples/typescript/test/integ/environment.ts
+++ b/examples/typescript/test/integ/environment.ts
@@ -23,6 +23,7 @@ import { join } from "node:path";
 import { Client, Registry, Worker, openBlobCache, type Flow } from "@superdurable/dex";
 
 import { HOUR_MS } from "../../src/config/env.js";
+import { datasetDealFlow } from "../../src/workflow/datasetdeal/dataset-deal-flow.js";
 import { engagementFlow } from "../../src/workflow/engagement/engagement-flow.js";
 import { orchestrationFlow } from "../../src/workflow/microservices/orchestration-flow.js";
 import { moneyTransferFlow } from "../../src/workflow/money/transfer/money-transfer-flow.js";
@@ -31,6 +32,7 @@ import { subscriptionFlow } from "../../src/workflow/subscription/subscription-f
 
 export interface IntegEnvironment {
   readonly client: Client;
+  readonly datasetDealFlow: typeof datasetDealFlow;
   readonly moneyTransferFlow: typeof moneyTransferFlow;
   readonly engagementFlow: typeof engagementFlow;
   readonly orchestrationFlow: typeof orchestrationFlow;
@@ -63,6 +65,7 @@ export async function releaseIntegEnvironment(): Promise<void> {
 async function startIntegEnvironment(): Promise<IntegEnvironment> {
   const serverAddress = process.env.DEX_FLOW_SERVICE_ADDRESS ?? "127.0.0.1:8801";
   const flows: readonly Flow<any>[] = [
+    datasetDealFlow,
     moneyTransferFlow,
     engagementFlow,
     orchestrationFlow,
@@ -86,6 +89,7 @@ async function startIntegEnvironment(): Promise<IntegEnvironment> {
   });
   return {
     client,
+    datasetDealFlow,
     moneyTransferFlow,
     engagementFlow,
     orchestrationFlow,

--- a/sdk-typescript/src/worker-dispatcher.ts
+++ b/sdk-typescript/src/worker-dispatcher.ts
@@ -180,7 +180,13 @@ export class WorkerDispatcher {
       request.conditionResults,
       values.slice(offset),
     );
-    return { ...request, attributes, stepExeLocals, conditionResults };
+    return {
+      ...request,
+      stepInput: values[0],
+      attributes,
+      stepExeLocals,
+      conditionResults,
+    };
   }
 
   private async hydrateRPC(request: InvokeWorkerRPCRequest): Promise<InvokeWorkerRPCRequest> {

--- a/sdk-typescript/test/integ/basic.integration.test.ts
+++ b/sdk-typescript/test/integ/basic.integration.test.ts
@@ -104,6 +104,15 @@ test("model input is serialized and invalid runtime input is rejected", async ()
   });
 });
 
+test("blob-backed model input is hydrated before execute", async () => {
+  const flow = new ModelInputFlow();
+  await withEnvironment([flow], async ({ client }) => {
+    const id = flowId("blob-backed-model-input");
+    await client.startFlow(flow, id, { value: 10, payload: "large-input".repeat(1_000) });
+    assert.equal(await client.waitForFlow(id, doubleCodec, 30_000), 10);
+  });
+});
+
 test("Flow config override survives Continue-As-New", async () => {
   const flow = new BasicFlow();
   await withEnvironment([flow], async ({ client }) => {

--- a/sdk-typescript/test/integ/shared.ts
+++ b/sdk-typescript/test/integ/shared.ts
@@ -19,6 +19,7 @@ import {
 
 export interface ModelInput {
   value: number;
+  payload?: string;
 }
 
 export const modelInputCodec = jsonCodec<ModelInput>({


### PR DESCRIPTION
## Summary

- port the Go dataset-deal workflow and comprehensive process DSL to the TypeScript examples
- add a controller for starting deals, waiting for initialization, and triggering named conditions
- add integration and HTTP route coverage for the complete dataset-deal path
- hydrate blob-backed Step inputs before dispatching them to TypeScript user code

## User impact

The TypeScript example now demonstrates a realistic multi-party workflow with typed process definitions, condition-driven transitions, durable state, and controller endpoints. The start endpoint waits for the initialization Step to complete before returning, so callers can safely trigger subsequent conditions.

## Validation

- `cd sdk-typescript && npm run typecheck && npm run build && npm test`
- `cd sdk-typescript && DEX_SERVER_ADDRESS=127.0.0.1:38801 node --test --test-concurrency=1 dist/test/integ/basic.integration.test.js`
- `cd examples/typescript && npm run typecheck && npm test`
- `cd examples/typescript && DEX_FLOW_SERVICE_ADDRESS=127.0.0.1:38801 node --test --test-concurrency=1 dist/test/integ/dataset-deal.test.js`
- `make copyright-check`
