### PR TITLE
examples(java): add reusable long-retry failure flow

### DIFF
--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -47,6 +47,7 @@ Examples catch concrete types from `io.superdurable.dex.exceptions`.
 - [Signup](./src/main/java/io/superdurable/dex/workflow/signup)
 - [Job post](./src/main/java/io/superdurable/dex/workflow/jobpost)
 - [Shortlist candidates](./src/main/java/io/superdurable/dex/workflow/shortlistcandidates)
+- [Retrying Worker failure](./src/main/java/io/superdurable/dex/workflow/retryingfailure)
 
 ## Design patterns
 

--- a/examples/java/src/main/java/io/superdurable/dex/controller/RetryingFailureController.java
+++ b/examples/java/src/main/java/io/superdurable/dex/controller/RetryingFailureController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.superdurable.dex.controller;
+
+import io.superdurable.dex.Client;
+import io.superdurable.dex.StartFlowOptions;
+import io.superdurable.dex.StopFlowOptions;
+import io.superdurable.dex.StopType;
+import io.superdurable.dex.workflow.retryingfailure.RetryingFailureFlow;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/retrying-failure")
+public final class RetryingFailureController {
+    private static final Duration FLOW_TIMEOUT = Duration.ofHours(24);
+
+    private final Client client;
+    private final RetryingFailureFlow flow;
+
+    public RetryingFailureController(final Client client, final RetryingFailureFlow flow) {
+        this.client = client;
+        this.flow = flow;
+    }
+
+    @GetMapping("/start")
+    public ResponseEntity<Map<String, String>> start(@RequestParam final String workflowId) {
+        final String runId = client.startFlow(
+                flow,
+                workflowId,
+                null,
+                StartFlowOptions.newBuilder().timeout(FLOW_TIMEOUT).build());
+        final Map<String, String> response = new LinkedHashMap<String, String>();
+        response.put("flowID", workflowId);
+        response.put("runID", runId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/stop")
+    public ResponseEntity<Map<String, String>> stop(@RequestParam final String workflowId) {
+        client.stopFlow(
+                workflowId,
+                new StopFlowOptions(StopType.TERMINATE, "retry demonstration finished"));
+        final Map<String, String> response = new LinkedHashMap<String, String>();
+        response.put("flowID", workflowId);
+        response.put("status", "terminated");
+        return ResponseEntity.ok(response);
+    }
+}

--- a/examples/java/src/main/java/io/superdurable/dex/workflow/retryingfailure/README.md
+++ b/examples/java/src/main/java/io/superdurable/dex/workflow/retryingfailure/README.md
@@ -1,0 +1,26 @@
+# Retrying Worker failure
+
+This Flow intentionally throws an `IllegalStateException` from its execute method and retries every
+10 minutes. Use it to inspect an active Step's latest Worker error type, detail, gRPC status, and
+Java stack trace in Dex Web.
+
+The Step uses synchronous durability so its retry is represented as a pending backend activity.
+The Flow allows up to 100 attempts and the controller starts it with a 24-hour timeout.
+
+With `dexcli dev` and the Java examples application running:
+
+```text
+http://localhost:8080/retrying-failure/start?workflowId=java-retrying-failure-1
+```
+
+Then open the Flow in Dex Web:
+
+```text
+http://localhost:8802/flows/java-retrying-failure-1
+```
+
+Stop the demonstration when finished:
+
+```text
+http://localhost:8080/retrying-failure/stop?workflowId=java-retrying-failure-1
+```

--- a/examples/java/src/main/java/io/superdurable/dex/workflow/retryingfailure/RetryingFailureFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/workflow/retryingfailure/RetryingFailureFlow.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.superdurable.dex.workflow.retryingfailure;
+
+import io.superdurable.dex.Context;
+import io.superdurable.dex.Flow;
+import io.superdurable.dex.RetryPolicy;
+import io.superdurable.dex.Step;
+import io.superdurable.dex.StepDecision;
+import io.superdurable.dex.StepDurability;
+import io.superdurable.dex.StepList;
+import io.superdurable.dex.StepOptions;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public final class RetryingFailureFlow implements Flow<Void> {
+    private static final Duration RETRY_INTERVAL = Duration.ofMinutes(10);
+    private static final int MAXIMUM_ATTEMPTS = 100;
+
+    private final RetryingExecuteStep start = new RetryingExecuteStep();
+
+    @Override
+    public StepList<Void> getSteps() {
+        return StepList.startStep(start);
+    }
+
+    static final class RetryingExecuteStep implements Step<Void> {
+        @Override
+        public Class<Void> getInputType() {
+            return Void.class;
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final Void input) {
+            throw new IllegalStateException(
+                    "Java Execute failed; next retry is scheduled in 10 minutes");
+        }
+
+        @Override
+        public StepOptions getStepOptions() {
+            return StepOptions.newBuilder()
+                    .executeRetry(RetryPolicy.newBuilder()
+                            .initialInterval(RETRY_INTERVAL)
+                            .backoffCoefficient(1.0)
+                            .maximumInterval(RETRY_INTERVAL)
+                            .maximumAttempts(MAXIMUM_ATTEMPTS)
+                            .build())
+                    .executeDurability(StepDurability.SYNC)
+                    .build();
+        }
+    }
+}

--- a/examples/java/src/test/java/io/superdurable/dex/integ/IntegEnvironment.java
+++ b/examples/java/src/test/java/io/superdurable/dex/integ/IntegEnvironment.java
@@ -30,6 +30,7 @@ import io.superdurable.dex.workflow.engagement.EngagementFlow;
 import io.superdurable.dex.workflow.microservices.OrchestrationFlow;
 import io.superdurable.dex.workflow.money.transfer.MoneyTransferFlow;
 import io.superdurable.dex.workflow.polling.PollingFlow;
+import io.superdurable.dex.workflow.retryingfailure.RetryingFailureFlow;
 import io.superdurable.dex.workflow.subscription.SubscriptionFlow;
 
 import java.io.IOException;
@@ -61,6 +62,7 @@ final class IntegEnvironment implements AutoCloseable {
     private final EngagementFlow engagementFlow;
     private final OrchestrationFlow orchestrationFlow;
     private final PollingFlow pollingFlow;
+    private final RetryingFailureFlow retryingFailureFlow;
     private final SubscriptionFlow subscriptionFlow;
 
     private IntegEnvironment(
@@ -74,6 +76,7 @@ final class IntegEnvironment implements AutoCloseable {
             final EngagementFlow engagementFlow,
             final OrchestrationFlow orchestrationFlow,
             final PollingFlow pollingFlow,
+            final RetryingFailureFlow retryingFailureFlow,
             final SubscriptionFlow subscriptionFlow) {
         this.cacheDirectory = cacheDirectory;
         this.blobCache = blobCache;
@@ -85,6 +88,7 @@ final class IntegEnvironment implements AutoCloseable {
         this.engagementFlow = engagementFlow;
         this.orchestrationFlow = orchestrationFlow;
         this.pollingFlow = pollingFlow;
+        this.retryingFailureFlow = retryingFailureFlow;
         this.subscriptionFlow = subscriptionFlow;
     }
 
@@ -97,12 +101,14 @@ final class IntegEnvironment implements AutoCloseable {
         final EngagementFlow engagementFlow = new EngagementFlow(service);
         final OrchestrationFlow orchestrationFlow = new OrchestrationFlow(service);
         final PollingFlow pollingFlow = new PollingFlow(service);
+        final RetryingFailureFlow retryingFailureFlow = new RetryingFailureFlow();
         final SubscriptionFlow subscriptionFlow = new SubscriptionFlow(service);
         final List<Flow<?>> flows = Arrays.<Flow<?>>asList(
                 moneyTransferFlow,
                 engagementFlow,
                 orchestrationFlow,
                 pollingFlow,
+                retryingFailureFlow,
                 subscriptionFlow);
 
         final Path cacheDirectory = Files.createTempDirectory("dex-java-examples-integ-");
@@ -145,6 +151,7 @@ final class IntegEnvironment implements AutoCloseable {
                 engagementFlow,
                 orchestrationFlow,
                 pollingFlow,
+                retryingFailureFlow,
                 subscriptionFlow);
     }
 
@@ -166,6 +173,10 @@ final class IntegEnvironment implements AutoCloseable {
 
     PollingFlow pollingFlow() {
         return pollingFlow;
+    }
+
+    RetryingFailureFlow retryingFailureFlow() {
+        return retryingFailureFlow;
     }
 
     SubscriptionFlow subscriptionFlow() {

--- a/examples/java/src/test/java/io/superdurable/dex/integ/RetryingFailureIntegTest.java
+++ b/examples/java/src/test/java/io/superdurable/dex/integ/RetryingFailureIntegTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.superdurable.dex.integ;
+
+import io.superdurable.dex.StopFlowOptions;
+import io.superdurable.dex.StopType;
+import io.superdurable.dex.exceptions.LongPollTimeoutException;
+import io.superdurable.dex.workflow.retryingfailure.RetryingFailureFlow;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(SharedIntegExtension.class)
+public class RetryingFailureIntegTest {
+    @Test
+    void executeFailureRemainsActiveForItsLongRetry() {
+        final IntegEnvironment environment = SharedIntegExtension.environment();
+        final RetryingFailureFlow flow = environment.retryingFailureFlow();
+        final String flowId = environment.newFlowId("retrying-failure");
+
+        final String runId = environment.client().startFlow(
+                flow,
+                flowId,
+                null,
+                environment.startOptions());
+        assertNotNull(runId);
+        assertFalse(runId.isEmpty());
+
+        try {
+            assertThrows(
+                    LongPollTimeoutException.class,
+                    () -> environment.client().waitForFlow(
+                            flowId,
+                            Void.class,
+                            Duration.ofSeconds(1)));
+        } finally {
+            environment.client().stopFlow(
+                    flowId,
+                    new StopFlowOptions(StopType.TERMINATE, "integration test cleanup"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a reusable Java `RetryingFailureFlow` that intentionally throws and retries every 10 minutes
- add HTTP endpoints to start and stop the demonstration from the Java examples application
- document the Dex Web inspection workflow and add integration coverage for the long retry path

## Rationale

The Worker exception-stack example used during PR #228 validation is useful for repeatedly inspecting active Step failure metadata. Checking it into `examples/java` makes the same scenario available without rebuilding a temporary test harness.

## User impact

With `dexcli dev` and the Java examples app running, users can start the Flow at `/retrying-failure/start`, inspect its Worker error and Java stack in Dex Web, and terminate it through `/retrying-failure/stop`.

## Validation

- `./gradlew --include-build ../../sdk-java test --tests 'io.superdurable.dex.workflow.*' --no-daemon`
- `./run-integration-tests.sh`
- `make copyright-check`

The published-SDK-only build currently fails on unchanged `main` because Maven Central `0.0.3` does not yet contain APIs already used by the Java examples (`io.superdurable.dex.exceptions` and `Wait.until`). The repository SDK composite build and full integration suite pass.
