### PR TITLE
ci: use self-hosted runners after merges

### DIFF
--- a/.github/scripts/check-ci-runners.sh
+++ b/.github/scripts/check-ci-runners.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+workflow_dir="${1:-.github/workflows}"
+runner_policy="runs-on: \${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || "
+failures=0
+
+shopt -s nullglob
+workflows=("$workflow_dir"/*-ci.yml "$workflow_dir"/*-ci.yaml)
+
+if (( ${#workflows[@]} == 0 )); then
+  echo "No CI workflows found in $workflow_dir."
+  exit 1
+fi
+
+for workflow in "${workflows[@]}"; do
+  while IFS=: read -r line_number runner_line; do
+    if [[ "$runner_line" != *"$runner_policy"* ]]; then
+      echo "$workflow:$line_number must route main pushes to a self-hosted runner."
+      failures=$((failures + 1))
+    fi
+  done < <(grep -nE '^[[:space:]]*runs-on:' "$workflow" || true)
+done
+
+if (( failures > 0 )); then
+  exit 1
+fi
+
+echo "All CI jobs route main pushes to self-hosted runners."

--- a/.github/workflows/blob-cache-go-ci.yml
+++ b/.github/workflows/blob-cache-go-ci.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   blob-cache:
     name: Blob cache tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: blob-cache-go

--- a/.github/workflows/check-gate-ci.yml
+++ b/.github/workflows/check-gate-ci.yml
@@ -16,10 +16,12 @@ concurrency:
 jobs:
   check-gate:
     name: Check Gate CI
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
+      - name: Validate CI runner policy
+        run: make ci-runner-check
       - uses: dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request'

--- a/.github/workflows/cla-ci.yml
+++ b/.github/workflows/cla-ci.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   cla-check:
     name: Contributor agreement
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - name: Verify signature record

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   check:
     name: Build and local-stack integration
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/copyright-ci.yml
+++ b/.github/workflows/copyright-ci.yml
@@ -53,7 +53,7 @@ on:
 jobs:
   copyright-check:
     name: License headers
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/examples-go-ci.yml
+++ b/.github/workflows/examples-go-ci.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   unit:
     name: SDK build
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: examples/go
@@ -66,7 +66,7 @@ jobs:
 
   e2e:
     name: End-to-end tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: examples/go

--- a/.github/workflows/examples-java-ci.yml
+++ b/.github/workflows/examples-java-ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   unit:
     name: Build + unit tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: examples/java
@@ -34,7 +34,7 @@ jobs:
 
   integ:
     name: Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: examples/java

--- a/.github/workflows/examples-python-ci.yml
+++ b/.github/workflows/examples-python-ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   integ:
     name: Install + integ tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: examples/python

--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   unit:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: sdk-go
@@ -53,7 +53,7 @@ jobs:
 
   worker-integration:
     name: Worker integration tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: sdk-go
@@ -70,7 +70,7 @@ jobs:
 
   client-integration:
     name: Client integration tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: sdk-go
@@ -87,7 +87,7 @@ jobs:
 
   e2e:
     name: Integration coverage
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 25
     permissions:
       contents: read

--- a/.github/workflows/sdk-java-ci.yml
+++ b/.github/workflows/sdk-java-ci.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   contracts:
     name: User contracts (Java ${{ matrix.java-version }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +65,7 @@ jobs:
 
   publication:
     name: Maven publication
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 15
     env:
       RUSTUP_TOOLCHAIN: '1.88.0'
@@ -89,7 +89,7 @@ jobs:
 
   tests:
     name: Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 25
     permissions:
       contents: read

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   contracts:
     name: User contracts (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -69,7 +69,7 @@ jobs:
       run: uv run --frozen pyright tests/typecheck_contracts.py tests/integ
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: sdk-python
@@ -131,7 +131,7 @@ jobs:
 
   integration:
     name: Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 25
     permissions:
       contents: read

--- a/.github/workflows/sdk-rust-ci.yml
+++ b/.github/workflows/sdk-rust-ci.yml
@@ -35,7 +35,7 @@ env:
 jobs:
   quality:
     name: Format and Clippy
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 15
     defaults:
       run:
@@ -51,12 +51,12 @@ jobs:
 
   tests:
     name: Tests (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || matrix.os }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: ${{ fromJSON(github.event_name == 'push' && github.ref == 'refs/heads/main' && '["self-hosted"]' || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
     defaults:
       run:
         working-directory: sdk-rust
@@ -69,7 +69,7 @@ jobs:
 
   integration:
     name: Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 25
     defaults:
       run:

--- a/.github/workflows/sdk-typescript-ci.yml
+++ b/.github/workflows/sdk-typescript-ci.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   contracts:
     name: User contracts (Node ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +68,7 @@ jobs:
 
   integration:
     name: Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   unit:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: server
@@ -36,7 +36,7 @@ jobs:
 
   attribute-store-integ:
     name: Attribute Store integration
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     defaults:
       run:
@@ -61,7 +61,7 @@ jobs:
 
   blob-store-integ:
     name: Blob Store integration
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     defaults:
       run:
@@ -84,7 +84,7 @@ jobs:
 
   web-api-integ:
     name: Web API integration (${{ matrix.backend }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -117,7 +117,7 @@ jobs:
 
   temporal-integ:
     name: Temporal integration (partition ${{ matrix.partition }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 35
     strategy:
       fail-fast: false
@@ -144,7 +144,7 @@ jobs:
 
   cadence-integ:
     name: Cadence integration (partition ${{ matrix.partition }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 35
     strategy:
       fail-fast: false

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   check:
     name: Typecheck, tests, and build
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: web

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,8 @@ check until the record is updated.
 
 Root workflows under [`.github/workflows/`](.github/workflows/) run path-filtered jobs for server and each SDK/samples tree, plus the copyright check. Prefer fixing those over re-adding nested `*/.github/workflows` duplicates.
 
+Every job in a `*-ci.yml` workflow must use a self-hosted runner for pushes to `main` while retaining its GitHub-hosted runner for pull requests and manual runs. Use `${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}` (with the appropriate hosted fallback), and run `make ci-runner-check` before submitting workflow changes.
+
 ## Releases (monorepo tags)
 
 Each component has its own version and tag prefix. Create a GitHub Release for that tag only — workflows filter on the prefix so one release does not publish another component.

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,13 @@
 
 ROOT_DIR := $(abspath .)
 
-.PHONY: help copyright copyright-check
+.PHONY: help ci-runner-check copyright copyright-check
 
 help: ## Show targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-22s %s\n", $$1, $$2}'
+
+ci-runner-check: ## Verify CI workflows route main pushes to self-hosted runners
+	bash .github/scripts/check-ci-runners.sh
 
 copyright: ## Add or upgrade license headers using the legacy manifest
 	cd server && GOWORK=off go run ./cmd/tools/copyright -rootDir "$(ROOT_DIR)"


### PR DESCRIPTION
## Summary

- route pushes to `main` in every `*-ci.yml` job to self-hosted runners
- keep pull request and manual runs on their existing GitHub-hosted runners
- collapse the Rust cross-platform matrix to one self-hosted job after merges
- enforce the policy in Check Gate and document the contributor workflow

## Rationale

GitHub-hosted public repository runner capacity is insufficient for post-merge CI. Pull request CI remains isolated on GitHub-hosted runners, while trusted pushes to `main` use repository self-hosted capacity.

## User impact

No product behavior changes. CI after a merge or direct push to `main` runs on self-hosted infrastructure. PR and manual CI behavior remains unchanged.

## Validation

- `make ci-runner-check`
- negative runner-policy fixture
- `actionlint` on all changed CI workflows
- `shellcheck .github/scripts/check-ci-runners.sh`
- `make copyright-check`
