### PR TITLE
Add attribute index sync logs and typed tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,10 @@ limit and user agreement.
 
 ## Go-Specific Rules
 
+### Strongly Typed Log Tags
+
+Do not add new `tag.Value` call sites. Add a semantic, strongly typed constructor in `server/service/common/log/tag` instead. When modifying an existing `tag.Value`, migrate it rather than copying the pattern.
+
 ### Config Field Comments
 
 Every config struct field must have a Go doc comment:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,7 @@ limit and user agreement.
 
 ### Strongly Typed Log Tags
 
-Do not add new `tag.Value` call sites. Add a semantic, strongly typed constructor in `server/service/common/log/tag` instead. When modifying an existing `tag.Value`, migrate it rather than copying the pattern.
+Never use or reintroduce `tag.Value`. Add a semantic, strongly typed constructor in `server/service/common/log/tag` for each structured field.
 
 ### Config Field Comments
 

--- a/server/integ/runtime.go
+++ b/server/integ/runtime.go
@@ -266,7 +266,7 @@ func startInProcessDexService(t *testing.T, testConfig DexServiceTestConfig) *in
 		context.Background(),
 		cfg.Interpreter.EffectiveAttributeIndexSyncTimeout(),
 	)
-	err = indexsync.New(&cfg.Interpreter, unifiedClient).Sync(syncCtx, attributeIndexes)
+	err = indexsync.New(&cfg.Interpreter, unifiedClient, logger).Sync(syncCtx, attributeIndexes)
 	cancelSync()
 	require.NoError(t, err)
 	startInterpreter(t, worker)

--- a/server/service/api/routers.go
+++ b/server/service/api/routers.go
@@ -127,7 +127,7 @@ func (s *Server) Run() error {
 
 // Serve hosts the gRPC services on listener.
 func (s *Server) Serve(listener net.Listener) error {
-	s.logger.Info("FlowService gRPC listening", tag.Value(listener.Addr().String()))
+	s.logger.Info("FlowService gRPC listening", tag.Address(listener.Addr().String()))
 
 	if err := s.readyCheck(context.Background()); err != nil {
 		s.logger.Error("initial readiness check failed", tag.Error(err))
@@ -183,8 +183,8 @@ func unaryRecover(logger log.Logger) grpc.UnaryServerInterceptor {
 			if recovered := recover(); recovered != nil {
 				logger.Error(
 					"gRPC handler panic",
-					tag.Value(fmt.Sprintf("%v", recovered)),
-					tag.Value(info.FullMethod),
+					tag.Panic(fmt.Sprintf("%v", recovered)),
+					tag.OperationName(info.FullMethod),
 				)
 				err = status.Error(codes.Internal, "internal panic")
 			}
@@ -204,8 +204,8 @@ func unaryLog(logger log.Logger) grpc.UnaryServerInterceptor {
 		resp, err := handler(ctx, req)
 		logger.Debug(
 			"gRPC call",
-			tag.Value(info.FullMethod),
-			tag.Value(time.Since(start).String()),
+			tag.OperationName(info.FullMethod),
+			tag.Elapsed(time.Since(start)),
 			tag.Error(err),
 		)
 		return resp, err

--- a/server/service/api/service.go
+++ b/server/service/api/service.go
@@ -90,7 +90,7 @@ func NewApiService(
 		workerPool:         workerPool,
 		stepInputPopulator: history.NewAsyncStepInputSnapshotPopulator(blobStoreCfg, client, store),
 		attributeStore:     attributeStore,
-		indexSynchronizer:  indexsync.New(interpreterCfg, client),
+		indexSynchronizer:  indexsync.New(interpreterCfg, client, logger),
 	}, nil
 }
 

--- a/server/service/bootstrap/bootstrap.go
+++ b/server/service/bootstrap/bootstrap.go
@@ -134,7 +134,7 @@ func (r *Runtime) createServices() error {
 		return err
 	}
 	r.blobStore = store
-	r.indexSynchronizer = indexsync.New(&r.cfg.Interpreter, client)
+	r.indexSynchronizer = indexsync.New(&r.cfg.Interpreter, client, r.logger)
 	if r.options.Services.API {
 		r.apiServer = api.NewServer(
 			&r.cfg.Api,

--- a/server/service/common/attributestore/manager.go
+++ b/server/service/common/attributestore/manager.go
@@ -148,7 +148,7 @@ func openStoreEntry(
 		name:   name,
 		cfg:    cfg,
 		db:     database,
-		logger: logger.WithTags(tag.Value(name)),
+		logger: logger.WithTags(tag.AttributeStore(name)),
 	}
 	if err := database.PingContext(ctx); err != nil {
 		if closeErr := database.Close(); closeErr != nil {
@@ -432,16 +432,16 @@ func (e *storeEntry) writeBatch(
 	for name, value := range latest {
 		column, found := snapshot.columns[name]
 		if !found {
-			e.logger.Error("skip Attribute Store item: column does not exist", tag.Value(name))
+			e.logger.Error("skip Attribute Store item: column does not exist", tag.AttributeName(name))
 			continue
 		}
 		if name == snapshot.primaryKey {
-			e.logger.Error("skip Attribute Store item: primary key is immutable", tag.Value(name))
+			e.logger.Error("skip Attribute Store item: primary key is immutable", tag.AttributeName(name))
 			continue
 		}
 		converted, err := column.convert(value, e.cfg.Type)
 		if err != nil {
-			e.logger.Error("skip incompatible Attribute Store item", tag.Value(name), tag.Error(err))
+			e.logger.Error("skip incompatible Attribute Store item", tag.AttributeName(name), tag.Error(err))
 			continue
 		}
 		filtered[name] = filteredValue{column: column, value: converted}

--- a/server/service/common/blobstore/store_impl.go
+++ b/server/service/common/blobstore/store_impl.go
@@ -159,17 +159,17 @@ func (b *blobStoreImpl) WriteObject(
 		var re s3.ResponseError
 		if errors.As(err, &re) {
 			b.logger.Error("PutObject S3 API error",
-				tag.Key("requestId"), tag.Value(re.ServiceRequestID()),
-				tag.Key("hostId"), tag.Value(re.ServiceHostID()),
-				tag.Key("bucket"), tag.Value(b.activeStorage.S3Bucket),
-				tag.Key("workflowId"), tag.Value(workflowId),
+				tag.RequestID(re.ServiceRequestID()),
+				tag.HostID(re.ServiceHostID()),
+				tag.Bucket(b.activeStorage.S3Bucket),
+				tag.WorkflowID(workflowId),
 				tag.Error(err))
 			err = fmt.Errorf("failed to write object (requestId=%s, hostId=%s): %w",
 				re.ServiceRequestID(), re.ServiceHostID(), err)
 		} else {
 			b.logger.Error("PutObject error",
-				tag.Key("bucket"), tag.Value(b.activeStorage.S3Bucket),
-				tag.Key("workflowId"), tag.Value(workflowId),
+				tag.Bucket(b.activeStorage.S3Bucket),
+				tag.WorkflowID(workflowId),
 				tag.Error(err))
 			err = fmt.Errorf("failed to write object: %w", err)
 		}
@@ -179,8 +179,8 @@ func (b *blobStoreImpl) WriteObject(
 		if err = b.cacheAttributeObject(storeId, path, data, b.blobCacheWriteCounter); err != nil {
 			b.writeObjectErrorCounter.Inc(1)
 			b.logger.Error("Attribute blob cache write failed",
-				tag.Key("path"), tag.Value(path),
-				tag.Key("storeId"), tag.Value(storeId),
+				tag.Path(path),
+				tag.StoreID(storeId),
 				tag.Error(err))
 			err = fmt.Errorf("failed to cache written object: %w", err)
 			return
@@ -312,8 +312,8 @@ func (b *blobStoreImpl) ReadObject(ctx context.Context, storeId, path string) ([
 		if err != nil {
 			b.readObjectErrorCounter.Inc(1)
 			b.logger.Error("Attribute blob cache read failed",
-				tag.Key("path"), tag.Value(path),
-				tag.Key("storeId"), tag.Value(storeId),
+				tag.Path(path),
+				tag.StoreID(storeId),
 				tag.Error(err))
 			return nil, fmt.Errorf("failed to read cached object: %w", err)
 		}
@@ -328,19 +328,19 @@ func (b *blobStoreImpl) ReadObject(ctx context.Context, storeId, path string) ([
 		var re s3.ResponseError
 		if errors.As(err, &re) {
 			b.logger.Error("GetObject S3 API error",
-				tag.Key("requestId"), tag.Value(re.ServiceRequestID()),
-				tag.Key("hostId"), tag.Value(re.ServiceHostID()),
-				tag.Key("bucket"), tag.Value(storeConfig.S3Bucket),
-				tag.Key("path"), tag.Value(path),
-				tag.Key("storeId"), tag.Value(storeId),
+				tag.RequestID(re.ServiceRequestID()),
+				tag.HostID(re.ServiceHostID()),
+				tag.Bucket(storeConfig.S3Bucket),
+				tag.Path(path),
+				tag.StoreID(storeId),
 				tag.Error(err))
 			return nil, fmt.Errorf("failed to read object (requestId=%s, hostId=%s): %w",
 				re.ServiceRequestID(), re.ServiceHostID(), err)
 		}
 		b.logger.Error("GetObject error",
-			tag.Key("bucket"), tag.Value(storeConfig.S3Bucket),
-			tag.Key("path"), tag.Value(path),
-			tag.Key("storeId"), tag.Value(storeId),
+			tag.Bucket(storeConfig.S3Bucket),
+			tag.Path(path),
+			tag.StoreID(storeId),
 			tag.Error(err))
 		return nil, fmt.Errorf("failed to read object: %w", err)
 	}
@@ -348,8 +348,8 @@ func (b *blobStoreImpl) ReadObject(ctx context.Context, storeId, path string) ([
 		if err := b.cacheAttributeObject(storeId, path, data, b.blobCacheReadFillCounter); err != nil {
 			b.readObjectErrorCounter.Inc(1)
 			b.logger.Error("Attribute blob cache fill failed",
-				tag.Key("path"), tag.Value(path),
-				tag.Key("storeId"), tag.Value(storeId),
+				tag.Path(path),
+				tag.StoreID(storeId),
 				tag.Error(err))
 			return nil, fmt.Errorf("failed to fill object cache: %w", err)
 		}
@@ -535,10 +535,10 @@ func (b *blobStoreImpl) DeleteWorkflowObjects(ctx context.Context, storeId, work
 			var re s3.ResponseError
 			if errors.As(err, &re) {
 				b.logger.Error("ListObjectsV2 S3 API error",
-					tag.Key("requestId"), tag.Value(re.ServiceRequestID()),
-					tag.Key("hostId"), tag.Value(re.ServiceHostID()),
-					tag.Key("bucket"), tag.Value(storeConfig.S3Bucket),
-					tag.Key("workflowPath"), tag.Value(workflowPath),
+					tag.RequestID(re.ServiceRequestID()),
+					tag.HostID(re.ServiceHostID()),
+					tag.Bucket(storeConfig.S3Bucket),
+					tag.WorkflowPath(workflowPath),
 					tag.Error(err))
 				return fmt.Errorf("failed to list objects for deletion (requestId=%s, hostId=%s): %w",
 					re.ServiceRequestID(), re.ServiceHostID(), err)
@@ -575,10 +575,10 @@ func (b *blobStoreImpl) DeleteWorkflowObjects(ctx context.Context, storeId, work
 				var re s3.ResponseError
 				if errors.As(err, &re) {
 					b.logger.Error("DeleteObjects S3 API error",
-						tag.Key("requestId"), tag.Value(re.ServiceRequestID()),
-						tag.Key("hostId"), tag.Value(re.ServiceHostID()),
-						tag.Key("bucket"), tag.Value(storeConfig.S3Bucket),
-						tag.Key("workflowPath"), tag.Value(workflowPath),
+						tag.RequestID(re.ServiceRequestID()),
+						tag.HostID(re.ServiceHostID()),
+						tag.Bucket(storeConfig.S3Bucket),
+						tag.WorkflowPath(workflowPath),
 						tag.Error(err))
 					return fmt.Errorf("failed to delete objects (requestId=%s, hostId=%s): %w",
 						re.ServiceRequestID(), re.ServiceHostID(), err)
@@ -597,9 +597,9 @@ func (b *blobStoreImpl) DeleteWorkflowObjects(ctx context.Context, storeId, work
 				}
 				resultMetadata := fmt.Sprintf("%+v", deleteResult.ResultMetadata)
 				b.logger.Error("DeleteObjects failed",
-					tag.Key("bucket"), tag.Value(storeConfig.S3Bucket),
-					tag.Key("workflowPath"), tag.Value(workflowPath),
-					tag.Key("resultMetadata"), tag.Value(resultMetadata))
+					tag.Bucket(storeConfig.S3Bucket),
+					tag.WorkflowPath(workflowPath),
+					tag.ResultMetadata(resultMetadata))
 				return fmt.Errorf("some objects failed to delete (resultMetadata=%s): %s", resultMetadata, strings.Join(errorMsgs, "; "))
 			}
 
@@ -614,9 +614,9 @@ func (b *blobStoreImpl) DeleteWorkflowObjects(ctx context.Context, storeId, work
 	}
 
 	b.logger.Info("DeleteWorkflowObjects completed",
-		tag.Key("bucket"), tag.Value(storeConfig.S3Bucket),
-		tag.Key("workflowPath"), tag.Value(workflowPath),
-		tag.Key("totalDeleted"), tag.Value(totalDeleted))
+		tag.Bucket(storeConfig.S3Bucket),
+		tag.WorkflowPath(workflowPath),
+		tag.TotalDeleted(totalDeleted))
 
 	return nil
 }

--- a/server/service/common/log/tag/tags.go
+++ b/server/service/common/log/tag/tags.go
@@ -18,13 +18,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications after the Legacy Cutoff are licensed under the
+// Super Durable Source License 1.0.
+// Legacy Materials remain under their original licenses.
+// See LICENSE and LEGACY_NOTICES.md.
 
 package tag
 
 import (
 	"fmt"
 	"time"
+
+	"github.com/superdurable/dex/gen/dexpb"
 )
 
 // LoggingCallAtKey is reserved tag
@@ -42,6 +49,36 @@ const LoggingCallAtKey = "logging-call-at"
 // Error returns tag for Error
 func Error(err error) Tag {
 	return newErrorTag("error", err)
+}
+
+// Interval returns the polling interval tag.
+func Interval(interval time.Duration) Tag {
+	return newDurationTag("interval", interval)
+}
+
+// Elapsed returns the elapsed duration tag.
+func Elapsed(elapsed time.Duration) Tag {
+	return newDurationTag("elapsed", elapsed)
+}
+
+// IndexCount returns the attribute index count tag.
+func IndexCount(count int) Tag {
+	return newInt("index-count", count)
+}
+
+// Requested returns requested attribute indexes.
+func Requested(indexes map[string]dexpb.IndexType) Tag {
+	return newObjectTag("requested", indexes)
+}
+
+// Missing returns missing attribute indexes.
+func Missing(indexes map[string]dexpb.IndexType) Tag {
+	return newObjectTag("missing", indexes)
+}
+
+// Indexes returns attribute indexes.
+func Indexes(indexes map[string]dexpb.IndexType) Tag {
+	return newObjectTag("indexes", indexes)
 }
 
 // Timestamp returns tag for Timestamp

--- a/server/service/common/log/tag/tags.go
+++ b/server/service/common/log/tag/tags.go
@@ -81,6 +81,61 @@ func Indexes(indexes map[string]dexpb.IndexType) Tag {
 	return newObjectTag("indexes", indexes)
 }
 
+// Panic returns the recovered panic tag.
+func Panic(recovered string) Tag {
+	return newStringTag("panic", recovered)
+}
+
+// RequestID returns the service request ID tag.
+func RequestID(requestID string) Tag {
+	return newStringTag("request-id", requestID)
+}
+
+// HostID returns the service host ID tag.
+func HostID(hostID string) Tag {
+	return newStringTag("host-id", hostID)
+}
+
+// Bucket returns the object storage bucket tag.
+func Bucket(bucket string) Tag {
+	return newStringTag("bucket", bucket)
+}
+
+// Path returns the object storage path tag.
+func Path(path string) Tag {
+	return newStringTag("path", path)
+}
+
+// StoreID returns the blob store ID tag.
+func StoreID(storeID string) Tag {
+	return newStringTag("store-id", storeID)
+}
+
+// WorkflowPath returns the workflow object prefix tag.
+func WorkflowPath(workflowPath string) Tag {
+	return newStringTag("workflow-path", workflowPath)
+}
+
+// ResultMetadata returns storage response metadata.
+func ResultMetadata(metadata string) Tag {
+	return newStringTag("result-metadata", metadata)
+}
+
+// TotalDeleted returns the deleted object count tag.
+func TotalDeleted(total int) Tag {
+	return newInt("total-deleted", total)
+}
+
+// AttributeStore returns the Attribute Store name tag.
+func AttributeStore(name string) Tag {
+	return newStringTag("attribute-store", name)
+}
+
+// AttributeName returns the Attribute name tag.
+func AttributeName(name string) Tag {
+	return newStringTag("attribute-name", name)
+}
+
 // Timestamp returns tag for Timestamp
 func Timestamp(timestamp time.Time) Tag {
 	return newTimeTag("timestamp", timestamp)
@@ -182,19 +237,9 @@ func Env(env string) Tag {
 	return newStringTag("env", env)
 }
 
-// Key returns tag for Key
-func Key(k string) Tag {
-	return newStringTag("key", k)
-}
-
 // Name returns tag for Name
 func Name(k string) Tag {
 	return newStringTag("name", k)
-}
-
-// Value returns tag for Value
-func Value(v interface{}) Tag {
-	return newObjectTag("value", v)
 }
 
 // ValueType returns tag for ValueType

--- a/server/service/indexsync/synchronizer.go
+++ b/server/service/indexsync/synchronizer.go
@@ -101,7 +101,7 @@ func (s *Synchronizer) listUntilAvailable(ctx context.Context) (map[string]dexpb
 	for {
 		existing, err := s.client.ListAttributeIndexes(ctx)
 		if err == nil {
-			s.logger.Debug("Attribute index list poll succeeded", tag.Value(map[string]interface{}{
+			s.logger.Info("Attribute index list poll succeeded", tag.Value(map[string]interface{}{
 				"indexCount": len(existing),
 			}))
 			return existing, nil
@@ -109,7 +109,7 @@ func (s *Synchronizer) listUntilAvailable(ctx context.Context) (map[string]dexpb
 		if !isRetryable(err) {
 			return nil, backendError(err)
 		}
-		s.logger.Debug("Attribute index list poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
+		s.logger.Info("Attribute index list poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
 			"nextPollInterval": interval,
 		}))
 		if err := waitForPoll(ctx, interval); err != nil {
@@ -133,7 +133,7 @@ func (s *Synchronizer) retryRegistration(
 			if !isRetryable(err) {
 				return backendError(err)
 			}
-			s.logger.Debug("Attribute index registration poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
+			s.logger.Info("Attribute index registration poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
 				"nextPollInterval": nextPollInterval(interval),
 			}))
 			interval = nextPollInterval(interval)
@@ -142,13 +142,13 @@ func (s *Synchronizer) retryRegistration(
 		missing, err := s.missingIndexes(requested, existing)
 		if err != nil || len(missing) == 0 {
 			if err == nil {
-				s.logger.Debug("Attribute indexes became visible during registration retry", tag.Value(map[string]interface{}{
+				s.logger.Info("Attribute indexes became visible during registration retry", tag.Value(map[string]interface{}{
 					"requested": requested,
 				}))
 			}
 			return err
 		}
-		s.logger.Debug("Attribute indexes remain unregistered", tag.Value(map[string]interface{}{
+		s.logger.Info("Attribute indexes remain unregistered", tag.Value(map[string]interface{}{
 			"missing":          missing,
 			"nextPollInterval": nextPollInterval(interval),
 		}))
@@ -177,20 +177,20 @@ func (s *Synchronizer) waitUntilVisible(
 			missing, compareErr := s.missingIndexes(requested, existing)
 			if compareErr != nil || len(missing) == 0 {
 				if compareErr == nil {
-					s.logger.Debug("Attribute indexes are visible", tag.Value(map[string]interface{}{
+					s.logger.Info("Attribute indexes are visible", tag.Value(map[string]interface{}{
 						"requested": requested,
 					}))
 				}
 				return compareErr
 			}
-			s.logger.Debug("Attribute indexes are not visible yet", tag.Value(map[string]interface{}{
+			s.logger.Info("Attribute indexes are not visible yet", tag.Value(map[string]interface{}{
 				"missing":          missing,
 				"nextPollInterval": nextPollInterval(interval),
 			}))
 		} else if !isRetryable(err) {
 			return backendError(err)
 		} else {
-			s.logger.Debug("Attribute index visibility poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
+			s.logger.Info("Attribute index visibility poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
 				"nextPollInterval": nextPollInterval(interval),
 			}))
 		}
@@ -203,11 +203,11 @@ func (s *Synchronizer) addAttributeIndexes(
 	indexes map[string]dexpb.IndexType,
 ) error {
 	startedAt := time.Now()
-	s.logger.Debug("Adding attribute indexes", tag.Value(map[string]interface{}{
+	s.logger.Info("Adding attribute indexes", tag.Value(map[string]interface{}{
 		"indexes": indexes,
 	}))
 	err := s.client.AddAttributeIndexes(ctx, indexes)
-	s.logger.Debug("Add attribute indexes returned", tag.Error(err), tag.Value(map[string]interface{}{
+	s.logger.Info("Add attribute indexes returned", tag.Error(err), tag.Value(map[string]interface{}{
 		"elapsed": time.Since(startedAt),
 		"indexes": indexes,
 	}))

--- a/server/service/indexsync/synchronizer.go
+++ b/server/service/indexsync/synchronizer.go
@@ -18,6 +18,8 @@ import (
 	"github.com/superdurable/dex/config"
 	"github.com/superdurable/dex/gen/dexpb"
 	serviceerrors "github.com/superdurable/dex/service/common/errors"
+	"github.com/superdurable/dex/service/common/log"
+	"github.com/superdurable/dex/service/common/log/tag"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -39,17 +41,21 @@ type Client interface {
 type Synchronizer struct {
 	cfg    *config.Interpreter
 	client Client
+	logger log.Logger
 }
 
 // New creates an attribute index synchronizer.
-func New(interpreterCfg *config.Interpreter, client Client) *Synchronizer {
+func New(interpreterCfg *config.Interpreter, client Client, logger log.Logger) *Synchronizer {
 	if interpreterCfg == nil {
 		panic("interpreter config must not be nil")
 	}
 	if client == nil {
 		panic("attribute index client must not be nil")
 	}
-	return &Synchronizer{cfg: interpreterCfg, client: client}
+	if logger == nil {
+		panic("attribute index logger must not be nil")
+	}
+	return &Synchronizer{cfg: interpreterCfg, client: client, logger: logger}
 }
 
 // Sync creates missing indexes and waits until the backend reports them.
@@ -73,7 +79,7 @@ func (s *Synchronizer) Sync(ctx context.Context, requested map[string]dexpb.Inde
 		return err
 	}
 
-	if addErr := s.client.AddAttributeIndexes(syncCtx, missing); addErr != nil {
+	if addErr := s.addAttributeIndexes(syncCtx, missing); addErr != nil {
 		existing, listErr := s.client.ListAttributeIndexes(syncCtx)
 		if listErr == nil {
 			remaining, compareErr := s.missingIndexes(requested, existing)
@@ -95,11 +101,17 @@ func (s *Synchronizer) listUntilAvailable(ctx context.Context) (map[string]dexpb
 	for {
 		existing, err := s.client.ListAttributeIndexes(ctx)
 		if err == nil {
+			s.logger.Debug("Attribute index list poll succeeded", tag.Value(map[string]interface{}{
+				"indexCount": len(existing),
+			}))
 			return existing, nil
 		}
 		if !isRetryable(err) {
 			return nil, backendError(err)
 		}
+		s.logger.Debug("Attribute index list poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
+			"nextPollInterval": interval,
+		}))
 		if err := waitForPoll(ctx, interval); err != nil {
 			return nil, syncDeadlineError(err)
 		}
@@ -121,14 +133,26 @@ func (s *Synchronizer) retryRegistration(
 			if !isRetryable(err) {
 				return backendError(err)
 			}
+			s.logger.Debug("Attribute index registration poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
+				"nextPollInterval": nextPollInterval(interval),
+			}))
 			interval = nextPollInterval(interval)
 			continue
 		}
 		missing, err := s.missingIndexes(requested, existing)
 		if err != nil || len(missing) == 0 {
+			if err == nil {
+				s.logger.Debug("Attribute indexes became visible during registration retry", tag.Value(map[string]interface{}{
+					"requested": requested,
+				}))
+			}
 			return err
 		}
-		addErr := s.client.AddAttributeIndexes(ctx, missing)
+		s.logger.Debug("Attribute indexes remain unregistered", tag.Value(map[string]interface{}{
+			"missing":          missing,
+			"nextPollInterval": nextPollInterval(interval),
+		}))
+		addErr := s.addAttributeIndexes(ctx, missing)
 		if addErr == nil {
 			return s.waitUntilVisible(ctx, requested)
 		}
@@ -152,13 +176,42 @@ func (s *Synchronizer) waitUntilVisible(
 		if err == nil {
 			missing, compareErr := s.missingIndexes(requested, existing)
 			if compareErr != nil || len(missing) == 0 {
+				if compareErr == nil {
+					s.logger.Debug("Attribute indexes are visible", tag.Value(map[string]interface{}{
+						"requested": requested,
+					}))
+				}
 				return compareErr
 			}
+			s.logger.Debug("Attribute indexes are not visible yet", tag.Value(map[string]interface{}{
+				"missing":          missing,
+				"nextPollInterval": nextPollInterval(interval),
+			}))
 		} else if !isRetryable(err) {
 			return backendError(err)
+		} else {
+			s.logger.Debug("Attribute index visibility poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
+				"nextPollInterval": nextPollInterval(interval),
+			}))
 		}
 		interval = nextPollInterval(interval)
 	}
+}
+
+func (s *Synchronizer) addAttributeIndexes(
+	ctx context.Context,
+	indexes map[string]dexpb.IndexType,
+) error {
+	startedAt := time.Now()
+	s.logger.Debug("Adding attribute indexes", tag.Value(map[string]interface{}{
+		"indexes": indexes,
+	}))
+	err := s.client.AddAttributeIndexes(ctx, indexes)
+	s.logger.Debug("Add attribute indexes returned", tag.Error(err), tag.Value(map[string]interface{}{
+		"elapsed": time.Since(startedAt),
+		"indexes": indexes,
+	}))
+	return err
 }
 
 func (s *Synchronizer) missingIndexes(

--- a/server/service/indexsync/synchronizer.go
+++ b/server/service/indexsync/synchronizer.go
@@ -101,17 +101,13 @@ func (s *Synchronizer) listUntilAvailable(ctx context.Context) (map[string]dexpb
 	for {
 		existing, err := s.client.ListAttributeIndexes(ctx)
 		if err == nil {
-			s.logger.Info("Attribute index list poll succeeded", tag.Value(map[string]interface{}{
-				"indexCount": len(existing),
-			}))
+			s.logger.Info("Attribute index list poll succeeded", tag.IndexCount(len(existing)))
 			return existing, nil
 		}
 		if !isRetryable(err) {
 			return nil, backendError(err)
 		}
-		s.logger.Info("Attribute index list poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
-			"nextPollInterval": interval,
-		}))
+		s.logger.Info("Attribute index list poll will retry", tag.Error(err), tag.Interval(interval))
 		if err := waitForPoll(ctx, interval); err != nil {
 			return nil, syncDeadlineError(err)
 		}
@@ -133,25 +129,26 @@ func (s *Synchronizer) retryRegistration(
 			if !isRetryable(err) {
 				return backendError(err)
 			}
-			s.logger.Info("Attribute index registration poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
-				"nextPollInterval": nextPollInterval(interval),
-			}))
+			s.logger.Info(
+				"Attribute index registration poll will retry",
+				tag.Error(err),
+				tag.Interval(nextPollInterval(interval)),
+			)
 			interval = nextPollInterval(interval)
 			continue
 		}
 		missing, err := s.missingIndexes(requested, existing)
 		if err != nil || len(missing) == 0 {
 			if err == nil {
-				s.logger.Info("Attribute indexes became visible during registration retry", tag.Value(map[string]interface{}{
-					"requested": requested,
-				}))
+				s.logger.Info("Attribute indexes became visible during registration retry", tag.Requested(requested))
 			}
 			return err
 		}
-		s.logger.Info("Attribute indexes remain unregistered", tag.Value(map[string]interface{}{
-			"missing":          missing,
-			"nextPollInterval": nextPollInterval(interval),
-		}))
+		s.logger.Info(
+			"Attribute indexes remain unregistered",
+			tag.Missing(missing),
+			tag.Interval(nextPollInterval(interval)),
+		)
 		addErr := s.addAttributeIndexes(ctx, missing)
 		if addErr == nil {
 			return s.waitUntilVisible(ctx, requested)
@@ -177,22 +174,23 @@ func (s *Synchronizer) waitUntilVisible(
 			missing, compareErr := s.missingIndexes(requested, existing)
 			if compareErr != nil || len(missing) == 0 {
 				if compareErr == nil {
-					s.logger.Info("Attribute indexes are visible", tag.Value(map[string]interface{}{
-						"requested": requested,
-					}))
+					s.logger.Info("Attribute indexes are visible", tag.Requested(requested))
 				}
 				return compareErr
 			}
-			s.logger.Info("Attribute indexes are not visible yet", tag.Value(map[string]interface{}{
-				"missing":          missing,
-				"nextPollInterval": nextPollInterval(interval),
-			}))
+			s.logger.Info(
+				"Attribute indexes are not visible yet",
+				tag.Missing(missing),
+				tag.Interval(nextPollInterval(interval)),
+			)
 		} else if !isRetryable(err) {
 			return backendError(err)
 		} else {
-			s.logger.Info("Attribute index visibility poll will retry", tag.Error(err), tag.Value(map[string]interface{}{
-				"nextPollInterval": nextPollInterval(interval),
-			}))
+			s.logger.Info(
+				"Attribute index visibility poll will retry",
+				tag.Error(err),
+				tag.Interval(nextPollInterval(interval)),
+			)
 		}
 		interval = nextPollInterval(interval)
 	}
@@ -203,15 +201,15 @@ func (s *Synchronizer) addAttributeIndexes(
 	indexes map[string]dexpb.IndexType,
 ) error {
 	startedAt := time.Now()
-	s.logger.Info("Adding attribute indexes", tag.Value(map[string]interface{}{
-		"indexes": indexes,
-	}))
+	s.logger.Info("Adding attribute indexes", tag.Indexes(indexes))
 	err := s.client.AddAttributeIndexes(ctx, indexes)
-	s.logger.Info("Add attribute indexes returned", tag.Error(err), tag.Value(map[string]interface{}{
-		"elapsed": time.Since(startedAt),
-		"indexes": indexes,
-	}))
-	return err
+	elapsed := time.Since(startedAt)
+	if err != nil {
+		s.logger.Info("Add attribute indexes failed", tag.Error(err), tag.Elapsed(elapsed), tag.Indexes(indexes))
+		return err
+	}
+	s.logger.Info("Add attribute indexes succeeded", tag.Elapsed(elapsed), tag.Indexes(indexes))
+	return nil
 }
 
 func (s *Synchronizer) missingIndexes(

--- a/server/service/indexsync/synchronizer_test.go
+++ b/server/service/indexsync/synchronizer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/superdurable/dex/config"
 	"github.com/superdurable/dex/gen/dexpb"
+	"github.com/superdurable/dex/service/common/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -40,7 +41,7 @@ func TestSyncReturnsImmediatelyForExistingIndexes(t *testing.T) {
 	client := &scriptedClient{listResults: []listResult{{indexes: map[string]dexpb.IndexType{
 		"Status": dexpb.IndexType_INDEX_TYPE_KEYWORD,
 	}}}}
-	synchronizer := New(testConfig(time.Second), client)
+	synchronizer := New(testConfig(time.Second), client, log.NewNoop())
 
 	started := time.Now()
 	err := synchronizer.Sync(context.Background(), map[string]dexpb.IndexType{
@@ -58,7 +59,7 @@ func TestSyncWaitsForNewIndexesToBecomeVisible(t *testing.T) {
 		{indexes: map[string]dexpb.IndexType{}},
 		{indexes: map[string]dexpb.IndexType{"Status": dexpb.IndexType_INDEX_TYPE_KEYWORD}},
 	}}
-	synchronizer := New(testConfig(time.Second), client)
+	synchronizer := New(testConfig(time.Second), client, log.NewNoop())
 
 	err := synchronizer.Sync(context.Background(), map[string]dexpb.IndexType{
 		"Status": dexpb.IndexType_INDEX_TYPE_KEYWORD,
@@ -77,7 +78,7 @@ func TestSyncAcceptsConcurrentRegistration(t *testing.T) {
 		},
 		addErr: status.Error(codes.AlreadyExists, "registered concurrently"),
 	}
-	synchronizer := New(testConfig(time.Second), client)
+	synchronizer := New(testConfig(time.Second), client, log.NewNoop())
 
 	err := synchronizer.Sync(context.Background(), map[string]dexpb.IndexType{
 		"Status": dexpb.IndexType_INDEX_TYPE_KEYWORD,
@@ -97,7 +98,7 @@ func TestSyncRetriesTransientRegistration(t *testing.T) {
 		},
 		addErrors: []error{status.Error(codes.Unavailable, "not accepted"), nil},
 	}
-	synchronizer := New(testConfig(time.Second), client)
+	synchronizer := New(testConfig(time.Second), client, log.NewNoop())
 
 	err := synchronizer.Sync(context.Background(), map[string]dexpb.IndexType{
 		"Status": dexpb.IndexType_INDEX_TYPE_KEYWORD,
@@ -112,7 +113,7 @@ func TestSyncFailsImmediatelyForPermissionErrors(t *testing.T) {
 	client := &scriptedClient{listResults: []listResult{{
 		err: status.Error(codes.PermissionDenied, "denied"),
 	}}}
-	synchronizer := New(testConfig(time.Second), client)
+	synchronizer := New(testConfig(time.Second), client, log.NewNoop())
 
 	started := time.Now()
 	err := synchronizer.Sync(context.Background(), map[string]dexpb.IndexType{
@@ -128,7 +129,7 @@ func TestSyncUsesEarlierCallerDeadline(t *testing.T) {
 	client := &scriptedClient{listResults: []listResult{{
 		err: status.Error(codes.Unavailable, "not ready"),
 	}}}
-	synchronizer := New(testConfig(time.Second), client)
+	synchronizer := New(testConfig(time.Second), client, log.NewNoop())
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
 	defer cancel()
 
@@ -146,7 +147,7 @@ func TestSyncUsesConfiguredPropagationDeadline(t *testing.T) {
 	client := &scriptedClient{listResults: []listResult{
 		{indexes: map[string]dexpb.IndexType{}},
 	}}
-	synchronizer := New(testConfig(25*time.Millisecond), client)
+	synchronizer := New(testConfig(25*time.Millisecond), client, log.NewNoop())
 
 	err := synchronizer.Sync(context.Background(), map[string]dexpb.IndexType{
 		"Status": dexpb.IndexType_INDEX_TYPE_KEYWORD,
@@ -163,7 +164,7 @@ func TestSyncNormalizesBackendIndexTypes(t *testing.T) {
 		}}},
 		normalizeKeywordArray: true,
 	}
-	synchronizer := New(testConfig(time.Second), client)
+	synchronizer := New(testConfig(time.Second), client, log.NewNoop())
 
 	err := synchronizer.Sync(context.Background(), map[string]dexpb.IndexType{
 		"Tags": dexpb.IndexType_INDEX_TYPE_KEYWORD_ARRAY,


### PR DESCRIPTION
## Summary

- inject the server logger into the attribute index synchronizer
- emit INFO logs for initial listing, registration retries, and visibility polling
- time the backend add-index call so blocked registration is distinguishable from propagation delay
- replace every repository `tag.Value` caller with semantic typed tags
- remove the generic `tag.Value` and unused `tag.Key` constructors
- add an agent rule prohibiting `tag.Value` from being reintroduced

## Tests

- `make -C server unitTests`
- `make copyright-check`