### PR TITLE
Add single-condition wait syntax to SDKs

### DIFF
--- a/.github/workflows/examples-go-ci.yml
+++ b/.github/workflows/examples-go-ci.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - "examples/go/**"
+      - "sdk-go/**"
       - "cli/**"
       - ".github/workflows/examples-go-ci.yml"
   pull_request:
     paths:
       - "examples/go/**"
+      - "sdk-go/**"
       - "cli/**"
       - ".github/workflows/examples-go-ci.yml"
   workflow_dispatch:
@@ -26,7 +28,9 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: examples/go/go.mod
-          cache-dependency-path: examples/go/go.sum
+          cache-dependency-path: |
+            examples/go/go.sum
+            sdk-go/go.sum
       - name: Verify released SDK dependency
         env:
           GOWORK: "off"
@@ -48,6 +52,8 @@ jobs:
             echo "::error::$module resolves to $resolved_version, expected $required_version"
             exit 1
           fi
+      - name: Use checkout SDK
+        run: go mod edit -replace github.com/superdurable/dex/sdk-go=../../sdk-go
       - name: Build
         env:
           GOWORK: "off"
@@ -68,7 +74,9 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: examples/go/go.mod
-          cache-dependency-path: examples/go/go.sum
+          cache-dependency-path: |
+            examples/go/go.sum
+            sdk-go/go.sum
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -76,6 +84,8 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - name: Install Temporal CLI runtime for dexcli dev
         uses: temporalio/setup-temporal@v0
+      - name: Use checkout SDK
+        run: go mod edit -replace github.com/superdurable/dex/sdk-go=../../sdk-go
       - name: End-to-end tests
         run: make e2eTests
       - name: Upload service logs

--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -2030,6 +2030,7 @@ type ConditionOption interface {
 }
 
 func SkipWaitImmediately() *Wait
+func Until(condition Condition) *Wait
 func AllOf(conditions ...Condition) *Wait
 func AnyOf(conditions ...Condition) *Wait
 func Combo(conditions ...Condition) ConditionCombination

--- a/examples/go/workflows/datasetdeal/workflow.go
+++ b/examples/go/workflows/datasetdeal/workflow.go
@@ -171,7 +171,7 @@ func (step preConditionStep) WaitFor(
 	if err := PendingPreConditionName.Set(ctx, state.PreCondition.Name); err != nil {
 		return nil, err
 	}
-	return dex.AllOf(ConditionMessages.ForOne(state.PreCondition.Name)), nil
+	return dex.Until(ConditionMessages.ForOne(state.PreCondition.Name)), nil
 }
 
 func (step preConditionStep) Execute(
@@ -308,7 +308,7 @@ func (step postConditionStep) WaitFor(
 	if state.PostCondition == nil || state.PostCondition.WaitFor == nil {
 		return dex.SkipWaitImmediately(), nil
 	}
-	return dex.AllOf(ConditionMessages.ForOne(state.PostCondition.WaitFor.Name)), nil
+	return dex.Until(ConditionMessages.ForOne(state.PostCondition.WaitFor.Name)), nil
 }
 
 func (step postConditionStep) Execute(

--- a/examples/go/workflows/jobpost/workflow.go
+++ b/examples/go/workflows/jobpost/workflow.go
@@ -31,11 +31,11 @@ import (
 var (
 	Title = dex.DefineAttribute[string](
 		"Title",
-		dex.Indexed(dex.AttributeIndex{Type: dex.IndexText}),
+		dex.Indexed(dex.AttributeIndex{Type: dex.IndexFullText}),
 	)
 	JobDescription = dex.DefineAttribute[string](
 		"JobDescription",
-		dex.Indexed(dex.AttributeIndex{Type: dex.IndexText}),
+		dex.Indexed(dex.AttributeIndex{Type: dex.IndexFullText}),
 	)
 	LastUpdateTimeMillis = dex.DefineAttribute[int64](
 		"LastUpdateTimeMillis",

--- a/examples/go/workflows/patterns/drainchannels/draininternal/workflow.go
+++ b/examples/go/workflows/patterns/drainchannels/draininternal/workflow.go
@@ -92,7 +92,7 @@ func (upsertMongoRecordStep) WaitFor(
 	ctx dex.Context,
 	_ dex.None,
 ) (*dex.Wait, error) {
-	return dex.AnyOf(UpsertMongoData.ForOne()), nil
+	return dex.Until(UpsertMongoData.ForOne()), nil
 }
 
 func (step upsertMongoRecordStep) Execute(

--- a/examples/go/workflows/patterns/drainchannels/signal/workflow.go
+++ b/examples/go/workflows/patterns/drainchannels/signal/workflow.go
@@ -60,7 +60,7 @@ func (processSignalStep) WaitFor(
 	input string,
 ) (*dex.Wait, error) {
 	if input == "" {
-		return dex.AnyOf(QueueSignalChannel.ForOne()), nil
+		return dex.Until(QueueSignalChannel.ForOne()), nil
 	}
 	return dex.SkipWaitImmediately(), nil
 }

--- a/examples/go/workflows/patterns/interruptible/workflow.go
+++ b/examples/go/workflows/patterns/interruptible/workflow.go
@@ -91,7 +91,7 @@ func (workAExecutionStep) WaitFor(
 	ctx dex.Context,
 	input WorkJobParametersInput,
 ) (*dex.Wait, error) {
-	return dex.AnyOf(dex.Timer(1500 * time.Millisecond)), nil
+	return dex.Until(dex.Timer(1500 * time.Millisecond)), nil
 }
 
 func (workAExecutionStep) Execute(
@@ -128,7 +128,7 @@ func (workNExecutionStep) WaitFor(
 	ctx dex.Context,
 	input WorkJobParametersInput,
 ) (*dex.Wait, error) {
-	return dex.AnyOf(dex.Timer(3 * time.Second)), nil
+	return dex.Until(dex.Timer(3 * time.Second)), nil
 }
 
 func (workNExecutionStep) Execute(

--- a/examples/go/workflows/patterns/intervention/workflow.go
+++ b/examples/go/workflows/patterns/intervention/workflow.go
@@ -89,7 +89,7 @@ func (getDataStep) WaitFor(
 	isRetry bool,
 ) (*dex.Wait, error) {
 	fmt.Println("Waiting for incoming data")
-	return dex.AllOf(DataChannel.ForOne()), nil
+	return dex.Until(DataChannel.ForOne()), nil
 }
 
 func (getDataStep) Execute(

--- a/examples/go/workflows/patterns/parallel/await.go
+++ b/examples/go/workflows/patterns/parallel/await.go
@@ -112,7 +112,7 @@ func (awaitAllUsersNotifiedStep) WaitFor(
 	_ dex.Context,
 	countOfJobSeekers int,
 ) (*dex.Wait, error) {
-	return dex.AllOf(NotifyChannel.ForN(countOfJobSeekers)), nil
+	return dex.Until(NotifyChannel.ForN(countOfJobSeekers)), nil
 }
 
 func (awaitAllUsersNotifiedStep) Execute(

--- a/examples/go/workflows/patterns/parentchild/child.go
+++ b/examples/go/workflows/patterns/parentchild/child.go
@@ -55,7 +55,7 @@ func (childProcessingStep) WaitFor(
 	input string,
 ) (*dex.Wait, error) {
 	delay := time.Duration(rand.Intn(5)) * time.Second
-	return dex.AnyOf(dex.Timer(delay)), nil
+	return dex.Until(dex.Timer(delay)), nil
 }
 
 func (childProcessingStep) Execute(

--- a/examples/go/workflows/patterns/parentchild/parent.go
+++ b/examples/go/workflows/patterns/parentchild/parent.go
@@ -100,7 +100,7 @@ func (loopForNextTaskStep) WaitFor(
 	ctx dex.Context,
 	_ dex.None,
 ) (*dex.Wait, error) {
-	return dex.AnyOf(TaskQueue.ForOne()), nil
+	return dex.Until(TaskQueue.ForOne()), nil
 }
 
 func (loopForNextTaskStep) Execute(
@@ -160,7 +160,7 @@ func (awaitChildWorkflowCompletionStep) WaitFor(
 	_ dex.Context,
 	input WaitForChildInput,
 ) (*dex.Wait, error) {
-	return dex.AnyOf(dex.Timer(time.Duration(input.TimerSeconds) * time.Second)), nil
+	return dex.Until(dex.Timer(time.Duration(input.TimerSeconds) * time.Second)), nil
 }
 
 func (step awaitChildWorkflowCompletionStep) Execute(

--- a/examples/go/workflows/patterns/polling/simple.go
+++ b/examples/go/workflows/patterns/polling/simple.go
@@ -54,7 +54,7 @@ func (simplePollingStep) WaitFor(
 	ctx dex.Context,
 	_ dex.None,
 ) (*dex.Wait, error) {
-	return dex.AnyOf(dex.Timer(10 * time.Second)), nil
+	return dex.Until(dex.Timer(10 * time.Second)), nil
 }
 
 func (simplePollingStep) Execute(

--- a/examples/go/workflows/patterns/scalableparallel/child.go
+++ b/examples/go/workflows/patterns/scalableparallel/child.go
@@ -73,7 +73,7 @@ func (processingStep) WaitFor(
 	input string,
 ) (*dex.Wait, error) {
 	delay := time.Duration(rand.Intn(60)) * time.Second
-	return dex.AnyOf(dex.Timer(delay)), nil
+	return dex.Until(dex.Timer(delay)), nil
 }
 
 func (step processingStep) Execute(

--- a/examples/go/workflows/patterns/timeout/workflow.go
+++ b/examples/go/workflows/patterns/timeout/workflow.go
@@ -68,7 +68,7 @@ func (timeoutStep) WaitFor(
 	ctx dex.Context,
 	_ dex.None,
 ) (*dex.Wait, error) {
-	return dex.AnyOf(dex.Timer(time.Minute)), nil
+	return dex.Until(dex.Timer(time.Minute)), nil
 }
 
 func (timeoutStep) Execute(
@@ -89,7 +89,7 @@ func (taskStep) WaitFor(
 	if workflowSuccessful {
 		return dex.SkipWaitImmediately(), nil
 	}
-	return dex.AnyOf(dex.Timer(65 * time.Second)), nil
+	return dex.Until(dex.Timer(65 * time.Second)), nil
 }
 
 func (taskStep) Execute(

--- a/examples/go/workflows/polling/workflow.go
+++ b/examples/go/workflows/polling/workflow.go
@@ -110,7 +110,7 @@ func (pollStep) WaitFor(
 	dex.Context,
 	int,
 ) (*dex.Wait, error) {
-	return dex.AnyOf(dex.Timer(time.Second)), nil
+	return dex.Until(dex.Timer(time.Second)), nil
 }
 
 func (step pollStep) Execute(

--- a/examples/go/workflows/subscription/workflow.go
+++ b/examples/go/workflows/subscription/workflow.go
@@ -184,7 +184,7 @@ func (cancelStep) WaitFor(
 	dex.Context,
 	dex.None,
 ) (*dex.Wait, error) {
-	return dex.AllOf(CancelSubscription.ForOne()), nil
+	return dex.Until(CancelSubscription.ForOne()), nil
 }
 
 func (step cancelStep) Execute(
@@ -206,7 +206,7 @@ func (updateChargeAmountStep) WaitFor(
 	dex.Context,
 	dex.None,
 ) (*dex.Wait, error) {
-	return dex.AllOf(UpdateChargeAmount.ForOne()), nil
+	return dex.Until(UpdateChargeAmount.ForOne()), nil
 }
 
 func (updateChargeAmountStep) Execute(
@@ -245,7 +245,7 @@ func waitForTrial(
 ) *dex.Wait {
 	// send welcome email
 	applicationService.SendEmail(customer.Email, "welcome email", "hello content")
-	return dex.AllOf(dex.Timer(customer.Subscription.TrialPeriod))
+	return dex.Until(dex.Timer(customer.Subscription.TrialPeriod))
 }
 
 func executeTrial() *dex.StepDecision {
@@ -256,7 +256,7 @@ func waitForCharge(customer Customer, periodNumber int) (*dex.Wait, bool) {
 	if periodNumber >= customer.Subscription.MaxBillingPeriods {
 		return dex.SkipWaitImmediately(), true
 	}
-	return dex.AllOf(dex.Timer(customer.Subscription.BillingPeriod)), false
+	return dex.Until(dex.Timer(customer.Subscription.BillingPeriod)), false
 }
 
 func executeCharge(

--- a/examples/go/workflows/subscription/workflow_test.go
+++ b/examples/go/workflows/subscription/workflow_test.go
@@ -56,7 +56,7 @@ func TestWaitForTrial(t *testing.T) {
 
 	wait := waitForTrial(testCustomer, applicationService)
 
-	require.Equal(t, dex.AllOf(dex.Timer(testCustomer.Subscription.TrialPeriod)), wait)
+	require.Equal(t, dex.Until(dex.Timer(testCustomer.Subscription.TrialPeriod)), wait)
 	require.Equal(t, []recordedEmail{{
 		recipient: testCustomer.Email,
 		subject:   "welcome email",
@@ -75,7 +75,7 @@ func TestWaitForCharge(t *testing.T) {
 		wait, subscriptionOver := waitForCharge(testCustomer, 0)
 
 		require.False(t, subscriptionOver)
-		require.Equal(t, dex.AllOf(dex.Timer(testCustomer.Subscription.BillingPeriod)), wait)
+		require.Equal(t, dex.Until(dex.Timer(testCustomer.Subscription.BillingPeriod)), wait)
 	})
 
 	t.Run("completed subscription", func(t *testing.T) {
@@ -124,7 +124,7 @@ func TestCancelSubscription(t *testing.T) {
 
 	wait, err := (cancelStep{}).WaitFor(nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, dex.AllOf(CancelSubscription.ForOne()), wait)
+	require.Equal(t, dex.Until(CancelSubscription.ForOne()), wait)
 
 	decision := executeCancel(testCustomer, applicationService)
 	require.Equal(t, []recordedEmail{{
@@ -138,7 +138,7 @@ func TestCancelSubscription(t *testing.T) {
 func TestUpdateChargeAmount(t *testing.T) {
 	wait, err := (updateChargeAmountStep{}).WaitFor(nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, dex.AllOf(UpdateChargeAmount.ForOne()), wait)
+	require.Equal(t, dex.Until(UpdateChargeAmount.ForOne()), wait)
 
 	updatedCustomer, decision, err := executeUpdateChargeAmount(testCustomer, []int{200})
 	require.NoError(t, err)

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/drainchannels/internal/DrainInternalChannelsFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/drainchannels/internal/DrainInternalChannelsFlow.java
@@ -90,7 +90,7 @@ public class DrainInternalChannelsFlow implements Flow<String> {
 
         @Override
         public Wait waitFor(final Context context, final Void input) {
-            return Wait.anyOf(upsertMongoData.forOne());
+            return Wait.until(upsertMongoData.forOne());
         }
 
         @Override

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/drainchannels/signal/DrainSignalChannelsFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/drainchannels/signal/DrainSignalChannelsFlow.java
@@ -57,7 +57,7 @@ public class DrainSignalChannelsFlow implements Flow<String> {
         @Override
         public Wait waitFor(final Context context, final String input) {
             if (input == null) {
-                return Wait.anyOf(queueSignalChannel.forOne());
+                return Wait.until(queueSignalChannel.forOne());
             }
             return Wait.skipImmediately();
         }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/interruptible/InterruptibleExecutionFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/interruptible/InterruptibleExecutionFlow.java
@@ -80,7 +80,7 @@ public class InterruptibleExecutionFlow implements Flow<Void> {
 
         @Override
         public Wait waitFor(final Context context, final WorkJobParametersInput input) {
-            return Wait.anyOf(Timer.byDuration(Duration.ofMillis(1500)));
+            return Wait.until(Timer.byDuration(Duration.ofMillis(1500)));
         }
 
         @Override
@@ -117,7 +117,7 @@ public class InterruptibleExecutionFlow implements Flow<Void> {
 
         @Override
         public Wait waitFor(final Context context, final WorkJobParametersInput input) {
-            return Wait.anyOf(Timer.byDuration(Duration.ofSeconds(3)));
+            return Wait.until(Timer.byDuration(Duration.ofSeconds(3)));
         }
 
         @Override

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/intervention/ManualInterventionFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/intervention/ManualInterventionFlow.java
@@ -85,7 +85,7 @@ public class ManualInterventionFlow implements Flow<Void> {
         @Override
         public Wait waitFor(final Context context, final Boolean isRetry) {
             System.out.println("Waiting for incoming data");
-            return Wait.allOf(dataChannel.forOne());
+            return Wait.until(dataChannel.forOne());
         }
 
         @Override

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/parallel/ParallelStatesWithAwaitFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/parallel/ParallelStatesWithAwaitFlow.java
@@ -101,7 +101,7 @@ public class ParallelStatesWithAwaitFlow implements Flow<Integer> {
 
         @Override
         public Wait waitFor(final Context context, final Integer countOfJobSeekers) {
-            return Wait.allOf(notifyChannel.forN(countOfJobSeekers));
+            return Wait.until(notifyChannel.forN(countOfJobSeekers));
         }
 
         @Override

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/parentchild/ParentFlowV2.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/parentchild/ParentFlowV2.java
@@ -107,7 +107,7 @@ public class ParentFlowV2 implements Flow<Integer> {
 
         @Override
         public Wait waitFor(final Context context, final Void input) {
-            return Wait.anyOf(taskQueue.forOne());
+            return Wait.until(taskQueue.forOne());
         }
 
         @Override
@@ -153,7 +153,7 @@ public class ParentFlowV2 implements Flow<Integer> {
 
         @Override
         public Wait waitFor(final Context context, final WaitForChildInput input) {
-            return Wait.anyOf(Timer.byDuration(Duration.ofSeconds(input.timerSeconds)));
+            return Wait.until(Timer.byDuration(Duration.ofSeconds(input.timerSeconds)));
         }
 
         @Override

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/polling/SimplePollingFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/polling/SimplePollingFlow.java
@@ -51,7 +51,7 @@ public class SimplePollingFlow implements Flow<Void> {
 
         @Override
         public Wait waitFor(final Context context, final Void input) {
-            return Wait.anyOf(Timer.byDuration(Duration.ofSeconds(10)));
+            return Wait.until(Timer.byDuration(Duration.ofSeconds(10)));
         }
 
         @Override

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/scalableparallel/ChildFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/scalableparallel/ChildFlow.java
@@ -71,7 +71,7 @@ public class ChildFlow implements Flow<String> {
         @Override
         public Wait waitFor(final Context context, final String input) {
             final int random = new Random().nextInt(60);
-            return Wait.anyOf(Timer.byDuration(Duration.ofSeconds(random)));
+            return Wait.until(Timer.byDuration(Duration.ofSeconds(random)));
         }
 
         @Override

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/timeout/FlowGracefulTimeout.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/workflow/timeout/FlowGracefulTimeout.java
@@ -67,7 +67,7 @@ public class FlowGracefulTimeout implements Flow<Boolean> {
 
         @Override
         public Wait waitFor(final Context context, final Void input) {
-            return Wait.anyOf(Timer.byDuration(Duration.ofMinutes(1)));
+            return Wait.until(Timer.byDuration(Duration.ofMinutes(1)));
         }
 
         @Override
@@ -87,7 +87,7 @@ public class FlowGracefulTimeout implements Flow<Boolean> {
             if (workflowSuccessful) {
                 return Wait.skipImmediately();
             }
-            return Wait.anyOf(Timer.byDuration(Duration.ofSeconds(65)));
+            return Wait.until(Timer.byDuration(Duration.ofSeconds(65)));
         }
 
         @Override

--- a/examples/java/src/main/java/io/superdurable/dex/workflow/polling/PollingFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/workflow/polling/PollingFlow.java
@@ -110,7 +110,7 @@ public class PollingFlow implements Flow<Integer> {
 
         @Override
         public Wait waitFor(final Context context, final Integer maximumPolls) {
-            return Wait.anyOf(Timer.byDuration(Duration.ofSeconds(1)));
+            return Wait.until(Timer.byDuration(Duration.ofSeconds(1)));
         }
 
         @Override

--- a/examples/java/src/main/java/io/superdurable/dex/workflow/subscription/SubscriptionFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/workflow/subscription/SubscriptionFlow.java
@@ -104,7 +104,7 @@ public class SubscriptionFlow implements Flow<Customer> {
         public Wait waitFor(final Context context, final Void input) {
             final Customer customer = customerDetails.get(context);
             SubscriptionBilling.sendWelcomeEmail(customer, service);
-            return Wait.allOf(Timer.byDuration(SubscriptionBilling.trialPeriod(customer)));
+            return Wait.until(Timer.byDuration(SubscriptionBilling.trialPeriod(customer)));
         }
 
         @Override
@@ -129,7 +129,7 @@ public class SubscriptionFlow implements Flow<Customer> {
                 return Wait.skipImmediately();
             }
             billingPeriodNumber.set(context, periodNumber + 1);
-            return Wait.allOf(Timer.byDuration(SubscriptionBilling.billingPeriod(customer)));
+            return Wait.until(Timer.byDuration(SubscriptionBilling.billingPeriod(customer)));
         }
 
         @Override
@@ -155,7 +155,7 @@ public class SubscriptionFlow implements Flow<Customer> {
 
         @Override
         public Wait waitFor(final Context context, final Void input) {
-            return Wait.allOf(cancelSubscription.forOne());
+            return Wait.until(cancelSubscription.forOne());
         }
 
         @Override
@@ -174,7 +174,7 @@ public class SubscriptionFlow implements Flow<Customer> {
 
         @Override
         public Wait waitFor(final Context context, final Void input) {
-            return Wait.allOf(updateChargeAmount.forOne());
+            return Wait.until(updateChargeAmount.forOne());
         }
 
         @Override

--- a/examples/python/dex_examples/ai_agent_email/ai_agent_flow.py
+++ b/examples/python/dex_examples/ai_agent_email/ai_agent_flow.py
@@ -152,7 +152,7 @@ class Agent(Step[None]):
     def wait_for(self, context: Context, input: None) -> Wait:
         del input
         self.flow.status.set(context, STATUS_WAITING)
-        return Wait.any_of(self.flow.user_input.for_one())
+        return Wait.until(self.flow.user_input.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del input

--- a/examples/python/dex_examples/patterns/workflow/drainchannels/internal/drain_internal_channels_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/drainchannels/internal/drain_internal_channels_flow.py
@@ -95,7 +95,7 @@ class UpsertMongoRecord(Step[None]):
 
     def wait_for(self, context: Context, input: None) -> Wait:
         del context, input
-        return Wait.any_of(self.upsert_mongo_data.for_one())
+        return Wait.until(self.upsert_mongo_data.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del input

--- a/examples/python/dex_examples/patterns/workflow/drainchannels/signal/drain_signal_channels_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/drainchannels/signal/drain_signal_channels_flow.py
@@ -39,7 +39,7 @@ class ProcessSignal(Step[str]):
     def wait_for(self, context: Context, input: str) -> Wait:
         del context
         if input is None:
-            return Wait.any_of(self.queue_signal_channel.for_one())
+            return Wait.until(self.queue_signal_channel.for_one())
         return Wait.skip_immediately()
 
     async def execute(  # type: ignore[override]

--- a/examples/python/dex_examples/patterns/workflow/interruptible/interruptible_execution_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/interruptible/interruptible_execution_flow.py
@@ -46,7 +46,7 @@ class WorkAExecution(Step[WorkJobParametersInput]):
 
     def wait_for(self, context: Context, input: WorkJobParametersInput) -> Wait:
         del context, input
-        return Wait.any_of(Timer.by_duration(timedelta(seconds=2)))
+        return Wait.until(Timer.by_duration(timedelta(seconds=2)))
 
     def execute(
         self,
@@ -77,7 +77,7 @@ class WorkNExecution(Step[WorkJobParametersInput]):
 
     def wait_for(self, context: Context, input: WorkJobParametersInput) -> Wait:
         del context, input
-        return Wait.any_of(Timer.by_duration(timedelta(seconds=3)))
+        return Wait.until(Timer.by_duration(timedelta(seconds=3)))
 
     def execute(
         self,

--- a/examples/python/dex_examples/patterns/workflow/intervention/manual_intervention_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/intervention/manual_intervention_flow.py
@@ -59,7 +59,7 @@ class GetData(Step[bool]):
     def wait_for(self, context: Context, input: bool) -> Wait:
         del context, input
         print("Waiting for incoming data")
-        return Wait.all_of(self.data_channel.for_one())
+        return Wait.until(self.data_channel.for_one())
 
     def execute(self, context: Context, input: bool) -> StepDecision:
         if input:

--- a/examples/python/dex_examples/patterns/workflow/parallel/parallel_states_with_await_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/parallel/parallel_states_with_await_flow.py
@@ -58,7 +58,7 @@ class AwaitAllUsersNotified(Step[int]):
 
     def wait_for(self, context: Context, input: int) -> Wait:
         del context
-        return Wait.all_of(self.notify_channel.for_n(input))
+        return Wait.until(self.notify_channel.for_n(input))
 
     def execute(self, context: Context, input: int) -> StepDecision:
         context.record_event(

--- a/examples/python/dex_examples/patterns/workflow/parentchild/parent_flow_v2.py
+++ b/examples/python/dex_examples/patterns/workflow/parentchild/parent_flow_v2.py
@@ -59,7 +59,7 @@ class AwaitChildWorkflowCompletion(Step[WaitForChildInput]):
 
     def wait_for(self, context: Context, input: WaitForChildInput) -> Wait:
         del context
-        return Wait.any_of(Timer.by_duration(timedelta(seconds=input.timer_seconds)))
+        return Wait.until(Timer.by_duration(timedelta(seconds=input.timer_seconds)))
 
     async def execute(  # type: ignore[override]
         self, context: Context, input: WaitForChildInput
@@ -126,7 +126,7 @@ class LoopForNextTask(Step[None]):
 
     def wait_for(self, context: Context, input: None) -> Wait:
         del context, input
-        return Wait.any_of(self.task_queue.for_one())
+        return Wait.until(self.task_queue.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del input

--- a/examples/python/dex_examples/patterns/workflow/polling/simple_polling_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/polling/simple_polling_flow.py
@@ -45,7 +45,7 @@ class SimplePolling(Step[None]):
 
     def wait_for(self, context: Context, input: None) -> Wait:
         del context, input
-        return Wait.any_of(Timer.by_duration(POLLING_INTERVAL))
+        return Wait.until(Timer.by_duration(POLLING_INTERVAL))
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input

--- a/examples/python/dex_examples/patterns/workflow/scalableparallel/child_flow.py
+++ b/examples/python/dex_examples/patterns/workflow/scalableparallel/child_flow.py
@@ -51,7 +51,7 @@ class Processing(Step[str]):
 
     def wait_for(self, context: Context, input: str) -> Wait:
         del context, input
-        return Wait.any_of(Timer.by_duration(timedelta(seconds=random.randint(1, 3))))
+        return Wait.until(Timer.by_duration(timedelta(seconds=random.randint(1, 3))))
 
     async def execute(  # type: ignore[override]
         self, context: Context, input: str

--- a/examples/python/dex_examples/patterns/workflow/timeout/flow_graceful_timeout.py
+++ b/examples/python/dex_examples/patterns/workflow/timeout/flow_graceful_timeout.py
@@ -38,7 +38,7 @@ SLOW_TASK_DURATION = timedelta(seconds=65)
 class Timeout(Step[None]):
     def wait_for(self, context: Context, input: None) -> Wait:
         del context, input
-        return Wait.any_of(Timer.by_duration(TIMEOUT_DURATION))
+        return Wait.until(Timer.by_duration(TIMEOUT_DURATION))
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
@@ -50,7 +50,7 @@ class Task(Step[bool]):
         del context
         if input:
             return Wait.skip_immediately()
-        return Wait.any_of(Timer.by_duration(SLOW_TASK_DURATION))
+        return Wait.until(Timer.by_duration(SLOW_TASK_DURATION))
 
     def execute(self, context: Context, input: bool) -> StepDecision:
         del context, input

--- a/examples/python/dex_examples/resourcecontrol/processing_flow.py
+++ b/examples/python/dex_examples/resourcecontrol/processing_flow.py
@@ -97,7 +97,7 @@ class GpuProcessingComplete(Step[None]):
 
     def wait_for(self, context: Context, input: None) -> Wait:
         del context, input
-        return Wait.any_of(Timer.by_duration(POLL_INTERVAL))
+        return Wait.until(Timer.by_duration(POLL_INTERVAL))
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del input
@@ -145,7 +145,7 @@ class ValidationComplete(Step[None]):
 
     def wait_for(self, context: Context, input: None) -> Wait:
         del context, input
-        return Wait.any_of(Timer.by_duration(POLL_INTERVAL))
+        return Wait.until(Timer.by_duration(POLL_INTERVAL))
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del input

--- a/examples/python/dex_examples/workflow/polling/polling_flow.py
+++ b/examples/python/dex_examples/workflow/polling/polling_flow.py
@@ -76,7 +76,7 @@ class Poll(Step[int]):
 
     def wait_for(self, context: Context, input: int) -> Wait:
         del context, input
-        return Wait.any_of(Timer.by_duration(timedelta(seconds=1)))
+        return Wait.until(Timer.by_duration(timedelta(seconds=1)))
 
     def execute(self, context: Context, input: int) -> StepDecision:
         self.service.call_api1("calling API1 for polling service C")

--- a/examples/python/dex_examples/workflow/subscription/subscription_flow.py
+++ b/examples/python/dex_examples/workflow/subscription/subscription_flow.py
@@ -58,7 +58,7 @@ class ChargeCurrentBill(Step[None]):
             context.set_step_execution_local(SUBSCRIPTION_OVER_KEY, True)
             return Wait.skip_immediately()
         self.billing_period_number.set(context, period_number + 1)
-        return Wait.all_of(
+        return Wait.until(
             Timer.by_duration(subscription_billing.billing_period(customer))
         )
 
@@ -89,7 +89,7 @@ class Trial(Step[None]):
         del input
         customer = self.customer_details.get(context)
         subscription_billing.send_welcome_email(customer, self.service)
-        return Wait.all_of(
+        return Wait.until(
             Timer.by_duration(subscription_billing.trial_period(customer))
         )
 
@@ -112,7 +112,7 @@ class Cancel(Step[None]):
 
     def wait_for(self, context: Context, input: None) -> Wait:
         del context, input
-        return Wait.all_of(self.cancel_subscription.for_one())
+        return Wait.until(self.cancel_subscription.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del input
@@ -132,7 +132,7 @@ class UpdateChargeAmount(Step[None]):
 
     def wait_for(self, context: Context, input: None) -> Wait:
         del context, input
-        return Wait.all_of(self.update_charge_amount.for_one())
+        return Wait.until(self.update_charge_amount.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del input

--- a/examples/python/sync-python/sync_examples/flows/parent_child.py
+++ b/examples/python/sync-python/sync_examples/flows/parent_child.py
@@ -52,7 +52,7 @@ MAX_WAIT_SECONDS = 10
 class ChildProcessing(Step[str]):
     def wait_for(self, context: Context, input: str) -> Wait:
         del context, input
-        return Wait.any_of(Timer.by_duration(timedelta(seconds=random.randint(1, 3))))
+        return Wait.until(Timer.by_duration(timedelta(seconds=random.randint(1, 3))))
 
     def execute(self, context: Context, input: str) -> StepDecision:
         del context, input
@@ -81,7 +81,7 @@ class AwaitChildWorkflowCompletion(Step[WaitForChildInput]):
 
     def wait_for(self, context: Context, input: WaitForChildInput) -> Wait:
         del context
-        return Wait.any_of(Timer.by_duration(timedelta(seconds=input.timer_seconds)))
+        return Wait.until(Timer.by_duration(timedelta(seconds=input.timer_seconds)))
 
     def execute(
         self, context: Context, input: WaitForChildInput
@@ -144,7 +144,7 @@ class LoopForNextTask(Step[None]):
 
     def wait_for(self, context: Context, input: None) -> Wait:
         del context, input
-        return Wait.any_of(self.task_queue.for_one())
+        return Wait.until(self.task_queue.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del input

--- a/examples/typescript/src/patterns/workflow/drainchannels/internal/drain-internal-channels-flow.ts
+++ b/examples/typescript/src/patterns/workflow/drainchannels/internal/drain-internal-channels-flow.ts
@@ -77,7 +77,7 @@ class UpsertMongoRecord implements Step<void> {
   }
 
   public waitFor(_context: Context, _input: void): Wait {
-    return Wait.anyOf(this.flow.upsertMongoData.forOne());
+    return Wait.until(this.flow.upsertMongoData.forOne());
   }
 
   public execute(context: Context, _input: void): StepDecision {

--- a/examples/typescript/src/patterns/workflow/drainchannels/signal/drain-signal-channels-flow.ts
+++ b/examples/typescript/src/patterns/workflow/drainchannels/signal/drain-signal-channels-flow.ts
@@ -44,7 +44,7 @@ class ProcessSignal implements Step<string | undefined> {
 
   public waitFor(_context: Context, input: string | undefined): Wait {
     if (input === undefined) {
-      return Wait.anyOf(this.flow.queueSignalChannel.forOne());
+      return Wait.until(this.flow.queueSignalChannel.forOne());
     }
     return Wait.skipImmediately();
   }

--- a/examples/typescript/src/patterns/workflow/interruptible/interruptible-execution-flow.ts
+++ b/examples/typescript/src/patterns/workflow/interruptible/interruptible-execution-flow.ts
@@ -71,7 +71,7 @@ class WorkAExecution implements Step<WorkJobParametersInput> {
   }
 
   public waitFor(_context: Context, _input: WorkJobParametersInput): Wait {
-    return Wait.anyOf(Timer.byDuration(1500));
+    return Wait.until(Timer.byDuration(1500));
   }
 
   public execute(context: Context, input: WorkJobParametersInput): StepDecision {
@@ -107,7 +107,7 @@ class WorkNExecution implements Step<WorkJobParametersInput> {
   }
 
   public waitFor(_context: Context, _input: WorkJobParametersInput): Wait {
-    return Wait.anyOf(Timer.byDuration(3000));
+    return Wait.until(Timer.byDuration(3000));
   }
 
   public execute(context: Context, input: WorkJobParametersInput): StepDecision {

--- a/examples/typescript/src/patterns/workflow/intervention/manual-intervention-flow.ts
+++ b/examples/typescript/src/patterns/workflow/intervention/manual-intervention-flow.ts
@@ -63,7 +63,7 @@ class GetData implements Step<boolean> {
 
   public waitFor(_context: Context, _isRetry: boolean): Wait {
     console.log("Waiting for incoming data");
-    return Wait.allOf(this.flow.dataChannel.forOne());
+    return Wait.until(this.flow.dataChannel.forOne());
   }
 
   public execute(context: Context, isRetry: boolean): StepDecision {

--- a/examples/typescript/src/patterns/workflow/parallel/parallel-states-with-await-flow.ts
+++ b/examples/typescript/src/patterns/workflow/parallel/parallel-states-with-await-flow.ts
@@ -99,7 +99,7 @@ class AwaitAllUsersNotified implements Step<number> {
   }
 
   public waitFor(_context: Context, countOfJobSeekers: number): Wait {
-    return Wait.allOf(this.flow.notifyChannel.forN(countOfJobSeekers));
+    return Wait.until(this.flow.notifyChannel.forN(countOfJobSeekers));
   }
 
   public execute(context: Context, countOfJobSeekers: number): StepDecision {

--- a/examples/typescript/src/patterns/workflow/parentchild/parent-flow-v2.ts
+++ b/examples/typescript/src/patterns/workflow/parentchild/parent-flow-v2.ts
@@ -81,7 +81,7 @@ class LoopForNextTask implements Step<void> {
   }
 
   public waitFor(_context: Context, _input: void): Wait {
-    return Wait.anyOf(this.flow.taskQueue.forOne());
+    return Wait.until(this.flow.taskQueue.forOne());
   }
 
   public execute(context: Context, _input: void): StepDecision {
@@ -136,7 +136,7 @@ class AwaitChildWorkflowCompletion implements Step<WaitForChildInput> {
   }
 
   public waitFor(_context: Context, input: WaitForChildInput): Wait {
-    return Wait.anyOf(Timer.byDuration(input.timerSeconds * 1000));
+    return Wait.until(Timer.byDuration(input.timerSeconds * 1000));
   }
 
   public async execute(

--- a/examples/typescript/src/patterns/workflow/polling/simple-polling-flow.ts
+++ b/examples/typescript/src/patterns/workflow/polling/simple-polling-flow.ts
@@ -38,7 +38,7 @@ class SimplePolling implements Step<void> {
   }
 
   public waitFor(_context: Context, _input: void): Wait {
-    return Wait.anyOf(Timer.byDuration(10_000));
+    return Wait.until(Timer.byDuration(10_000));
   }
 
   public execute(_context: Context, _input: void): StepDecision {

--- a/examples/typescript/src/patterns/workflow/scalableparallel/child-flow.ts
+++ b/examples/typescript/src/patterns/workflow/scalableparallel/child-flow.ts
@@ -45,7 +45,7 @@ class Processing implements Step<string> {
 
   public waitFor(_context: Context, _input: string): Wait {
     const randomSeconds = Math.floor(Math.random() * 60);
-    return Wait.anyOf(Timer.byDuration(randomSeconds * 1000));
+    return Wait.until(Timer.byDuration(randomSeconds * 1000));
   }
 
   public async execute(context: Context, _input: string): Promise<StepDecision> {

--- a/examples/typescript/src/patterns/workflow/timeout/flow-graceful-timeout.ts
+++ b/examples/typescript/src/patterns/workflow/timeout/flow-graceful-timeout.ts
@@ -56,7 +56,7 @@ class Timeout implements Step<void> {
   }
 
   public waitFor(_context: Context, _input: void): Wait {
-    return Wait.anyOf(Timer.byDuration(60_000));
+    return Wait.until(Timer.byDuration(60_000));
   }
 
   public execute(_context: Context, _input: void): StepDecision {
@@ -75,7 +75,7 @@ class Task implements Step<boolean> {
     if (workflowSuccessful) {
       return Wait.skipImmediately();
     }
-    return Wait.anyOf(Timer.byDuration(65_000));
+    return Wait.until(Timer.byDuration(65_000));
   }
 
   public execute(_context: Context, _workflowSuccessful: boolean): StepDecision {

--- a/examples/typescript/src/workflow/polling/polling-flow.ts
+++ b/examples/typescript/src/workflow/polling/polling-flow.ts
@@ -123,7 +123,7 @@ class Poll implements Step<number> {
   }
 
   public waitFor(_context: Context, _maximumPolls: number): Wait {
-    return Wait.anyOf(Timer.byDuration(POLL_INTERVAL_MS));
+    return Wait.until(Timer.byDuration(POLL_INTERVAL_MS));
   }
 
   public execute(context: Context, maximumPolls: number): StepDecision {

--- a/examples/typescript/src/workflow/subscription/subscription-flow.ts
+++ b/examples/typescript/src/workflow/subscription/subscription-flow.ts
@@ -127,7 +127,7 @@ class Trial implements Step<void> {
   public waitFor(context: Context, _input: void): Wait {
     const customer = this.flow.customerDetails.get(context);
     SubscriptionBilling.sendWelcomeEmail(customer, this.flow.service);
-    return Wait.allOf(Timer.byDuration(SubscriptionBilling.trialPeriod(customer)));
+    return Wait.until(Timer.byDuration(SubscriptionBilling.trialPeriod(customer)));
   }
 
   public execute(context: Context, _input: void): StepDecision {
@@ -153,7 +153,7 @@ class ChargeCurrentBill implements Step<void> {
       return Wait.skipImmediately();
     }
     this.flow.billingPeriodNumber.set(context, periodNumber + 1);
-    return Wait.allOf(Timer.byDuration(SubscriptionBilling.billingPeriod(customer)));
+    return Wait.until(Timer.byDuration(SubscriptionBilling.billingPeriod(customer)));
   }
 
   public execute(context: Context, _input: void): StepDecision {
@@ -179,7 +179,7 @@ class Cancel implements Step<void> {
   }
 
   public waitFor(_context: Context, _input: void): Wait {
-    return Wait.allOf(this.flow.cancelSubscription.forOne());
+    return Wait.until(this.flow.cancelSubscription.forOne());
   }
 
   public execute(context: Context, _input: void): StepDecision {
@@ -199,7 +199,7 @@ class UpdateChargeAmount implements Step<void> {
   }
 
   public waitFor(_context: Context, _input: void): Wait {
-    return Wait.allOf(this.flow.updateChargeAmount.forOne());
+    return Wait.until(this.flow.updateChargeAmount.forOne());
   }
 
   public execute(context: Context, _input: void): StepDecision {

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -86,6 +86,8 @@ Execute-only steps embed `dex.StepDefaultsNoWaitFor[IN]`. Step transitions use
 
 `StepOptions.WaitForMethodTimeout` and `ExecuteMethodTimeout` bound the two
 handler calls. Timer and channel conditions determine how long a Step waits.
+Use `dex.Until(condition)` for one condition, and `dex.AllOf` or `dex.AnyOf`
+for multiple conditions.
 
 Use `dex.None` when a Step, RPC, or Channel has no application payload, and pass
 `nil` at every call site. It rejects accidental values unlike `any` and makes

--- a/sdk-go/dex/condition.go
+++ b/sdk-go/dex/condition.go
@@ -26,6 +26,10 @@ func SkipWaitImmediately() *Wait {
 	return &Wait{kind: skipWaitImmediately}
 }
 
+func Until(condition Condition) *Wait {
+	return AllOf(condition)
+}
+
 func AllOf(conditions ...Condition) *Wait {
 	return &Wait{kind: waitAllOf, conditions: conditions}
 }

--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -329,6 +329,7 @@ var _ = dex.AllOf(
 	commandChannel.ForOne(),
 	dex.Timer(time.Minute, dex.WithConditionID("all")),
 )
+var _ = dex.Until(commandChannel.ForOne())
 var _ = dex.AnyOf(
 	commandChannel.ForOne(),
 	dex.Timer(time.Minute, dex.WithConditionID("any")),

--- a/sdk-go/integ/rpc_test.go
+++ b/sdk-go/integ/rpc_test.go
@@ -89,7 +89,7 @@ func (rpcFlowStep) WaitFor(
 	dex.Context,
 	int,
 ) (*dex.Wait, error) {
-	return dex.AnyOf(rpcFlowChannel.ForOne()), nil
+	return dex.Until(rpcFlowChannel.ForOne()), nil
 }
 
 func (rpcFlowStep) Execute(

--- a/sdk-go/integ/timer_test.go
+++ b/sdk-go/integ/timer_test.go
@@ -35,7 +35,7 @@ func (timerStep) WaitFor(
 	_ dex.Context,
 	seconds int,
 ) (*dex.Wait, error) {
-	return dex.AllOf(dex.Timer(time.Duration(seconds) * time.Second)), nil
+	return dex.Until(dex.Timer(time.Duration(seconds) * time.Second)), nil
 }
 
 func (timerStep) Execute(

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -62,7 +62,7 @@ Channel<Void> wakeup = Channel.define("wakeup", Void.class);
 Wait factories read from the domain nouns they create:
 
 ```java
-return Wait.allOf(
+return Wait.until(
         Timer.byDuration(Duration.ofSeconds(1)));
 ```
 

--- a/sdk-java/src/main/java/io/superdurable/dex/Wait.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Wait.java
@@ -43,6 +43,10 @@ public final class Wait {
         return ofConditions(Kind.SKIP_IMMEDIATELY);
     }
 
+    public static Wait until(final Condition condition) {
+        return allOf(condition);
+    }
+
     public static Wait allOf(final Condition... conditions) {
         return ofConditions(Kind.ALL_OF, conditions);
     }

--- a/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
@@ -291,7 +291,7 @@ public class UserContractsTest {
 
         @Override
         public Wait waitFor(final Context context, final OrderInput input) {
-            return Wait.anyOf(COMMANDS.forOne());
+            return Wait.until(COMMANDS.forOne());
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/ConditionalCompleteWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/ConditionalCompleteWorkflow.java
@@ -55,7 +55,7 @@ class ConditionalCompleteWorkflow implements Flow<Boolean> {
 
         @Override
         public Wait waitFor(final Context context, final Boolean useSignal) {
-            return Wait.anyOf((useSignal ? signal : internal).forOne());
+            return Wait.until((useSignal ? signal : internal).forOne());
         }
 
         @Override

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/InternalChannelWaitingWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/InternalChannelWaitingWorkflow.java
@@ -50,7 +50,7 @@ final class InternalChannelWaitingStep implements Step<Integer> {
 
     @Override
     public Wait waitFor(final Context context, final Integer input) {
-        return Wait.allOf(channel.forN(2));
+        return Wait.until(channel.forN(2));
     }
 
     @Override

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/PersistenceSetAttributesWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/PersistenceSetAttributesWorkflow.java
@@ -92,7 +92,7 @@ final class PersistenceSetAttributesWorkflow implements Flow<String> {
 
         @Override
         public Wait waitFor(final Context context, final String input) {
-            return Wait.allOf(proceed.forOne());
+            return Wait.until(proceed.forOne());
         }
 
         @Override

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/ResetWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/ResetWorkflow.java
@@ -99,7 +99,7 @@ class ResetWorkflow implements Flow<Void> {
 
         @Override
         public Wait waitFor(final Context context, final Void input) {
-            return Wait.anyOf(channel.forOne());
+            return Wait.until(channel.forOne());
         }
 
         @Override

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/RpcWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/RpcWorkflow.java
@@ -141,7 +141,7 @@ class RpcWorkflow implements Flow<Integer> {
 
         @Override
         public Wait waitFor(final Context context, final Integer input) {
-            return Wait.anyOf(internal.forOne());
+            return Wait.until(internal.forOne());
         }
 
         @Override

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/SkipWaitUntilMixedWaitWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/SkipWaitUntilMixedWaitWorkflow.java
@@ -60,7 +60,7 @@ final class SkipWaitUntilMixedWaitWorkflow implements Flow<Integer> {
 
         @Override
         public Wait waitFor(final Context context, final Integer input) {
-            return Wait.allOf(Timer.byDuration(Duration.ofSeconds(1)));
+            return Wait.until(Timer.byDuration(Duration.ofSeconds(1)));
         }
 
         @Override

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsLockingWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsLockingWorkflow.java
@@ -100,7 +100,7 @@ final class StateOptionsLockingWorkflow implements Flow<Integer> {
 
         @Override
         public Wait waitFor(final Context context, final Integer parallelism) {
-            return Wait.allOf(completed.forN(parallelism));
+            return Wait.until(completed.forN(parallelism));
         }
 
         @Override

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/TimerWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/TimerWorkflow.java
@@ -39,7 +39,7 @@ final class TimerStep implements Step<Integer> {
 
     @Override
     public Wait waitFor(final Context context, final Integer input) {
-        return Wait.allOf(Timer.byDuration(Duration.ofSeconds(input), "test-timer-id"));
+        return Wait.until(Timer.byDuration(Duration.ofSeconds(input), "test-timer-id"));
     }
 
     @Override

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -23,7 +23,7 @@ class Run(dex.Step[str]):
     def wait_for(
         self, context: dex.Context, input: str
     ) -> dex.Wait:
-        return dex.Wait.all_of(
+        return dex.Wait.until(
             dex.Timer.by_duration(timedelta(seconds=1))
         )
 

--- a/sdk-python/dex/wait.py
+++ b/sdk-python/dex/wait.py
@@ -34,6 +34,10 @@ class Wait:
         return Wait(WaitKind.SKIP_IMMEDIATELY)
 
     @staticmethod
+    def until(condition: Condition) -> Wait:
+        return Wait.all_of(condition)
+
+    @staticmethod
     def all_of(*conditions: Condition) -> Wait:
         return Wait(WaitKind.ALL_OF, conditions)
 

--- a/sdk-python/tests/integ/README.md
+++ b/sdk-python/tests/integ/README.md
@@ -21,7 +21,7 @@ uv run --frozen pyright tests/integ
 
 - Python annotations derive Step and RPC codecs; Attribute and Channel values
   declare ordinary Python types.
-- `Wait.all_of(Timer.by_duration(...))` and handle methods keep nested calls
+- `Wait.until(Timer.by_duration(...))` and handle methods keep nested calls
   readable.
 - RPC methods remain normal bound methods and are passed directly to
   `Client.invoke_rpc`.

--- a/sdk-python/tests/integ/conditional_complete_flow.py
+++ b/sdk-python/tests/integ/conditional_complete_flow.py
@@ -37,7 +37,7 @@ class ConditionalStep(Step[bool]):
 
     def wait_for(self, context: Context, input: bool) -> Wait:
         del context
-        return Wait.any_of((self.signal if input else self.internal).for_one())
+        return Wait.until((self.signal if input else self.internal).for_one())
 
     def execute(self, context: Context, input: bool) -> StepDecision:
         next_value = self.counter.get(context) + 1

--- a/sdk-python/tests/integ/mixed_wait_flow.py
+++ b/sdk-python/tests/integ/mixed_wait_flow.py
@@ -30,7 +30,7 @@ class MixedTimerStep(Step[int]):
 
     def wait_for(self, context: Context, input: int) -> Wait:
         del context, input
-        return Wait.all_of(Timer.by_duration(timedelta(seconds=1)))
+        return Wait.until(Timer.by_duration(timedelta(seconds=1)))
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context

--- a/sdk-python/tests/integ/reset_flow.py
+++ b/sdk-python/tests/integ/reset_flow.py
@@ -40,7 +40,7 @@ class ResetWaitStep(Step[None]):
 
     def wait_for(self, context: Context, input: None) -> Wait:
         del context, input
-        return Wait.any_of(self.channel.for_one())
+        return Wait.until(self.channel.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input

--- a/sdk-python/tests/integ/rpc_flow.py
+++ b/sdk-python/tests/integ/rpc_flow.py
@@ -40,7 +40,7 @@ class RpcFirstStep(Step[int]):
 
     def wait_for(self, context: Context, input: int) -> Wait:
         del context, input
-        return Wait.any_of(self.internal.for_one())
+        return Wait.until(self.internal.for_one())
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context, input

--- a/sdk-python/tests/integ/rpc_locking_flow.py
+++ b/sdk-python/tests/integ/rpc_locking_flow.py
@@ -40,7 +40,7 @@ class LockWaitStep(Step[None]):
 
     def wait_for(self, context: Context, input: None) -> Wait:
         del context, input
-        return Wait.any_of(self.channel.for_one())
+        return Wait.until(self.channel.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input

--- a/sdk-python/tests/integ/set_attributes_flow.py
+++ b/sdk-python/tests/integ/set_attributes_flow.py
@@ -35,7 +35,7 @@ class SetAttributesCompleteStep(Step[str]):
 
     def wait_for(self, context: Context, input: str) -> Wait:
         del context, input
-        return Wait.all_of(self.proceed.for_one())
+        return Wait.until(self.proceed.for_one())
 
     def execute(self, context: Context, input: str) -> StepDecision:
         del context, input

--- a/sdk-python/tests/integ/timer_flow.py
+++ b/sdk-python/tests/integ/timer_flow.py
@@ -25,7 +25,7 @@ from dex import (
 class TimerStep(Step[int]):
     def wait_for(self, context: Context, input: int) -> Wait:
         del context
-        return Wait.all_of(
+        return Wait.until(
             Timer.by_duration(
                 timedelta(seconds=input),
                 condition_id="test-timer-id",

--- a/sdk-python/tests/integ/waiting_internal_channel_flow.py
+++ b/sdk-python/tests/integ/waiting_internal_channel_flow.py
@@ -27,7 +27,7 @@ class WaitingInternalStep(Step[int]):
 
     def wait_for(self, context: Context, input: int) -> Wait:
         del context, input
-        return Wait.all_of(self.channel.for_n(2))
+        return Wait.until(self.channel.for_n(2))
 
     def execute(self, context: Context, input: int) -> StepDecision:
         return graceful_complete(input + sum(self.channel.results(context)))

--- a/sdk-python/tests/test_contracts.py
+++ b/sdk-python/tests/test_contracts.py
@@ -266,7 +266,7 @@ def test_builtin_codecs_enforce_wire_types_and_ranges() -> None:
 
 
 def test_fluent_wait_factories_validate_channel_bounds() -> None:
-    wait = Wait.all_of(Timer.by_duration(timedelta(seconds=1)))
+    wait = Wait.until(Timer.by_duration(timedelta(seconds=1)))
     assert len(wait.conditions) == 1
     with pytest.raises(ValueError, match="requires a bound"):
         COMMANDS.for_range()

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -26,7 +26,7 @@ class ApproveOrder implements Step<string> {
   }
 
   waitFor(_context: Context, _orderId: string): Wait {
-    return Wait.allOf(Timer.byDuration(1_000));
+    return Wait.until(Timer.byDuration(1_000));
   }
 
   execute(_context: Context, orderId: string): StepDecision {

--- a/sdk-typescript/src/wait.ts
+++ b/sdk-typescript/src/wait.ts
@@ -162,6 +162,9 @@ export const Wait = Object.freeze({
   skipImmediately(): Wait {
     return { kind: "skipImmediately", conditions: [], combinations: [] };
   },
+  until(condition: Condition): Wait {
+    return Wait.allOf(condition);
+  },
   allOf(...conditions: readonly Condition[]): Wait {
     return { kind: "allOf", conditions, combinations: [] };
   },

--- a/sdk-typescript/test/contracts.test.ts
+++ b/sdk-typescript/test/contracts.test.ts
@@ -162,7 +162,7 @@ test("canonical codecs enforce wire kinds and int64 range", () => {
 });
 
 test("fluent wait factories validate channel bounds", () => {
-  const wait = Wait.allOf(Timer.byDuration(1_000));
+  const wait = Wait.until(Timer.byDuration(1_000));
   assert.equal(wait.conditions.length, 1);
   assert.throws(() => commands.range(), /requires a bound/);
 });

--- a/sdk-typescript/test/integ/README.md
+++ b/sdk-typescript/test/integ/README.md
@@ -24,7 +24,7 @@ Full integration verification:
 
 - Flow and Step are interfaces, while explicit codecs provide the runtime type
   information erased by TypeScript.
-- `Wait.allOf(Timer.byDuration(...))` and domain factories keep nested calls
+- `Wait.until(Timer.byDuration(...))` and domain factories keep nested calls
   readable.
 - Decorated RPC method references preserve their input and output types through
   `Client.invokeRPC`.

--- a/sdk-typescript/test/integ/async_handlers_flows.ts
+++ b/sdk-typescript/test/integ/async_handlers_flows.ts
@@ -100,7 +100,7 @@ class RpcEchoStep implements Step<string> {
   }
 
   public waitFor(): Wait {
-    return Wait.anyOf(this.proceed.forOne());
+    return Wait.until(this.proceed.forOne());
   }
 
   public execute(_context: Context, input: string): StepDecision {

--- a/sdk-typescript/test/integ/conditional_complete_flow.ts
+++ b/sdk-typescript/test/integ/conditional_complete_flow.ts
@@ -40,7 +40,7 @@ class ConditionalStep implements Step<boolean> {
   }
 
   public waitFor(_context: Context, useSignal: boolean): Wait {
-    return Wait.anyOf((useSignal ? this.signal : this.internal).forOne());
+    return Wait.until((useSignal ? this.signal : this.internal).forOne());
   }
 
   public execute(context: Context, useSignal: boolean): StepDecision {

--- a/sdk-typescript/test/integ/mixed_sync_async_flow.ts
+++ b/sdk-typescript/test/integ/mixed_sync_async_flow.ts
@@ -108,7 +108,7 @@ class SyncChannelWaitStep implements Step<string> {
   }
 
   public waitFor(): Wait {
-    return Wait.anyOf(this.proceed.forOne());
+    return Wait.until(this.proceed.forOne());
   }
 
   public execute(_context: Context, input: string): StepDecision {

--- a/sdk-typescript/test/integ/mixed_wait_flow.ts
+++ b/sdk-typescript/test/integ/mixed_wait_flow.ts
@@ -32,7 +32,7 @@ class MixedTimerStep implements Step<number> {
   }
 
   public waitFor(_context: Context, _input: number): Wait {
-    return Wait.allOf(Timer.byDuration(1_000));
+    return Wait.until(Timer.byDuration(1_000));
   }
 
   public execute(_context: Context, input: number): StepDecision {

--- a/sdk-typescript/test/integ/rpc_flow.ts
+++ b/sdk-typescript/test/integ/rpc_flow.ts
@@ -54,7 +54,7 @@ class RpcFirstStep implements Step<number> {
   }
 
   public waitFor(_context: Context, _input: number): Wait {
-    return Wait.anyOf(this.internal.forOne());
+    return Wait.until(this.internal.forOne());
   }
 
   public execute(_context: Context, _input: number): StepDecision {

--- a/sdk-typescript/test/integ/rpc_locking_flow.ts
+++ b/sdk-typescript/test/integ/rpc_locking_flow.ts
@@ -62,7 +62,7 @@ class LockWaitStep implements Step<void> {
   }
 
   public waitFor(_context: Context, _input: void): Wait {
-    return Wait.anyOf(this.channel.forOne());
+    return Wait.until(this.channel.forOne());
   }
 
   public execute(_context: Context, _input: void): StepDecision {

--- a/sdk-typescript/test/integ/set_attributes_flow.ts
+++ b/sdk-typescript/test/integ/set_attributes_flow.ts
@@ -39,7 +39,7 @@ class SetAttributesCompleteStep implements Step<string> {
   }
 
   public waitFor(_context: Context, _input: string): Wait {
-    return Wait.allOf(this.proceed.forOne());
+    return Wait.until(this.proceed.forOne());
   }
 
   public execute(_context: Context, _input: string): StepDecision {

--- a/sdk-typescript/test/integ/timer_flow.ts
+++ b/sdk-typescript/test/integ/timer_flow.ts
@@ -29,7 +29,7 @@ class TimerStep implements Step<number> {
 
   public async waitFor(_context: Context, input: number): Promise<Wait> {
     await Promise.resolve();
-    return Wait.allOf(Timer.byDuration(input * 1_000, "test-timer-id"));
+    return Wait.until(Timer.byDuration(input * 1_000, "test-timer-id"));
   }
 
   public async execute(_context: Context, _input: number): Promise<StepDecision> {

--- a/sdk-typescript/test/integ/waiting_internal_channel_flow.ts
+++ b/sdk-typescript/test/integ/waiting_internal_channel_flow.ts
@@ -31,7 +31,7 @@ class WaitingInternalStep implements Step<number> {
   }
 
   public waitFor(_context: Context, _input: number): Wait {
-    return Wait.allOf(this.channel.forN(2));
+    return Wait.until(this.channel.forN(2));
   }
 
   public execute(context: Context, input: number): StepDecision {


### PR DESCRIPTION
## Summary

- add `Wait.until(condition)` to Java, Python, and TypeScript
- add `dex.Until(condition)` to Go
- implement each single-condition helper as an `allOf`/`AllOf` wrapper
- migrate single-condition SDK integration workflows and examples while retaining aggregate APIs for multiple or dynamic conditions
- update Go SDK contracts and design documentation

## Validation

- Java contract tests, example compilation, and full `dexcli dev` integration suite
- Go SDK unit tests, example compilation, and full E2E integration suite
- Python contract tests, strict mypy, pyright, pre-commit, example tests, and full 51-test integration suite
- TypeScript typecheck, contract tests, example tests, and full 65-test integration suite
- repository copyright check
