### PR TITLE
sdk-go: return pointer RPC results

### DIFF
--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -343,13 +343,13 @@ A method is an RPC only when its signature is exactly:
 func(
 	ctx dex.Context,
 	input IN,
-) (dex.RPCResult[OUT], error)
+) (*dex.RPCResult[OUT], error)
 ```
 
 The receiver is supplied by reflection and is not part of the application
 signature. `Context` must be the SDK interface, the second result must be
-`error`, and the first result must be a concrete `RPCResult[OUT]`. Pointer
-results and defined lookalike result types are not accepted. Every exported
+`error`, and the first result must be a pointer to a concrete `RPCResult[OUT]`.
+Value results and defined lookalike result types are not accepted. Every exported
 method on the registered Flow value other than the `Flow` interface methods
 (`GetFlowType`, `GetSteps`, `GetPersistenceSchema`) must match this RPC
 signature; otherwise registration fails. Unexported methods are ignored.
@@ -367,10 +367,12 @@ implements the `Flow` interface but exported methods exist only on the pointer
 type, registration fails and names those methods so the application registers a
 pointer instead of discovering an incomplete method set.
 
-`RPCResult[OUT]` implements a private erasure contract so the reflected result
+`*RPCResult[OUT]` implements a private erasure contract so the reflected result
 can expose its output and next movements without exporting a non-generic
-wrapper. RPC invocation still receives and returns concrete Go values in Phase
-3 tests; protobuf conversion and invocation state belong to Phase 4.
+wrapper. Handlers return `nil, err` on failure; `nil, nil` is rejected as an
+invalid Worker result. RPC invocation still receives and returns concrete Go
+values in Phase 3 tests; protobuf conversion and invocation state belong to
+Phase 4.
 
 Package-level functions, closures, method expressions, and anonymous wrappers
 are not registrable RPCs. The later non-generic client accepts a direct bound
@@ -2198,7 +2200,7 @@ RPC output and its optional next-step movements are explicit:
 type RPC[IN, OUT any] func(
 	ctx Context,
 	input IN,
-) (RPCResult[OUT], error)
+) (*RPCResult[OUT], error)
 
 type RPCResult[OUT any] struct {
 	Output    OUT
@@ -2214,8 +2216,8 @@ type BillingFlow struct{}
 func (BillingFlow) Refund(
 	ctx dex.Context,
 	input RefundInput,
-) (dex.RPCResult[RefundOutput], error) {
-	return dex.RPCResult[RefundOutput]{Output: RefundOutput{}}, nil
+) (*dex.RPCResult[RefundOutput], error) {
+	return &dex.RPCResult[RefundOutput]{Output: RefundOutput{}}, nil
 }
 
 var Billing = BillingFlow{}

--- a/examples/go/workflows/engagement/workflow.go
+++ b/examples/go/workflows/engagement/workflow.go
@@ -80,29 +80,32 @@ func (*EngagementFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (*EngagementFlow) Describe(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[EngagementDescription], error) {
+) (*dex.RPCResult[EngagementDescription], error) {
 	description, err := describe(ctx)
-	return dex.RPCResult[EngagementDescription]{Output: description}, err
+	if err != nil {
+		return nil, err
+	}
+	return &dex.RPCResult[EngagementDescription]{Output: description}, nil
 }
 
 func (*EngagementFlow) Decline(
 	ctx dex.Context,
 	note string,
-) (dex.RPCResult[Status], error) {
+) (*dex.RPCResult[Status], error) {
 	status, err := EngagementStatus.Get(ctx)
 	if err != nil {
-		return dex.RPCResult[Status]{}, err
+		return nil, err
 	}
 	if status != StatusInitiated {
-		return dex.RPCResult[Status]{}, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"can only decline an initiated engagement; current status is %q",
 			status,
 		)
 	}
 	if err := updateStatus(ctx, StatusDeclined, note); err != nil {
-		return dex.RPCResult[Status]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[Status]{
+	return &dex.RPCResult[Status]{
 		Output: StatusDeclined,
 		NextSteps: []dex.StepMovement{
 			dex.MovementOf(notifyExternalSystemStep{}, StatusDeclined),
@@ -113,24 +116,24 @@ func (*EngagementFlow) Decline(
 func (*EngagementFlow) Accept(
 	ctx dex.Context,
 	note string,
-) (dex.RPCResult[Status], error) {
+) (*dex.RPCResult[Status], error) {
 	status, err := EngagementStatus.Get(ctx)
 	if err != nil {
-		return dex.RPCResult[Status]{}, err
+		return nil, err
 	}
 	if status != StatusInitiated && status != StatusDeclined {
-		return dex.RPCResult[Status]{}, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"can only accept an initiated or declined engagement; current status is %q",
 			status,
 		)
 	}
 	if err := updateStatus(ctx, StatusAccepted, note); err != nil {
-		return dex.RPCResult[Status]{}, err
+		return nil, err
 	}
 	if err := CompleteProcess.Publish(ctx, nil); err != nil {
-		return dex.RPCResult[Status]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[Status]{
+	return &dex.RPCResult[Status]{
 		Output: StatusAccepted,
 		NextSteps: []dex.StepMovement{
 			dex.MovementOf(notifyExternalSystemStep{}, StatusAccepted),

--- a/examples/go/workflows/jobpost/workflow.go
+++ b/examples/go/workflows/jobpost/workflow.go
@@ -74,38 +74,44 @@ func (*JobPostFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (*JobPostFlow) Get(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[JobInfo], error) {
+) (*dex.RPCResult[JobInfo], error) {
 	info, err := readJobInfo(ctx)
-	return dex.RPCResult[JobInfo]{Output: info}, err
+	if err != nil {
+		return nil, err
+	}
+	return &dex.RPCResult[JobInfo]{Output: info}, nil
 }
 
 func (*JobPostFlow) GetWithStrongConsistency(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[JobInfo], error) {
+) (*dex.RPCResult[JobInfo], error) {
 	info, err := readJobInfo(ctx)
-	return dex.RPCResult[JobInfo]{Output: info}, err
+	if err != nil {
+		return nil, err
+	}
+	return &dex.RPCResult[JobInfo]{Output: info}, nil
 }
 
 func (*JobPostFlow) Update(
 	ctx dex.Context,
 	input JobInfo,
-) (dex.RPCResult[dex.None], error) {
+) (*dex.RPCResult[dex.None], error) {
 	if err := Title.Set(ctx, input.Title); err != nil {
-		return dex.RPCResult[dex.None]{}, err
+		return nil, err
 	}
 	if err := JobDescription.Set(ctx, input.Description); err != nil {
-		return dex.RPCResult[dex.None]{}, err
+		return nil, err
 	}
 	if err := LastUpdateTimeMillis.Set(ctx, time.Now().UnixMilli()); err != nil {
-		return dex.RPCResult[dex.None]{}, err
+		return nil, err
 	}
 	if input.Notes != "" {
 		if err := Notes.Set(ctx, input.Notes); err != nil {
-			return dex.RPCResult[dex.None]{}, err
+			return nil, err
 		}
 	}
-	return dex.RPCResult[dex.None]{
+	return &dex.RPCResult[dex.None]{
 		NextSteps: []dex.StepMovement{dex.MovementOf(externalUpdateStep{}, nil)},
 	}, nil
 }

--- a/examples/go/workflows/microservices/workflow.go
+++ b/examples/go/workflows/microservices/workflow.go
@@ -60,15 +60,15 @@ func (*OrchestrationFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (*OrchestrationFlow) Swap(
 	ctx dex.Context,
 	newData string,
-) (dex.RPCResult[string], error) {
+) (*dex.RPCResult[string], error) {
 	oldData, err := Data.Get(ctx)
 	if err != nil {
-		return dex.RPCResult[string]{}, err
+		return nil, err
 	}
 	if err := Data.Set(ctx, newData); err != nil {
-		return dex.RPCResult[string]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[string]{Output: oldData}, nil
+	return &dex.RPCResult[string]{Output: oldData}, nil
 }
 
 type callAPI1Step struct {

--- a/examples/go/workflows/patterns/interruptible/workflow.go
+++ b/examples/go/workflows/patterns/interruptible/workflow.go
@@ -61,11 +61,11 @@ func (*InterruptibleExecutionFlow) GetPersistenceSchema() dex.PersistenceSchema 
 func (*InterruptibleExecutionFlow) Interrupt(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[dex.None], error) {
+) (*dex.RPCResult[dex.None], error) {
 	if err := InterruptSignal.Set(ctx, "cancel"); err != nil {
-		return dex.RPCResult[dex.None]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[dex.None]{}, nil
+	return &dex.RPCResult[dex.None]{}, nil
 }
 
 type initStep struct {

--- a/examples/go/workflows/patterns/reminders/workflow.go
+++ b/examples/go/workflows/patterns/reminders/workflow.go
@@ -74,23 +74,23 @@ func (*ReminderFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (*ReminderFlow) Accept(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[dex.None], error) {
+) (*dex.RPCResult[dex.None], error) {
 	currentStatus, err := StatusAttribute.Get(ctx)
 	if err != nil {
-		return dex.RPCResult[dex.None]{}, err
+		return nil, err
 	}
 	if currentStatus != string(StatusInitiated) {
-		return dex.RPCResult[dex.None]{}, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"can only accept in INITIATED status",
 		)
 	}
 	if err := StatusAttribute.Set(ctx, string(StatusAccepted)); err != nil {
-		return dex.RPCResult[dex.None]{}, err
+		return nil, err
 	}
 	if err := CompleteProcess.Publish(ctx, nil); err != nil {
-		return dex.RPCResult[dex.None]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[dex.None]{}, nil
+	return &dex.RPCResult[dex.None]{}, nil
 }
 
 type initStep struct {

--- a/examples/go/workflows/patterns/resettabletimer/workflow.go
+++ b/examples/go/workflows/patterns/resettabletimer/workflow.go
@@ -58,11 +58,11 @@ func (*ResettableTimerFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (*ResettableTimerFlow) SendResetMessage(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[dex.None], error) {
+) (*dex.RPCResult[dex.None], error) {
 	if err := ResetTimerChannel.Publish(ctx, "reset"); err != nil {
-		return dex.RPCResult[dex.None]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[dex.None]{}, nil
+	return &dex.RPCResult[dex.None]{}, nil
 }
 
 type resettableTimerStep struct {

--- a/examples/go/workflows/patterns/scalableparallel/parent.go
+++ b/examples/go/workflows/patterns/scalableparallel/parent.go
@@ -72,26 +72,26 @@ func (*ParentFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (*ParentFlow) Enqueue(
 	ctx dex.Context,
 	request BatchEnqueueRequest,
-) (dex.RPCResult[bool], error) {
+) (*dex.RPCResult[bool], error) {
 	if TaskQueue.Size(ctx)+len(request.List) > MaxBufferedTasks {
-		return dex.RPCResult[bool]{Output: false}, nil
+		return &dex.RPCResult[bool]{Output: false}, nil
 	}
 	for _, uuid := range request.List {
 		if err := TaskQueue.Publish(ctx, uuid); err != nil {
-			return dex.RPCResult[bool]{}, err
+			return nil, err
 		}
 	}
-	return dex.RPCResult[bool]{Output: true}, nil
+	return &dex.RPCResult[bool]{Output: true}, nil
 }
 
 func (*ParentFlow) CompleteChildWorkflow(
 	ctx dex.Context,
 	childWorkflowID string,
-) (dex.RPCResult[dex.None], error) {
+) (*dex.RPCResult[dex.None], error) {
 	if err := ChildComplete.Publish(ctx, childWorkflowID, nil); err != nil {
-		return dex.RPCResult[dex.None]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[dex.None]{}, nil
+	return &dex.RPCResult[dex.None]{}, nil
 }
 
 type initStep struct {

--- a/examples/go/workflows/patterns/storage/workflow.go
+++ b/examples/go/workflows/patterns/storage/workflow.go
@@ -64,42 +64,42 @@ func (*StorageFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (*StorageFlow) AddItem(
 	ctx dex.Context,
 	request AddStorageItemRequest,
-) (dex.RPCResult[dex.None], error) {
+) (*dex.RPCResult[dex.None], error) {
 	if request.Key == "" {
-		return dex.RPCResult[dex.None]{}, fmt.Errorf("key is null")
+		return nil, fmt.Errorf("key is null")
 	}
 	if request.Value == "" {
-		return dex.RPCResult[dex.None]{}, fmt.Errorf("value is null")
+		return nil, fmt.Errorf("value is null")
 	}
 	if err := Store.Set(ctx, request.Key, request.Value); err != nil {
-		return dex.RPCResult[dex.None]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[dex.None]{}, nil
+	return &dex.RPCResult[dex.None]{}, nil
 }
 
 func (*StorageFlow) GetItem(
 	ctx dex.Context,
 	itemKey string,
-) (dex.RPCResult[string], error) {
+) (*dex.RPCResult[string], error) {
 	value, err := Store.Get(ctx, itemKey)
 	if err != nil {
 		var notFound *dex.AttributeNotFoundError
 		if errors.As(err, &notFound) {
-			return dex.RPCResult[string]{}, nil
+			return &dex.RPCResult[string]{}, nil
 		}
-		return dex.RPCResult[string]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[string]{Output: value}, nil
+	return &dex.RPCResult[string]{Output: value}, nil
 }
 
 func (*StorageFlow) RemoveItem(
 	ctx dex.Context,
 	itemKey string,
-) (dex.RPCResult[dex.None], error) {
+) (*dex.RPCResult[dex.None], error) {
 	if err := Store.Delete(ctx, itemKey); err != nil {
-		return dex.RPCResult[dex.None]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[dex.None]{}, nil
+	return &dex.RPCResult[dex.None]{}, nil
 }
 
 var (

--- a/examples/go/workflows/patterns/waitforstatecompletion/workflow.go
+++ b/examples/go/workflows/patterns/waitforstatecompletion/workflow.go
@@ -65,12 +65,12 @@ func (*WaitForStateCompletionFlow) GetPersistenceSchema() dex.PersistenceSchema 
 func (*WaitForStateCompletionFlow) GetJobSeekerData(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[JobSeekerData], error) {
+) (*dex.RPCResult[JobSeekerData], error) {
 	data, err := JobSeekerDataAttribute.Get(ctx)
 	if err != nil {
-		return dex.RPCResult[JobSeekerData]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[JobSeekerData]{Output: data}, nil
+	return &dex.RPCResult[JobSeekerData]{Output: data}, nil
 }
 
 type persistDataStep struct {

--- a/examples/go/workflows/shortlistcandidates/employer_opt_in.go
+++ b/examples/go/workflows/shortlistcandidates/employer_opt_in.go
@@ -65,19 +65,19 @@ func (*EmployerOptInFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (*EmployerOptInFlow) IsOptedIn(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[bool], error) {
+) (*dex.RPCResult[bool], error) {
 	optedIn, err := EmployerOptInStatus.Get(ctx)
 	if err != nil {
-		return dex.RPCResult[bool]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[bool]{Output: optedIn}, nil
+	return &dex.RPCResult[bool]{Output: optedIn}, nil
 }
 
 func (*EmployerOptInFlow) OptOut(
 	_ dex.Context,
 	_ dex.None,
-) (dex.RPCResult[dex.None], error) {
-	return dex.RPCResult[dex.None]{
+) (*dex.RPCResult[dex.None], error) {
+	return &dex.RPCResult[dex.None]{
 		NextSteps: []dex.StepMovement{dex.MovementOf(optOutStep{}, nil)},
 	}, nil
 }

--- a/examples/go/workflows/shortlistcandidates/shortlist.go
+++ b/examples/go/workflows/shortlistcandidates/shortlist.go
@@ -91,9 +91,12 @@ func (*ShortlistFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (*ShortlistFlow) GetEmailSentTimestamp(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[int64], error) {
+) (*dex.RPCResult[int64], error) {
 	timestamp, err := ShortlistEmailSentTimestamp.Get(ctx)
-	return dex.RPCResult[int64]{Output: timestamp}, err
+	if err != nil {
+		return nil, err
+	}
+	return &dex.RPCResult[int64]{Output: timestamp}, nil
 }
 
 type shortlistStep struct {

--- a/examples/go/workflows/signup/workflow.go
+++ b/examples/go/workflows/signup/workflow.go
@@ -66,21 +66,21 @@ func (*UserSignupFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (*UserSignupFlow) Verify(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[string], error) {
+) (*dex.RPCResult[string], error) {
 	status, err := Status.Get(ctx)
 	if err != nil {
-		return dex.RPCResult[string]{}, err
+		return nil, err
 	}
 	if status == "verified" {
-		return dex.RPCResult[string]{Output: "already verified"}, nil
+		return &dex.RPCResult[string]{Output: "already verified"}, nil
 	}
 	if err := Status.Set(ctx, "verified"); err != nil {
-		return dex.RPCResult[string]{}, err
+		return nil, err
 	}
 	if err := Verify.Publish(ctx, nil); err != nil {
-		return dex.RPCResult[string]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[string]{Output: "done"}, nil
+	return &dex.RPCResult[string]{Output: "done"}, nil
 }
 
 type submitStep struct {

--- a/examples/go/workflows/subscription/workflow.go
+++ b/examples/go/workflows/subscription/workflow.go
@@ -79,12 +79,12 @@ func (*SubscriptionFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (*SubscriptionFlow) Describe(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[Subscription], error) {
+) (*dex.RPCResult[Subscription], error) {
 	customer, err := CustomerDetails.Get(ctx)
 	if err != nil {
-		return dex.RPCResult[Subscription]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[Subscription]{Output: customer.Subscription}, nil
+	return &dex.RPCResult[Subscription]{Output: customer.Subscription}, nil
 }
 
 type initializeStep struct {

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -128,7 +128,7 @@ Go method name:
 func (
 	ctx dex.Context,
 	input IN,
-) (dex.RPCResult[OUT], error)
+) (*dex.RPCResult[OUT], error)
 ```
 
 Exported methods with any other signature fail registration. Unexported methods
@@ -136,7 +136,8 @@ are ignored. Register a pointer Flow value when methods use pointer receivers; a
 value-typed Flow that only exposes those methods on `*T` fails registration
 instead of silently omitting them. Client calls must pass the direct bound
 method value, such as `Orders.Update`; package functions, method expressions,
-closures, and wrappers are rejected.
+closures, and wrappers are rejected. Return `nil, err` on failure; returning
+`nil, nil` is an invalid Worker result.
 
 Registered Flow and Step values are retained and may be invoked concurrently.
 They must be immutable or concurrency-safe and must keep

--- a/sdk-go/dex/client_integration_test.go
+++ b/sdk-go/dex/client_integration_test.go
@@ -93,8 +93,8 @@ func (clientTestFlow) GetPersistenceSchema() PersistenceSchema {
 func (clientTestFlow) Update(
 	Context,
 	clientTestRPCInput,
-) (RPCResult[clientTestRPCOutput], error) {
-	return RPCResult[clientTestRPCOutput]{Output: clientTestRPCOutput{}}, nil
+) (*RPCResult[clientTestRPCOutput], error) {
+	return &RPCResult[clientTestRPCOutput]{Output: clientTestRPCOutput{}}, nil
 }
 
 func (clientNoStartFlow) GetSteps() []StepDef {

--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -156,8 +156,8 @@ func (contractFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (contractFlow) Update(
 	ctx dex.Context,
 	input stepInput,
-) (dex.RPCResult[command], error) {
-	return dex.RPCResult[command]{
+) (*dex.RPCResult[command], error) {
+	return &dex.RPCResult[command]{
 		Output:    command{Name: "updated"},
 		NextSteps: []dex.StepMovement{dex.MovementOf(executeOnly, input)},
 	}, nil
@@ -166,8 +166,8 @@ func (contractFlow) Update(
 func (contractFlow) Describe(
 	dex.Context,
 	dex.None,
-) (dex.RPCResult[command], error) {
-	return dex.RPCResult[command]{Output: command{Name: "described"}}, nil
+) (*dex.RPCResult[command], error) {
+	return &dex.RPCResult[command]{Output: command{Name: "described"}}, nil
 }
 
 var flow = contractFlow{}

--- a/sdk-go/dex/flow.go
+++ b/sdk-go/dex/flow.go
@@ -40,8 +40,8 @@ package dex
 //	func (OrderFlow) GetSnapshot(
 //		ctx dex.Context,
 //		input GetSnapshotInput,
-//	) (dex.RPCResult[OrderSnapshot], error) {
-//		return dex.RPCResult[OrderSnapshot]{Output: OrderSnapshot{}}, nil
+//	) (*dex.RPCResult[OrderSnapshot], error) {
+//		return &dex.RPCResult[OrderSnapshot]{Output: OrderSnapshot{}}, nil
 //	}
 //
 //	var Orders = OrderFlow{}

--- a/sdk-go/dex/proto_mapper.go
+++ b/sdk-go/dex/proto_mapper.go
@@ -679,7 +679,10 @@ func mapUniqueChannels(channels []ChannelDef) ([]string, error) {
 	return mapped, nil
 }
 
-func mapRPCResult[OUT any](result RPCResult[OUT]) (*dexpb.InvokeWorkerRPCResponse, error) {
+func mapRPCResult[OUT any](result *RPCResult[OUT]) (*dexpb.InvokeWorkerRPCResponse, error) {
+	if result == nil {
+		return nil, fmt.Errorf("dex: RPC returned nil")
+	}
 	output, err := encodeValue(result.Output)
 	if err != nil {
 		return nil, err

--- a/sdk-go/dex/registration.go
+++ b/sdk-go/dex/registration.go
@@ -500,7 +500,7 @@ func (registry *Registry) resolveRPC(reference any) (*registeredFlow, *registere
 		return nil, nil, err
 	}
 	referenceType := reflect.TypeOf(reference)
-	result := reflect.Zero(referenceType.Out(0)).Interface().(rpcResult)
+	result := reflect.Zero(referenceType.Out(0).Elem()).Interface().(rpcResult)
 	inputType := referenceType.In(1)
 	outputType := result.rpcOutputType()
 	identity, err := rpcMethodIdentity(reference)

--- a/sdk-go/dex/registration_test.go
+++ b/sdk-go/dex/registration_test.go
@@ -147,9 +147,9 @@ func (flow *registrationFlow) GetPersistenceSchema() PersistenceSchema {
 func (flow *registrationFlow) Update(
 	_ Context,
 	input registrationInput,
-) (RPCResult[registrationOutput], error) {
+) (*RPCResult[registrationOutput], error) {
 	flow.rpcCalls++
-	return RPCResult[registrationOutput]{Output: registrationOutput{Value: input.Value}}, nil
+	return &RPCResult[registrationOutput]{Output: registrationOutput{Value: input.Value}}, nil
 }
 
 type invalidRPCRegistrationFlow struct {
@@ -179,18 +179,18 @@ func (invalidRPCRegistrationFlow) WrongResult(
 	return registrationOutput{}, nil
 }
 
-func (invalidRPCRegistrationFlow) PointerResult(
+func (invalidRPCRegistrationFlow) ValueResult(
 	Context,
 	registrationInput,
-) (*RPCResult[registrationOutput], error) {
-	return nil, nil
+) (RPCResult[registrationOutput], error) {
+	return RPCResult[registrationOutput]{}, nil
 }
 
 func (invalidRPCRegistrationFlow) Update(
 	Context,
 	registrationInput,
-) (RPCResult[registrationOutput], error) {
-	return RPCResult[registrationOutput]{}, nil
+) (*RPCResult[registrationOutput], error) {
+	return &RPCResult[registrationOutput]{}, nil
 }
 
 type valueRegistrationFlow struct{}
@@ -210,8 +210,8 @@ func (valueRegistrationFlow) GetPersistenceSchema() PersistenceSchema {
 func (valueRegistrationFlow) Query(
 	Context,
 	registrationInput,
-) (RPCResult[registrationOutput], error) {
-	return RPCResult[registrationOutput]{Output: registrationOutput{Value: "value"}}, nil
+) (*RPCResult[registrationOutput], error) {
+	return &RPCResult[registrationOutput]{Output: registrationOutput{Value: "value"}}, nil
 }
 
 type mixedReceiverRegistrationFlow struct{}
@@ -231,8 +231,8 @@ func (mixedReceiverRegistrationFlow) GetPersistenceSchema() PersistenceSchema {
 func (*mixedReceiverRegistrationFlow) Update(
 	Context,
 	registrationInput,
-) (RPCResult[registrationOutput], error) {
-	return RPCResult[registrationOutput]{}, nil
+) (*RPCResult[registrationOutput], error) {
+	return &RPCResult[registrationOutput]{}, nil
 }
 
 type errorRegistrationFlow struct {
@@ -254,8 +254,8 @@ func (errorRegistrationFlow) GetPersistenceSchema() PersistenceSchema {
 func (flow errorRegistrationFlow) Fail(
 	Context,
 	registrationInput,
-) (RPCResult[registrationOutput], error) {
-	return RPCResult[registrationOutput]{}, flow.rpcError
+) (*RPCResult[registrationOutput], error) {
+	return nil, flow.rpcError
 }
 
 type registrationContext struct {
@@ -368,7 +368,7 @@ func TestRegistryRejectsNonRPCExportedMethods(t *testing.T) {
 	require.Nil(t, assembled)
 	require.ErrorContains(t, err, "exported methods")
 	require.ErrorContains(t, err, "ExportedHelper")
-	require.ErrorContains(t, err, "PointerResult")
+	require.ErrorContains(t, err, "ValueResult")
 	require.ErrorContains(t, err, "WrongResult")
 	require.ErrorContains(t, err, "must be RPCs")
 }
@@ -863,7 +863,7 @@ func TestRPCDiscoveryInvocationAndIdentity(t *testing.T) {
 	wrapper := func(
 		ctx Context,
 		input registrationInput,
-	) (RPCResult[registrationOutput], error) {
+	) (*RPCResult[registrationOutput], error) {
 		return pointerFlow.Update(ctx, input)
 	}
 	_, err = rpcMethodName(wrapper)
@@ -890,6 +890,6 @@ func TestRPCInvocationReturnsApplicationError(t *testing.T) {
 func packageRegistrationRPC(
 	Context,
 	registrationInput,
-) (RPCResult[registrationOutput], error) {
-	return RPCResult[registrationOutput]{}, nil
+) (*RPCResult[registrationOutput], error) {
+	return &RPCResult[registrationOutput]{}, nil
 }

--- a/sdk-go/dex/rpc.go
+++ b/sdk-go/dex/rpc.go
@@ -15,7 +15,7 @@ import "reflect"
 type RPC[IN, OUT any] func(
 	ctx Context,
 	input IN,
-) (RPCResult[OUT], error)
+) (*RPCResult[OUT], error)
 
 type RPCResult[OUT any] struct {
 	Output    OUT

--- a/sdk-go/dex/rpc_registration.go
+++ b/sdk-go/dex/rpc_registration.go
@@ -61,7 +61,7 @@ func discoverRPCs(flow Flow) (map[string]*registeredRPC, error) {
 	if len(invalid) > 0 {
 		sort.Strings(invalid)
 		return nil, fmt.Errorf(
-			"exported methods %v must be RPCs with signature (Context, IN) (RPCResult[OUT], error)",
+			"exported methods %v must be RPCs with signature (Context, IN) (*RPCResult[OUT], error)",
 			invalid,
 		)
 	}
@@ -107,7 +107,7 @@ func newRegisteredRPC(
 	if !rpcMethodType(methodType, true) {
 		return nil, false
 	}
-	result := reflect.Zero(methodType.Out(0)).Interface().(rpcResult)
+	result := reflect.Zero(methodType.Out(0).Elem()).Interface().(rpcResult)
 	return &registeredRPC{
 		method:      receiver.Method(method.Index),
 		durableName: method.Name,
@@ -132,6 +132,9 @@ func (rpc *registeredRPC) invoke(
 	results := rpc.method.Call([]reflect.Value{contextValue, inputValue})
 	if !results[1].IsNil() {
 		return nil, results[1].Interface().(error)
+	}
+	if results[0].IsNil() {
+		return nil, nil
 	}
 	return results[0].Interface().(rpcResult), nil
 }
@@ -174,11 +177,14 @@ func rpcMethodType(methodType reflect.Type, hasReceiver bool) bool {
 		inputOffset = 1
 		expectedInputs = 3
 	}
-	return methodType.NumIn() == expectedInputs &&
-		methodType.In(inputOffset) == contextType &&
-		methodType.NumOut() == 2 &&
-		methodType.Out(0).Kind() == reflect.Struct &&
-		methodType.Out(0).Implements(rpcResultType) &&
+	if methodType.NumIn() != expectedInputs || methodType.NumOut() != 2 {
+		return false
+	}
+	resultType := methodType.Out(0)
+	return methodType.In(inputOffset) == contextType &&
+		resultType.Kind() == reflect.Pointer &&
+		resultType.Elem().Kind() == reflect.Struct &&
+		resultType.Implements(rpcResultType) &&
 		methodType.Out(1) == errorType
 }
 

--- a/sdk-go/dex/worker_integration_test.go
+++ b/sdk-go/dex/worker_integration_test.go
@@ -209,25 +209,28 @@ func (workerTestFlow) GetPersistenceSchema() PersistenceSchema {
 func (workerTestFlow) Update(
 	ctx Context,
 	input workerTestInput,
-) (RPCResult[workerTestOutput], error) {
+) (*RPCResult[workerTestOutput], error) {
 	if input.Mode == "panic" {
 		panic("RPC panic")
 	}
+	if input.Mode == "nil-result" {
+		return nil, nil
+	}
 	if input.Mode == "status" {
-		return RPCResult[workerTestOutput]{}, status.Error(codes.PermissionDenied, "denied")
+		return nil, status.Error(codes.PermissionDenied, "denied")
 	}
 	before := workerTestCommands.Size(ctx)
 	if err := workerTestCommands.Publish(ctx, "local"); err != nil {
-		return RPCResult[workerTestOutput]{}, err
+		return nil, err
 	}
 	after := workerTestCommands.Size(ctx)
 	if err := workerTestItems.Set(ctx, input.OrderID, after); err != nil {
-		return RPCResult[workerTestOutput]{}, err
+		return nil, err
 	}
 	if err := ctx.RecordEvent("updated", input); err != nil {
-		return RPCResult[workerTestOutput]{}, err
+		return nil, err
 	}
-	return RPCResult[workerTestOutput]{
+	return &RPCResult[workerTestOutput]{
 		Output: workerTestOutput{Before: before, After: after},
 		NextSteps: []StepMovement{
 			MovementOf(workerTestFinish, input),
@@ -255,13 +258,13 @@ func (*workerBlockingFlow) GetPersistenceSchema() PersistenceSchema {
 func (flow *workerBlockingFlow) Block(
 	ctx Context,
 	_ struct{},
-) (RPCResult[bool], error) {
+) (*RPCResult[bool], error) {
 	flow.enteredOnce.Do(func() { close(flow.entered) })
 	select {
 	case <-flow.release:
-		return RPCResult[bool]{Output: true}, nil
+		return &RPCResult[bool]{Output: true}, nil
 	case <-ctx.Done():
-		return RPCResult[bool]{}, ctx.Err()
+		return nil, ctx.Err()
 	}
 }
 
@@ -458,6 +461,21 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 			},
 			code:   codes.InvalidArgument,
 			detail: "Execute returned nil",
+			errorType: fmt.Sprintf(
+				"%T",
+				&InvalidStepResultError{},
+			),
+		},
+		{
+			name: "nil RPC result",
+			call: func() error {
+				_, err := client.InvokeWorkerRPC(context.Background(), workerRPCRequest(
+					t, workerTestInput{Mode: "nil-result"},
+				))
+				return err
+			},
+			code:   codes.InvalidArgument,
+			detail: "RPC returned nil",
 			errorType: fmt.Sprintf(
 				"%T",
 				&InvalidStepResultError{},

--- a/sdk-go/dex/worker_mapping.go
+++ b/sdk-go/dex/worker_mapping.go
@@ -234,6 +234,9 @@ func mapRegisteredRPCResult(
 	flow *registeredFlow,
 	result rpcResult,
 ) (*dexpb.InvokeWorkerRPCResponse, error) {
+	if result == nil {
+		return nil, fmt.Errorf("RPC returned nil")
+	}
 	output, err := encodeValue(result.rpcOutput())
 	if err != nil {
 		return nil, err

--- a/sdk-go/examples/order/client.go
+++ b/sdk-go/examples/order/client.go
@@ -30,8 +30,8 @@ type UpdateOrderOutput struct {
 func (OrderFlow) UpdateOrder(
 	ctx dex.Context,
 	input UpdateOrderInput,
-) (dex.RPCResult[UpdateOrderOutput], error) {
-	return dex.RPCResult[UpdateOrderOutput]{
+) (*dex.RPCResult[UpdateOrderOutput], error) {
+	return &dex.RPCResult[UpdateOrderOutput]{
 		Output: UpdateOrderOutput{Status: input.Status},
 	}, nil
 }

--- a/sdk-go/examples/rpc/main.go
+++ b/sdk-go/examples/rpc/main.go
@@ -35,8 +35,8 @@ func (BillingFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (BillingFlow) Refund(
 	ctx dex.Context,
 	input RefundInput,
-) (dex.RPCResult[RefundOutput], error) {
-	return dex.RPCResult[RefundOutput]{Output: RefundOutput{Accepted: true}}, nil
+) (*dex.RPCResult[RefundOutput], error) {
+	return &dex.RPCResult[RefundOutput]{Output: RefundOutput{Accepted: true}}, nil
 }
 
 var Billing = BillingFlow{}

--- a/sdk-go/integ/no_startstate_test.go
+++ b/sdk-go/integ/no_startstate_test.go
@@ -28,8 +28,8 @@ func (noStartStepFlow) GetSteps() []dex.StepDef {
 func (noStartStepFlow) Start(
 	dex.Context,
 	int,
-) (dex.RPCResult[int], error) {
-	return dex.RPCResult[int]{
+) (*dex.RPCResult[int], error) {
+	return &dex.RPCResult[int]{
 		Output:    2,
 		NextSteps: []dex.StepMovement{dex.MovementOf(noStartFinishStep{}, 2)},
 	}, nil

--- a/sdk-go/integ/no_state_test.go
+++ b/sdk-go/integ/no_state_test.go
@@ -38,38 +38,41 @@ func (noStepFlow) GetPersistenceSchema() dex.PersistenceSchema {
 func (noStepFlow) Fail(
 	dex.Context,
 	int,
-) (dex.RPCResult[int], error) {
-	return dex.RPCResult[int]{}, fmt.Errorf("planned no-step RPC failure")
+) (*dex.RPCResult[int], error) {
+	return nil, fmt.Errorf("planned no-step RPC failure")
 }
 
 func (noStepFlow) IncreaseCounter(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[int], error) {
+) (*dex.RPCResult[int], error) {
 	current, err := noStepCounter.Get(ctx)
 	var missing *dex.AttributeNotFoundError
 	if errors.As(err, &missing) {
 		current = 0
 	} else if err != nil {
-		return dex.RPCResult[int]{}, err
+		return nil, err
 	}
 	next := current + 1
 	if err := noStepCounter.Set(ctx, next); err != nil {
-		return dex.RPCResult[int]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[int]{Output: next}, nil
+	return &dex.RPCResult[int]{Output: next}, nil
 }
 
 func (noStepFlow) GetCounter(
 	ctx dex.Context,
 	_ dex.None,
-) (dex.RPCResult[int], error) {
+) (*dex.RPCResult[int], error) {
 	counter, err := noStepCounter.Get(ctx)
 	var missing *dex.AttributeNotFoundError
 	if errors.As(err, &missing) {
-		return dex.RPCResult[int]{Output: 0}, nil
+		return &dex.RPCResult[int]{Output: 0}, nil
 	}
-	return dex.RPCResult[int]{Output: counter}, err
+	if err != nil {
+		return nil, err
+	}
+	return &dex.RPCResult[int]{Output: counter}, nil
 }
 
 func TestFlowWithoutSteps(t *testing.T) {

--- a/sdk-go/integ/rpc_test.go
+++ b/sdk-go/integ/rpc_test.go
@@ -51,23 +51,23 @@ type rpcIncrementOutput struct {
 func (rpcFlow) Increment(
 	ctx dex.Context,
 	input int,
-) (dex.RPCResult[rpcIncrementOutput], error) {
+) (*dex.RPCResult[rpcIncrementOutput], error) {
 	_, err := rpcFlowStatus.Get(ctx)
 	statusFound := true
 	var notFound *dex.AttributeNotFoundError
 	if errors.As(err, &notFound) {
 		statusFound = false
 	} else if err != nil {
-		return dex.RPCResult[rpcIncrementOutput]{}, err
+		return nil, err
 	}
 	before := rpcFlowChannel.Size(ctx)
 	if err := rpcFlowStatus.Set(ctx, "invoked"); err != nil {
-		return dex.RPCResult[rpcIncrementOutput]{}, err
+		return nil, err
 	}
 	if err := rpcFlowChannel.Publish(ctx, input+1); err != nil {
-		return dex.RPCResult[rpcIncrementOutput]{}, err
+		return nil, err
 	}
-	return dex.RPCResult[rpcIncrementOutput]{Output: rpcIncrementOutput{
+	return &dex.RPCResult[rpcIncrementOutput]{Output: rpcIncrementOutput{
 		Value:       input + 1,
 		SizeBefore:  before,
 		SizeAfter:   rpcFlowChannel.Size(ctx),
@@ -78,8 +78,8 @@ func (rpcFlow) Increment(
 func (rpcFlow) Fail(
 	dex.Context,
 	int,
-) (dex.RPCResult[int], error) {
-	return dex.RPCResult[int]{}, fmt.Errorf("planned RPC failure")
+) (*dex.RPCResult[int], error) {
+	return nil, fmt.Errorf("planned RPC failure")
 }
 
 type rpcFlowStep struct {


### PR DESCRIPTION
## Summary

- change Go RPC handlers to return `*RPCResult[OUT]`
- allow idiomatic `return nil, err` error paths
- reject `(nil, nil)` as an invalid Worker result
- update Go SDK contracts, integration tests, examples, and documentation

## Rationale

Returning `RPCResult[OUT]` by value forces every error path to construct a
verbose zero value. A pointer result makes the absence of a result explicit on
failure while retaining `RPCResult` for output and next-step movements.

## User impact

This is an intentional pre-launch breaking API change. Go RPC handlers now use:

```go
func (Flow) RPC(ctx dex.Context, input Input) (*dex.RPCResult[Output], error)
```

Handlers should return `nil, err` on failure. Returning `nil, nil` is rejected
as `InvalidStepResultError`.

## Validation

- `make -C sdk-go tests`
- `make -C sdk-go e2eTests`
- composite `examples/go` test suite against the checkout SDK
- `make copyright-check`
