### PR TITLE
sdk-go: add explicit error contract

### DIFF
--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -167,7 +167,7 @@ Explicit IDs must be non-empty, unique, and outside the reserved prefix.
 
 The internal error mapper preserves the gRPC code, Dex substatus and detail,
 plus original worker code, type, and detail. A gRPC error without Dex details
-uses `ErrorUncategorized`; local non-gRPC errors remain unchanged.
+uses `ErrorSubStatusUncategorized`; local non-gRPC errors remain unchanged.
 
 The private hydration seam accepts blob arms and returns concrete values in the
 same order. It deduplicates repeated references and validates count and arm
@@ -830,7 +830,7 @@ and buffered attributes, events, and channel messages.
 
 Every Worker failure crosses gRPC as a status with one `WorkerErrorResponse`.
 The server can therefore preserve the original worker code, concrete error
-type, and detail in its public `dex.Error` conversion.
+type, and detail in the Client's public `WorkerInvocationError` conversion.
 
 | Failure | gRPC code |
 |---|---|
@@ -1136,7 +1136,7 @@ Every public method follows the same transport boundary:
 3. select or generate any required request ID once;
 4. assemble one generated request with an empty `run_id`;
 5. call the generated FlowService stub with the caller's context;
-6. convert a gRPC failure through `convertRPCError`;
+6. translate a gRPC failure using the endpoint's Flow requirement;
 7. hydrate all response blob arms in one ordered batch; and
 8. map and decode only after the complete response is valid.
 
@@ -1145,8 +1145,9 @@ wire `run_id` lets the server follow Continue-as-New. ResetFlow returns the new
 run ID, while StartFlow returns the created or matched run ID. The public Client
 does not add a run-specific variant in Phase 5.
 
-Local validation, encoding, and decoding errors remain ordinary Go errors.
-Only errors received from FlowService become `*dex.Error`.
+Local validation errors remain ordinary Go errors. Encoding and decoding errors
+use `*dex.ValueMappingError`. Only errors received from FlowService become
+`*dex.ServiceError` or a concrete service error wrapping it.
 
 The Client builds each protobuf request once. gRPC's pre-commit transparent
 retry therefore reuses the same request and request ID. Phase 5 does not add a
@@ -1322,8 +1323,10 @@ durations round up and negative durations fail locally.
 WaitForFlow leaves zero timeout as the server-configured maximum long poll. A
 successful response maps status and error metadata, then hydrates every
 requested completion output before returning. `NeedsResults=false` never
-requires result decoding. A long-poll timeout remains a `*dex.Error` with
-`DeadlineExceeded` and `ErrorLongPollTimeout`.
+requires result decoding. A long-poll timeout returns
+`*dex.LongPollTimeoutError` with `DeadlineExceeded` and the Flow ID. A closed
+Flow whose status is not completed returns `*dex.FlowUncompletedError` with its
+Flow ID, current run ID, status, error metadata, and requested completions.
 
 SkipTimer requires a non-empty step type and exactly one TimerID selector: a
 non-empty condition ID or a non-negative index. A nil execution number defaults
@@ -1372,7 +1375,7 @@ miss batching, response-kind validation, and admission behavior remain the
 Phase 4 contract.
 
 Hydration errors are classified at the boundary that owns the call. A remote
-LoadBlobs status becomes `*dex.Error` for a public Client call. A malformed,
+LoadBlobs status becomes `*dex.ServiceError` for a public Client call. A malformed,
 missing, wrong-kind, or still-blob response remains a local SDK response error.
 The Worker retains its WorkerError classification. The shared hydrator does not
 expose Worker-specific errors to Client applications.
@@ -1383,18 +1386,20 @@ network I/O.
 
 ### Error conversion and cancellation
 
-Every generated FlowService error passes through `convertRPCError` exactly
-once. It preserves gRPC code, Dex substatus, detail, and original Worker error.
-Unknown or absent Dex details map to `ErrorUncategorized`.
+Every generated FlowService error passes through the service error translator
+exactly once. It preserves operation, Flow ID, gRPC code, Dex substatus,
+detail, original Worker error, and the gRPC cause. Unknown, absent, or malformed
+Dex details map to `ServiceError` with `ErrorSubStatusUncategorized`.
 
 Caller cancellation and deadlines propagate through gRPC. If gRPC returns
-their status, the Client exposes `*dex.Error` with `Canceled` or
+their status, the Client exposes `*dex.ServiceError` with `Canceled` or
 `DeadlineExceeded`. A context already done before request assembly returns its
 context error locally and sends no RPC.
 
-The Client never converts codec, reflection, option, response-shape, or closed
-Client failures into fake gRPC statuses. `errors.As(err, *dex.Error)` therefore
-continues to distinguish remote service failures from local SDK misuse.
+The Client never converts definition, codec, reflection, option, response-shape,
+or closed Client failures into fake gRPC statuses. Matching
+`*dex.ServiceError` therefore distinguishes remote service failures from local
+SDK errors.
 
 ### Integration suite migration
 
@@ -2425,6 +2430,15 @@ type WaitForFlowResult struct {
 	ErrorMessage string
 }
 
+type FlowUncompletedError struct {
+	FlowID       string
+	RunID        string
+	Status       FlowStatus
+	ErrorType    FlowErrorType
+	ErrorMessage string
+	Completions  []StepCompletion
+}
+
 type SearchFlowEntry struct {
 	FlowID           string
 	RunID            string
@@ -2622,15 +2636,16 @@ type AttributeNotFoundError struct {
 `Instance` is populated for `AttributeMap` reads. The error supports
 `errors.As` and is never converted to a gRPC status.
 
-All FlowService failures are returned as an SDK error that preserves both gRPC
-status and Dex details:
+All FlowService failures preserve gRPC status, Dex details, operation, Flow ID,
+and the original gRPC cause:
 
 ```go
-type Error struct {
-	Code                codes.Code
-	SubStatus           ErrorSubStatus
-	Detail              string
-	OriginalWorkerError *WorkerError
+type ServiceError struct {
+	Op        string
+	FlowID    string
+	Code      codes.Code
+	SubStatus ErrorSubStatus
+	Detail    string
 }
 
 type WorkerError struct {
@@ -2642,17 +2657,35 @@ type WorkerError struct {
 type ErrorSubStatus uint8
 
 const (
-	ErrorUncategorized ErrorSubStatus = iota + 1
-	ErrorFlowAlreadyStarted
-	ErrorFlowNotFound
-	ErrorWorkerAPI
-	ErrorLongPollTimeout
+	ErrorSubStatusUncategorized ErrorSubStatus = iota + 1
+	ErrorSubStatusFlowAlreadyStarted
+	ErrorSubStatusFlowNotFound
+	ErrorSubStatusWorkerAPI
+	ErrorSubStatusLongPollTimeout
 )
 ```
 
-`Error` implements `error` and supports `errors.As`. Application-worker
-failures remain distinguishable from backend `Unavailable`; long-poll timeout
-retains `DeadlineExceeded` plus `LongPollTimeout`.
+Applications use `errors.As` with `FlowAlreadyStartedError`,
+`FlowNotFoundError`, `FlowNotActiveError`, `WorkerInvocationError`,
+`RPCLockConflictError`, or `LongPollTimeoutError`. Each unwraps through
+`ServiceError` to the original gRPC status. `ErrorSubStatus` remains diagnostic
+metadata.
+
+`FlowUncompletedError` is a local terminal-state error rather than a
+`ServiceError`. It exposes `FlowID`, `RunID`, `Status`, `ErrorType`,
+`ErrorMessage`, and `Completions` from the wait response.
+
+GetAttribute, GetAttributes, WaitForFlow, and ResetFlow require an existing
+Flow. Mutations, RPC, publish, stop, timer, config, and step or attribute wait
+operations require an active Flow. The shared server `FLOW_NOT_EXISTS`
+sub-status maps to the corresponding concrete error using that endpoint
+requirement.
+
+Registry and unregistered-definition failures return `FlowDefinitionError`.
+Invalid Wait, StepDecision, and RPCResult values return
+`InvalidStepResultError` from WorkerService. Value encoding and decoding
+failures return `ValueMappingError`; invalid call arguments remain ordinary Go
+errors.
 
 ### End-to-end authoring example
 

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -38,6 +38,15 @@ The defaults connect to Dex at `localhost:8801`. These environment variables ove
 - `DEX_BLOB_CACHE_DIR`: shared Client/Worker blob-cache directory.
 - `DATASET_DEAL_POSTGRES_URL`: Dataset Deal PostgreSQL connection URL.
 
+## Error handling
+
+Examples match expected SDK failures with `errors.As`. Reads use
+`FlowNotFoundError`; RPC, publish, and mutation paths use `FlowNotActiveError`.
+Duplicate starts use `FlowAlreadyStartedError`, and server long-poll expiry uses
+`LongPollTimeoutError`. A Flow that closes without completing returns
+`FlowUncompletedError`. `ServiceError.SubStatus` is retained for diagnostics
+and is not used for control flow.
+
 When Dex runs in Docker, set `DEX_WORKER_TARGET=host.docker.internal:8803`.
 
 ## Verify every example

--- a/examples/go/cmd/deepverify/main.go
+++ b/examples/go/cmd/deepverify/main.go
@@ -897,8 +897,8 @@ func ensureStorage(ctx context.Context, client *dex.Client) error {
 	if err == nil {
 		return nil
 	}
-	var dexErr *dex.Error
-	if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorFlowAlreadyStarted {
+	var duplicate *dex.FlowAlreadyStartedError
+	if errors.As(err, &duplicate) {
 		return nil
 	}
 	return err
@@ -1029,18 +1029,19 @@ func verifyRecovery(ctx context.Context, client *dex.Client, stamp string) resul
 	if err != nil {
 		return fail(name, "", err)
 	}
-	wait, err := client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
+	_, err = client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
 		NeedsResults: true,
 		Timeout:      90 * time.Second,
 	})
-	if err != nil {
+	var uncompleted *dex.FlowUncompletedError
+	if !errors.As(err, &uncompleted) {
 		return fail(name, "", err)
 	}
-	if wait.Status != dex.FlowFailed {
-		return fail(name, fmt.Sprintf("expected FlowFailed got %v msg=%s", wait.Status, wait.ErrorMessage), nil)
+	if uncompleted.Status != dex.FlowFailed {
+		return fail(name, fmt.Sprintf("expected FlowFailed got %v msg=%s", uncompleted.Status, uncompleted.ErrorMessage), nil)
 	}
-	if !strings.Contains(wait.ErrorMessage, "Failed to process transaction") {
-		return fail(name, "msg="+wait.ErrorMessage, nil)
+	if !strings.Contains(uncompleted.ErrorMessage, "Failed to process transaction") {
+		return fail(name, "msg="+uncompleted.ErrorMessage, nil)
 	}
 	return pass(name, "payment fail → void → ForceFail as designed")
 }
@@ -1101,8 +1102,8 @@ func verifyParentChild(ctx context.Context, client *dex.Client, stamp string) re
 		Timeout:      3 * time.Second,
 	})
 	if err != nil {
-		var dexErr *dex.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorLongPollTimeout {
+		var timeout *dex.LongPollTimeoutError
+		if errors.As(err, &timeout) {
 			return pass(name, "children completed; parent still running (by design)")
 		}
 		return fail(name, "parent status", err)
@@ -1225,18 +1226,19 @@ func verifyTimeoutFail(ctx context.Context, client *dex.Client, stamp string) re
 		return fail(name, "", err)
 	}
 	// 1m ForceFail + worker backlog under reminder load needs headroom.
-	wait, err := client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
+	_, err = client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
 		NeedsResults: true,
 		Timeout:      3 * time.Minute,
 	})
-	if err != nil {
+	var uncompleted *dex.FlowUncompletedError
+	if !errors.As(err, &uncompleted) {
 		return fail(name, "", err)
 	}
-	if wait.Status != dex.FlowFailed {
-		return fail(name, fmt.Sprintf("expected failed got %v msg=%s", wait.Status, wait.ErrorMessage), nil)
+	if uncompleted.Status != dex.FlowFailed {
+		return fail(name, fmt.Sprintf("expected failed got %v msg=%s", uncompleted.Status, uncompleted.ErrorMessage), nil)
 	}
-	if !strings.Contains(wait.ErrorMessage, "did not finish the task in time") {
-		return fail(name, "msg="+wait.ErrorMessage, nil)
+	if !strings.Contains(uncompleted.ErrorMessage, "did not finish the task in time") {
+		return fail(name, "msg="+uncompleted.ErrorMessage, nil)
 	}
 	return pass(name, "1m timeout ForceFail as designed")
 }
@@ -1262,14 +1264,18 @@ func verifyCron(ctx context.Context, client *dex.Client) result {
 		NeedsResults: true,
 		Timeout:      60 * time.Second,
 	})
+	outcome := "completed"
 	if err != nil {
-		return fail(name, "WaitForFlow "+tickID, err)
-	}
-	if wait.Status != dex.FlowCompleted && wait.Status != dex.FlowContinuedAsNew {
+		var uncompleted *dex.FlowUncompletedError
+		if !errors.As(err, &uncompleted) || uncompleted.Status != dex.FlowContinuedAsNew {
+			return fail(name, "WaitForFlow "+tickID, err)
+		}
+		outcome = "continued as new"
+	} else if wait.Status != dex.FlowCompleted {
 		return fail(name, fmt.Sprintf("status=%v msg=%s", wait.Status, wait.ErrorMessage), nil)
 	}
 	_ = client.StopFlow(ctx, cronID, dex.StopOptions{})
-	return pass(name, fmt.Sprintf("schedule tick completed id=%s", tickID))
+	return pass(name, fmt.Sprintf("schedule tick %s id=%s", outcome, tickID))
 }
 
 func waitForCronTickID(cronID string, timeout time.Duration) (string, error) {

--- a/examples/go/cmd/server/dex/dataset_deal_controller.go
+++ b/examples/go/cmd/server/dex/dataset_deal_controller.go
@@ -545,14 +545,15 @@ func (*datasetDealController) serveUIFile(
 }
 
 func (*datasetDealController) respondError(request *gin.Context, err error) {
-	var sdkError *sdk.Error
+	var missing *sdk.FlowNotFoundError
+	var inactive *sdk.FlowNotActiveError
 	switch {
 	case errors.Is(err, datasetdeal.ErrProcessExists):
 		request.JSON(http.StatusConflict, gin.H{"error": err.Error()})
 	case errors.Is(err, datasetdeal.ErrProcessNotFound),
 		errors.Is(err, datasetdeal.ErrExecutionNotFound):
 		request.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
-	case errors.As(err, &sdkError) && sdkError.SubStatus == sdk.ErrorFlowNotFound:
+	case errors.As(err, &missing), errors.As(err, &inactive):
 		request.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 	default:
 		request.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/examples/go/cmd/server/dex/design_pattern_controller.go
+++ b/examples/go/cmd/server/dex/design_pattern_controller.go
@@ -317,8 +317,8 @@ func (controller *designPatternController) ensureStorageFlow(ctx context.Context
 	if err == nil {
 		return nil
 	}
-	var dexErr *sdk.Error
-	if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowAlreadyStarted {
+	var duplicate *sdk.FlowAlreadyStartedError
+	if errors.As(err, &duplicate) {
 		return nil
 	}
 	return err
@@ -515,8 +515,8 @@ func (controller *designPatternController) startOrSignalDrain(request *gin.Conte
 		respondString(request, "Signaled the workflow", nil)
 		return
 	}
-	var dexErr *sdk.Error
-	if !errors.As(err, &dexErr) || dexErr.SubStatus != sdk.ErrorFlowNotFound {
+	var inactive *sdk.FlowNotActiveError
+	if !errors.As(err, &inactive) {
 		respondString(request, "", err)
 		return
 	}

--- a/examples/go/cmd/server/dex/dex.go
+++ b/examples/go/cmd/server/dex/dex.go
@@ -263,8 +263,8 @@ func startCronSchedule(client *sdk.Client) {
 		},
 	)
 	if err != nil {
-		var dexErr *sdk.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowAlreadyStarted {
+		var duplicate *sdk.FlowAlreadyStartedError
+		if errors.As(err, &duplicate) {
 			return
 		}
 		// Temporal Schedule.Create returns no run ID; SDK surfaces that after register.

--- a/examples/go/cmd/server/dex/shortlist_controller.go
+++ b/examples/go/cmd/server/dex/shortlist_controller.go
@@ -66,8 +66,8 @@ func (controller *shortlistController) optIn(request *gin.Context) {
 		sdk.StartFlowOptions{Timeout: &timeout},
 	)
 	if err != nil {
-		var dexErr *sdk.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowAlreadyStarted {
+		var duplicate *sdk.FlowAlreadyStartedError
+		if errors.As(err, &duplicate) {
 			request.String(
 				http.StatusOK,
 				fmt.Sprintf("Employer %s has already opted in", employerID),
@@ -98,8 +98,8 @@ func (controller *shortlistController) optOut(request *gin.Context) {
 		sdk.InvokeOptions{},
 	)
 	if err != nil {
-		var dexErr *sdk.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowNotFound {
+		var inactive *sdk.FlowNotActiveError
+		if errors.As(err, &inactive) {
 			request.String(
 				http.StatusOK,
 				fmt.Sprintf("Employer %s is not in the opt-in status", employerID),
@@ -161,8 +161,8 @@ func (controller *shortlistController) shortlist(request *gin.Context) {
 		sdk.StartFlowOptions{Timeout: &timeout},
 	)
 	if err != nil {
-		var dexErr *sdk.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowAlreadyStarted {
+		var duplicate *sdk.FlowAlreadyStartedError
+		if errors.As(err, &duplicate) {
 			request.String(
 				http.StatusOK,
 				fmt.Sprintf("Already running workflowId: %s", flowID),
@@ -191,8 +191,8 @@ func (controller *shortlistController) revokeShortlist(request *gin.Context) {
 		nil,
 	)
 	if err != nil {
-		var dexErr *sdk.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowNotFound {
+		var inactive *sdk.FlowNotActiveError
+		if errors.As(err, &inactive) {
 			request.String(
 				http.StatusOK,
 				fmt.Sprintf("No running workflow to revoke for %s", employerID+"-"+candidateID),
@@ -222,8 +222,8 @@ func (controller *shortlistController) emailSentTimestamp(request *gin.Context) 
 		sdk.InvokeOptions{},
 	)
 	if err != nil {
-		var dexErr *sdk.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowNotFound {
+		var inactive *sdk.FlowNotActiveError
+		if errors.As(err, &inactive) {
 			request.Status(http.StatusNotFound)
 			return
 		}

--- a/examples/go/cmd/server/dex/signup_controller.go
+++ b/examples/go/cmd/server/dex/signup_controller.go
@@ -68,8 +68,8 @@ func (controller *signupController) submit(request *gin.Context) {
 		sdk.StartFlowOptions{Timeout: &timeout},
 	)
 	if err != nil {
-		var dexErr *sdk.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == sdk.ErrorFlowAlreadyStarted {
+		var duplicate *sdk.FlowAlreadyStartedError
+		if errors.As(err, &duplicate) {
 			request.JSON(http.StatusOK, "username already started registry")
 			return
 		}

--- a/examples/go/workflows/patterns/parentchild/README.md
+++ b/examples/go/workflows/patterns/parentchild/README.md
@@ -5,3 +5,7 @@
 - `GET /design-pattern/parentchild/start?workflowId={workflowId}&numRequests={n}`
 
 Concurrency per parent: 3
+
+The parent ignores `FlowAlreadyStartedError` when a child already exists and
+handles `LongPollTimeoutError` when a child remains active beyond the selected
+wait duration.

--- a/examples/go/workflows/patterns/parentchild/parent.go
+++ b/examples/go/workflows/patterns/parentchild/parent.go
@@ -138,8 +138,8 @@ func (step startChildWorkflowStep) Execute(
 		dex.StartFlowOptions{},
 	)
 	if err != nil {
-		var dexErr *dex.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorFlowAlreadyStarted {
+		var duplicate *dex.FlowAlreadyStartedError
+		if errors.As(err, &duplicate) {
 			fmt.Println("ignore this error because it is already started")
 		} else {
 			return nil, err
@@ -181,8 +181,8 @@ func (step awaitChildWorkflowCompletionStep) Execute(
 		dex.WaitForFlowOptions{Timeout: time.Duration(waitSeconds) * time.Second},
 	)
 	if err != nil {
-		var dexErr *dex.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorLongPollTimeout {
+		var timeout *dex.LongPollTimeoutError
+		if errors.As(err, &timeout) {
 			nextTimer := input.TimerSeconds * 2
 			if nextTimer > 10 {
 				nextTimer = 10

--- a/examples/go/workflows/patterns/scalableparallel/child.go
+++ b/examples/go/workflows/patterns/scalableparallel/child.go
@@ -95,8 +95,8 @@ func (step processingStep) Execute(
 				dex.InvokeOptions{},
 			)
 			if rpcErr != nil {
-				var dexErr *dex.Error
-				if errors.As(rpcErr, &dexErr) && dexErr.SubStatus == dex.ErrorFlowNotFound {
+				var inactive *dex.FlowNotActiveError
+				if errors.As(rpcErr, &inactive) {
 					fmt.Println(
 						"Parent workflow may have completed, might be duplicate " +
 							"completion request, ignore it.",

--- a/examples/go/workflows/patterns/scalableparallel/parent.go
+++ b/examples/go/workflows/patterns/scalableparallel/parent.go
@@ -187,9 +187,8 @@ func (step loopForNextMessageStep) Execute(
 			},
 		)
 		if startErr != nil {
-			var dexErr *dex.Error
-			if errors.As(startErr, &dexErr) &&
-				dexErr.SubStatus == dex.ErrorFlowAlreadyStarted {
+			var duplicate *dex.FlowAlreadyStartedError
+			if errors.As(startErr, &duplicate) {
 				fmt.Println(
 					"already started by other state/workflow, ignore it " +
 						"-- not waiting for it",

--- a/examples/go/workflows/patterns/scalableparallel/receiver.go
+++ b/examples/go/workflows/patterns/scalableparallel/receiver.go
@@ -85,8 +85,8 @@ func (step requestStep) Execute(
 		dex.InvokeOptions{},
 	)
 	if err != nil {
-		var dexErr *dex.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorFlowNotFound {
+		var inactive *dex.FlowNotActiveError
+		if errors.As(err, &inactive) {
 			flowTimeout := time.Hour
 			_, startErr := client.StartFlow(
 				context.Background(),

--- a/examples/go/workflows/shortlistcandidates/ids.go
+++ b/examples/go/workflows/shortlistcandidates/ids.go
@@ -51,8 +51,8 @@ func IsOptedIn(
 		dex.InvokeOptions{},
 	)
 	if err != nil {
-		var dexErr *dex.Error
-		if errors.As(err, &dexErr) && dexErr.SubStatus == dex.ErrorFlowNotFound {
+		var inactive *dex.FlowNotActiveError
+		if errors.As(err, &inactive) {
 			return false, nil
 		}
 		return false, err

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -227,9 +227,42 @@ wait-update APIs. Only `StartFlowOptions.RequestID` is public because it may be
 a stable business identifier spanning separate calls.
 
 Client is safe for concurrent calls. `Close` is idempotent and closes only its
-owned gRPC connection. Calls after Close return a local error. Remote
-FlowService failures become `*dex.Error`; local validation and codec failures
-remain ordinary Go errors.
+owned gRPC connection. Calls after Close return a local error.
+
+Remote FlowService failures use concrete Go error types. Match expected
+conditions with `errors.As` instead of comparing gRPC codes or sub-statuses:
+
+```go
+var inactive *dex.FlowNotActiveError
+if errors.As(err, &inactive) {
+	// The Flow exists historically but cannot accept this mutation or RPC.
+}
+```
+
+`FlowNotFoundError` is returned by reads requiring an existing Flow, including
+GetAttribute, GetAttributes, WaitForFlow, and ResetFlow. Mutations, RPCs,
+publishes, timer operations, and step or attribute waits return
+`FlowNotActiveError` when no active Flow is available.
+
+Duplicate starts return `FlowAlreadyStartedError`. Server long polls return
+`LongPollTimeoutError`, including the operation and Flow ID. Worker handler
+failures return `WorkerInvocationError`; its `Worker` field preserves the
+original Worker code, type, and detail. Concurrent locking RPCs return
+`RPCLockConflictError` separately.
+
+`WaitForFlow` returns `FlowUncompletedError` when a Flow closes as failed,
+timed out, terminated, canceled, or continued-as-new. The error exposes
+`FlowID`, `RunID`, `Status`, `ErrorType`, `ErrorMessage`, and any requested
+`Completions`.
+
+Every specific service error unwraps to `*dex.ServiceError` and then to the
+original gRPC error. `ServiceError` exposes `Op`, `FlowID`, `Code`, `SubStatus`,
+and `Detail`; sub-status is diagnostic metadata, not application control flow.
+Unknown or malformed server details fall back to `ServiceError`.
+
+Registry failures use `FlowDefinitionError`, invalid Worker handler results use
+`InvalidStepResultError`, and codec failures use `ValueMappingError`. Ordinary
+argument and context errors remain ordinary Go errors.
 
 ## Value encoding
 

--- a/sdk-go/dex/client.go
+++ b/sdk-go/dex/client.go
@@ -171,9 +171,9 @@ func (client *Client) hydrateValues(
 	if err := client.hydrator.HydrateValuesInPlace(ctx, valuePointers); err != nil {
 		var failure *workerFailure
 		if errors.As(err, &failure) {
-			return convertRPCError(failure.cause)
+			return translateRPCError(failure.cause, "LoadBlobs", "", flowTargetNone)
 		}
-		return convertRPCError(err)
+		return translateRPCError(err, "LoadBlobs", "", flowTargetNone)
 	}
 	return nil
 }
@@ -195,6 +195,28 @@ const (
 	FlowCanceled
 	FlowContinuedAsNew
 )
+
+// String returns the Flow status name.
+func (status FlowStatus) String() string {
+	switch status {
+	case FlowRunning:
+		return "running"
+	case FlowCompleted:
+		return "completed"
+	case FlowFailed:
+		return "failed"
+	case FlowTimedOut:
+		return "timed out"
+	case FlowTerminated:
+		return "terminated"
+	case FlowCanceled:
+		return "canceled"
+	case FlowContinuedAsNew:
+		return "continued as new"
+	default:
+		return fmt.Sprintf("unknown status %d", status)
+	}
+}
 
 type FlowErrorType uint8
 
@@ -281,7 +303,7 @@ func (client *Client) StartFlow(
 		RequestId:          requestID,
 	})
 	if err != nil {
-		return "", convertRPCError(err)
+		return "", translateRPCError(err, "StartFlow", flowID, flowTargetNone)
 	}
 	if response == nil || response.RunId == "" {
 		return "", fmt.Errorf("dex: StartFlow response has no run ID")
@@ -434,7 +456,7 @@ func (client *Client) StopFlow(
 		StopType: stopType,
 		Reason:   reason,
 	})
-	return convertRPCError(err)
+	return translateRPCError(err, "StopFlow", flowID, flowTargetActive)
 }
 
 func (client *Client) WaitForFlow(
@@ -455,12 +477,49 @@ func (client *Client) WaitForFlow(
 		WaitTimeSeconds: timeout,
 	})
 	if err != nil {
-		return WaitForFlowResult{}, convertRPCError(err)
+		return WaitForFlowResult{}, translateRPCError(
+			err,
+			"WaitForFlow",
+			flowID,
+			flowTargetExisting,
+		)
 	}
 	if err := client.hydrateValues(ctx, waitForFlowValuePointers(response)); err != nil {
 		return WaitForFlowResult{}, err
 	}
-	return mapWaitForFlowResult(response)
+	result, err := mapWaitForFlowResult(response)
+	if err != nil {
+		return WaitForFlowResult{}, err
+	}
+	if result.Status == FlowCompleted {
+		return result, nil
+	}
+	runID, err := client.flowRunID(ctx, flowID)
+	if err != nil {
+		return WaitForFlowResult{}, err
+	}
+	return WaitForFlowResult{}, &FlowUncompletedError{
+		FlowID:       flowID,
+		RunID:        runID,
+		Status:       result.Status,
+		ErrorType:    result.ErrorType,
+		ErrorMessage: result.ErrorMessage,
+		Completions:  result.Completions,
+	}
+}
+
+func (client *Client) flowRunID(ctx context.Context, flowID string) (string, error) {
+	response, err := client.service.GetFlowSummary(ctx, &dexpb.GetFlowSummaryRequest{
+		FlowId: flowID,
+	})
+	if err != nil {
+		return "", translateRPCError(err, "GetFlowSummary", flowID, flowTargetExisting)
+	}
+	if response == nil || response.FlowExecutionId == nil ||
+		response.FlowExecutionId.RunId == "" {
+		return "", fmt.Errorf("dex: GetFlowSummary response has no run ID")
+	}
+	return response.FlowExecutionId.RunId, nil
 }
 
 func waitForFlowValuePointers(response *dexpb.WaitForFlowResponse) []**dexpb.Value {
@@ -491,7 +550,7 @@ func (client *Client) SearchFlows(
 	}
 	response, err := client.service.SearchFlows(ctx, request)
 	if err != nil {
-		return SearchFlowsPage{}, convertRPCError(err)
+		return SearchFlowsPage{}, translateRPCError(err, "SearchFlows", "", flowTargetNone)
 	}
 	if err := client.hydrateValues(ctx, searchFlowValuePointers(response)); err != nil {
 		return SearchFlowsPage{}, err
@@ -532,7 +591,7 @@ func (client *Client) ResetFlow(
 	request.FlowId = flowID
 	response, err := client.service.ResetFlow(ctx, request)
 	if err != nil {
-		return "", convertRPCError(err)
+		return "", translateRPCError(err, "ResetFlow", flowID, flowTargetExisting)
 	}
 	if response == nil || response.RunId == "" {
 		return "", fmt.Errorf("dex: ResetFlow response has no run ID")
@@ -563,7 +622,7 @@ func (client *Client) SkipTimer(
 		TimerConditionId:    conditionID,
 		TimerConditionIndex: conditionIndex,
 	})
-	return convertRPCError(err)
+	return translateRPCError(err, "SkipTimer", flowID, flowTargetActive)
 }
 
 func effectiveExecutionNumber(stepExecution StepExecutionID) (int32, error) {
@@ -607,7 +666,7 @@ func (client *Client) UpdateFlowConfig(
 		FlowId:     flowID,
 		FlowConfig: mapped,
 	})
-	return convertRPCError(err)
+	return translateRPCError(err, "UpdateFlowConfig", flowID, flowTargetActive)
 }
 
 func (client *Client) WaitForStepCompletion(
@@ -641,7 +700,7 @@ func (client *Client) WaitForStepCompletion(
 			RequestId:           requestID,
 		},
 	)
-	return convertRPCError(err)
+	return translateRPCError(err, "WaitForStepCompletion", flowID, flowTargetActive)
 }
 
 func (client *Client) TriggerContinueAsNew(
@@ -655,7 +714,7 @@ func (client *Client) TriggerContinueAsNew(
 		ctx,
 		&dexpb.TriggerContinueAsNewRequest{FlowId: flowID},
 	)
-	return convertRPCError(err)
+	return translateRPCError(err, "TriggerContinueAsNew", flowID, flowTargetActive)
 }
 
 func (client *Client) HealthCheck(ctx context.Context) (HealthInfo, error) {
@@ -664,7 +723,7 @@ func (client *Client) HealthCheck(ctx context.Context) (HealthInfo, error) {
 	}
 	response, err := client.service.HealthCheck(ctx, &emptypb.Empty{})
 	if err != nil {
-		return HealthInfo{}, convertRPCError(err)
+		return HealthInfo{}, translateRPCError(err, "HealthCheck", "", flowTargetNone)
 	}
 	return mapHealthInfo(response)
 }
@@ -725,7 +784,7 @@ func (client *Client) publishToChannel(
 		FlowId:   flowID,
 		Messages: messages,
 	})
-	return convertRPCError(err)
+	return translateRPCError(err, "PublishToChannel", flowID, flowTargetActive)
 }
 
 func (client *Client) GetAttribute(
@@ -774,7 +833,7 @@ func (client *Client) getAttribute(
 		Keys:   []string{name},
 	})
 	if err != nil {
-		return false, convertRPCError(err)
+		return false, translateRPCError(err, "GetAttribute", flowID, flowTargetExisting)
 	}
 	value, found, err := client.singleAttributeValue(ctx, response, name)
 	if err != nil || !found {
@@ -887,7 +946,7 @@ func (client *Client) GetAttributes(
 		Keys:   keys,
 	})
 	if err != nil {
-		return nil, convertRPCError(err)
+		return nil, translateRPCError(err, "GetAttributes", flowID, flowTargetExisting)
 	}
 	if response == nil {
 		return nil, fmt.Errorf("dex: GetAttributes response is nil")
@@ -960,7 +1019,7 @@ func (client *Client) setAttributes(
 		Attributes: mapped,
 		RequestId:  requestID,
 	})
-	return convertRPCError(err)
+	return translateRPCError(err, "SetAttributes", flowID, flowTargetActive)
 }
 
 func (client *Client) WaitForAttributeEqual(
@@ -1042,7 +1101,7 @@ func (client *Client) waitForAttributeEqual(
 		WaitTimeSeconds: timeout,
 		RequestId:       requestID,
 	})
-	return convertRPCError(err)
+	return translateRPCError(err, "WaitForAttribute", flowID, flowTargetActive)
 }
 
 func (client *Client) InvokeRPC(
@@ -1102,7 +1161,7 @@ func (client *Client) InvokeRPC(
 		RequestId:         requestID,
 	})
 	if err != nil {
-		return convertRPCError(err)
+		return translateRPCError(err, "InvokeRPC", flowID, flowTargetActive)
 	}
 	if response == nil {
 		return fmt.Errorf("dex: InvokeRPC response is nil")

--- a/sdk-go/dex/client_integration_test.go
+++ b/sdk-go/dex/client_integration_test.go
@@ -36,7 +36,9 @@ import (
 	"github.com/superdurable/dex/sdk-go/dex/ptr"
 	"github.com/superdurable/dex/sdk-go/gen/dexpb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -112,6 +114,7 @@ type clientTestFlowService struct {
 	waitAttributeRequest *dexpb.WaitForAttributeRequest
 	stopRequest          *dexpb.StopFlowRequest
 	waitFlowRequest      *dexpb.WaitForFlowRequest
+	flowSummaryRequest   *dexpb.GetFlowSummaryRequest
 	searchRequest        *dexpb.SearchFlowsRequest
 	resetRequest         *dexpb.ResetFlowRequest
 	skipTimerRequest     *dexpb.SkipTimerRequest
@@ -126,6 +129,14 @@ func (service *clientTestFlowService) StartFlow(
 	request *dexpb.StartFlowRequest,
 ) (*dexpb.StartFlowResponse, error) {
 	service.startRequest = request
+	if request.FlowId == "duplicate" {
+		return nil, clientTestServiceError(
+			codes.AlreadyExists,
+			dexpb.ErrorSubStatus_ERROR_SUB_STATUS_FLOW_ALREADY_STARTED,
+			"Flow already started",
+			nil,
+		)
+	}
 	return &dexpb.StartFlowResponse{RunId: "run-1"}, nil
 }
 
@@ -134,6 +145,9 @@ func (service *clientTestFlowService) PublishToChannel(
 	request *dexpb.PublishToChannelRequest,
 ) (*emptypb.Empty, error) {
 	service.publishRequest = request
+	if request.FlowId == "inactive" {
+		return nil, clientTestMissingFlowError()
+	}
 	return &emptypb.Empty{}, nil
 }
 
@@ -142,6 +156,9 @@ func (service *clientTestFlowService) GetAttributes(
 	request *dexpb.GetAttributesRequest,
 ) (*dexpb.GetAttributesResponse, error) {
 	service.getAttributesRequest = request
+	if request.FlowId == "missing-read" {
+		return nil, clientTestMissingFlowError()
+	}
 	attributes := make([]*dexpb.KV, 0, len(request.Keys))
 	for _, key := range request.Keys {
 		var value *dexpb.Value
@@ -160,6 +177,9 @@ func (service *clientTestFlowService) SetAttributes(
 	request *dexpb.SetAttributesRequest,
 ) (*emptypb.Empty, error) {
 	service.setRequests = append(service.setRequests, request)
+	if request.FlowId == "inactive" {
+		return nil, clientTestMissingFlowError()
+	}
 	return &emptypb.Empty{}, nil
 }
 
@@ -187,6 +207,29 @@ func (service *clientTestFlowService) InvokeRPC(
 	request *dexpb.InvokeRPCRequest,
 ) (*dexpb.InvokeRPCResponse, error) {
 	service.invokeRequest = request
+	if request.FlowId == "worker" {
+		return nil, clientTestServiceError(
+			codes.FailedPrecondition,
+			dexpb.ErrorSubStatus_ERROR_SUB_STATUS_WORKER_API_ERROR,
+			"Worker invocation failed",
+			&WorkerError{
+				Code:   codes.InvalidArgument,
+				Type:   "ValidationError",
+				Detail: "invalid input",
+			},
+		)
+	}
+	if request.FlowId == "lock" {
+		return nil, clientTestServiceError(
+			codes.Aborted,
+			dexpb.ErrorSubStatus_ERROR_SUB_STATUS_WORKER_API_ERROR,
+			"RPC lock conflict",
+			nil,
+		)
+	}
+	if request.FlowId == "inactive" {
+		return nil, clientTestMissingFlowError()
+	}
 	output, err := encodeValue(clientTestRPCOutput{Status: "updated"})
 	if err != nil {
 		return nil, err
@@ -199,6 +242,9 @@ func (service *clientTestFlowService) WaitForAttribute(
 	request *dexpb.WaitForAttributeRequest,
 ) (*emptypb.Empty, error) {
 	service.waitAttributeRequest = request
+	if request.FlowId == "inactive" {
+		return nil, clientTestMissingFlowError()
+	}
 	return &emptypb.Empty{}, nil
 }
 
@@ -207,6 +253,9 @@ func (service *clientTestFlowService) StopFlow(
 	request *dexpb.StopFlowRequest,
 ) (*emptypb.Empty, error) {
 	service.stopRequest = request
+	if request.FlowId == "inactive" {
+		return nil, clientTestMissingFlowError()
+	}
 	return &emptypb.Empty{}, nil
 }
 
@@ -215,6 +264,31 @@ func (service *clientTestFlowService) WaitForFlow(
 	request *dexpb.WaitForFlowRequest,
 ) (*dexpb.WaitForFlowResponse, error) {
 	service.waitFlowRequest = request
+	if request.FlowId == "timeout" {
+		return nil, clientTestServiceError(
+			codes.DeadlineExceeded,
+			dexpb.ErrorSubStatus_ERROR_SUB_STATUS_LONG_POLL_TIME_OUT,
+			"long poll timed out",
+			nil,
+		)
+	}
+	if request.FlowId == "missing-read" {
+		return nil, clientTestMissingFlowError()
+	}
+	if request.FlowId == "uncompleted" {
+		return &dexpb.WaitForFlowResponse{
+			FlowStatus:   dexpb.FlowStatus_FLOW_STATUS_FAILED,
+			ErrorType:    dexpb.FlowErrorType_FLOW_ERROR_TYPE_WORKER_API_FAIL,
+			ErrorMessage: "worker failed",
+			Results: []*dexpb.StepCompletionOutput{{
+				CompletedStepType:        "dex.clientTestStep",
+				CompletedStepExecutionId: "dex.clientTestStep-1",
+				CompletedStepOutput: &dexpb.Value{
+					Kind: &dexpb.Value_StringValue{StringValue: "partial"},
+				},
+			}},
+		}, nil
+	}
 	return &dexpb.WaitForFlowResponse{
 		FlowStatus: dexpb.FlowStatus_FLOW_STATUS_COMPLETED,
 		Results: []*dexpb.StepCompletionOutput{{
@@ -226,6 +300,19 @@ func (service *clientTestFlowService) WaitForFlow(
 				},
 			},
 		}},
+	}, nil
+}
+
+func (service *clientTestFlowService) GetFlowSummary(
+	_ context.Context,
+	request *dexpb.GetFlowSummaryRequest,
+) (*dexpb.GetFlowSummaryResponse, error) {
+	service.flowSummaryRequest = request
+	return &dexpb.GetFlowSummaryResponse{
+		FlowExecutionId: &dexpb.FlowExecutionID{
+			FlowId: request.FlowId,
+			RunId:  "run-uncompleted",
+		},
 	}, nil
 }
 
@@ -257,6 +344,9 @@ func (service *clientTestFlowService) ResetFlow(
 	request *dexpb.ResetFlowRequest,
 ) (*dexpb.ResetFlowResponse, error) {
 	service.resetRequest = request
+	if request.FlowId == "missing-read" {
+		return nil, clientTestMissingFlowError()
+	}
 	return &dexpb.ResetFlowResponse{RunId: "run-2"}, nil
 }
 
@@ -265,6 +355,9 @@ func (service *clientTestFlowService) SkipTimer(
 	request *dexpb.SkipTimerRequest,
 ) (*emptypb.Empty, error) {
 	service.skipTimerRequest = request
+	if request.FlowId == "inactive" {
+		return nil, clientTestMissingFlowError()
+	}
 	return &emptypb.Empty{}, nil
 }
 
@@ -273,6 +366,9 @@ func (service *clientTestFlowService) UpdateFlowConfig(
 	request *dexpb.UpdateFlowConfigRequest,
 ) (*emptypb.Empty, error) {
 	service.updateConfigRequest = request
+	if request.FlowId == "inactive" {
+		return nil, clientTestMissingFlowError()
+	}
 	return &emptypb.Empty{}, nil
 }
 
@@ -281,6 +377,9 @@ func (service *clientTestFlowService) WaitForStepCompletion(
 	request *dexpb.WaitForStepCompletionRequest,
 ) (*dexpb.WaitForStepCompletionResponse, error) {
 	service.waitStepRequest = request
+	if request.FlowId == "inactive" {
+		return nil, clientTestMissingFlowError()
+	}
 	return &dexpb.WaitForStepCompletionResponse{}, nil
 }
 
@@ -289,6 +388,9 @@ func (service *clientTestFlowService) TriggerContinueAsNew(
 	request *dexpb.TriggerContinueAsNewRequest,
 ) (*emptypb.Empty, error) {
 	service.continueAsNewRequest = request
+	if request.FlowId == "inactive" {
+		return nil, clientTestMissingFlowError()
+	}
 	return &emptypb.Empty{}, nil
 }
 
@@ -297,6 +399,34 @@ func (service *clientTestFlowService) HealthCheck(
 	*emptypb.Empty,
 ) (*dexpb.HealthInfo, error) {
 	return &dexpb.HealthInfo{Condition: "SERVING", Hostname: "test", Duration: 1}, nil
+}
+
+func clientTestServiceError(
+	code codes.Code,
+	subStatus dexpb.ErrorSubStatus,
+	detail string,
+	worker *WorkerError,
+) error {
+	response := &dexpb.ErrorResponse{SubStatus: subStatus, Detail: detail}
+	if worker != nil {
+		response.OriginalWorkerErrorStatus = int32(worker.Code)
+		response.OriginalWorkerErrorType = worker.Type
+		response.OriginalWorkerErrorDetail = worker.Detail
+	}
+	withDetails, err := status.New(code, detail).WithDetails(response)
+	if err != nil {
+		panic(err)
+	}
+	return withDetails.Err()
+}
+
+func clientTestMissingFlowError() error {
+	return clientTestServiceError(
+		codes.NotFound,
+		dexpb.ErrorSubStatus_ERROR_SUB_STATUS_FLOW_NOT_EXISTS,
+		"Flow does not exist",
+		nil,
+	)
 }
 
 func TestClientFlowAndPersistenceTransport(t *testing.T) {
@@ -492,6 +622,142 @@ func TestClientRPCResultsAndAdministrativeTransport(t *testing.T) {
 	cancel()
 	_, err = openClient.HealthCheck(canceledCtx)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestClientExplicitServiceErrors(t *testing.T) {
+	client, service := newClientIntegration(t)
+	ctx := context.Background()
+
+	_, err := client.StartFlow(
+		ctx,
+		clientTestFlow{},
+		"duplicate",
+		clientTestInput{},
+		StartFlowOptions{},
+	)
+	var duplicate *FlowAlreadyStartedError
+	require.ErrorAs(t, err, &duplicate)
+	require.Equal(t, "duplicate", duplicate.FlowID)
+
+	var value string
+	_, err = client.GetAttribute(ctx, "missing-read", clientTestStatus, &value)
+	var missing *FlowNotFoundError
+	require.ErrorAs(t, err, &missing)
+	require.Equal(t, "GetAttribute", missing.Op)
+	_, err = client.WaitForFlow(ctx, "missing-read", WaitForFlowOptions{})
+	require.ErrorAs(t, err, &missing)
+	_, err = client.ResetFlow(ctx, "missing-read", ResetOptions{Type: ResetToBeginning})
+	require.ErrorAs(t, err, &missing)
+
+	activeCalls := []struct {
+		name string
+		call func() error
+	}{
+		{name: "publish", call: func() error {
+			return client.PublishToChannel(ctx, "inactive", clientTestCommands, "value")
+		}},
+		{name: "set attribute", call: func() error {
+			return client.SetAttribute(ctx, "inactive", clientTestStatus, "value")
+		}},
+		{name: "wait for attribute", call: func() error {
+			return client.WaitForAttributeEqual(
+				ctx,
+				"inactive",
+				clientTestStatus,
+				"value",
+				WaitOptions{},
+			)
+		}},
+		{name: "stop", call: func() error {
+			return client.StopFlow(ctx, "inactive", StopOptions{})
+		}},
+		{name: "skip timer", call: func() error {
+			return client.SkipTimer(
+				ctx,
+				"inactive",
+				StepExecutionID{StepType: GetFinalStepType(clientTestStep{})},
+				TimerID{ConditionID: "timer"},
+			)
+		}},
+		{name: "update config", call: func() error {
+			return client.UpdateFlowConfig(ctx, "inactive", FlowConfig{})
+		}},
+		{name: "wait for step", call: func() error {
+			return client.WaitForStepCompletion(
+				ctx,
+				"inactive",
+				StepExecutionID{StepType: GetFinalStepType(clientTestStep{})},
+				WaitOptions{},
+			)
+		}},
+		{name: "continue as new", call: func() error {
+			return client.TriggerContinueAsNew(ctx, "inactive")
+		}},
+	}
+	for _, testCase := range activeCalls {
+		t.Run(testCase.name, func(t *testing.T) {
+			var inactive *FlowNotActiveError
+			require.ErrorAs(t, testCase.call(), &inactive)
+			require.Equal(t, "inactive", inactive.FlowID)
+		})
+	}
+
+	var output clientTestRPCOutput
+	err = client.InvokeRPC(
+		ctx,
+		"worker",
+		clientTestFlow{}.Update,
+		clientTestRPCInput{},
+		&output,
+		InvokeOptions{},
+	)
+	var worker *WorkerInvocationError
+	require.ErrorAs(t, err, &worker)
+	require.Equal(t, codes.InvalidArgument, worker.Worker.Code)
+	require.Equal(t, "ValidationError", worker.Worker.Type)
+	require.Equal(t, "invalid input", worker.Worker.Detail)
+
+	err = client.InvokeRPC(
+		ctx,
+		"lock",
+		clientTestFlow{}.Update,
+		clientTestRPCInput{},
+		&output,
+		InvokeOptions{},
+	)
+	var conflict *RPCLockConflictError
+	require.ErrorAs(t, err, &conflict)
+
+	err = client.InvokeRPC(
+		ctx,
+		"inactive",
+		clientTestFlow{}.Update,
+		clientTestRPCInput{},
+		&output,
+		InvokeOptions{},
+	)
+	var inactive *FlowNotActiveError
+	require.ErrorAs(t, err, &inactive)
+
+	_, err = client.WaitForFlow(ctx, "timeout", WaitForFlowOptions{})
+	var timeout *LongPollTimeoutError
+	require.ErrorAs(t, err, &timeout)
+	require.Equal(t, "timeout", timeout.FlowID)
+	require.Equal(t, codes.DeadlineExceeded, status.Code(timeout))
+
+	_, err = client.WaitForFlow(ctx, "uncompleted", WaitForFlowOptions{NeedsResults: true})
+	var uncompleted *FlowUncompletedError
+	require.ErrorAs(t, err, &uncompleted)
+	require.Equal(t, "uncompleted", uncompleted.FlowID)
+	require.Equal(t, "run-uncompleted", uncompleted.RunID)
+	require.Equal(t, FlowFailed, uncompleted.Status)
+	require.Equal(t, FlowErrorWorkerMethod, uncompleted.ErrorType)
+	require.Equal(t, "worker failed", uncompleted.ErrorMessage)
+	require.Len(t, uncompleted.Completions, 1)
+	var partial string
+	require.NoError(t, uncompleted.Completions[0].Output.Decode(&partial))
+	require.Equal(t, "partial", partial)
+	require.Equal(t, "uncompleted", service.flowSummaryRequest.FlowId)
 }
 
 func newClientIntegration(t *testing.T) (*Client, *clientTestFlowService) {

--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"math"
 	"testing"
 	"time"
 
@@ -117,6 +118,18 @@ var _ dex.Step[stepInput] = executeOnly
 
 type contractFlow struct {
 	dex.FlowDefaults
+}
+
+type unregisteredContractFlow struct {
+	dex.FlowDefaults
+}
+
+func (unregisteredContractFlow) GetSteps() []dex.StepDef {
+	return nil
+}
+
+func (unregisteredContractFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{}
 }
 
 func (contractFlow) GetSteps() []dex.StepDef {
@@ -226,6 +239,30 @@ func TestPublicContractsCompile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, err = client.StartFlow(
+		context.Background(),
+		unregisteredContractFlow{},
+		"unregistered",
+		nil,
+		dex.StartFlowOptions{},
+	)
+	var definition *dex.FlowDefinitionError
+	if !errors.As(err, &definition) {
+		t.Fatalf("unregistered Flow error is not FlowDefinitionError: %v", err)
+	}
+	unregisteredAttribute := dex.DefineAttribute[string]("unregistered")
+	err = client.SetAttribute(
+		context.Background(),
+		"flow-id",
+		unregisteredAttribute,
+		"value",
+	)
+	if !errors.As(err, &definition) {
+		t.Fatalf("unregistered attribute error is not FlowDefinitionError: %v", err)
+	}
+	if definition.Definition != `attribute "unregistered"` {
+		t.Fatalf("unregistered attribute context is missing: %#v", definition)
+	}
 	if err := client.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -234,18 +271,53 @@ func TestPublicContractsCompile(t *testing.T) {
 	}
 }
 
-func TestErrorSupportsErrorsAs(t *testing.T) {
-	sdkError := error(&dex.Error{
+func TestServiceErrorsSupportErrorsAs(t *testing.T) {
+	serviceError := &dex.ServiceError{
+		Op:        "WaitForFlow",
+		FlowID:    "flow-id",
 		Code:      codes.NotFound,
-		SubStatus: dex.ErrorFlowNotFound,
+		SubStatus: dex.ErrorSubStatusFlowNotFound,
 		Detail:    "flow is missing",
-	})
-	var target *dex.Error
-	if !errors.As(sdkError, &target) {
-		t.Fatal("SDK error does not support errors.As")
 	}
-	if target.Code != codes.NotFound {
-		t.Fatalf("unexpected code: %s", target.Code)
+	sdkError := error(&dex.FlowNotFoundError{ServiceError: serviceError})
+	var missing *dex.FlowNotFoundError
+	if !errors.As(sdkError, &missing) {
+		t.Fatal("specific SDK error does not support errors.As")
+	}
+	var target *dex.ServiceError
+	if !errors.As(sdkError, &target) {
+		t.Fatal("SDK error does not unwrap to ServiceError")
+	}
+	if target.Code != codes.NotFound || target.FlowID != "flow-id" {
+		t.Fatalf("unexpected service error: %#v", target)
+	}
+}
+
+func TestLocalErrorContracts(t *testing.T) {
+	_, err := dex.NewRegistry([]dex.Flow{nil})
+	var definition *dex.FlowDefinitionError
+	if !errors.As(err, &definition) {
+		t.Fatalf("registry error is not FlowDefinitionError: %v", err)
+	}
+
+	indexed := dex.DefineAttribute[float64](
+		"score",
+		dex.Indexed(dex.AttributeIndex{Type: dex.IndexDouble}),
+	)
+	_, err = dex.InitialAttribute(indexed, math.NaN())
+	var mapping *dex.ValueMappingError
+	if !errors.As(err, &mapping) {
+		t.Fatalf("mapping error is not ValueMappingError: %v", err)
+	}
+
+	uncompletedErr := error(&dex.FlowUncompletedError{
+		FlowID: "flow-id",
+		RunID:  "run-id",
+		Status: dex.FlowFailed,
+	})
+	var uncompleted *dex.FlowUncompletedError
+	if !errors.As(uncompletedErr, &uncompleted) {
+		t.Fatalf("Flow uncompleted error does not support errors.As: %v", uncompletedErr)
 	}
 }
 

--- a/sdk-go/dex/errors.go
+++ b/sdk-go/dex/errors.go
@@ -29,6 +29,87 @@ type AttributeNotFoundError struct {
 	Instance      string
 }
 
+// FlowDefinitionError reports an invalid or unregistered Flow definition.
+type FlowDefinitionError struct {
+	FlowType   string
+	Definition string
+	Err        error
+}
+
+func (e *FlowDefinitionError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	prefix := "dex: flow definition"
+	if e.FlowType != "" {
+		prefix = fmt.Sprintf("dex: flow %q definition", e.FlowType)
+	}
+	if e.Definition != "" {
+		prefix += " " + e.Definition
+	}
+	if e.Err == nil {
+		return prefix
+	}
+	return prefix + ": " + e.Err.Error()
+}
+
+func (e *FlowDefinitionError) Unwrap() error {
+	return e.Err
+}
+
+// InvalidStepResultError reports an invalid Worker handler result.
+type InvalidStepResultError struct {
+	FlowType string
+	StepType string
+	Method   string
+	Err      error
+}
+
+func (e *InvalidStepResultError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	prefix := fmt.Sprintf("dex: flow %q", e.FlowType)
+	if e.StepType != "" {
+		prefix += fmt.Sprintf(" step %q", e.StepType)
+	}
+	if e.Method != "" {
+		prefix += " " + e.Method
+	}
+	if e.Err == nil {
+		return prefix + " returned an invalid result"
+	}
+	return prefix + ": " + e.Err.Error()
+}
+
+func (e *InvalidStepResultError) Unwrap() error {
+	return e.Err
+}
+
+// ValueMappingError reports a Dex value conversion failure.
+type ValueMappingError struct {
+	Operation string
+	Err       error
+}
+
+func (e *ValueMappingError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	prefix := "dex: map value"
+	if e.Operation != "" {
+		prefix = "dex: " + e.Operation + " value"
+	}
+	if e.Err == nil {
+		return prefix
+	}
+	return prefix + ": " + e.Err.Error()
+}
+
+func (e *ValueMappingError) Unwrap() error {
+	return e.Err
+}
+
 func (e *AttributeNotFoundError) Error() string {
 	if e.Instance == "" {
 		return fmt.Sprintf("dex: attribute %q not found", e.AttributeName)
@@ -40,40 +121,145 @@ func (e *AttributeNotFoundError) Error() string {
 	)
 }
 
-type Error struct {
-	Code                codes.Code
-	SubStatus           ErrorSubStatus
-	Detail              string
-	OriginalWorkerError *WorkerError
+// ServiceError reports a FlowService failure.
+type ServiceError struct {
+	Op        string
+	FlowID    string
+	Code      codes.Code
+	SubStatus ErrorSubStatus
+	Detail    string
+	cause     error
 }
 
-func (e *Error) Error() string {
+func (e *ServiceError) Error() string {
 	if e == nil {
 		return "<nil>"
 	}
-	if e.Detail == "" {
-		return e.Code.String()
+	prefix := "dex"
+	if e.Op != "" {
+		prefix += ": " + e.Op
 	}
-	return fmt.Sprintf("%s: %s", e.Code, e.Detail)
+	if e.FlowID != "" {
+		prefix += fmt.Sprintf(" flow %q", e.FlowID)
+	}
+	if e.Detail == "" {
+		return fmt.Sprintf("%s: %s", prefix, e.Code)
+	}
+	return fmt.Sprintf("%s: %s: %s", prefix, e.Code, e.Detail)
 }
 
+func (e *ServiceError) Unwrap() error {
+	return e.cause
+}
+
+// FlowAlreadyStartedError reports a duplicate Flow start.
+type FlowAlreadyStartedError struct {
+	*ServiceError
+}
+
+func (e *FlowAlreadyStartedError) Unwrap() error {
+	return e.ServiceError
+}
+
+// FlowNotFoundError reports a missing Flow for an existing-Flow operation.
+type FlowNotFoundError struct {
+	*ServiceError
+}
+
+func (e *FlowNotFoundError) Unwrap() error {
+	return e.ServiceError
+}
+
+// FlowNotActiveError reports a missing active Flow.
+type FlowNotActiveError struct {
+	*ServiceError
+}
+
+func (e *FlowNotActiveError) Unwrap() error {
+	return e.ServiceError
+}
+
+// WorkerInvocationError reports a WorkerService or user-handler failure.
+type WorkerInvocationError struct {
+	*ServiceError
+	Worker *WorkerError
+}
+
+func (e *WorkerInvocationError) Unwrap() error {
+	return e.ServiceError
+}
+
+// RPCLockConflictError reports concurrent RPC lock contention.
+type RPCLockConflictError struct {
+	*ServiceError
+}
+
+func (e *RPCLockConflictError) Unwrap() error {
+	return e.ServiceError
+}
+
+// LongPollTimeoutError reports an expired server long poll.
+type LongPollTimeoutError struct {
+	*ServiceError
+}
+
+func (e *LongPollTimeoutError) Unwrap() error {
+	return e.ServiceError
+}
+
+// FlowUncompletedError reports a Flow that closed without completing.
+type FlowUncompletedError struct {
+	FlowID       string
+	RunID        string
+	Status       FlowStatus
+	ErrorType    FlowErrorType
+	ErrorMessage string
+	Completions  []StepCompletion
+}
+
+func (e *FlowUncompletedError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	prefix := fmt.Sprintf("dex: flow %q did not complete: %s", e.FlowID, e.Status)
+	if e.ErrorMessage == "" {
+		return prefix
+	}
+	return prefix + ": " + e.ErrorMessage
+}
+
+// WorkerError preserves the original WorkerService failure.
 type WorkerError struct {
 	Code   codes.Code
 	Type   string
 	Detail string
 }
 
+// ErrorSubStatus is Dex's diagnostic service error classification.
 type ErrorSubStatus uint8
 
 const (
-	ErrorUncategorized ErrorSubStatus = iota + 1
-	ErrorFlowAlreadyStarted
-	ErrorFlowNotFound
-	ErrorWorkerAPI
-	ErrorLongPollTimeout
+	ErrorSubStatusUncategorized ErrorSubStatus = iota + 1
+	ErrorSubStatusFlowAlreadyStarted
+	ErrorSubStatusFlowNotFound
+	ErrorSubStatusWorkerAPI
+	ErrorSubStatusLongPollTimeout
 )
 
-func convertRPCError(err error) error {
+type flowTargetRequirement uint8
+
+const (
+	flowTargetNone flowTargetRequirement = iota
+	flowTargetExisting
+	flowTargetActive
+)
+
+func translateRPCError(
+	err error,
+	op string,
+	flowID string,
+	requirement flowTargetRequirement,
+) error {
 	if err == nil {
 		return nil
 	}
@@ -81,45 +267,114 @@ func convertRPCError(err error) error {
 	if !ok {
 		return err
 	}
-	dexError := &Error{
+	serviceError := &ServiceError{
+		Op:        op,
+		FlowID:    flowID,
 		Code:      rpcStatus.Code(),
-		SubStatus: ErrorUncategorized,
+		SubStatus: ErrorSubStatusUncategorized,
 		Detail:    rpcStatus.Message(),
+		cause:     err,
 	}
+	var response *dexpb.ErrorResponse
 	for _, detail := range rpcStatus.Details() {
-		response, isDexError := detail.(*dexpb.ErrorResponse)
-		if !isDexError {
-			continue
+		if malformed, isMalformed := detail.(error); isMalformed {
+			serviceError.Detail = fmt.Sprintf(
+				"Dex returned malformed error details: %v",
+				malformed,
+			)
+			return serviceError
 		}
-		dexError.SubStatus = mapErrorSubStatus(response.SubStatus)
-		if response.Detail != "" {
-			dexError.Detail = response.Detail
+		var isDexError bool
+		response, isDexError = detail.(*dexpb.ErrorResponse)
+		if isDexError {
+			break
 		}
-		if response.OriginalWorkerErrorDetail != "" ||
-			response.OriginalWorkerErrorType != "" ||
-			response.OriginalWorkerErrorStatus != 0 {
-			dexError.OriginalWorkerError = &WorkerError{
-				Code:   codes.Code(response.OriginalWorkerErrorStatus),
-				Type:   response.OriginalWorkerErrorType,
-				Detail: response.OriginalWorkerErrorDetail,
-			}
-		}
-		break
 	}
-	return dexError
+	if response == nil {
+		return serviceError
+	}
+	serviceError.SubStatus = mapErrorSubStatus(response.SubStatus)
+	if response.Detail != "" {
+		serviceError.Detail = response.Detail
+	}
+	switch serviceError.SubStatus {
+	case ErrorSubStatusFlowAlreadyStarted:
+		return &FlowAlreadyStartedError{ServiceError: serviceError}
+	case ErrorSubStatusFlowNotFound:
+		switch requirement {
+		case flowTargetExisting:
+			return &FlowNotFoundError{ServiceError: serviceError}
+		case flowTargetActive:
+			return &FlowNotActiveError{ServiceError: serviceError}
+		default:
+			return serviceError
+		}
+	case ErrorSubStatusWorkerAPI:
+		if serviceError.Code == codes.Aborted {
+			return &RPCLockConflictError{ServiceError: serviceError}
+		}
+		return &WorkerInvocationError{
+			ServiceError: serviceError,
+			Worker:       mapWorkerError(response),
+		}
+	case ErrorSubStatusLongPollTimeout:
+		return &LongPollTimeoutError{ServiceError: serviceError}
+	default:
+		return serviceError
+	}
+}
+
+func mapWorkerError(response *dexpb.ErrorResponse) *WorkerError {
+	if response.OriginalWorkerErrorDetail == "" &&
+		response.OriginalWorkerErrorType == "" &&
+		response.OriginalWorkerErrorStatus == 0 {
+		return nil
+	}
+	return &WorkerError{
+		Code:   codes.Code(response.OriginalWorkerErrorStatus),
+		Type:   response.OriginalWorkerErrorType,
+		Detail: response.OriginalWorkerErrorDetail,
+	}
 }
 
 func mapErrorSubStatus(subStatus dexpb.ErrorSubStatus) ErrorSubStatus {
 	switch subStatus {
 	case dexpb.ErrorSubStatus_ERROR_SUB_STATUS_FLOW_ALREADY_STARTED:
-		return ErrorFlowAlreadyStarted
+		return ErrorSubStatusFlowAlreadyStarted
 	case dexpb.ErrorSubStatus_ERROR_SUB_STATUS_FLOW_NOT_EXISTS:
-		return ErrorFlowNotFound
+		return ErrorSubStatusFlowNotFound
 	case dexpb.ErrorSubStatus_ERROR_SUB_STATUS_WORKER_API_ERROR:
-		return ErrorWorkerAPI
+		return ErrorSubStatusWorkerAPI
 	case dexpb.ErrorSubStatus_ERROR_SUB_STATUS_LONG_POLL_TIME_OUT:
-		return ErrorLongPollTimeout
+		return ErrorSubStatusLongPollTimeout
 	default:
-		return ErrorUncategorized
+		return ErrorSubStatusUncategorized
 	}
+}
+
+func newFlowDefinitionError(
+	flowType string,
+	definition string,
+	err error,
+) error {
+	var existing *FlowDefinitionError
+	if errors.As(err, &existing) {
+		return err
+	}
+	return &FlowDefinitionError{
+		FlowType:   flowType,
+		Definition: definition,
+		Err:        err,
+	}
+}
+
+func wrapValueMappingError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var existing *ValueMappingError
+	if errors.As(err, &existing) {
+		return err
+	}
+	return &ValueMappingError{Operation: operation, Err: err}
 }

--- a/sdk-go/dex/errors_test.go
+++ b/sdk-go/dex/errors_test.go
@@ -16,11 +16,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/superdurable/dex/sdk-go/gen/dexpb"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
-func TestConvertRPCErrorPreservesDexDetails(t *testing.T) {
+func TestTranslateRPCErrorPreservesWorkerDetailsAndUnwraps(t *testing.T) {
 	rpcStatus, err := status.New(codes.FailedPrecondition, "fallback").WithDetails(
 		&dexpb.ErrorResponse{
 			Detail:                    "worker failed",
@@ -32,25 +34,58 @@ func TestConvertRPCErrorPreservesDexDetails(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	converted := convertRPCError(rpcStatus.Err())
-	var dexError *Error
-	require.ErrorAs(t, converted, &dexError)
-	require.Equal(t, codes.FailedPrecondition, dexError.Code)
-	require.Equal(t, ErrorWorkerAPI, dexError.SubStatus)
-	require.Equal(t, "worker failed", dexError.Detail)
-	require.Equal(t, codes.InvalidArgument, dexError.OriginalWorkerError.Code)
-	require.Equal(t, "ValidationError", dexError.OriginalWorkerError.Type)
-	require.Equal(t, "invalid input", dexError.OriginalWorkerError.Detail)
+	translated := translateRPCError(
+		rpcStatus.Err(),
+		"InvokeRPC",
+		"flow-1",
+		flowTargetActive,
+	)
+	var workerError *WorkerInvocationError
+	require.ErrorAs(t, translated, &workerError)
+	require.Equal(t, codes.InvalidArgument, workerError.Worker.Code)
+	require.Equal(t, "ValidationError", workerError.Worker.Type)
+	require.Equal(t, "invalid input", workerError.Worker.Detail)
+
+	var serviceError *ServiceError
+	require.ErrorAs(t, translated, &serviceError)
+	require.Equal(t, "InvokeRPC", serviceError.Op)
+	require.Equal(t, "flow-1", serviceError.FlowID)
+	require.Equal(t, codes.FailedPrecondition, serviceError.Code)
+	require.Equal(t, ErrorSubStatusWorkerAPI, serviceError.SubStatus)
+	require.Equal(t, "worker failed", serviceError.Detail)
+	require.Equal(t, codes.FailedPrecondition, status.Code(translated))
 }
 
-func TestConvertRPCErrorFallbackAndLocalError(t *testing.T) {
-	converted := convertRPCError(status.Error(codes.Unavailable, "backend unavailable"))
-	var dexError *Error
-	require.ErrorAs(t, converted, &dexError)
-	require.Equal(t, ErrorUncategorized, dexError.SubStatus)
-	require.Equal(t, "backend unavailable", dexError.Detail)
+func TestTranslateRPCErrorFallbackAndLocalError(t *testing.T) {
+	translated := translateRPCError(
+		status.Error(codes.Unavailable, "backend unavailable"),
+		"HealthCheck",
+		"",
+		flowTargetNone,
+	)
+	var serviceError *ServiceError
+	require.ErrorAs(t, translated, &serviceError)
+	require.Equal(t, ErrorSubStatusUncategorized, serviceError.SubStatus)
+	require.Equal(t, "backend unavailable", serviceError.Detail)
 
 	local := errors.New("local")
-	require.Same(t, local, convertRPCError(local))
-	require.NoError(t, convertRPCError(nil))
+	require.Same(t, local, translateRPCError(local, "", "", flowTargetNone))
+	require.NoError(t, translateRPCError(nil, "", "", flowTargetNone))
+}
+
+func TestTranslateRPCErrorMalformedDetailsFallback(t *testing.T) {
+	rpcError := status.ErrorProto(&statuspb.Status{
+		Code:    int32(codes.Internal),
+		Message: "broken details",
+		Details: []*anypb.Any{{
+			TypeUrl: "type.googleapis.com/dex.ErrorResponse",
+			Value:   []byte{0xff},
+		}},
+	})
+	translated := translateRPCError(rpcError, "WaitForFlow", "flow-1", flowTargetExisting)
+	var serviceError *ServiceError
+	require.ErrorAs(t, translated, &serviceError)
+	require.ErrorContains(t, translated, "malformed error details")
+	var missing *FlowNotFoundError
+	require.NotErrorAs(t, translated, &missing)
 }

--- a/sdk-go/dex/registration.go
+++ b/sdk-go/dex/registration.go
@@ -61,16 +61,22 @@ func NewRegistry(flows []Flow) (*Registry, error) {
 	indexTypes := make(map[string]IndexType)
 	for index, flow := range flows {
 		if nilInterface(flow) {
-			return nil, fmt.Errorf("dex: flow at index %d is nil", index)
+			return nil, newFlowDefinitionError(
+				"",
+				"",
+				fmt.Errorf("flow at index %d is nil", index),
+			)
 		}
+		flowType := GetFinalFlowType(flow)
 		registered, err := assembled.registerFlow(flow, indexTypes)
 		if err != nil {
-			return nil, err
+			return nil, newFlowDefinitionError(flowType, "", err)
 		}
 		if _, found := assembled.flows[registered.flowType]; found {
-			return nil, fmt.Errorf(
-				"dex: duplicate flow type %q",
+			return nil, newFlowDefinitionError(
 				registered.flowType,
+				"",
+				fmt.Errorf("duplicate flow type %q", registered.flowType),
 			)
 		}
 		assembled.flows[registered.flowType] = registered
@@ -447,14 +453,21 @@ func (registry *Registry) resolveFlow(reference Flow) (*registeredFlow, error) {
 	}
 	registered, found := registry.lookupFlow(flowType)
 	if !found {
-		return nil, fmt.Errorf("dex: flow %q is not registered", flowType)
+		return nil, newFlowDefinitionError(
+			flowType,
+			"",
+			fmt.Errorf("flow is not registered"),
+		)
 	}
 	if reflect.TypeOf(reference) != reflect.TypeOf(registered.flow) {
-		return nil, fmt.Errorf(
-			"dex: flow %q type %s does not match registered type %s",
+		return nil, newFlowDefinitionError(
 			flowType,
-			reflect.TypeOf(reference),
-			reflect.TypeOf(registered.flow),
+			"",
+			fmt.Errorf(
+				"type %s does not match registered type %s",
+				reflect.TypeOf(reference),
+				reflect.TypeOf(registered.flow),
+			),
 		)
 	}
 	return registered, nil
@@ -501,11 +514,14 @@ func (registry *Registry) resolveRPC(reference any) (*registeredFlow, *registere
 			return flow, registered, nil
 		}
 	}
-	return nil, nil, fmt.Errorf(
-		"dex: RPC %q with input %s and output %s is not registered",
-		rpcName,
-		inputType,
-		outputType,
+	return nil, nil, newFlowDefinitionError(
+		"",
+		fmt.Sprintf("rpc %q", rpcName),
+		fmt.Errorf(
+			"input %s and output %s are not registered",
+			inputType,
+			outputType,
+		),
 	)
 }
 
@@ -533,7 +549,11 @@ func (registry *Registry) resolveAttribute(
 			return registered, nil
 		}
 	}
-	return registeredAttribute{}, fmt.Errorf("dex: attribute %q is not registered", name)
+	return registeredAttribute{}, newFlowDefinitionError(
+		"",
+		fmt.Sprintf("attribute %q", name),
+		fmt.Errorf("attribute is not registered"),
+	)
 }
 
 func (registry *Registry) resolveChannel(
@@ -559,7 +579,11 @@ func (registry *Registry) resolveChannel(
 			return registered, nil
 		}
 	}
-	return registeredChannel{}, fmt.Errorf("dex: channel %q is not registered", name)
+	return registeredChannel{}, newFlowDefinitionError(
+		"",
+		fmt.Sprintf("channel %q", name),
+		fmt.Errorf("channel is not registered"),
+	)
 }
 
 func (flow *registeredFlow) lookupStep(

--- a/sdk-go/dex/value.go
+++ b/sdk-go/dex/value.go
@@ -46,7 +46,10 @@ func (value Value) Decode(valuePtr any) error {
 	return decodeValue(value.value, valuePtr)
 }
 
-func encodeValue(value any) (*dexpb.Value, error) {
+func encodeValue(value any) (encoded *dexpb.Value, err error) {
+	defer func() {
+		err = wrapValueMappingError("encode", err)
+	}()
 	if value == nil {
 		return encodeJSONObject(value)
 	}
@@ -139,13 +142,16 @@ func encodeJSONObject(value any) (*dexpb.Value, error) {
 func encodeAttributeValue(
 	value any,
 	index *AttributeIndex,
-) (*dexpb.Value, *dexpb.IndexConfig, error) {
+) (encoded *dexpb.Value, config *dexpb.IndexConfig, err error) {
+	defer func() {
+		err = wrapValueMappingError("encode indexed", err)
+	}()
 	if index == nil {
-		encoded, err := encodeValue(value)
+		encoded, err = encodeValue(value)
 		return encoded, nil, err
 	}
 
-	encoded, err := encodeIndexedValue(value, index.Type)
+	encoded, err = encodeIndexedValue(value, index.Type)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -231,6 +237,17 @@ func decodeValue(value *dexpb.Value, valuePtr any) error {
 	if err != nil {
 		return err
 	}
+	return decodeValueInto(value, target, valuePtr)
+}
+
+func decodeValueInto(
+	value *dexpb.Value,
+	target reflect.Value,
+	valuePtr any,
+) (err error) {
+	defer func() {
+		err = wrapValueMappingError("decode", err)
+	}()
 	if value == nil || value.Kind == nil {
 		return fmt.Errorf("dex: value has no concrete kind")
 	}

--- a/sdk-go/dex/worker_integration_test.go
+++ b/sdk-go/dex/worker_integration_test.go
@@ -372,10 +372,11 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 	defer closeService()
 
 	tests := []struct {
-		name   string
-		call   func() error
-		code   codes.Code
-		detail string
+		name      string
+		call      func() error
+		code      codes.Code
+		detail    string
+		errorType string
 	}{
 		{
 			name: "unknown flow",
@@ -441,6 +442,10 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 			},
 			code:   codes.InvalidArgument,
 			detail: "WaitFor returned nil",
+			errorType: fmt.Sprintf(
+				"%T",
+				&InvalidStepResultError{},
+			),
 		},
 		{
 			name: "nil decision",
@@ -453,6 +458,10 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 			},
 			code:   codes.InvalidArgument,
 			detail: "Execute returned nil",
+			errorType: fmt.Sprintf(
+				"%T",
+				&InvalidStepResultError{},
+			),
 		},
 		{
 			name: "application error",
@@ -495,7 +504,11 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 			if testCase.detail != "" {
 				require.Contains(t, rpcStatus.Message(), testCase.detail)
 			}
-			requireWorkerErrorDetail(t, rpcStatus)
+			details := requireWorkerErrorDetail(t, rpcStatus)
+			if testCase.errorType != "" {
+				require.Equal(t, testCase.errorType, details.ErrorType)
+				require.Contains(t, details.Detail, GetFinalFlowType(workerFlow))
+			}
 		})
 	}
 }
@@ -1063,10 +1076,14 @@ func mustEncodeWorkerTestValue(t *testing.T, value any) *dexpb.Value {
 	return encoded
 }
 
-func requireWorkerErrorDetail(t *testing.T, rpcStatus *status.Status) {
+func requireWorkerErrorDetail(
+	t *testing.T,
+	rpcStatus *status.Status,
+) *dexpb.WorkerErrorResponse {
 	require.Len(t, rpcStatus.Details(), 1)
-	_, ok := rpcStatus.Details()[0].(*dexpb.WorkerErrorResponse)
+	details, ok := rpcStatus.Details()[0].(*dexpb.WorkerErrorResponse)
 	require.True(t, ok)
+	return details
 }
 
 func unusedWorkerAddress(t *testing.T) string {

--- a/sdk-go/dex/worker_service.go
+++ b/sdk-go/dex/worker_service.go
@@ -117,7 +117,12 @@ func (service *workerService) invokeWaitForMethod(
 	}
 	waiting, transient, err := mapRegisteredWait(flow, wait)
 	if err != nil {
-		return nil, newWorkerFailure(codes.InvalidArgument, err)
+		return nil, newWorkerFailure(codes.InvalidArgument, &InvalidStepResultError{
+			FlowType: flow.flowType,
+			StepType: step.stepType,
+			Method:   "WaitFor",
+			Err:      err,
+		})
 	}
 	return &dexpb.InvokeWaitForMethodResponse{
 		UpsertAttributes:      invocation.mappedAttributeWrites(),
@@ -200,7 +205,12 @@ func (service *workerService) invokeExecuteMethod(
 	}
 	mapped, err := mapRegisteredDecision(flow, decision)
 	if err != nil {
-		return nil, newWorkerFailure(codes.InvalidArgument, err)
+		return nil, newWorkerFailure(codes.InvalidArgument, &InvalidStepResultError{
+			FlowType: flow.flowType,
+			StepType: step.stepType,
+			Method:   "Execute",
+			Err:      err,
+		})
 	}
 	return &dexpb.InvokeExecuteMethodResponse{
 		StepDecision:     mapped,
@@ -276,7 +286,11 @@ func (service *workerService) invokeWorkerRPC(
 	}
 	response, err := mapRegisteredRPCResult(flow, result)
 	if err != nil {
-		return nil, newWorkerFailure(codes.InvalidArgument, err)
+		return nil, newWorkerFailure(codes.InvalidArgument, &InvalidStepResultError{
+			FlowType: flow.flowType,
+			Method:   "RPC " + request.RpcName,
+			Err:      err,
+		})
 	}
 	response.UpsertAttributes = invocation.mappedAttributeWrites()
 	response.RecordEvents = invocation.recordedEvents

--- a/sdk-go/integ/abnormal_exit_test.go
+++ b/sdk-go/integ/abnormal_exit_test.go
@@ -54,7 +54,7 @@ func TestAbnormalExitFlow(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotEmpty(t, runID)
-	result := waitForFlow(t, flowID, false)
+	result := waitForUncompletedFlow(t, flowID, false)
 	require.Equal(t, dex.FlowFailed, result.Status)
 	require.Equal(t, dex.FlowErrorWorkerMethod, result.ErrorType)
 	require.True(t, strings.Contains(result.ErrorMessage, "abnormal exit step"))

--- a/sdk-go/integ/basic_test.go
+++ b/sdk-go/integ/basic_test.go
@@ -140,7 +140,8 @@ func TestBasicFlow(t *testing.T) {
 	require.NotEmpty(t, runID)
 
 	_, err = integClient.StartFlow(ctx, basicFlow{}, flowID, 1, dex.StartFlowOptions{})
-	requireDexError(t, err, dex.ErrorFlowAlreadyStarted)
+	var duplicate *dex.FlowAlreadyStartedError
+	require.ErrorAs(t, err, &duplicate)
 
 	result := waitForFlow(t, flowID, true)
 	require.Equal(t, dex.FlowCompleted, result.Status)
@@ -150,7 +151,8 @@ func TestBasicFlow(t *testing.T) {
 	require.Equal(t, 3, output)
 
 	_, err = integClient.WaitForFlow(ctx, newFlowID(t, "missing"), dex.WaitForFlowOptions{})
-	requireDexError(t, err, dex.ErrorFlowNotFound)
+	var missing *dex.FlowNotFoundError
+	require.ErrorAs(t, err, &missing)
 }
 
 func TestProceedOnWaitForFailureFlow(t *testing.T) {

--- a/sdk-go/integ/main_test.go
+++ b/sdk-go/integ/main_test.go
@@ -186,12 +186,22 @@ func waitForFlow(t *testing.T, flowID string, needsResults bool) dex.WaitForFlow
 	return result
 }
 
-func requireDexError(t *testing.T, err error, subStatus dex.ErrorSubStatus) *dex.Error {
+func waitForUncompletedFlow(
+	t *testing.T,
+	flowID string,
+	needsResults bool,
+) *dex.FlowUncompletedError {
 	t.Helper()
-	var sdkError *dex.Error
-	require.ErrorAs(t, err, &sdkError)
-	require.Equal(t, subStatus, sdkError.SubStatus)
-	return sdkError
+	_, err := integClient.WaitForFlow(
+		integrationContext(t),
+		flowID,
+		dex.WaitForFlowOptions{NeedsResults: needsResults, Timeout: 45 * time.Second},
+	)
+	var uncompleted *dex.FlowUncompletedError
+	require.ErrorAs(t, err, &uncompleted)
+	require.Equal(t, flowID, uncompleted.FlowID)
+	require.NotEmpty(t, uncompleted.RunID)
+	return uncompleted
 }
 
 func availablePort() (string, error) {

--- a/sdk-go/integ/no_state_test.go
+++ b/sdk-go/integ/no_state_test.go
@@ -11,6 +11,7 @@
 package integ
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -20,6 +21,8 @@ import (
 	"github.com/superdurable/dex/sdk-go/dex"
 )
 
+var noStepCounter = dex.DefineAttribute[int]("counter")
+
 type noStepFlow struct {
 	emptyFlowSchema
 }
@@ -28,11 +31,45 @@ func (noStepFlow) GetSteps() []dex.StepDef {
 	return nil
 }
 
+func (noStepFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{Attributes: []dex.AttributeDef{noStepCounter}}
+}
+
 func (noStepFlow) Fail(
 	dex.Context,
 	int,
 ) (dex.RPCResult[int], error) {
 	return dex.RPCResult[int]{}, fmt.Errorf("planned no-step RPC failure")
+}
+
+func (noStepFlow) IncreaseCounter(
+	ctx dex.Context,
+	_ dex.None,
+) (dex.RPCResult[int], error) {
+	current, err := noStepCounter.Get(ctx)
+	var missing *dex.AttributeNotFoundError
+	if errors.As(err, &missing) {
+		current = 0
+	} else if err != nil {
+		return dex.RPCResult[int]{}, err
+	}
+	next := current + 1
+	if err := noStepCounter.Set(ctx, next); err != nil {
+		return dex.RPCResult[int]{}, err
+	}
+	return dex.RPCResult[int]{Output: next}, nil
+}
+
+func (noStepFlow) GetCounter(
+	ctx dex.Context,
+	_ dex.None,
+) (dex.RPCResult[int], error) {
+	counter, err := noStepCounter.Get(ctx)
+	var missing *dex.AttributeNotFoundError
+	if errors.As(err, &missing) {
+		return dex.RPCResult[int]{Output: 0}, nil
+	}
+	return dex.RPCResult[int]{Output: counter}, err
 }
 
 func TestFlowWithoutSteps(t *testing.T) {
@@ -74,10 +111,11 @@ func TestFlowWithoutSteps(t *testing.T) {
 		&output,
 		dex.InvokeOptions{},
 	)
-	sdkError := requireDexError(t, err, dex.ErrorWorkerAPI)
-	require.NotNil(t, sdkError.OriginalWorkerError)
+	var workerError *dex.WorkerInvocationError
+	require.ErrorAs(t, err, &workerError)
+	require.NotNil(t, workerError.Worker)
 	require.True(t, strings.Contains(
-		sdkError.OriginalWorkerError.Detail,
+		workerError.Worker.Detail,
 		"planned no-step RPC failure",
 	))
 	require.NoError(t, integClient.StopFlow(
@@ -85,6 +123,63 @@ func TestFlowWithoutSteps(t *testing.T) {
 		flowID,
 		dex.StopOptions{Type: dex.FailFlow, Reason: "test"},
 	))
-	result := waitForFlow(t, flowID, false)
+	result := waitForUncompletedFlow(t, flowID, false)
 	require.Equal(t, dex.FlowFailed, result.Status)
+}
+
+func TestRPCLockConflict(t *testing.T) {
+	ctx := integrationContext(t)
+	flow := noStepFlow{}
+	flowID := newFlowID(t, "rpc-lock")
+	_, err := integClient.StartFlow(ctx, flow, flowID, nil, dex.StartFlowOptions{})
+	require.NoError(t, err)
+
+	const attempts = 100
+	results := make(chan error, attempts)
+	for index := 0; index < attempts; index++ {
+		go func() {
+			var output int
+			results <- integClient.InvokeRPC(
+				ctx,
+				flowID,
+				flow.IncreaseCounter,
+				nil,
+				&output,
+				dex.InvokeOptions{LockAttributes: []dex.AttributeLock{
+					dex.LockAttribute(noStepCounter),
+				}},
+			)
+		}()
+	}
+
+	succeeded := 0
+	conflicted := 0
+	for index := 0; index < attempts; index++ {
+		rpcErr := <-results
+		var conflict *dex.RPCLockConflictError
+		if errors.As(rpcErr, &conflict) {
+			conflicted++
+			continue
+		}
+		require.NoError(t, rpcErr)
+		succeeded++
+	}
+	require.Positive(t, succeeded)
+	require.Positive(t, conflicted)
+
+	var counter int
+	require.NoError(t, integClient.InvokeRPC(
+		ctx,
+		flowID,
+		flow.GetCounter,
+		nil,
+		&counter,
+		dex.InvokeOptions{},
+	))
+	require.Equal(t, succeeded, counter)
+	require.NoError(t, integClient.StopFlow(
+		ctx,
+		flowID,
+		dex.StopOptions{Type: dex.FailFlow, Reason: "test"},
+	))
 }

--- a/sdk-go/integ/rpc_test.go
+++ b/sdk-go/integ/rpc_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/superdurable/dex/sdk-go/dex"
@@ -126,6 +127,22 @@ func TestRPCFlow(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	_, err = integClient.WaitForFlow(
+		ctx,
+		flowID,
+		dex.WaitForFlowOptions{Timeout: time.Second},
+	)
+	var timeout *dex.LongPollTimeoutError
+	require.ErrorAs(t, err, &timeout)
+	err = integClient.WaitForAttributeEqual(
+		ctx,
+		flowID,
+		rpcFlowStatus,
+		"never",
+		dex.WaitOptions{Timeout: time.Second},
+	)
+	require.ErrorAs(t, err, &timeout)
+
 	var failedOutput int
 	err = integClient.InvokeRPC(
 		ctx,
@@ -135,10 +152,11 @@ func TestRPCFlow(t *testing.T) {
 		&failedOutput,
 		dex.InvokeOptions{},
 	)
-	sdkError := requireDexError(t, err, dex.ErrorWorkerAPI)
-	require.NotNil(t, sdkError.OriginalWorkerError)
+	var workerError *dex.WorkerInvocationError
+	require.ErrorAs(t, err, &workerError)
+	require.NotNil(t, workerError.Worker)
 	require.True(t, strings.Contains(
-		sdkError.OriginalWorkerError.Detail,
+		workerError.Worker.Detail,
 		"planned RPC failure",
 	))
 
@@ -164,4 +182,25 @@ func TestRPCFlow(t *testing.T) {
 	var flowOutput int
 	require.NoError(t, result.Completions[0].Output.Decode(&flowOutput))
 	require.Equal(t, 3, flowOutput)
+
+	var status string
+	found, err := integClient.GetAttribute(ctx, flowID, rpcFlowStatus, &status)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "invoked", status)
+
+	err = integClient.SetAttribute(ctx, flowID, rpcFlowStatus, "closed")
+	var inactive *dex.FlowNotActiveError
+	require.ErrorAs(t, err, &inactive)
+	err = integClient.PublishToChannel(ctx, flowID, rpcFlowChannel, 4)
+	require.ErrorAs(t, err, &inactive)
+	err = integClient.InvokeRPC(
+		ctx,
+		flowID,
+		flow.Increment,
+		1,
+		&output,
+		dex.InvokeOptions{},
+	)
+	require.ErrorAs(t, err, &inactive)
 }

--- a/sdk-go/integ/signal_test.go
+++ b/sdk-go/integ/signal_test.go
@@ -144,6 +144,14 @@ func runChannelFlow(
 		dex.StartFlowOptions{},
 	)
 	require.NoError(t, err)
+	err = integClient.WaitForStepCompletion(
+		ctx,
+		flowID,
+		dex.StepExecutionID{StepType: dex.GetFinalStepType(channelFlowFirstStep{})},
+		dex.WaitOptions{Timeout: time.Second},
+	)
+	var timeout *dex.LongPollTimeoutError
+	require.ErrorAs(t, err, &timeout)
 	require.NoError(t, integClient.PublishToChannel(
 		ctx,
 		flowID,
@@ -185,5 +193,6 @@ func runChannelFlow(
 		first,
 		100,
 	)
-	requireDexError(t, err, dex.ErrorFlowNotFound)
+	var inactive *dex.FlowNotActiveError
+	require.ErrorAs(t, err, &inactive)
 }

--- a/sdk-go/integ/workflow_uncompleted_test.go
+++ b/sdk-go/integ/workflow_uncompleted_test.go
@@ -114,7 +114,7 @@ func TestFlowTimeout(t *testing.T) {
 		dex.StartFlowOptions{Timeout: &timeout},
 	)
 	require.NoError(t, err)
-	result := waitForFlow(t, flowID, false)
+	result := waitForUncompletedFlow(t, flowID, false)
 	require.Equal(t, dex.FlowTimedOut, result.Status)
 }
 
@@ -130,7 +130,7 @@ func TestFlowCancel(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, integClient.StopFlow(ctx, flowID, dex.StopOptions{}))
-	result := waitForFlow(t, flowID, false)
+	result := waitForUncompletedFlow(t, flowID, false)
 	require.Equal(t, dex.FlowCanceled, result.Status)
 }
 
@@ -144,7 +144,7 @@ func TestForceFailFlow(t *testing.T) {
 		dex.StartFlowOptions{},
 	)
 	require.NoError(t, err)
-	result := waitForFlow(t, flowID, false)
+	result := waitForUncompletedFlow(t, flowID, false)
 	require.Equal(t, dex.FlowFailed, result.Status)
 	require.Equal(t, dex.FlowErrorStepDecision, result.ErrorType)
 	require.True(t, strings.Contains(result.ErrorMessage, "a failing message"))
@@ -160,7 +160,7 @@ func TestWaitForFailureFlow(t *testing.T) {
 		dex.StartFlowOptions{},
 	)
 	require.NoError(t, err)
-	result := waitForFlow(t, flowID, false)
+	result := waitForUncompletedFlow(t, flowID, false)
 	require.Equal(t, dex.FlowFailed, result.Status)
 	require.Equal(t, dex.FlowErrorWorkerMethod, result.ErrorType)
 	require.True(t, strings.Contains(result.ErrorMessage, "test WaitFor failing"))
@@ -176,7 +176,7 @@ func TestWaitForMethodTimeoutFlow(t *testing.T) {
 		dex.StartFlowOptions{},
 	)
 	require.NoError(t, err)
-	result := waitForFlow(t, flowID, false)
+	result := waitForUncompletedFlow(t, flowID, false)
 	require.Equal(t, dex.FlowFailed, result.Status)
 	require.Equal(t, dex.FlowErrorWorkerMethod, result.ErrorType)
 	require.NotEmpty(t, result.ErrorMessage)


### PR DESCRIPTION
## Summary

- replace Go SDK sub-status comparisons with concrete, `errors.As`-friendly error types
- distinguish existing-Flow reads from active-Flow operations and preserve worker/gRPC diagnostics
- improve Flow registration, value mapping, invalid Step result, and uncompleted Flow errors
- migrate Go integration tests, E2E coverage, examples, and SDK design documentation

## User impact

Applications can handle expected conditions such as missing Flows, inactive Flows, duplicate starts, worker failures, RPC lock conflicts, and long-poll timeouts without comparing raw gRPC codes or Dex sub-status values.

## Validation

- `GOCACHE=/tmp/dex-go-build-cache make -C sdk-go tests`
- `GOCACHE=/tmp/dex-go-build-cache make -C sdk-go e2eTests`
- `GOCACHE=/tmp/dex-go-build-cache go test -v ./cmd/... ./workflows/...` from `examples/go`
- `make copyright-check`
