### PR TITLE
docs(sdks): document all public APIs

### DIFF
--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "sdk-go/**"
+      - "blob-cache-go/**"
       - "protos/**"
       - "server/**"
       - "cli/**"
@@ -16,6 +17,7 @@ on:
   pull_request:
     paths:
       - "sdk-go/**"
+      - "blob-cache-go/**"
       - "protos/**"
       - "server/**"
       - "cli/**"
@@ -48,6 +50,8 @@ jobs:
           cache-dependency-path: |
             sdk-go/go.sum
             go.work.sum
+      - name: Validate public API documentation
+        run: make docsCheck
       - name: Unit tests
         run: make unitTests
 

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -86,6 +86,8 @@ jobs:
         enable-cache: true
     - name: Install dependencies
       run: uv sync --locked
+    - name: Validate public API documentation
+      run: uv run --frozen python scripts/check_public_docs.py
     - name: Verify generated protobuf stubs
       run: |
         make -C ../protos proto-python

--- a/.github/workflows/sdk-rust-ci.yml
+++ b/.github/workflows/sdk-rust-ci.yml
@@ -46,6 +46,8 @@ jobs:
         run: rustup toolchain install 1.88.0 --profile minimal --component rustfmt,clippy
       - name: Check formatting
         run: cargo fmt --all --check
+      - name: Validate public API documentation
+        run: make docs-check
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 

--- a/.github/workflows/sdk-typescript-ci.yml
+++ b/.github/workflows/sdk-typescript-ci.yml
@@ -61,6 +61,8 @@ jobs:
           cache-dependency-path: sdk-typescript/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Validate public API documentation
+        run: npm run docs:check
       - name: Check static types
         run: npm run typecheck
       - name: Test contracts

--- a/sdk-go/Makefile
+++ b/sdk-go/Makefile
@@ -116,7 +116,7 @@ define remake
 endef
 
 
-.PHONY: release clean
+.PHONY: release clean docsCheck
 
 idl-code-gen: # regenerate Go SDK protobuf stubs from protos/dex.proto
 	$(MAKE) -C ../protos proto-sdk-go
@@ -157,6 +157,9 @@ clientIntegTests:
 unitTests:
 	$Q go test -v ./dex ./examples/...
 
+docsCheck:
+	$Q go run ./scripts/check-public-docs.go dex logging ../blob-cache-go/blobcache
+
 tests: unitTests clientIntegTests workerIntegTests
 
 ci-tests:
@@ -164,7 +167,7 @@ ci-tests:
 
 fmt:
 	$Q gofmt -s -w ./dex ./examples ./integ
-  
+
 help:
 	@# print help first, so it's visible
 	@printf "\033[36m%-20s\033[0m %s\n" 'help' 'Prints a help message showing any specially-commented targets'

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -330,8 +330,16 @@ make unitTests
 make clientIntegTests
 make workerIntegTests
 make e2eTests
+make docsCheck
 make copyright-check
 ```
+
+`docsCheck` parses the hand-written `dex`, `logging`, and shared `blobcache`
+packages and requires a Go doc comment on every exported type, function,
+method, field, interface method, constant, and variable. Comments must begin
+with the declared name. Generated protobufs and tests are excluded. Use
+`go doc dex.<Name>` (or an IDE hover) to inspect the same application-facing
+API documentation locally.
 
 `e2eTests` uses the current checkout's `dexcli dev` environment. It
 runs the migrated iWF Go SDK scenarios through the public Dex SDK.

--- a/sdk-go/dex/attribute.go
+++ b/sdk-go/dex/attribute.go
@@ -13,12 +13,24 @@ package dex
 import "github.com/superdurable/dex/sdk-go/gen/dexpb"
 
 // Attribute defines a typed persisted value.
+//
+// Declare an Attribute once, include it in the Flow's PersistenceSchema, and reuse the same value
+// from Step and RPC code. Values use the SDK's native scalar and JSON encoding rules.
 // String values require valid UTF-8; use []byte for arbitrary bytes.
+//
+// Example:
+//
+//	var orderStatus = dex.DefineAttribute[string](
+//		"order-status",
+//		dex.Indexed(dex.AttributeIndex{Type: dex.IndexKeyword}),
+//	)
 type Attribute[T any] struct {
 	name  string
 	index *AttributeIndex
 }
 
+// DefineAttribute creates a typed Attribute with a stable name and optional search index.
+// The definition does not perform I/O; register it through PersistenceSchema before use.
 func DefineAttribute[T any](key string, options ...AttributeOption) Attribute[T] {
 	config := applyAttributeOptions(options)
 	return Attribute[T]{name: key, index: config.index}
@@ -26,6 +38,9 @@ func DefineAttribute[T any](key string, options ...AttributeOption) Attribute[T]
 
 // AttributeDef is the interface of Attribute, without Go's generic
 // So that internal sdk can use it to workaround Go's generic limitations
+//
+// AttributeDef is sealed. Applications obtain values from DefineAttribute or
+// DefineAttributeMap, then pass them to PersistenceSchema and Client methods.
 type AttributeDef interface {
 	attributeName() string
 	attributeIndex() *AttributeIndex
@@ -33,6 +48,7 @@ type AttributeDef interface {
 }
 
 // Get returns the current value. Missing values return AttributeNotFoundError.
+// It returns an error when ctx is not an SDK invocation or the value cannot be decoded.
 func (a Attribute[T]) Get(ctx Context) (value T, err error) {
 	invocation, ok := ctx.(attributeInvocation)
 	if !ok {
@@ -48,6 +64,8 @@ func (a Attribute[T]) Get(ctx Context) (value T, err error) {
 	return value, nil
 }
 
+// Set stages value for durable persistence when the current Step or RPC invocation succeeds.
+// It returns an error when ctx is not an SDK invocation or value cannot be encoded or indexed.
 func (a Attribute[T]) Set(ctx Context, value T) error {
 	invocation, ok := ctx.(attributeInvocation)
 	if !ok {
@@ -56,6 +74,8 @@ func (a Attribute[T]) Set(ctx Context, value T) error {
 	return invocation.setAttribute(a.name, value, a.index)
 }
 
+// Delete stages removal of this Attribute. Deleting a missing value is valid.
+// It returns an error when ctx is not an SDK invocation.
 func (a Attribute[T]) Delete(ctx Context) error {
 	invocation, ok := ctx.(attributeInvocation)
 	if !ok {
@@ -64,6 +84,7 @@ func (a Attribute[T]) Delete(ctx Context) error {
 	return invocation.deleteAttribute(a.name, a.index)
 }
 
+// AttributeName returns the stable name sent to Dex and used in PersistenceSchema.
 func (a Attribute[T]) AttributeName() string {
 	return a.name
 }
@@ -81,18 +102,24 @@ func (Attribute[T]) attributeIsMap() bool {
 }
 
 // AttributeMap defines keyed typed persisted values.
+//
+// Register the map once in PersistenceSchema, then supply an instance string for every access and
+// lock.
 // String values require valid UTF-8; use []byte for arbitrary bytes.
 type AttributeMap[T any] struct {
 	name  string
 	index *AttributeIndex
 }
 
+// DefineAttributeMap creates a typed Attribute map with a stable name and optional search index.
+// The definition performs no I/O; register it through PersistenceSchema before use.
 func DefineAttributeMap[T any](name string, options ...AttributeOption) AttributeMap[T] {
 	config := applyAttributeOptions(options)
 	return AttributeMap[T]{name: name, index: config.index}
 }
 
 // Get returns the current map value. Missing instances return AttributeNotFoundError.
+// It returns an error when ctx is invalid or the value cannot be decoded.
 func (a AttributeMap[T]) Get(
 	ctx Context,
 	instance string,
@@ -114,6 +141,8 @@ func (a AttributeMap[T]) Get(
 	return value, nil
 }
 
+// Set stages value for one map instance when the invocation succeeds.
+// It returns an error for an invalid context or a value that cannot be encoded or indexed.
 func (a AttributeMap[T]) Set(ctx Context, instance string, value T) error {
 	invocation, ok := ctx.(attributeInvocation)
 	if !ok {
@@ -122,6 +151,8 @@ func (a AttributeMap[T]) Set(ctx Context, instance string, value T) error {
 	return invocation.setAttributeMap(a.name, instance, value, a.index)
 }
 
+// Delete stages removal of one map instance. Deleting a missing instance is valid.
+// It returns an error when ctx is not an SDK invocation.
 func (a AttributeMap[T]) Delete(ctx Context, instance string) error {
 	invocation, ok := ctx.(attributeInvocation)
 	if !ok {
@@ -130,6 +161,7 @@ func (a AttributeMap[T]) Delete(ctx Context, instance string) error {
 	return invocation.deleteAttributeMap(a.name, instance, a.index)
 }
 
+// AttributeName returns the stable shared name of this Attribute map.
 func (a AttributeMap[T]) AttributeName() string {
 	return a.name
 }
@@ -146,40 +178,59 @@ func (AttributeMap[T]) attributeIsMap() bool {
 	return true
 }
 
+// AttributeOption configures an Attribute or AttributeMap definition.
+// Use Indexed to create values; the interface is sealed to SDK implementations.
 type AttributeOption interface {
 	applyAttribute(*attributeConfig)
 }
 
+// IndexType identifies the search representation required for an indexed Attribute value.
 type IndexType uint8
 
 const (
+	// IndexKeyword indexes one exact UTF-8 string for equality and aggregation queries.
 	IndexKeyword IndexType = iota + 1
+	// IndexFullText indexes analyzed UTF-8 text for full-text queries.
 	IndexFullText
+	// IndexKeywordArray indexes a slice or array of exact UTF-8 strings.
 	IndexKeywordArray
+	// IndexInt indexes a signed or unsigned integer that fits in int64.
 	IndexInt
+	// IndexDouble indexes a finite floating-point value.
 	IndexDouble
+	// IndexBool indexes a Boolean value.
 	IndexBool
+	// IndexDatetime indexes time.Time or an RFC3339Nano string.
 	IndexDatetime
 )
 
 // AttributeIndex configures visibility indexing; datetime values use time.Time or RFC3339Nano strings.
+// An empty IndexKey uses the Attribute name
+// for single values and a derived physical name for map instances.
 type AttributeIndex struct {
-	Type     IndexType
+	// Type selects the required value representation.
+	Type IndexType
+	// IndexKey overrides the physical search field; empty uses the Attribute-derived key.
 	IndexKey string
 }
 
+// Indexed enables search indexing with index on an Attribute or AttributeMap definition.
 func Indexed(index AttributeIndex) AttributeOption {
 	return indexedAttributeOption{index: index}
 }
 
+// AttributeLock identifies one Attribute or Attribute-map instance lock.
+// Create locks with LockAttribute or LockAttributeMap, then place them in StepOptions or InvokeOptions.
 type AttributeLock interface {
 	attributeLock()
 }
 
+// LockAttribute creates a lock for the single value represented by attribute.
 func LockAttribute[T any](attribute Attribute[T]) AttributeLock {
 	return attributeLock{name: attribute.name}
 }
 
+// LockAttributeMap creates a lock scoped to one Attribute-map instance.
 func LockAttributeMap[T any](
 	attribute AttributeMap[T],
 	instance string,
@@ -187,6 +238,8 @@ func LockAttributeMap[T any](
 	return attributeLock{name: attribute.name, instance: instance, isMap: true}
 }
 
+// InitialAttribute encodes a value for StartFlowOptions.Attributes.
+// It returns ValueMappingError when the value is unsupported or incompatible with its index.
 func InitialAttribute[T any](
 	attribute Attribute[T],
 	value T,
@@ -204,10 +257,14 @@ func InitialAttribute[T any](
 	}, nil
 }
 
+// InitialAttributeDef is an encoded Attribute initialization accepted by StartFlowOptions.
+// Values are created by InitialAttribute and InitialAttributeMapValue.
 type InitialAttributeDef interface {
 	initialAttribute()
 }
 
+// InitialAttributeMapValue encodes one Attribute-map instance for StartFlowOptions.Attributes.
+// It returns ValueMappingError when the value is unsupported or incompatible with its index.
 func InitialAttributeMapValue[T any](
 	attribute AttributeMap[T],
 	instance string,

--- a/sdk-go/dex/attribute.go
+++ b/sdk-go/dex/attribute.go
@@ -39,7 +39,7 @@ func DefineAttribute[T any](key string, options ...AttributeOption) Attribute[T]
 // AttributeDef is the interface of Attribute, without Go's generic
 // So that internal sdk can use it to workaround Go's generic limitations
 //
-// AttributeDef is sealed. Applications obtain values from DefineAttribute or
+// AttributeDef is internal to the SDK. Applications create values with DefineAttribute or
 // DefineAttributeMap, then pass them to PersistenceSchema and Client methods.
 type AttributeDef interface {
 	attributeName() string
@@ -179,7 +179,7 @@ func (AttributeMap[T]) attributeIsMap() bool {
 }
 
 // AttributeOption configures an Attribute or AttributeMap definition.
-// Use Indexed to create values; the interface is sealed to SDK implementations.
+// Use Indexed to create values; custom implementations are not supported.
 type AttributeOption interface {
 	applyAttribute(*attributeConfig)
 }

--- a/sdk-go/dex/channel.go
+++ b/sdk-go/dex/channel.go
@@ -30,7 +30,7 @@ func DefineChannel[T any](name string) Channel[T] {
 
 // ChannelDef is the interface of Channel, without Go's generic
 //
-// ChannelDef is sealed. Applications obtain values from DefineChannel or
+// ChannelDef is internal to the SDK. Applications create values with DefineChannel or
 // DefineChannelMap, then pass them to PersistenceSchema and Client methods.
 type ChannelDef interface {
 	channelName() string

--- a/sdk-go/dex/channel.go
+++ b/sdk-go/dex/channel.go
@@ -10,7 +10,7 @@
 
 package dex
 
-// Channel defines one durable FIFO stream of typed messages.
+// Channel defines one durable FIFO queue of typed messages.
 //
 // Add the Channel to PersistenceSchema. Clients and handlers may publish messages; Step WaitFor
 // methods create Conditions that wait on queue-size bounds and later decode consumed results.

--- a/sdk-go/dex/channel.go
+++ b/sdk-go/dex/channel.go
@@ -10,20 +10,35 @@
 
 package dex
 
+// Channel defines one durable FIFO stream of typed messages.
+//
+// Add the Channel to PersistenceSchema. Clients and handlers may publish messages; Step WaitFor
+// methods create Conditions that wait on queue-size bounds and later decode consumed results.
+//
+// Example:
+//
+//	var approvals = dex.DefineChannel[Approval]("approvals")
+//	return dex.AnyOf(approvals.ForOne(), dex.Timer(5*time.Minute)), nil
 type Channel[T any] struct {
 	name string
 }
 
+// DefineChannel creates a typed Channel with a stable name without performing I/O.
 func DefineChannel[T any](name string) Channel[T] {
 	return Channel[T]{name: name}
 }
 
 // ChannelDef is the interface of Channel, without Go's generic
+//
+// ChannelDef is sealed. Applications obtain values from DefineChannel or
+// DefineChannelMap, then pass them to PersistenceSchema and Client methods.
 type ChannelDef interface {
 	channelName() string
 	channelIsMap() bool
 }
 
+// Publish stages one message from the current Step or RPC invocation.
+// It returns an error when ctx is invalid or value cannot be encoded.
 func (c Channel[T]) Publish(ctx Context, value T) error {
 	invocation, ok := ctx.(channelInvocation)
 	if !ok {
@@ -32,22 +47,27 @@ func (c Channel[T]) Publish(ctx Context, value T) error {
 	return invocation.publishChannel(c.name, value)
 }
 
+// ForOne returns a Condition that consumes exactly one queued message.
 func (c Channel[T]) ForOne(options ...ConditionOption) Condition {
 	return newChannelCondition(c.name, "", false, nil, nil, options)
 }
 
+// ForN returns a Condition that consumes exactly count queued messages.
 func (c Channel[T]) ForN(count int, options ...ConditionOption) Condition {
 	return newChannelCondition(c.name, "", false, &count, &count, options)
 }
 
+// AtLeast returns a Condition satisfied when at least count messages are queued.
 func (c Channel[T]) AtLeast(count int, options ...ConditionOption) Condition {
 	return newChannelCondition(c.name, "", false, &count, nil, options)
 }
 
+// AtMost returns a Condition satisfied when no more than count messages are queued.
 func (c Channel[T]) AtMost(count int, options ...ConditionOption) Condition {
 	return newChannelCondition(c.name, "", false, nil, &count, options)
 }
 
+// AtLeastAtMost returns a Condition with inclusive lower and upper queue-size bounds.
 func (c Channel[T]) AtLeastAtMost(
 	atLeast int,
 	atMost int,
@@ -63,6 +83,8 @@ func (c Channel[T]) AtLeastAtMost(
 	)
 }
 
+// Size returns the invocation snapshot's queued-message count.
+// It panics when ctx did not originate from Dex.
 func (c Channel[T]) Size(ctx Context) int {
 	invocation, ok := ctx.(channelInvocation)
 	if !ok {
@@ -71,6 +93,8 @@ func (c Channel[T]) Size(ctx Context) int {
 	return invocation.channelSize(c.name)
 }
 
+// GetConditionResults decodes messages consumed by this Channel's satisfied Condition.
+// It returns an error for an invalid context or an undecodable message.
 func (c Channel[T]) GetConditionResults(ctx Context) ([]T, error) {
 	invocation, ok := ctx.(channelInvocation)
 	if !ok {
@@ -83,6 +107,7 @@ func (c Channel[T]) GetConditionResults(ctx Context) ([]T, error) {
 	return results, nil
 }
 
+// ChannelName returns the stable name sent to Dex and used in PersistenceSchema.
 func (c Channel[T]) ChannelName() string {
 	return c.name
 }
@@ -95,14 +120,19 @@ func (Channel[T]) channelIsMap() bool {
 	return false
 }
 
+// ChannelMap defines independently queued Channel instances under one shared name.
+// Register the map once in PersistenceSchema and supply an instance string to each operation.
 type ChannelMap[T any] struct {
 	name string
 }
 
+// DefineChannelMap creates a typed Channel map with a stable name.
 func DefineChannelMap[T any](name string) ChannelMap[T] {
 	return ChannelMap[T]{name: name}
 }
 
+// Publish stages one typed message for instance from the current invocation.
+// It returns an error when ctx is invalid or value cannot be encoded.
 func (c ChannelMap[T]) Publish(ctx Context, instance string, value T) error {
 	invocation, ok := ctx.(channelInvocation)
 	if !ok {
@@ -111,6 +141,7 @@ func (c ChannelMap[T]) Publish(ctx Context, instance string, value T) error {
 	return invocation.publishChannelMap(c.name, instance, value)
 }
 
+// ForOne returns an instance Condition that consumes exactly one message.
 func (c ChannelMap[T]) ForOne(
 	instance string,
 	options ...ConditionOption,
@@ -118,6 +149,7 @@ func (c ChannelMap[T]) ForOne(
 	return newChannelCondition(c.name, instance, true, nil, nil, options)
 }
 
+// ForN returns an instance Condition that consumes exactly count messages.
 func (c ChannelMap[T]) ForN(
 	instance string,
 	count int,
@@ -133,6 +165,7 @@ func (c ChannelMap[T]) ForN(
 	)
 }
 
+// AtLeast returns an instance Condition with an inclusive lower queue-size bound.
 func (c ChannelMap[T]) AtLeast(
 	instance string,
 	count int,
@@ -141,6 +174,7 @@ func (c ChannelMap[T]) AtLeast(
 	return newChannelCondition(c.name, instance, true, &count, nil, options)
 }
 
+// AtMost returns an instance Condition with an inclusive upper queue-size bound.
 func (c ChannelMap[T]) AtMost(
 	instance string,
 	count int,
@@ -149,6 +183,7 @@ func (c ChannelMap[T]) AtMost(
 	return newChannelCondition(c.name, instance, true, nil, &count, options)
 }
 
+// AtLeastAtMost returns an instance Condition with inclusive lower and upper bounds.
 func (c ChannelMap[T]) AtLeastAtMost(
 	instance string,
 	atLeast int,
@@ -165,6 +200,8 @@ func (c ChannelMap[T]) AtLeastAtMost(
 	)
 }
 
+// Size returns the invocation snapshot's queue size for instance.
+// It panics when ctx did not originate from Dex.
 func (c ChannelMap[T]) Size(ctx Context, instance string) int {
 	invocation, ok := ctx.(channelInvocation)
 	if !ok {
@@ -173,6 +210,8 @@ func (c ChannelMap[T]) Size(ctx Context, instance string) int {
 	return invocation.channelMapSize(c.name, instance)
 }
 
+// GetConditionResults decodes messages consumed by instance's satisfied Condition.
+// It returns an error for an invalid context or an undecodable message.
 func (c ChannelMap[T]) GetConditionResults(
 	ctx Context,
 	instance string,
@@ -193,6 +232,7 @@ func (c ChannelMap[T]) GetConditionResults(
 	return results, nil
 }
 
+// ChannelName returns the stable shared name of this Channel map.
 func (c ChannelMap[T]) ChannelName() string {
 	return c.name
 }

--- a/sdk-go/dex/client.go
+++ b/sdk-go/dex/client.go
@@ -148,7 +148,7 @@ func resolveClientOptions(options ClientOptions) (string, *WorkerTarget, error) 
 // Close closes the owned FlowService connection.
 //
 // Close is idempotent. Calls begun after Close return an error; calls already in
-// progress are governed by their contexts and the gRPC connection shutdown.
+// progress are controlled by their contexts and the gRPC connection shutdown.
 func (client *Client) Close() error {
 	client.lifecycleMu.Lock()
 	defer client.lifecycleMu.Unlock()
@@ -284,9 +284,9 @@ type WaitForFlowResult struct {
 	Status FlowStatus
 	// Completions contains hydrated outputs when NeedsResults was true.
 	Completions []StepCompletion
-	// ErrorType is the Flow failure category when supplied.
+	// ErrorType is the Flow failure category when available.
 	ErrorType FlowErrorType
-	// ErrorMessage is the server completion detail when supplied.
+	// ErrorMessage is the server completion detail when available.
 	ErrorMessage string
 }
 
@@ -675,7 +675,7 @@ func searchFlowValuePointers(response *dexpb.SearchFlowsResponse) []**dexpb.Valu
 // ResetFlow creates a new run of an existing Flow and returns the new run ID.
 //
 // options selects the reset point, optional Step input, and reset reason. The server
-// keeps the Flow ID and starts a distinct run. ResetFlow returns validation or
+// keeps the Flow ID and starts a new run. ResetFlow returns validation or
 // serialization errors before the request, and context, transport, not-found, or
 // server errors after it is sent.
 func (client *Client) ResetFlow(
@@ -762,7 +762,7 @@ func resolveTimerID(timer TimerID) (string, *int32, error) {
 // UpdateFlowConfig replaces the mutable configuration of an active Flow.
 //
 // config is validated and serialized before the request. The update applies to
-// subsequent Flow decisions; work already dispatched is not recalled. The method
+// later Flow decisions; work already dispatched is not recalled. The method
 // returns validation, inactive-Flow, context, transport, or server errors.
 func (client *Client) UpdateFlowConfig(
 	ctx context.Context,

--- a/sdk-go/dex/client.go
+++ b/sdk-go/dex/client.go
@@ -40,6 +40,18 @@ type ClientOptions struct {
 }
 
 // Client calls FlowService with registered typed definitions.
+//
+// A Client is safe for concurrent use. Calls use their context for cancellation and
+// return an error after Close. The Client owns its gRPC connection; callers should
+// close it when the application shuts down.
+//
+//	client, err := dex.NewClient(registry, cache, dex.ClientOptions{})
+//	if err != nil {
+//		return err
+//	}
+//	defer client.Close()
+//	runID, err := client.StartFlow(ctx, orderFlow, "order-42", orderInput,
+//		dex.StartFlowOptions{})
 type Client struct {
 	registry     *Registry
 	cache        *blobcache.Cache
@@ -54,6 +66,12 @@ type Client struct {
 }
 
 // NewClient constructs a Client from shared dependencies.
+//
+// registry supplies the validated definitions and cache hydrates large values. The
+// Client connects lazily to ClientOptions.FlowServiceAddress, which defaults to
+// localhost:8801. It panics when registry or cache is nil. It returns an error when
+// an address or worker target is invalid, or the gRPC client cannot be created.
+// The caller owns the returned Client and must call Close.
 func NewClient(
 	registry *Registry,
 	cache *blobcache.Cache,
@@ -128,6 +146,9 @@ func resolveClientOptions(options ClientOptions) (string, *WorkerTarget, error) 
 }
 
 // Close closes the owned FlowService connection.
+//
+// Close is idempotent. Calls begun after Close return an error; calls already in
+// progress are governed by their contexts and the gRPC connection shutdown.
 func (client *Client) Close() error {
 	client.lifecycleMu.Lock()
 	defer client.lifecycleMu.Unlock()
@@ -178,21 +199,34 @@ func (client *Client) hydrateValues(
 	return nil
 }
 
+// AttributeWrite describes one value for Client.SetAttributes.
+// A nil Value is encoded as JSON null; use the single-value APIs when compile-time typing matters.
 type AttributeWrite struct {
-	Name  string
+	// Name is an Attribute name or the physical name of an Attribute-map instance.
+	Name string
+	// Value is the application value to encode.
 	Value any
+	// Index optionally supplies search-index metadata for the write.
 	Index *AttributeIndex
 }
 
+// FlowStatus describes the current or terminal state of a Flow run.
 type FlowStatus uint8
 
 const (
+	// FlowRunning means the Flow can still execute Steps or receive messages and RPCs.
 	FlowRunning FlowStatus = iota + 1
+	// FlowCompleted means the Flow completed successfully.
 	FlowCompleted
+	// FlowFailed means an unrecovered Step, RPC, or user-code error ended the Flow.
 	FlowFailed
+	// FlowTimedOut means the Flow exceeded its configured timeout.
 	FlowTimedOut
+	// FlowTerminated means an operator ended the Flow immediately.
 	FlowTerminated
+	// FlowCanceled means the Flow completed cooperative cancellation.
 	FlowCanceled
+	// FlowContinuedAsNew means history rolled into a successor run.
 	FlowContinuedAsNew
 )
 
@@ -218,51 +252,91 @@ func (status FlowStatus) String() string {
 	}
 }
 
+// FlowErrorType categorizes the failure recorded for an uncompleted Flow.
 type FlowErrorType uint8
 
 const (
+	// FlowErrorStepDecision identifies an invalid or failing Step decision.
 	FlowErrorStepDecision FlowErrorType = iota + 1
+	// FlowErrorClientAPI identifies a client API operation that failed the Flow.
 	FlowErrorClientAPI
+	// FlowErrorWorkerMethod identifies a failed Worker Step or RPC handler.
 	FlowErrorWorkerMethod
+	// FlowErrorInvalidUserCode identifies an invalid Flow or Step definition.
 	FlowErrorInvalidUserCode
+	// FlowErrorInternal identifies an internal Dex failure.
 	FlowErrorInternal
 )
 
+// StepCompletion contains one completed Step output returned by WaitForFlow.
 type StepCompletion struct {
-	StepType        string
+	// StepType is the registered Step type.
+	StepType string
+	// StepExecutionID is the completed execution's server identity.
 	StepExecutionID string
-	Output          Value
+	// Output is an opaque hydrated value decoded with Value.Decode.
+	Output Value
 }
 
+// WaitForFlowResult contains the terminal status and optional completed Step outputs.
 type WaitForFlowResult struct {
-	Status       FlowStatus
-	Completions  []StepCompletion
-	ErrorType    FlowErrorType
+	// Status is the terminal Flow status.
+	Status FlowStatus
+	// Completions contains hydrated outputs when NeedsResults was true.
+	Completions []StepCompletion
+	// ErrorType is the Flow failure category when supplied.
+	ErrorType FlowErrorType
+	// ErrorMessage is the server completion detail when supplied.
 	ErrorMessage string
 }
 
+// SearchFlowEntry contains one Flow row returned by SearchFlows.
 type SearchFlowEntry struct {
-	FlowID    string
-	RunID     string
-	FlowType  string
-	Status    FlowStatus
+	// FlowID is the application-assigned Flow ID.
+	FlowID string
+	// RunID is the server-assigned run ID.
+	RunID string
+	// FlowType is the registered Flow type.
+	FlowType string
+	// Status is the indexed Flow status.
+	Status FlowStatus
+	// StartedAt is the indexed start time.
 	StartedAt time.Time
-	ClosedAt  time.Time
+	// ClosedAt is zero while open or when the close time is unavailable.
+	ClosedAt time.Time
 	// IndexedAttributes contains values keyed by their physical index names.
 	IndexedAttributes map[string]Value
 }
 
+// SearchFlowsPage contains one page of Flow search results.
 type SearchFlowsPage struct {
-	Flows         []SearchFlowEntry
+	// Flows are returned in server-defined query order.
+	Flows []SearchFlowEntry
+	// NextPageToken is opaque and empty on the last page.
 	NextPageToken string
 }
 
+// HealthInfo describes one Dex health-check condition.
 type HealthInfo struct {
+	// Condition is the service-reported health state.
 	Condition string
-	Hostname  string
-	Duration  int32
+	// Hostname identifies the responding Dex server.
+	Hostname string
+	// Duration is the response duration in milliseconds.
+	Duration int32
 }
 
+// StartFlow starts a new Flow execution and returns its server-assigned run ID.
+//
+// flow must be registered with the Client's Registry, flowID must be non-empty,
+// and input must match the Flow's starting Step input type. options controls the
+// request ID, timeout, worker target, initial attributes, and Flow configuration;
+// omitted values use the registered Flow defaults. The method returns after the
+// server accepts the Flow, not after the Flow completes.
+//
+// StartFlow returns FlowAlreadyStartedError when flowID identifies an existing
+// Flow. It also returns validation, serialization, context, transport, or server
+// errors without transferring ownership of input.
 func (client *Client) StartFlow(
 	ctx context.Context,
 	flow Flow,
@@ -440,6 +514,12 @@ func resolveStartRequestID(override *string) (string, error) {
 	return *override, nil
 }
 
+// StopFlow requests cancellation or termination of the active Flow identified by flowID.
+//
+// options selects the stop mode and optional reason. The method returns after the
+// server accepts the request; it does not wait for the Flow to close. It returns
+// FlowNotActiveError when no active execution exists, plus validation, context,
+// transport, or server errors.
 func (client *Client) StopFlow(
 	ctx context.Context,
 	flowID string,
@@ -460,6 +540,14 @@ func (client *Client) StopFlow(
 	return translateRPCError(err, "StopFlow", flowID, flowTargetActive)
 }
 
+// WaitForFlow blocks until a Flow closes or the configured long-poll wait expires.
+//
+// options controls the server wait duration and whether Step completion results are
+// included. A completed Flow returns WaitForFlowResult. Any other closed status
+// returns FlowUncompletedError containing the run ID, status, failure details, and
+// available completions. LongPollTimeoutError means the Flow remained open; callers
+// may call WaitForFlow again. Context cancellation and hydration failures are also
+// returned.
 func (client *Client) WaitForFlow(
 	ctx context.Context,
 	flowID string,
@@ -536,6 +624,13 @@ func waitForFlowValuePointers(response *dexpb.WaitForFlowResponse) []**dexpb.Val
 	return pointers
 }
 
+// SearchFlows returns one server-ordered page of Flow executions matching query.
+//
+// query uses the Dex visibility query language. pageSize must satisfy the server's
+// accepted range, and nextPageToken must be empty for the first page or copied
+// unchanged from a previous SearchFlowsPage. Indexed attributes are hydrated before
+// return. An empty NextPageToken marks the final page. Validation, context,
+// hydration, transport, and server failures are returned as errors.
 func (client *Client) SearchFlows(
 	ctx context.Context,
 	query string,
@@ -577,6 +672,12 @@ func searchFlowValuePointers(response *dexpb.SearchFlowsResponse) []**dexpb.Valu
 	return pointers
 }
 
+// ResetFlow creates a new run of an existing Flow and returns the new run ID.
+//
+// options selects the reset point, optional Step input, and reset reason. The server
+// keeps the Flow ID and starts a distinct run. ResetFlow returns validation or
+// serialization errors before the request, and context, transport, not-found, or
+// server errors after it is sent.
 func (client *Client) ResetFlow(
 	ctx context.Context,
 	flowID string,
@@ -600,6 +701,13 @@ func (client *Client) ResetFlow(
 	return response.RunId, nil
 }
 
+// SkipTimer makes one waiting Timer condition immediately ready.
+//
+// stepExecution identifies the Step type and execution number; a nil execution
+// number means the first execution. timer must specify exactly one condition ID or
+// zero-based condition index. The call affects only an active Flow and returns after
+// the server accepts the skip. Invalid identifiers, inactive Flows, context,
+// transport, and server failures are returned as errors.
 func (client *Client) SkipTimer(
 	ctx context.Context,
 	flowID string,
@@ -651,6 +759,11 @@ func resolveTimerID(timer TimerID) (string, *int32, error) {
 	return timer.ConditionID, timer.Index, nil
 }
 
+// UpdateFlowConfig replaces the mutable configuration of an active Flow.
+//
+// config is validated and serialized before the request. The update applies to
+// subsequent Flow decisions; work already dispatched is not recalled. The method
+// returns validation, inactive-Flow, context, transport, or server errors.
 func (client *Client) UpdateFlowConfig(
 	ctx context.Context,
 	flowID string,
@@ -670,6 +783,13 @@ func (client *Client) UpdateFlowConfig(
 	return translateRPCError(err, "UpdateFlowConfig", flowID, flowTargetActive)
 }
 
+// WaitForStepCompletion blocks until a Step execution completes or the wait expires.
+//
+// stepExecution identifies the Step type and execution number; nil means execution
+// one. options controls the server-side long-poll duration. A nil error means the
+// requested execution completed, but this method does not return its output.
+// LongPollTimeoutError is retryable by calling the method again. Invalid identifiers,
+// inactive Flows, context, transport, and server errors are also returned.
 func (client *Client) WaitForStepCompletion(
 	ctx context.Context,
 	flowID string,
@@ -704,6 +824,11 @@ func (client *Client) WaitForStepCompletion(
 	return translateRPCError(err, "WaitForStepCompletion", flowID, flowTargetActive)
 }
 
+// TriggerContinueAsNew asks an active Flow to roll its history into a new run.
+//
+// The request returns after the server accepts it and does not wait for the rollover.
+// The Flow ID is preserved while the run ID changes. Empty identifiers, inactive
+// Flows, context cancellation, transport failures, and server failures return errors.
 func (client *Client) TriggerContinueAsNew(
 	ctx context.Context,
 	flowID string,
@@ -718,6 +843,11 @@ func (client *Client) TriggerContinueAsNew(
 	return translateRPCError(err, "TriggerContinueAsNew", flowID, flowTargetActive)
 }
 
+// HealthCheck returns the responding Dex server's current health condition.
+//
+// The result includes the server hostname and reported duration in milliseconds.
+// HealthCheck performs network I/O and honors ctx. It returns context, transport, or
+// server errors when no valid response is available.
 func (client *Client) HealthCheck(ctx context.Context) (HealthInfo, error) {
 	if err := client.validateCall(ctx); err != nil {
 		return HealthInfo{}, err
@@ -729,6 +859,11 @@ func (client *Client) HealthCheck(ctx context.Context) (HealthInfo, error) {
 	return mapHealthInfo(response)
 }
 
+// PublishToChannel appends values to a registered singleton Channel.
+//
+// Every value must match the Channel's element type and is published in argument
+// order. Supplying no values is a successful no-op. The method returns serialization,
+// registration, inactive-Flow, context, transport, or server errors.
 func (client *Client) PublishToChannel(
 	ctx context.Context,
 	flowID string,
@@ -738,6 +873,12 @@ func (client *Client) PublishToChannel(
 	return client.publishToChannel(ctx, flowID, channel, "", false, values)
 }
 
+// PublishToChannelMap appends values to one instance of a registered ChannelMap.
+//
+// instance is the logical map key and must be non-empty. Every value must match the
+// ChannelMap's element type and is published in argument order. Supplying no values
+// is a successful no-op. The method returns validation, serialization, registration,
+// inactive-Flow, context, transport, or server errors.
 func (client *Client) PublishToChannelMap(
 	ctx context.Context,
 	flowID string,
@@ -788,6 +929,12 @@ func (client *Client) publishToChannel(
 	return translateRPCError(err, "PublishToChannel", flowID, flowTargetActive)
 }
 
+// GetAttribute decodes a singleton Attribute from an existing Flow into valuePtr.
+//
+// valuePtr must be a non-nil pointer matching the registered Attribute value type.
+// The result is false with a nil error when the Attribute has not been set; valuePtr
+// is then unchanged. The method returns validation, decoding, registration,
+// hydration, not-found Flow, context, transport, or server errors.
 func (client *Client) GetAttribute(
 	ctx context.Context,
 	flowID string,
@@ -797,6 +944,12 @@ func (client *Client) GetAttribute(
 	return client.getAttribute(ctx, flowID, attribute, "", false, valuePtr)
 }
 
+// GetAttributeMap decodes one AttributeMap instance into valuePtr.
+//
+// instance must be non-empty and valuePtr must be a non-nil pointer matching the
+// registered value type. The result is false with a nil error when that instance has
+// not been set; valuePtr is then unchanged. Validation, decoding, registration,
+// hydration, not-found Flow, context, transport, and server failures return errors.
 func (client *Client) GetAttributeMap(
 	ctx context.Context,
 	flowID string,
@@ -873,6 +1026,11 @@ func (client *Client) singleAttributeValue(
 	return value, true, err
 }
 
+// SetAttribute writes a singleton Attribute on an active Flow.
+//
+// value must match the registered Attribute type. The server applies the write
+// atomically for this Attribute. The method returns type, serialization, registration,
+// inactive-Flow, context, transport, or server errors.
 func (client *Client) SetAttribute(
 	ctx context.Context,
 	flowID string,
@@ -882,6 +1040,11 @@ func (client *Client) SetAttribute(
 	return client.setAttribute(ctx, flowID, attribute, "", false, value)
 }
 
+// SetAttributeMap writes one AttributeMap instance on an active Flow.
+//
+// instance must be non-empty and value must match the registered value type. The
+// server applies the write atomically for this instance. Validation, serialization,
+// registration, inactive-Flow, context, transport, and server failures return errors.
 func (client *Client) SetAttributeMap(
 	ctx context.Context,
 	flowID string,
@@ -918,6 +1081,13 @@ func (client *Client) setAttribute(
 	}})
 }
 
+// GetAttributes returns raw values for several singleton Attributes in one request.
+//
+// Each Attribute must be registered, singleton, and unique. Missing Attributes are
+// absent from the returned map, whose keys are logical Attribute names. Call
+// Value.Decode with a correctly typed pointer to decode a value. Supplying no
+// Attributes returns an empty map without network I/O. Validation, hydration,
+// not-found Flow, context, transport, and server failures return errors.
 func (client *Client) GetAttributes(
 	ctx context.Context,
 	flowID string,
@@ -979,6 +1149,12 @@ func keyValuePointers(values []*dexpb.KV) []**dexpb.Value {
 	return pointers
 }
 
+// SetAttributes atomically writes several physical Attribute names on an active Flow.
+//
+// Each AttributeWrite supplies its name, value, and optional search index. Names must
+// be unique. Supplying no writes is a successful no-op without network I/O. The method
+// returns validation, serialization, inactive-Flow, context, transport, or server
+// errors; a failed request does not partially apply the batch.
 func (client *Client) SetAttributes(
 	ctx context.Context,
 	flowID string,
@@ -1023,6 +1199,13 @@ func (client *Client) setAttributes(
 	return translateRPCError(err, "SetAttributes", flowID, flowTargetActive)
 }
 
+// WaitForAttributeEqual blocks until a singleton Attribute equals value.
+//
+// value must match the registered Attribute type. options controls the server-side
+// long-poll duration. A nil error means equality was observed. LongPollTimeoutError
+// means the condition was not observed and the call may be repeated. Validation,
+// serialization, inactive-Flow, context, transport, and server failures also return
+// errors.
 func (client *Client) WaitForAttributeEqual(
 	ctx context.Context,
 	flowID string,
@@ -1041,6 +1224,12 @@ func (client *Client) WaitForAttributeEqual(
 	)
 }
 
+// WaitForAttributeMapEqual blocks until one AttributeMap instance equals value.
+//
+// instance must be non-empty and value must match the registered type. options
+// controls the server-side long-poll duration. A nil error means equality was
+// observed. LongPollTimeoutError is retryable. Validation, serialization,
+// inactive-Flow, context, transport, and server failures also return errors.
 func (client *Client) WaitForAttributeMapEqual(
 	ctx context.Context,
 	flowID string,
@@ -1105,6 +1294,18 @@ func (client *Client) waitForAttributeEqual(
 	return translateRPCError(err, "WaitForAttribute", flowID, flowTargetActive)
 }
 
+// InvokeRPC synchronously invokes a registered RPC on an active Flow.
+//
+// rpc identifies an RPC definition belonging to the Flow type, input must match its
+// input type, and outputPtr must be a non-nil pointer to its output type. options
+// controls timeout and Attribute locks. InvokeRPC blocks until the handler returns,
+// the timeout expires, or ctx is canceled, then decodes the result into outputPtr.
+// It may return validation, serialization, lock-conflict, worker, inactive-Flow,
+// context, hydration, transport, or server errors. outputPtr is not owned by Dex.
+//
+//	var result Quote
+//	err := client.InvokeRPC(ctx, "order-42", quoteRPC, request, &result,
+//		dex.InvokeOptions{})
 func (client *Client) InvokeRPC(
 	ctx context.Context,
 	flowID string,

--- a/sdk-go/dex/condition.go
+++ b/sdk-go/dex/condition.go
@@ -15,6 +15,17 @@ import (
 	"time"
 )
 
+// Wait describes when Dex may invoke a Step's Execute method.
+//
+// Build waits from durable Timer and Channel Conditions. Condition order determines timer indexes
+// used by TimerID and HasTimerFiredByIndex.
+//
+// Example:
+//
+//	return dex.AnyOf(
+//		approvals.ForOne(dex.WithConditionID("approved")),
+//		dex.Timer(5*time.Minute, dex.WithConditionID("timeout")),
+//	), nil
 type Wait struct {
 	kind         waitKind
 	conditions   []Condition
@@ -22,22 +33,27 @@ type Wait struct {
 	transient    *StepMovement
 }
 
+// SkipWaitImmediately asks Dex to invoke Execute without evaluating WaitFor conditions.
 func SkipWaitImmediately() *Wait {
 	return &Wait{kind: skipWaitImmediately}
 }
 
+// Until waits until one condition is satisfied.
 func Until(condition Condition) *Wait {
 	return AllOf(condition)
 }
 
+// AllOf waits until every condition is satisfied.
 func AllOf(conditions ...Condition) *Wait {
 	return &Wait{kind: waitAllOf, conditions: conditions}
 }
 
+// AnyOf waits until at least one condition is satisfied.
 func AnyOf(conditions ...Condition) *Wait {
 	return &Wait{kind: waitAnyOf, conditions: conditions}
 }
 
+// AnyComboOf waits until every Condition in at least one combination is satisfied.
 func AnyComboOf(combinations ...ConditionCombination) *Wait {
 	return &Wait{kind: waitAnyComboOf, combinations: combinations}
 }
@@ -47,10 +63,14 @@ func withTransientMovement(wait *Wait, movement StepMovement) *Wait {
 	return wait
 }
 
+// Condition represents one durable Timer or Channel predicate.
+// The interface is sealed; create values through Timer, Channel, or ChannelMap.
 type Condition interface {
 	condition()
 }
 
+// Timer returns a Condition satisfied after duration of durable workflow time.
+// The timer survives Worker restarts.
 func Timer(duration time.Duration, options ...ConditionOption) Condition {
 	condition := &conditionImpl{
 		kind:     conditionTimer,
@@ -60,18 +80,22 @@ func Timer(duration time.Duration, options ...ConditionOption) Condition {
 	return condition
 }
 
+// ConditionOption configures a Condition. The interface is sealed to SDK implementations.
 type ConditionOption interface {
 	applyCondition(*conditionImpl)
 }
 
+// WithConditionID assigns a stable timer or Channel Condition ID for later targeting.
 func WithConditionID(conditionID string) ConditionOption {
 	return conditionIDOption{conditionID: conditionID}
 }
 
+// ConditionCombination groups Conditions that must all succeed as one AnyComboOf branch.
 type ConditionCombination struct {
 	conditions []Condition
 }
 
+// Combo creates one branch satisfied only when all conditions are satisfied.
 func Combo(conditions ...Condition) ConditionCombination {
 	return ConditionCombination{conditions: conditions}
 }

--- a/sdk-go/dex/condition.go
+++ b/sdk-go/dex/condition.go
@@ -64,7 +64,7 @@ func withTransientMovement(wait *Wait, movement StepMovement) *Wait {
 }
 
 // Condition represents one durable Timer or Channel predicate.
-// The interface is sealed; create values through Timer, Channel, or ChannelMap.
+// Create values through Timer, Channel, or ChannelMap; custom implementations are not supported.
 type Condition interface {
 	condition()
 }
@@ -80,7 +80,7 @@ func Timer(duration time.Duration, options ...ConditionOption) Condition {
 	return condition
 }
 
-// ConditionOption configures a Condition. The interface is sealed to SDK implementations.
+// ConditionOption configures a Condition. Use WithConditionID to create an option.
 type ConditionOption interface {
 	applyCondition(*conditionImpl)
 }

--- a/sdk-go/dex/context.go
+++ b/sdk-go/dex/context.go
@@ -15,22 +15,40 @@ import (
 	"time"
 )
 
+// Context provides invocation metadata and stages durable mutations for Step and RPC handlers.
+//
+// A Context belongs to one handler attempt and must not outlive it. Attribute writes, Channel
+// publications, locals, and events commit atomically only when the handler returns successfully.
 type Context interface {
+	// Context supports cancellation and deadlines for the active handler attempt.
 	context.Context
 
+	// FlowID returns the application-assigned Flow ID.
 	FlowID() string
+	// RunID returns the server-assigned run ID.
 	RunID() string
+	// FlowStartedAt returns when the current Flow run started.
 	FlowStartedAt() time.Time
+	// StepExecutionID returns the current Step execution ID, or empty for an RPC.
 	StepExecutionID() string
+	// FromStepExecutionID returns the predecessor Step execution ID, or empty when absent.
 	FromStepExecutionID() string
+	// FirstAttemptAt returns when the first attempt of this handler invocation started.
 	FirstAttemptAt() time.Time
+	// Attempt returns the one-based handler attempt number.
 	Attempt() int32
 
+	// HasTimerFired reports whether any Timer Condition completed for this Execute invocation.
 	HasTimerFired() bool
+	// HasTimerFiredByIndex reports whether the zero-based Timer Condition completed.
 	HasTimerFiredByIndex(index int) bool
+	// WaitForMethodFailed reports whether Execute followed an exhausted WaitFor with Proceed policy.
 	WaitForMethodFailed() bool
 
+	// SetStepExecutionLocal stages value under key for later attempts of this Step execution.
 	SetStepExecutionLocal(key string, value any) error
+	// GetStepExecutionLocal decodes a local value into non-nil valuePtr and reports whether it exists.
 	GetStepExecutionLocal(key string, valuePtr any) (found bool, err error)
+	// RecordEvent records one uniquely named diagnostic event with a serializable payload.
 	RecordEvent(name string, value any) error
 }

--- a/sdk-go/dex/decision.go
+++ b/sdk-go/dex/decision.go
@@ -43,7 +43,7 @@ func MovementOf[IN any](
 	return movement
 }
 
-// GoToMulti moves to every supplied target, enabling concurrent active Steps.
+// GoToMulti moves to all targets, enabling concurrent active Steps.
 func GoToMulti(movements ...StepMovement) *StepDecision {
 	return &StepDecision{
 		kind:      decisionNext,
@@ -94,7 +94,7 @@ func DeadEnd() *StepDecision {
 }
 
 // ForceCompleteOnChannelsEmpty completes when every guarded Channel is empty.
-// Otherwise Dex follows the optional movements supplied through otherwise.
+// Otherwise Dex follows the movements in otherwise.
 func ForceCompleteOnChannelsEmpty(
 	output any,
 	channels []ChannelDef,
@@ -127,7 +127,7 @@ type CloseDecision struct {
 	channels []ChannelDef
 }
 
-// StepMoveOption configures one Step movement. The interface is sealed to SDK implementations.
+// StepMoveOption configures one Step movement. Use WithStepOptions to create an option.
 type StepMoveOption interface {
 	applyStepMovement(*StepMovement)
 }

--- a/sdk-go/dex/decision.go
+++ b/sdk-go/dex/decision.go
@@ -10,12 +10,15 @@
 
 package dex
 
+// StepMovement targets a Step with typed input and optional per-movement StepOptions.
+// Create movements with MovementOf when building multi-target or conditional decisions.
 type StepMovement struct {
 	step    StepDef
 	input   any
 	options *StepOptions
 }
 
+// GoTo returns a decision that moves to one typed target Step.
 func GoTo[IN any](
 	step Step[IN],
 	input IN,
@@ -24,6 +27,7 @@ func GoTo[IN any](
 	return GoToMulti(MovementOf(step, input, options...))
 }
 
+// MovementOf creates a typed Step movement for GoToMulti, RPCResult, or conditional completion.
 func MovementOf[IN any](
 	step Step[IN],
 	input IN,
@@ -39,6 +43,7 @@ func MovementOf[IN any](
 	return movement
 }
 
+// GoToMulti moves to every supplied target, enabling concurrent active Steps.
 func GoToMulti(movements ...StepMovement) *StepDecision {
 	return &StepDecision{
 		kind:      decisionNext,
@@ -46,6 +51,7 @@ func GoToMulti(movements ...StepMovement) *StepDecision {
 	}
 }
 
+// GracefulComplete completes after all other active Steps finish and returns output.
 func GracefulComplete(output any) *StepDecision {
 	return &StepDecision{
 		kind: decisionClose,
@@ -56,6 +62,7 @@ func GracefulComplete(output any) *StepDecision {
 	}
 }
 
+// ForceComplete completes immediately, abandons other active Steps, and returns output.
 func ForceComplete(output any) *StepDecision {
 	return &StepDecision{
 		kind: decisionClose,
@@ -66,6 +73,7 @@ func ForceComplete(output any) *StepDecision {
 	}
 }
 
+// ForceFail ends the Flow immediately with an application-provided reason.
 func ForceFail(reason string) *StepDecision {
 	return &StepDecision{
 		kind: decisionClose,
@@ -76,6 +84,8 @@ func ForceFail(reason string) *StepDecision {
 	}
 }
 
+// DeadEnd leaves the Flow running with no next Step.
+// Use it only when an RPC or external operation will resume the Flow later.
 func DeadEnd() *StepDecision {
 	return &StepDecision{
 		kind:  decisionClose,
@@ -83,6 +93,8 @@ func DeadEnd() *StepDecision {
 	}
 }
 
+// ForceCompleteOnChannelsEmpty completes when every guarded Channel is empty.
+// Otherwise Dex follows the optional movements supplied through otherwise.
 func ForceCompleteOnChannelsEmpty(
 	output any,
 	channels []ChannelDef,
@@ -99,12 +111,15 @@ func ForceCompleteOnChannelsEmpty(
 	}
 }
 
+// StepDecision describes the durable outcome of one successful Step Execute call.
 type StepDecision struct {
 	kind      decisionKind
 	movements []StepMovement
 	close     CloseDecision
 }
 
+// CloseDecision stores the terminal output, failure reason, and guarded Channels.
+// Applications create it through decision factories instead of constructing it directly.
 type CloseDecision struct {
 	kind     closeKind
 	output   any
@@ -112,10 +127,12 @@ type CloseDecision struct {
 	channels []ChannelDef
 }
 
+// StepMoveOption configures one Step movement. The interface is sealed to SDK implementations.
 type StepMoveOption interface {
 	applyStepMovement(*StepMovement)
 }
 
+// WithStepOptions overrides the target Step's registered options for one movement.
 func WithStepOptions(options *StepOptions) StepMoveOption {
 	return stepOptionsMoveOption{options: options}
 }

--- a/sdk-go/dex/errors.go
+++ b/sdk-go/dex/errors.go
@@ -147,7 +147,7 @@ type ServiceError struct {
 	FlowID string
 	// Code is the outer gRPC status code.
 	Code codes.Code
-	// SubStatus is Dex's specialized error classification.
+	// SubStatus is Dex's specific error classification.
 	SubStatus ErrorSubStatus
 	// Detail is the most specific server or transport message available.
 	Detail string
@@ -253,9 +253,9 @@ type FlowUncompletedError struct {
 	RunID string
 	// Status is the terminal non-completed status.
 	Status FlowStatus
-	// ErrorType is Dex's Flow failure category when supplied.
+	// ErrorType is Dex's Flow failure category when available.
 	ErrorType FlowErrorType
-	// ErrorMessage is the server completion detail when supplied.
+	// ErrorMessage is the server completion detail when available.
 	ErrorMessage string
 	// Completions contains completed Step outputs returned by Dex.
 	Completions []StepCompletion
@@ -287,7 +287,7 @@ type WorkerError struct {
 type ErrorSubStatus uint8
 
 const (
-	// ErrorSubStatusUncategorized means Dex supplied no recognized specialization.
+	// ErrorSubStatusUncategorized means Dex returned no specific status.
 	ErrorSubStatusUncategorized ErrorSubStatus = iota + 1
 	// ErrorSubStatusFlowAlreadyStarted identifies a Flow ID reuse conflict.
 	ErrorSubStatusFlowAlreadyStarted

--- a/sdk-go/dex/errors.go
+++ b/sdk-go/dex/errors.go
@@ -25,17 +25,23 @@ var (
 
 // AttributeNotFoundError reports a missing invocation attribute.
 type AttributeNotFoundError struct {
+	// AttributeName is the stable Attribute or AttributeMap name.
 	AttributeName string
-	Instance      string
+	// Instance is the missing map instance, or empty for a single Attribute.
+	Instance string
 }
 
 // FlowDefinitionError reports an invalid or unregistered Flow definition.
 type FlowDefinitionError struct {
-	FlowType   string
+	// FlowType identifies the invalid or unregistered Flow when known.
+	FlowType string
+	// Definition identifies the invalid Step, RPC, Attribute, or Channel when known.
 	Definition string
-	Err        error
+	// Err preserves the developer-actionable contract violation.
+	Err error
 }
 
+// Error formats the Flow definition and its underlying contract violation.
 func (e *FlowDefinitionError) Error() string {
 	if e == nil {
 		return "<nil>"
@@ -53,18 +59,24 @@ func (e *FlowDefinitionError) Error() string {
 	return prefix + ": " + e.Err.Error()
 }
 
+// Unwrap returns the underlying definition violation.
 func (e *FlowDefinitionError) Unwrap() error {
 	return e.Err
 }
 
 // InvalidStepResultError reports an invalid Worker handler result.
 type InvalidStepResultError struct {
+	// FlowType identifies the containing Flow.
 	FlowType string
+	// StepType identifies the Step, or empty for an RPC.
 	StepType string
-	Method   string
-	Err      error
+	// Method is WaitFor, Execute, or the RPC name.
+	Method string
+	// Err preserves the violated result contract.
+	Err error
 }
 
+// Error formats the handler location and invalid-result detail.
 func (e *InvalidStepResultError) Error() string {
 	if e == nil {
 		return "<nil>"
@@ -82,16 +94,20 @@ func (e *InvalidStepResultError) Error() string {
 	return prefix + ": " + e.Err.Error()
 }
 
+// Unwrap returns the underlying result-contract violation.
 func (e *InvalidStepResultError) Unwrap() error {
 	return e.Err
 }
 
 // ValueMappingError reports a Dex value conversion failure.
 type ValueMappingError struct {
+	// Operation describes whether encoding, decoding, indexing, or hydration failed.
 	Operation string
-	Err       error
+	// Err preserves the serializer or type-conversion failure.
+	Err error
 }
 
+// Error formats the value operation and underlying mapping failure.
 func (e *ValueMappingError) Error() string {
 	if e == nil {
 		return "<nil>"
@@ -106,10 +122,12 @@ func (e *ValueMappingError) Error() string {
 	return prefix + ": " + e.Err.Error()
 }
 
+// Unwrap returns the underlying value-mapping failure.
 func (e *ValueMappingError) Unwrap() error {
 	return e.Err
 }
 
+// Error identifies the missing Attribute or Attribute-map instance.
 func (e *AttributeNotFoundError) Error() string {
 	if e.Instance == "" {
 		return fmt.Sprintf("dex: attribute %q not found", e.AttributeName)
@@ -123,14 +141,20 @@ func (e *AttributeNotFoundError) Error() string {
 
 // ServiceError reports a FlowService failure.
 type ServiceError struct {
-	Op        string
-	FlowID    string
-	Code      codes.Code
+	// Op is the SDK operation that failed.
+	Op string
+	// FlowID is the targeted Flow ID, or empty for service-wide operations.
+	FlowID string
+	// Code is the outer gRPC status code.
+	Code codes.Code
+	// SubStatus is Dex's specialized error classification.
 	SubStatus ErrorSubStatus
-	Detail    string
-	cause     error
+	// Detail is the most specific server or transport message available.
+	Detail string
+	cause  error
 }
 
+// Error formats operation, Flow identity, gRPC code, and detail.
 func (e *ServiceError) Error() string {
 	if e == nil {
 		return "<nil>"
@@ -148,75 +172,96 @@ func (e *ServiceError) Error() string {
 	return fmt.Sprintf("%s: %s: %s", prefix, e.Code, e.Detail)
 }
 
+// Unwrap returns the original gRPC transport failure.
 func (e *ServiceError) Unwrap() error {
 	return e.cause
 }
 
 // FlowAlreadyStartedError reports a duplicate Flow start.
 type FlowAlreadyStartedError struct {
+	// ServiceError contains the failed StartFlow metadata.
 	*ServiceError
 }
 
+// Unwrap returns the shared service failure.
 func (e *FlowAlreadyStartedError) Unwrap() error {
 	return e.ServiceError
 }
 
 // FlowNotFoundError reports a missing Flow for an existing-Flow operation.
 type FlowNotFoundError struct {
+	// ServiceError contains the failed existing-Flow operation metadata.
 	*ServiceError
 }
 
+// Unwrap returns the shared service failure.
 func (e *FlowNotFoundError) Unwrap() error {
 	return e.ServiceError
 }
 
 // FlowNotActiveError reports a missing active Flow.
 type FlowNotActiveError struct {
+	// ServiceError contains the failed active-Flow operation metadata.
 	*ServiceError
 }
 
+// Unwrap returns the shared service failure.
 func (e *FlowNotActiveError) Unwrap() error {
 	return e.ServiceError
 }
 
 // WorkerInvocationError reports a WorkerService or user-handler failure.
 type WorkerInvocationError struct {
+	// ServiceError contains the outer Dex service failure.
 	*ServiceError
+	// Worker preserves the original Worker-side status, type, and detail.
 	Worker *WorkerError
 }
 
+// Unwrap returns the outer service failure.
 func (e *WorkerInvocationError) Unwrap() error {
 	return e.ServiceError
 }
 
 // RPCLockConflictError reports concurrent RPC lock contention.
 type RPCLockConflictError struct {
+	// ServiceError contains the aborted RPC metadata.
 	*ServiceError
 }
 
+// Unwrap returns the shared service failure.
 func (e *RPCLockConflictError) Unwrap() error {
 	return e.ServiceError
 }
 
 // LongPollTimeoutError reports an expired server long poll.
 type LongPollTimeoutError struct {
+	// ServiceError contains the timed-out wait metadata.
 	*ServiceError
 }
 
+// Unwrap returns the shared service failure.
 func (e *LongPollTimeoutError) Unwrap() error {
 	return e.ServiceError
 }
 
 // FlowUncompletedError reports a Flow that closed without completing.
 type FlowUncompletedError struct {
-	FlowID       string
-	RunID        string
-	Status       FlowStatus
-	ErrorType    FlowErrorType
+	// FlowID is the application-assigned Flow ID.
+	FlowID string
+	// RunID is the server-assigned terminal run ID.
+	RunID string
+	// Status is the terminal non-completed status.
+	Status FlowStatus
+	// ErrorType is Dex's Flow failure category when supplied.
+	ErrorType FlowErrorType
+	// ErrorMessage is the server completion detail when supplied.
 	ErrorMessage string
-	Completions  []StepCompletion
+	// Completions contains completed Step outputs returned by Dex.
+	Completions []StepCompletion
 }
 
+// Error formats the terminal Flow status and optional failure detail.
 func (e *FlowUncompletedError) Error() string {
 	if e == nil {
 		return "<nil>"
@@ -230,8 +275,11 @@ func (e *FlowUncompletedError) Error() string {
 
 // WorkerError preserves the original WorkerService failure.
 type WorkerError struct {
-	Code   codes.Code
-	Type   string
+	// Code is the original Worker gRPC status.
+	Code codes.Code
+	// Type is the original Worker error or exception type.
+	Type string
+	// Detail is the original Worker-provided message.
 	Detail string
 }
 
@@ -239,10 +287,15 @@ type WorkerError struct {
 type ErrorSubStatus uint8
 
 const (
+	// ErrorSubStatusUncategorized means Dex supplied no recognized specialization.
 	ErrorSubStatusUncategorized ErrorSubStatus = iota + 1
+	// ErrorSubStatusFlowAlreadyStarted identifies a Flow ID reuse conflict.
 	ErrorSubStatusFlowAlreadyStarted
+	// ErrorSubStatusFlowNotFound identifies an unknown or inactive Flow.
 	ErrorSubStatusFlowNotFound
+	// ErrorSubStatusWorkerAPI identifies a failed Step or RPC invocation.
 	ErrorSubStatusWorkerAPI
+	// ErrorSubStatusLongPollTimeout identifies an active wait whose deadline elapsed.
 	ErrorSubStatusLongPollTimeout
 )
 

--- a/sdk-go/dex/flow.go
+++ b/sdk-go/dex/flow.go
@@ -76,6 +76,7 @@ type Flow interface {
 // FlowDefaults uses the package-qualified Go type as the durable flow type.
 type FlowDefaults struct{}
 
+// GetFlowType returns empty so Registry derives the package-qualified Go type name.
 func (FlowDefaults) GetFlowType() string {
 	return ""
 }
@@ -84,6 +85,8 @@ func (FlowDefaults) GetFlowType() string {
 // registers. Every attribute or channel used from WaitFor, Execute, or RPC must
 // appear here.
 type PersistenceSchema struct {
+	// Attributes contains every Attribute and AttributeMap used by the Flow.
 	Attributes []AttributeDef
-	Channels   []ChannelDef
+	// Channels contains every Channel and ChannelMap used by the Flow.
+	Channels []ChannelDef
 }

--- a/sdk-go/dex/options.go
+++ b/sdk-go/dex/options.go
@@ -71,7 +71,7 @@ func ProceedToOnExecuteFailure[IN any](
 // StepOptions configures one Step's handler execution and persistence behavior.
 //
 // Zero values preserve server timeouts, retry behavior, and durability defaults. WaitFor failures
-// fail the Flow by default. Locks are held only for their respective handler invocation.
+// fail the Flow by default. Each lock is held only for the matching handler call.
 type StepOptions struct {
 	// WaitForMethodTimeout limits one WaitFor attempt; zero uses the server default.
 	WaitForMethodTimeout time.Duration
@@ -219,7 +219,7 @@ const (
 	CancelFlow StopType = iota + 1
 	// TerminateFlow ends the Flow immediately without cleanup.
 	TerminateFlow
-	// FailFlow marks the Flow failed with the supplied reason.
+	// FailFlow marks the Flow failed with Reason.
 	FailFlow
 )
 

--- a/sdk-go/dex/options.go
+++ b/sdk-go/dex/options.go
@@ -12,34 +12,52 @@ package dex
 
 import "time"
 
+// RetryPolicy overrides retry timing for a Step's WaitFor or Execute method.
+// Zero fields preserve server defaults; MaximumAttempts counts the initial attempt.
 type RetryPolicy struct {
-	InitialInterval    time.Duration
+	// InitialInterval is the delay before the first retry.
+	InitialInterval time.Duration
+	// BackoffCoefficient multiplies each successive retry interval.
 	BackoffCoefficient float64
-	MaximumInterval    time.Duration
-	MaximumAttempts    int32
-	TotalDuration      time.Duration
+	// MaximumInterval caps the delay between retries.
+	MaximumInterval time.Duration
+	// MaximumAttempts limits total attempts, including the initial attempt.
+	MaximumAttempts int32
+	// TotalDuration limits elapsed time across all attempts.
+	TotalDuration time.Duration
 }
 
+// StepDurability controls when staged persistence must be durably acknowledged.
 type StepDurability uint8
 
 const (
+	// StepDurabilityDefault uses the Flow or server default.
 	StepDurabilityDefault StepDurability = iota
+	// StepDurabilitySync waits for persistence before completing the handler request.
 	StepDurabilitySync
+	// StepDurabilityAsync permits persistence after accepting the handler result.
 	StepDurabilityAsync
 )
 
+// WaitForFailurePolicy selects behavior after WaitFor exhausts its retry policy.
 type WaitForFailurePolicy uint8
 
 const (
+	// FailFlowOnWaitForFailure ends the Flow after WaitFor exhausts retries.
 	FailFlowOnWaitForFailure WaitForFailurePolicy = iota
+	// ProceedOnWaitForFailure invokes Execute and exposes the failure through Context.
 	ProceedOnWaitForFailure
 )
 
+// ExecuteFailure identifies a recovery movement after Execute exhausts retries.
+// Create it with ProceedToOnExecuteFailure.
 type ExecuteFailure struct {
 	step    StepDef
 	options *StepOptions
 }
 
+// ProceedToOnExecuteFailure routes an Execute failure to step with the same typed input.
+// options override the recovery Step configuration for this movement; nil uses registered options.
 func ProceedToOnExecuteFailure[IN any](
 	step Step[IN],
 	options *StepOptions,
@@ -50,130 +68,217 @@ func ProceedToOnExecuteFailure[IN any](
 	}
 }
 
+// StepOptions configures one Step's handler execution and persistence behavior.
+//
+// Zero values preserve server timeouts, retry behavior, and durability defaults. WaitFor failures
+// fail the Flow by default. Locks are held only for their respective handler invocation.
 type StepOptions struct {
-	WaitForMethodTimeout  time.Duration
-	ExecuteMethodTimeout  time.Duration
-	WaitForRetry          *RetryPolicy
-	ExecuteRetry          *RetryPolicy
-	WaitForFailure        WaitForFailurePolicy
-	ExecuteFailure        *ExecuteFailure
-	WaitForDurability     StepDurability
-	ExecuteDurability     StepDurability
+	// WaitForMethodTimeout limits one WaitFor attempt; zero uses the server default.
+	WaitForMethodTimeout time.Duration
+	// ExecuteMethodTimeout limits one Execute attempt; zero uses the server default.
+	ExecuteMethodTimeout time.Duration
+	// WaitForRetry overrides the WaitFor retry policy; nil uses server defaults.
+	WaitForRetry *RetryPolicy
+	// ExecuteRetry overrides the Execute retry policy; nil uses server defaults.
+	ExecuteRetry *RetryPolicy
+	// WaitForFailure selects exhausted WaitFor behavior; zero fails the Flow.
+	WaitForFailure WaitForFailurePolicy
+	// ExecuteFailure selects a recovery Step after Execute exhausts retries.
+	ExecuteFailure *ExecuteFailure
+	// WaitForDurability overrides persistence durability for WaitFor writes.
+	WaitForDurability StepDurability
+	// ExecuteDurability overrides persistence durability for Execute writes.
+	ExecuteDurability StepDurability
+	// WaitForLockAttributes are acquired together for the WaitFor invocation.
 	WaitForLockAttributes []AttributeLock
+	// ExecuteLockAttributes are acquired together for the Execute invocation.
 	ExecuteLockAttributes []AttributeLock
 }
 
+// WorkerTarget identifies the application WorkerService endpoint Dex should call.
 type WorkerTarget struct {
-	Address  string
+	// Address is the advertised plaintext gRPC target, normally host:port.
+	Address string
+	// Headless bypasses service discovery and requires a direct host:port target.
 	Headless bool
 }
 
+// ActiveStepSearchMode controls which active Step types Dex indexes for Flow search.
 type ActiveStepSearchMode uint8
 
 const (
+	// SearchActiveStepsDefault uses the server default indexing policy.
 	SearchActiveStepsDefault ActiveStepSearchMode = iota
+	// SearchAllActiveSteps indexes every active Step, including execute-only Steps.
 	SearchAllActiveSteps
+	// SearchActiveStepsWithWaitFor indexes a Step only after WaitFor runs.
 	SearchActiveStepsWithWaitFor
+	// DisableActiveStepSearch disables active-Step indexing for the Flow.
 	DisableActiveStepSearch
 )
 
+// FlowConfig overrides mutable runtime behavior for one Flow.
+// Nil fields preserve server defaults.
 type FlowConfig struct {
-	ActiveStepSearchMode       *ActiveStepSearchMode
-	ContinueAsNewThreshold     *int32
+	// ActiveStepSearchMode controls active Step indexing.
+	ActiveStepSearchMode *ActiveStepSearchMode
+	// ContinueAsNewThreshold is the event-count threshold for Continue-As-New.
+	ContinueAsNewThreshold *int32
+	// ContinueAsNewPageSizeBytes caps history bytes carried into Continue-As-New.
 	ContinueAsNewPageSizeBytes *int32
-	StepDurability             *StepDurability
-	WorkerTarget               *WorkerTarget
+	// StepDurability sets the default persistence durability for Step writes.
+	StepDurability *StepDurability
+	// WorkerTarget routes future Step and RPC invocations.
+	WorkerTarget *WorkerTarget
 }
 
+// StartFlowOptions configures a new Flow execution.
+// Nil and zero fields preserve server defaults; RequestID is generated when omitted.
 type StartFlowOptions struct {
-	Timeout        *time.Duration
-	IDReusePolicy  IDReusePolicy
-	CronSchedule   string
-	StartDelay     *time.Duration
-	RetryPolicy    *FlowRetryPolicy
-	Attributes     []InitialAttributeDef
+	// Timeout limits total Flow execution duration.
+	Timeout *time.Duration
+	// IDReusePolicy controls reuse of an existing Flow ID.
+	IDReusePolicy IDReusePolicy
+	// CronSchedule is the server cron expression for recurring runs.
+	CronSchedule string
+	// StartDelay postpones the first Step after start acceptance.
+	StartDelay *time.Duration
+	// RetryPolicy configures whole-Flow retries after terminal failures.
+	RetryPolicy *FlowRetryPolicy
+	// Attributes supplies encoded initial Attribute and Attribute-map values.
+	Attributes []InitialAttributeDef
+	// ConfigOverride replaces registered Flow configuration for this execution.
 	ConfigOverride *FlowConfig
+	// AlreadyStarted controls whether an existing Flow is returned as success.
 	AlreadyStarted *AlreadyStartedOptions
 	// RequestID defaults to a UUID; set a stable business identifier for cross-call retries.
 	RequestID *string
 }
 
+// IDReusePolicy controls whether StartFlow may reuse a Flow ID.
 type IDReusePolicy uint8
 
 const (
+	// IDReuseDefault uses the server-configured reuse policy.
 	IDReuseDefault IDReusePolicy = iota
+	// IDReuseAllowIfPreviousFailed permits reuse only after a failed run.
 	IDReuseAllowIfPreviousFailed
+	// IDReuseAllowIfNotRunning permits reuse when no run is active.
 	IDReuseAllowIfNotRunning
+	// IDReuseDisallow rejects reuse regardless of previous status.
 	IDReuseDisallow
+	// IDReuseTerminateIfRunning terminates an active run before replacement.
 	IDReuseTerminateIfRunning
 )
 
+// FlowRetryPolicy configures whole-Flow retry timing after terminal failure.
 type FlowRetryPolicy struct {
-	InitialInterval    time.Duration
+	// InitialInterval is the delay before the first Flow retry.
+	InitialInterval time.Duration
+	// BackoffCoefficient multiplies successive Flow retry intervals.
 	BackoffCoefficient float64
-	MaximumInterval    time.Duration
-	MaximumAttempts    int32
+	// MaximumInterval caps time between Flow retries.
+	MaximumInterval time.Duration
+	// MaximumAttempts limits total Flow attempts, including the initial attempt.
+	MaximumAttempts int32
 }
 
+// AlreadyStartedOptions configures StartFlow behavior when the Flow ID already exists.
 type AlreadyStartedOptions struct {
+	// IgnoreError returns the existing run ID instead of FlowAlreadyStartedError.
 	IgnoreError bool
 }
 
+// InvokeOptions configures one RPC invocation.
 type InvokeOptions struct {
-	Timeout        time.Duration
+	// Timeout limits the RPC handler; zero uses its registered or server default.
+	Timeout time.Duration
+	// LockAttributes are acquired atomically for the RPC invocation.
 	LockAttributes []AttributeLock
 }
 
+// WaitOptions configures one long-poll wait operation.
 type WaitOptions struct {
+	// Timeout limits the long poll; zero uses the server default.
 	Timeout time.Duration
 }
 
+// WaitForFlowOptions controls Flow-result hydration and long-poll timeout.
 type WaitForFlowOptions struct {
+	// NeedsResults asks Dex to include completed Step outputs.
 	NeedsResults bool
-	Timeout      time.Duration
+	// Timeout limits the long poll; zero waits without an SDK override.
+	Timeout time.Duration
 }
 
+// StopType selects how StopFlow ends an active Flow.
 type StopType uint8
 
 const (
+	// CancelFlow requests cooperative cancellation.
 	CancelFlow StopType = iota + 1
+	// TerminateFlow ends the Flow immediately without cleanup.
 	TerminateFlow
+	// FailFlow marks the Flow failed with the supplied reason.
 	FailFlow
 )
 
+// StopOptions configures Client.StopFlow.
 type StopOptions struct {
-	Type   StopType
+	// Type selects cancel, terminate, or fail behavior.
+	Type StopType
+	// Reason is recorded with the stop operation.
 	Reason string
 }
 
+// StepExecutionID identifies one execution of a Step type within a Flow run.
 type StepExecutionID struct {
+	// StepType is the stable registered Step type.
 	StepType string
 	// ExecutionNumber defaults to one when omitted.
 	ExecutionNumber *int32
 }
 
+// TimerID selects one Timer Condition within a Step execution.
 type TimerID struct {
+	// ConditionID targets a Condition configured with WithConditionID.
 	ConditionID string
-	Index       *int32
+	// Index targets a zero-based Timer Condition position when non-nil.
+	Index *int32
 }
 
+// ResetType identifies the historical point selector used by ResetFlow.
 type ResetType uint8
 
 const (
+	// ResetByHistoryEventID resets at a workflow-history event ID.
 	ResetByHistoryEventID ResetType = iota + 1
+	// ResetToBeginning resets before the first history event.
 	ResetToBeginning
+	// ResetByHistoryEventTime resets at the last eligible event by time.
 	ResetByHistoryEventTime
+	// ResetByStepType resets before the first execution of a Step type.
 	ResetByStepType
+	// ResetByStepExecutionID resets before an exact Step execution.
 	ResetByStepExecutionID
 )
 
+// ResetOptions configures Client.ResetFlow and one reset-point selector.
 type ResetOptions struct {
-	Type                       ResetType
-	HistoryEventID             int32
-	Reason                     string
-	HistoryEventTime           time.Time
-	StepType                   string
-	StepExecutionID            string
+	// Type selects which reset-point field Dex reads.
+	Type ResetType
+	// HistoryEventID supplies the event ID for ResetByHistoryEventID.
+	HistoryEventID int32
+	// Reason is recorded with the reset operation.
+	Reason string
+	// HistoryEventTime supplies the time for ResetByHistoryEventTime.
+	HistoryEventTime time.Time
+	// StepType supplies the stable Step type for ResetByStepType.
+	StepType string
+	// StepExecutionID supplies the exact execution for ResetByStepExecutionID.
+	StepExecutionID string
+	// SkipChannelMessagesReapply prevents replay of post-reset Channel messages.
 	SkipChannelMessagesReapply bool
-	SkipLockingRPCReapply      bool
+	// SkipLockingRPCReapply prevents replay of post-reset locking RPCs.
+	SkipLockingRPCReapply bool
 }

--- a/sdk-go/dex/ptr/any.go
+++ b/sdk-go/dex/ptr/any.go
@@ -1,8 +1,21 @@
 // Legacy Materials in this file remain under their original licenses.
 // See LEGACY_NOTICES.md.
 
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications after the Legacy Cutoff are licensed under the
+// Super Durable Source License 1.0.
+// Legacy Materials remain under their original licenses.
+// See LICENSE and LEGACY_NOTICES.md.
+
 package ptr
 
+// Any returns a pointer to a copy of obj.
+//
+// It is useful for optional SDK fields whose literal values cannot otherwise be
+// addressed directly. Mutating the returned value does not mutate the original.
+//
+//	options := dex.StartFlowOptions{RequestID: ptr.Any("request-42")}
 func Any[T any](obj T) *T {
 	return &obj
 }

--- a/sdk-go/dex/registration.go
+++ b/sdk-go/dex/registration.go
@@ -63,7 +63,7 @@ type registeredChannel struct {
 
 // NewRegistry validates and assembles Flow definitions atomically.
 //
-// flows may be empty, but every supplied Flow must be non-nil and have a unique,
+// flows may be empty, but every Flow must be non-nil and have a unique,
 // package-qualified Flow type. NewRegistry also validates starting Steps, Step
 // options, RPC signatures, persistence definitions, and cross-Flow Attribute index
 // compatibility. It returns FlowDefinitionError for an invalid Flow and publishes no

--- a/sdk-go/dex/registration.go
+++ b/sdk-go/dex/registration.go
@@ -19,6 +19,11 @@ import (
 )
 
 // Registry stores immutable Flow definitions shared by Client and Worker.
+//
+// NewRegistry validates every definition before publishing the Registry. Build one
+// Registry during application startup and reuse it for every Client and
+// Worker that must exchange those Flow types. Registry is safe for concurrent reads
+// after NewRegistry returns.
 type Registry struct {
 	flows            map[string]*registeredFlow
 	attributeIndexes map[string]dexpb.IndexType
@@ -57,6 +62,17 @@ type registeredChannel struct {
 }
 
 // NewRegistry validates and assembles Flow definitions atomically.
+//
+// flows may be empty, but every supplied Flow must be non-nil and have a unique,
+// package-qualified Flow type. NewRegistry also validates starting Steps, Step
+// options, RPC signatures, persistence definitions, and cross-Flow Attribute index
+// compatibility. It returns FlowDefinitionError for an invalid Flow and publishes no
+// partially assembled Registry.
+//
+//	registry, err := dex.NewRegistry([]dex.Flow{OrderFlow{}, RefundFlow{}})
+//	if err != nil {
+//		return err
+//	}
 func NewRegistry(flows []Flow) (*Registry, error) {
 	assembled := &Registry{
 		flows: make(map[string]*registeredFlow, len(flows)),

--- a/sdk-go/dex/rpc.go
+++ b/sdk-go/dex/rpc.go
@@ -12,13 +12,29 @@ package dex
 
 import "reflect"
 
+// RPC is a typed Flow method that may read persistence and return output plus Step movements.
+//
+// Exported Flow methods matching this signature are registered under their Go method names. Return
+// a non-nil RPCResult on success or an error to report a Worker invocation failure.
+//
+// Example:
+//
+//	func (OrderFlow) GetStatus(
+//		ctx dex.Context,
+//		input GetStatusInput,
+//	) (*dex.RPCResult[OrderStatus], error) {
+//		return &dex.RPCResult[OrderStatus]{Output: OrderStatus{}}, nil
+//	}
 type RPC[IN, OUT any] func(
 	ctx Context,
 	input IN,
 ) (*RPCResult[OUT], error)
 
+// RPCResult carries typed RPC output and optional Step movements committed after success.
 type RPCResult[OUT any] struct {
-	Output    OUT
+	// Output is encoded as the RPC response value.
+	Output OUT
+	// NextSteps are scheduled in order after the RPC persistence changes commit.
 	NextSteps []StepMovement
 }
 

--- a/sdk-go/dex/step.go
+++ b/sdk-go/dex/step.go
@@ -126,6 +126,9 @@ func newStepDef[IN any](step Step[IN], starting bool) StepDef {
 
 // StepDef is the representation of Step, without Go's generic
 // So that internal sdk can use it to workaround Go's generic limitations
+//
+// StepDef is sealed. Applications create values with DefineStep or
+// DefineStartStep and return them from Flow.GetSteps.
 type StepDef interface {
 	stepType() string
 	stepInputType() reflect.Type
@@ -160,6 +163,7 @@ type DefaultStepType struct{}
 //		dex.DefaultStepOptions
 //	}
 type DefaultStepOptions struct {
+	// DefaultStepType supplies GetStepType using the package-qualified Go type.
 	DefaultStepType
 }
 
@@ -171,6 +175,7 @@ type DefaultStepOptions struct {
 //		dex.StepDefaults
 //	}
 type StepDefaults struct {
+	// DefaultStepOptions supplies default type naming and nil options.
 	DefaultStepOptions
 }
 
@@ -182,20 +187,25 @@ type StepDefaults struct {
 //		dex.StepDefaultsNoWaitFor[ShipOrderInput]
 //	}
 type StepDefaultsNoWaitFor[IN any] struct {
+	// StepDefaults supplies default type naming and nil options.
 	StepDefaults
+	// NoWaitFor marks the Step execute-only.
 	NoWaitFor[IN]
 }
 
+// WaitFor panics because registration must skip this method for execute-only Steps.
 func (NoWaitFor[IN]) WaitFor(Context, IN) (*Wait, error) {
 	panic("NoWaitFor: framework must skip WaitFor")
 }
 
 func (NoWaitFor[IN]) noWaitFor() {}
 
+// GetStepOptions returns nil so Dex uses server Step defaults.
 func (DefaultStepOptions) GetStepOptions() *StepOptions {
 	return nil
 }
 
+// GetStepType returns empty so Registry derives the package-qualified Go type name.
 func (DefaultStepType) GetStepType() string {
 	return ""
 }

--- a/sdk-go/dex/step.go
+++ b/sdk-go/dex/step.go
@@ -127,7 +127,7 @@ func newStepDef[IN any](step Step[IN], starting bool) StepDef {
 // StepDef is the representation of Step, without Go's generic
 // So that internal sdk can use it to workaround Go's generic limitations
 //
-// StepDef is sealed. Applications create values with DefineStep or
+// StepDef is internal to the SDK. Applications create values with DefineStep or
 // DefineStartStep and return them from Flow.GetSteps.
 type StepDef interface {
 	stepType() string

--- a/sdk-go/dex/value.go
+++ b/sdk-go/dex/value.go
@@ -37,11 +37,27 @@ var (
 )
 
 // Value is an opaque Dex value. Decoded string values contain valid UTF-8.
+//
+// Values returned by bulk Client reads are already hydrated. Use Decode with the
+// same Go type used by the corresponding Attribute. Primitive
+// values preserve their wire kind; structs, maps, and non-byte slices use JSON;
+// byte slices use the raw-bytes encoding.
 type Value struct {
 	value *dexpb.Value
 }
 
 // Decode decodes Value into a non-nil pointer.
+//
+// valuePtr must be a non-nil pointer compatible with the encoded wire value. Decode
+// replaces the pointed-to value on success and returns a ValueMappingError for an
+// incompatible target, malformed payload, unsupported encoding, or numeric overflow.
+//
+//	values, err := client.GetAttributes(ctx, flowID, statusAttribute)
+//	if err != nil {
+//		return err
+//	}
+//	var status string
+//	err = values[statusAttribute.AttributeName()].Decode(&status)
 func (value Value) Decode(valuePtr any) error {
 	return decodeValue(value.value, valuePtr)
 }

--- a/sdk-go/dex/value.go
+++ b/sdk-go/dex/value.go
@@ -39,7 +39,7 @@ var (
 // Value is an opaque Dex value. Decoded string values contain valid UTF-8.
 //
 // Values returned by bulk Client reads are already hydrated. Use Decode with the
-// same Go type used by the corresponding Attribute. Primitive
+// same Go type used by the matching Attribute. Primitive
 // values preserve their wire kind; structs, maps, and non-byte slices use JSON;
 // byte slices use the raw-bytes encoding.
 type Value struct {

--- a/sdk-go/dex/worker.go
+++ b/sdk-go/dex/worker.go
@@ -33,20 +33,39 @@ const (
 )
 
 // WorkerOptions configures the application-hosted WorkerService.
+//
+// Zero values select local plaintext defaults. BindAddress controls the listening
+// socket, while WorkerTarget is the address Dex advertises to running Flows; these
+// commonly differ in containers or headless service deployments.
 type WorkerOptions struct {
 	// BindAddress is the plaintext WorkerService listener for Dex; it may differ from WorkerTarget. Default: ":8803".
+	// It uses host:port syntax.
 	BindAddress string
 	// WorkerTarget is advertised to Dex and may differ from BindAddress. Default Address derives from BindAddress; Headless defaults false.
 	WorkerTarget WorkerTarget
 	// FlowServiceAddress is the plaintext Dex endpoint used for startup synchronization and blob hydration. Default: "localhost:8801".
+	// Startup synchronization registers Attribute indexes.
 	FlowServiceAddress string
 	// AttributeIndexSyncTimeout bounds index registration at startup. Default: two minutes.
+	// Negative durations are invalid.
 	AttributeIndexSyncTimeout time.Duration
 	// Logger defaults to the shared BlobCache logger.
+	// It receives concurrent structured Worker logs and falls back to slog.Default.
 	Logger Logger
 }
 
 // Worker hosts registered Flows over the private WorkerService protocol.
+//
+// A Worker is one-shot: construct it, call Start once, then call Stop during
+// shutdown. Start blocks while serving. Step and RPC handlers may execute
+// concurrently, so application handler state must provide its own synchronization.
+//
+//	worker, err := dex.NewWorker(registry, cache, dex.WorkerOptions{})
+//	if err != nil {
+//		return err
+//	}
+//	go func() { serveErr <- worker.Start() }()
+//	defer worker.Stop(context.Background())
 type Worker struct {
 	registry                  *Registry
 	bindAddress               string
@@ -73,6 +92,12 @@ const (
 )
 
 // NewWorker constructs a one-shot Worker from shared dependencies.
+//
+// registry supplies definitions and cache hydrates large values. It panics when
+// registry or cache is nil. It validates listener, advertised target,
+// FlowService address, and synchronization timeout, then creates the private gRPC
+// server and FlowService connection without starting the listener. The returned
+// Worker owns that connection; Start or Stop closes it.
 func NewWorker(
 	registry *Registry,
 	cache *blobcache.Cache,
@@ -222,6 +247,13 @@ func validatePlaintextTarget(address string, requireHostPort bool) error {
 }
 
 // Start serves WorkerService and blocks until Stop or a serve failure.
+//
+// Start may be called exactly once. Before listening, it synchronizes Attribute
+// indexes and waits up to
+// WorkerOptions.AttributeIndexSyncTimeout for Dex to accept the Registry's indexes.
+// It returns nil after a normal Stop, or an error for synchronization, listener,
+// serving, or invalid lifecycle state failures. Call Start on a dedicated goroutine
+// when the application must continue doing other work.
 func (worker *Worker) Start() error {
 	worker.lifecycleMu.Lock()
 	if worker.state != workerCreated {
@@ -265,6 +297,11 @@ func (worker *Worker) Start() error {
 }
 
 // Stop drains handlers until ctx expires, then force-stops the Worker.
+//
+// Stop accepts calls before Start and repeated calls after shutdown. A nil context is
+// invalid. If ctx expires while handlers are draining, Stop force-closes the gRPC
+// server, waits for cleanup, and returns ctx.Err. Stop closes the Worker's internal
+// FlowService connection before returning.
 func (worker *Worker) Stop(ctx context.Context) error {
 	if ctx == nil {
 		return fmt.Errorf("dex: Worker Stop context must not be nil")
@@ -309,6 +346,9 @@ func (worker *Worker) finish() {
 }
 
 // WorkerTarget returns a copy suitable for FlowConfig.WorkerTarget.
+//
+// The result is also suitable for ClientOptions.WorkerTarget. Mutating it does not
+// reconfigure the Worker.
 func (worker *Worker) WorkerTarget() *WorkerTarget {
 	target := worker.workerTarget
 	return &target

--- a/sdk-go/logging/logger.go
+++ b/sdk-go/logging/logger.go
@@ -13,10 +13,17 @@ package logging
 import "log/slog"
 
 // Logger receives structured SDK logs.
+//
+// msg is the human-readable event and keyvals contains alternating string keys and
+// values. Implementations should be safe for concurrent Client and Worker calls.
 type Logger interface {
+	// Debug records diagnostic detail normally disabled in production.
 	Debug(msg string, keyvals ...interface{})
+	// Info records routine SDK lifecycle and request information.
 	Info(msg string, keyvals ...interface{})
+	// Warn records a recoverable condition that may require operator attention.
 	Warn(msg string, keyvals ...interface{})
+	// Error records an SDK operation failure and its structured context.
 	Error(msg string, keyvals ...interface{})
 }
 

--- a/sdk-go/scripts/check-public-docs.go
+++ b/sdk-go/scripts/check-public-docs.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type documentationIssue struct {
+	position token.Position
+	message  string
+}
+
+func main() {
+	roots := os.Args[1:]
+	if len(roots) == 0 {
+		roots = []string{"dex", "logging"}
+	}
+	issues, err := inspectRoots(roots)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	for _, issue := range issues {
+		fmt.Fprintf(os.Stderr, "%s: %s\n", issue.position, issue.message)
+	}
+	if len(issues) > 0 {
+		fmt.Fprintf(os.Stderr, "public API documentation check failed with %d issue(s)\n", len(issues))
+		os.Exit(1)
+	}
+	fmt.Println("all hand-written Go SDK public APIs are documented")
+}
+
+func inspectRoots(roots []string) ([]documentationIssue, error) {
+	fileSet := token.NewFileSet()
+	var issues []documentationIssue
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if entry.Name() == "gen" || strings.HasPrefix(entry.Name(), ".") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			parsed, err := parser.ParseFile(fileSet, path, nil, parser.ParseComments)
+			if err != nil {
+				return fmt.Errorf("parse %s: %w", path, err)
+			}
+			issues = append(issues, inspectFile(fileSet, parsed)...)
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("inspect %s: %w", root, err)
+		}
+	}
+	return issues, nil
+}
+
+func inspectFile(fileSet *token.FileSet, file *ast.File) []documentationIssue {
+	var issues []documentationIssue
+	for _, declaration := range file.Decls {
+		switch typed := declaration.(type) {
+		case *ast.FuncDecl:
+			if typed.Name.IsExported() && receiverIsExported(typed.Recv) {
+				issues = append(issues, requireNamedDoc(fileSet, typed.Pos(), typed.Name.Name, typed.Doc)...)
+			}
+		case *ast.GenDecl:
+			issues = append(issues, inspectGeneralDeclaration(fileSet, typed)...)
+		}
+	}
+	return issues
+}
+
+func receiverIsExported(receiver *ast.FieldList) bool {
+	if receiver == nil || len(receiver.List) == 0 {
+		return true
+	}
+	return ast.IsExported(embeddedTypeName(receiver.List[0].Type))
+}
+
+func inspectGeneralDeclaration(fileSet *token.FileSet, declaration *ast.GenDecl) []documentationIssue {
+	var issues []documentationIssue
+	for _, specification := range declaration.Specs {
+		switch typed := specification.(type) {
+		case *ast.TypeSpec:
+			if !typed.Name.IsExported() {
+				continue
+			}
+			doc := typed.Doc
+			if doc == nil && len(declaration.Specs) == 1 {
+				doc = declaration.Doc
+			}
+			issues = append(issues, requireNamedDoc(fileSet, typed.Pos(), typed.Name.Name, doc)...)
+			issues = append(issues, inspectTypeMembers(fileSet, typed)...)
+		case *ast.ValueSpec:
+			for _, name := range typed.Names {
+				if !name.IsExported() {
+					continue
+				}
+				doc := typed.Doc
+				if doc == nil {
+					doc = typed.Comment
+				}
+				if doc == nil && len(declaration.Specs) == 1 && len(typed.Names) == 1 {
+					doc = declaration.Doc
+				}
+				issues = append(issues, requireNamedDoc(fileSet, name.Pos(), name.Name, doc)...)
+			}
+		}
+	}
+	return issues
+}
+
+func inspectTypeMembers(fileSet *token.FileSet, specification *ast.TypeSpec) []documentationIssue {
+	var fields *ast.FieldList
+	switch typed := specification.Type.(type) {
+	case *ast.StructType:
+		fields = typed.Fields
+	case *ast.InterfaceType:
+		fields = typed.Methods
+	default:
+		return nil
+	}
+	var issues []documentationIssue
+	for _, field := range fields.List {
+		for _, name := range exportedFieldNames(field) {
+			doc := field.Doc
+			if doc == nil {
+				doc = field.Comment
+			}
+			issues = append(issues, requireNamedDoc(fileSet, field.Pos(), name, doc)...)
+		}
+	}
+	return issues
+}
+
+func exportedFieldNames(field *ast.Field) []string {
+	var names []string
+	for _, name := range field.Names {
+		if name.IsExported() {
+			names = append(names, name.Name)
+		}
+	}
+	if len(field.Names) != 0 {
+		return names
+	}
+	name := embeddedTypeName(field.Type)
+	if ast.IsExported(name) {
+		return []string{name}
+	}
+	return nil
+}
+
+func embeddedTypeName(expression ast.Expr) string {
+	switch typed := expression.(type) {
+	case *ast.Ident:
+		return typed.Name
+	case *ast.SelectorExpr:
+		return typed.Sel.Name
+	case *ast.StarExpr:
+		return embeddedTypeName(typed.X)
+	case *ast.IndexExpr:
+		return embeddedTypeName(typed.X)
+	case *ast.IndexListExpr:
+		return embeddedTypeName(typed.X)
+	default:
+		return ""
+	}
+}
+
+func requireNamedDoc(
+	fileSet *token.FileSet,
+	position token.Pos,
+	name string,
+	doc *ast.CommentGroup,
+) []documentationIssue {
+	if doc == nil || strings.TrimSpace(doc.Text()) == "" {
+		return []documentationIssue{{
+			position: fileSet.Position(position),
+			message:  fmt.Sprintf("exported API %s has no doc comment", name),
+		}}
+	}
+	text := strings.TrimSpace(doc.Text())
+	if !strings.HasPrefix(text, name) {
+		return []documentationIssue{{
+			position: fileSet.Position(position),
+			message:  fmt.Sprintf("doc comment for %s must begin with its declared name", name),
+		}}
+	}
+	return nil
+}

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -223,7 +223,18 @@ make -C ../protos proto-python
 Checked-in Python stubs land in `dex/dexpb/`.
 #### Linting
 
-To run linting for this project:
+Validate that every `dex.__all__` class, function, constant, public method,
+argument, return value, dataclass field, enum value, and public instance
+attribute has a Google-style docstring:
+
+```bash
+uv run --frozen python scripts/check_public_docs.py
+```
+
+The checker resolves definitions from the public package export table, so
+private helpers and generated protobuf modules are excluded. Use `help(dex.Client)`
+or IDE hover information to read the same documentation. To run all other
+linting for this project:
 
 ```bash
 uv run --frozen pre-commit run --show-diff-on-failure --color=always --all-files

--- a/sdk-python/dex/async_client.py
+++ b/sdk-python/dex/async_client.py
@@ -60,7 +60,7 @@ class AsyncClient:
     use ``async with`` or await ``close`` during application shutdown.
 
     Attributes:
-        registry: The immutable definitions used to validate typed calls.
+        registry: Flow definitions used to validate typed calls.
         blob_cache: The open cache used to hydrate large values.
         options: The effective ClientOptions.
 
@@ -463,7 +463,7 @@ class AsyncClient:
             run_id: Optional exact run; ``""`` targets the active run.
 
         Raises:
-            ValueError: If no value is supplied or a name is empty.
+            ValueError: If no value is passed or a name is empty.
             TypeError: If map arguments or value types are invalid.
             ValueMappingError: If a value cannot be encoded.
             FlowNotActiveError: If the selected Flow run is closed.
@@ -791,7 +791,7 @@ class AsyncClient:
 
         Args:
             flow_id: The non-empty active Flow ID.
-            config: New optional fields applied to subsequent decisions.
+            config: New optional fields applied to later decisions.
 
         Raises:
             FlowNotActiveError: If the Flow is closed.

--- a/sdk-python/dex/async_client.py
+++ b/sdk-python/dex/async_client.py
@@ -53,12 +53,36 @@ ValueT = TypeVar("ValueT")
 
 
 class AsyncClient:
+    """Call Dex FlowService asynchronously through registered Flow definitions.
+
+    Methods perform non-blocking gRPC I/O and are safe to await from concurrent
+    tasks. The Client owns its asynchronous channel but not its Registry or BlobCache;
+    use ``async with`` or await ``close`` during application shutdown.
+
+    Attributes:
+        registry: The immutable definitions used to validate typed calls.
+        blob_cache: The open cache used to hydrate large values.
+        options: The effective ClientOptions.
+
+    Examples:
+        >>> async with AsyncClient(registry, cache) as client:
+        ...     run_id = await client.start_flow(orders, "order-42", input)
+        ...     result = await client.wait_for_flow("order-42", OrderResult)
+    """
+
     def __init__(
         self,
         registry: Registry,
         blob_cache: BlobCache,
         options: ClientOptions | None = None,
     ) -> None:
+        """Construct an AsyncClient and its lazy plaintext gRPC channel.
+
+        Args:
+            registry: The Flow Registry used for validation and codecs.
+            blob_cache: An open cache used for asynchronous hydration.
+            options: Service address and default Worker target; ``None`` uses defaults.
+        """
         self.registry = registry
         self.blob_cache = blob_cache
         self.options = options or ClientOptions()
@@ -76,6 +100,11 @@ class AsyncClient:
         self._closed = False
 
     async def __aenter__(self) -> AsyncClient:
+        """Return this Client for asynchronous context-manager use.
+
+        Returns:
+            This AsyncClient instance.
+        """
         return self
 
     async def __aexit__(
@@ -84,6 +113,13 @@ class AsyncClient:
         exception: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
+        """Close the Client when leaving an asynchronous context block.
+
+        Args:
+            exception_type: The active exception type, if any.
+            exception: The active exception value, if any.
+            traceback: The active traceback, if any.
+        """
         await self.close()
 
     async def start_flow(
@@ -93,6 +129,27 @@ class AsyncClient:
         input: InputT,
         options: StartFlowOptions = StartFlowOptions(),
     ) -> str:
+        """Start a Flow and return its server-assigned run ID.
+
+        The await completes after Dex accepts the Flow, not after completion. ``flow``
+        must be the exact registered instance and ``input`` must match its starting
+        Step annotation.
+
+        Args:
+            flow: The registered Flow instance to start.
+            flow_id: A non-empty application ID stable across runs.
+            input: The starting Step input, or ``None`` without a starting Step.
+            options: Timeout, reuse, retry, idempotency, and initial-state options.
+
+        Returns:
+            The server-assigned run ID.
+
+        Raises:
+            FlowAlreadyStartedError: If reuse policy rejects an existing Flow ID.
+            FlowDefinitionError: If ``flow`` is not registered.
+            ValueMappingError: If an input or initial Attribute cannot be encoded.
+            DexServiceError: If FlowService rejects or cannot perform the request.
+        """
         registered = self.registry._flow_for_instance(flow)
         request = pb.StartFlowRequest(
             flow_id=require_name(flow_id),
@@ -169,6 +226,27 @@ class AsyncClient:
         *,
         run_id: str = "",
     ) -> Any:
+        """Invoke a registered RPC and await its typed result.
+
+        Pass the bound method from the registered Flow instance. RPC timeout and
+        Attribute locks come from ``@rpc`` configuration.
+
+        Args:
+            rpc_method: A bound method decorated with ``@rpc``.
+            flow_id: The non-empty target Flow ID.
+            input: The annotated input, or ``None`` for an input-free RPC.
+            run_id: Optional exact run; ``""`` targets the active run.
+
+        Returns:
+            The decoded ``RPCResult.output``, or ``None`` for a no-output RPC.
+
+        Raises:
+            FlowDefinitionError: If the method is not registered.
+            RpcLockConflictError: If Attribute locks cannot be acquired.
+            WorkerInvocationError: If the application handler fails.
+            ValueMappingError: If input or output mapping fails.
+            DexServiceError: If the Flow is inactive or the service call fails.
+        """
         _, rpc = self.registry._rpc_for_method(rpc_method)
         encoded_input = (
             self._values.encode(input, rpc.input_codec)
@@ -232,6 +310,23 @@ class AsyncClient:
         *,
         run_id: str = "",
     ) -> Any:
+        """Await one decoded Attribute or AttributeMap instance.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            attribute: A typed singleton Attribute or AttributeMap definition.
+            instance: The non-empty map key; omit for a singleton Attribute.
+            run_id: Optional exact run; ``""`` targets the current run.
+
+        Returns:
+            The decoded value, or ``None`` when unset.
+
+        Raises:
+            TypeError: If singleton/map arguments do not match the definition.
+            ValueMappingError: If the stored value cannot be decoded.
+            FlowNotFoundError: If ``flow_id`` does not exist.
+            DexServiceError: If FlowService cannot perform the request.
+        """
         key = self._definition_name(attribute, instance)
         response = cast(
             pb.GetAttributesResponse,
@@ -283,6 +378,23 @@ class AsyncClient:
         *args: object,
         run_id: str = "",
     ) -> None:
+        """Write one Attribute or AttributeMap instance on an active Flow.
+
+        Singleton form is ``set_attribute(flow_id, attribute, value)``; map form is
+        ``set_attribute(flow_id, attribute_map, instance, value)``.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            attribute: A typed singleton Attribute or AttributeMap definition.
+            *args: The value, or a map instance followed by its value.
+            run_id: Optional exact run; ``""`` targets the active run.
+
+        Raises:
+            TypeError: If arguments or value type are invalid.
+            ValueMappingError: If the value cannot be encoded.
+            FlowNotActiveError: If the selected Flow run is closed.
+            DexServiceError: If FlowService cannot apply the write.
+        """
         instance, value = self._definition_value(attribute, args)
         write = pb.AttributeWrite(
             key=self._definition_name(attribute, instance),
@@ -339,6 +451,24 @@ class AsyncClient:
         *args: object,
         run_id: str = "",
     ) -> None:
+        """Append one or more typed values to a Channel.
+
+        Singleton form supplies values directly; ChannelMap form supplies an instance
+        followed by values. Dex preserves argument order within the request.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            channel: A typed singleton Channel or ChannelMap definition.
+            *args: Values, or a map instance followed by one or more values.
+            run_id: Optional exact run; ``""`` targets the active run.
+
+        Raises:
+            ValueError: If no value is supplied or a name is empty.
+            TypeError: If map arguments or value types are invalid.
+            ValueMappingError: If a value cannot be encoded.
+            FlowNotActiveError: If the selected Flow run is closed.
+            DexServiceError: If FlowService cannot publish the batch.
+        """
         if isinstance(channel, ChannelMap):
             if len(args) < 2 or not isinstance(args[0], str):
                 raise TypeError("ChannelMap publish requires instance and values")
@@ -386,6 +516,26 @@ class AsyncClient:
         output_type: type[Any] | None = None,
         timeout: timedelta | None = None,
     ) -> Any:
+        """Await Flow closure and optionally decode its latest Step output.
+
+        ``timeout`` is a server-side long-poll duration, not a local task deadline.
+        A LongPollTimeoutError is retryable by awaiting this method again.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            output_type: Optional Python type for the latest completed Step output.
+            timeout: Optional non-negative server-side wait duration.
+
+        Returns:
+            The decoded latest output, or ``None`` when no output type/value exists.
+
+        Raises:
+            LongPollTimeoutError: If the Flow remains open when the wait expires.
+            FlowUncompletedError: If the Flow closes without successful completion.
+            FlowNotFoundError: If ``flow_id`` does not exist.
+            ValueMappingError: If a requested output cannot be decoded.
+            DexServiceError: If FlowService cannot perform the wait.
+        """
         response = await self._wait_for_flow_response(flow_id, timeout)
         if output_type is None:
             return None
@@ -403,6 +553,18 @@ class AsyncClient:
         flow_id: str,
         options: StopFlowOptions = StopFlowOptions(),
     ) -> None:
+        """Request cancellation, termination, or failure of an active Flow.
+
+        The await completes after Dex accepts the request, not after terminal status.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            options: Stop mode and optional recorded reason.
+
+        Raises:
+            FlowNotActiveError: If no active run exists.
+            DexServiceError: If FlowService rejects or cannot perform the request.
+        """
         await self._call(
             self._service.StopFlow,
             pb.StopFlowRequest(
@@ -420,6 +582,18 @@ class AsyncClient:
         )
 
     async def describe_flow(self, flow_id: str) -> FlowInfo:
+        """Return summary metadata for the current or latest Flow run.
+
+        Args:
+            flow_id: The non-empty Flow ID to describe.
+
+        Returns:
+            Flow ID, run ID, Flow type, status, and UTC start time.
+
+        Raises:
+            FlowNotFoundError: If ``flow_id`` does not exist.
+            DexServiceError: If FlowService cannot return the summary.
+        """
         response = cast(
             pb.GetFlowSummaryResponse,
             await self._call(
@@ -444,6 +618,21 @@ class AsyncClient:
         page_size: int,
         next_page_token: str = "",
     ) -> SearchFlowsPage:
+        """Return one page of Flow runs matching a visibility query.
+
+        Args:
+            query: A Dex visibility query; an empty string uses server defaults.
+            page_size: The non-negative maximum result count requested.
+            next_page_token: Opaque token from the preceding page, or ``""`` first.
+
+        Returns:
+            Server-ordered entries with hydrated indexed Attributes and a next token.
+
+        Raises:
+            ValueError: If ``page_size`` is negative.
+            ValueMappingError: If an indexed Attribute cannot be hydrated.
+            DexServiceError: If FlowService cannot execute the query.
+        """
         if page_size < 0:
             raise ValueError("search page size must not be negative")
         response = cast(
@@ -486,6 +675,20 @@ class AsyncClient:
         )
 
     async def reset_flow(self, flow_id: str, options: ResetFlowOptions) -> str:
+        """Create a new run from a selected point in existing Flow history.
+
+        Args:
+            flow_id: The non-empty Flow ID whose history is reset.
+            options: Reset selector, reason, and replay controls.
+
+        Returns:
+            The new server-assigned run ID; the Flow ID is unchanged.
+
+        Raises:
+            FlowNotFoundError: If ``flow_id`` does not exist.
+            ValueError: If reset selector fields are invalid.
+            DexServiceError: If FlowService cannot reset the Flow.
+        """
         request = pb.ResetFlowRequest(
             flow_id=require_name(flow_id),
             reset_type={
@@ -525,6 +728,18 @@ class AsyncClient:
         step_execution_id: StepExecutionId,
         timer_id: TimerId,
     ) -> None:
+        """Make one waiting Timer condition immediately ready.
+
+        Args:
+            flow_id: The non-empty active Flow ID.
+            step_execution_id: The Step type and positive execution number.
+            timer_id: Exactly one Timer condition ID or zero-based index.
+
+        Raises:
+            FlowNotActiveError: If the Flow is closed.
+            ValueError: If an identifier is invalid.
+            DexServiceError: If FlowService cannot skip the Timer.
+        """
         request = pb.SkipTimerRequest(
             flow_id=require_name(flow_id),
             step_execution_id=(
@@ -545,6 +760,18 @@ class AsyncClient:
         step_execution_id: StepExecutionId,
         timeout: timedelta,
     ) -> None:
+        """Await one Step execution's completion or a long-poll timeout.
+
+        Args:
+            flow_id: The non-empty active Flow ID.
+            step_execution_id: The Step type and positive execution number.
+            timeout: The non-negative server-side wait duration.
+
+        Raises:
+            LongPollTimeoutError: If completion is not observed before ``timeout``.
+            FlowNotActiveError: If the Flow closes first.
+            DexServiceError: If FlowService cannot perform the wait.
+        """
         await self._call(
             self._service.WaitForStepCompletion,
             pb.WaitForStepCompletionRequest(
@@ -560,6 +787,17 @@ class AsyncClient:
         )
 
     async def update_flow_config(self, flow_id: str, config: FlowConfig) -> None:
+        """Replace mutable configuration for an active Flow.
+
+        Args:
+            flow_id: The non-empty active Flow ID.
+            config: New optional fields applied to subsequent decisions.
+
+        Raises:
+            FlowNotActiveError: If the Flow is closed.
+            ValueError: If a configuration value is invalid.
+            DexServiceError: If FlowService cannot apply the update.
+        """
         await self._call(
             self._service.UpdateFlowConfig,
             pb.UpdateFlowConfigRequest(
@@ -572,6 +810,17 @@ class AsyncClient:
         )
 
     async def trigger_continue_as_new(self, flow_id: str) -> None:
+        """Ask an active Flow to roll history into a new run.
+
+        The Flow ID remains stable and the run ID changes when rollover occurs.
+
+        Args:
+            flow_id: The non-empty active Flow ID.
+
+        Raises:
+            FlowNotActiveError: If the Flow is closed.
+            DexServiceError: If FlowService cannot accept the request.
+        """
         await self._call(
             self._service.TriggerContinueAsNew,
             pb.TriggerContinueAsNewRequest(flow_id=require_name(flow_id)),
@@ -581,6 +830,14 @@ class AsyncClient:
         )
 
     async def health_check(self) -> bool:
+        """Await the FlowService health endpoint.
+
+        Returns:
+            ``True`` when the service returns successfully.
+
+        Raises:
+            DexServiceError: If the service is unhealthy or unreachable.
+        """
         from google.protobuf import empty_pb2
 
         await self._call(
@@ -593,6 +850,11 @@ class AsyncClient:
         return True
 
     async def close(self) -> None:
+        """Close the owned asynchronous gRPC channel.
+
+        ``close`` is idempotent. Other methods must not be awaited afterward. The
+        Registry and BlobCache remain owned by the caller.
+        """
         if self._closed:
             return
         self._closed = True

--- a/sdk-python/dex/async_worker.py
+++ b/sdk-python/dex/async_worker.py
@@ -25,12 +25,37 @@ from dex.worker_options import WorkerOptions, WorkerTarget
 
 
 class AsyncWorker:
+    """Host asynchronous registered Step and RPC handlers over WorkerService.
+
+    A Worker is one-shot. Await ``start`` in a background task because it waits for
+    termination, and await ``stop`` or ``close`` during shutdown. Application
+    handlers may overlap on the event loop and must avoid blocking operations.
+
+    Attributes:
+        registry: The immutable Flow Registry served by this Worker.
+        blob_cache: The shared cache used to hydrate large values.
+        options: The effective WorkerOptions.
+
+    Examples:
+        >>> async with AsyncWorker(registry, cache) as worker:
+        ...     task = asyncio.create_task(worker.start())
+        ...     await worker.stop()
+        ...     await task
+    """
+
     def __init__(
         self,
         registry: Registry,
         blob_cache: BlobCache,
         options: WorkerOptions | None = None,
     ) -> None:
+        """Construct an AsyncWorker without starting its listener.
+
+        Args:
+            registry: A Registry created with ``allow_async_handlers=True``.
+            blob_cache: An open cache shared for asynchronous value hydration.
+            options: Networking and startup options; ``None`` uses defaults.
+        """
         self.registry = registry
         self.blob_cache = blob_cache
         self.options = options or WorkerOptions()
@@ -58,9 +83,21 @@ class AsyncWorker:
 
     @property
     def worker_target(self) -> WorkerTarget:
+        """Return the effective endpoint advertised to Dex.
+
+        Returns:
+            The immutable WorkerTarget, including the actual port after binding.
+        """
         return self._worker_target
 
     async def __aenter__(self) -> AsyncWorker:
+        """Return this Worker for asynchronous context-manager use.
+
+        Entering does not start the listener.
+
+        Returns:
+            This AsyncWorker instance.
+        """
         return self
 
     async def __aexit__(
@@ -69,9 +106,24 @@ class AsyncWorker:
         exception: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
+        """Close the Worker when leaving an asynchronous context block.
+
+        Args:
+            exception_type: The active exception type, if any.
+            exception: The active exception value, if any.
+            traceback: The active traceback, if any.
+        """
         await self.close()
 
     async def start(self) -> None:
+        """Synchronize Attribute indexes, serve WorkerService, and await shutdown.
+
+        ``start`` may be awaited exactly once. It contacts FlowService before binding
+        and completes only after ``stop`` terminates the server.
+
+        Raises:
+            RuntimeError: If lifecycle state, index synchronization, or binding fails.
+        """
         if self._state != "created":
             raise RuntimeError(f"AsyncWorker cannot start from state {self._state}")
         try:
@@ -104,6 +156,10 @@ class AsyncWorker:
         self._stopped.set()
 
     async def stop(self) -> None:
+        """Gracefully stop handlers and release asynchronous channel resources.
+
+        Calls before ``start`` and repeated calls after shutdown are safe.
+        """
         if self._state in ("stopped", "closed"):
             return
         self._state = "stopping"
@@ -114,6 +170,10 @@ class AsyncWorker:
         self._stopped.set()
 
     async def close(self) -> None:
+        """Stop the AsyncWorker and permanently mark it closed.
+
+        Repeated calls are safe; a closed Worker cannot be started again.
+        """
         await self.stop()
         self._state = "closed"
 

--- a/sdk-python/dex/async_worker.py
+++ b/sdk-python/dex/async_worker.py
@@ -32,7 +32,7 @@ class AsyncWorker:
     handlers may overlap on the event loop and must avoid blocking operations.
 
     Attributes:
-        registry: The immutable Flow Registry served by this Worker.
+        registry: The Flow Registry served by this Worker.
         blob_cache: The shared cache used to hydrate large values.
         options: The effective WorkerOptions.
 
@@ -86,7 +86,7 @@ class AsyncWorker:
         """Return the effective endpoint advertised to Dex.
 
         Returns:
-            The immutable WorkerTarget, including the actual port after binding.
+            The WorkerTarget, including the actual port after binding.
         """
         return self._worker_target
 

--- a/sdk-python/dex/attribute.py
+++ b/sdk-python/dex/attribute.py
@@ -21,6 +21,18 @@ ValueT = TypeVar("ValueT")
 
 
 class IndexType(Enum):
+    """Select how Dex indexes an Attribute for Flow search.
+
+    Attributes:
+        KEYWORD: Index an exact string value.
+        FULL_TEXT: Index a string for tokenized full-text matching.
+        KEYWORD_ARRAY: Index every string in a sequence as a keyword.
+        INT: Index a signed 64-bit integer.
+        DOUBLE: Index a finite floating-point number.
+        BOOL: Index a Boolean value.
+        DATETIME: Index a :class:`datetime.datetime` value.
+    """
+
     KEYWORD = "keyword"
     FULL_TEXT = "full_text"
     KEYWORD_ARRAY = "keyword_array"
@@ -32,12 +44,39 @@ class IndexType(Enum):
 
 @dataclass(frozen=True)
 class AttributeIndex:
+    """Configure the search index for an Attribute or AttributeMap.
+
+    Attributes:
+        type: The value representation accepted by the search index.
+        index_key: The physical search key. An empty value uses the Attribute name
+            for a singleton Attribute; AttributeMap definitions require an explicit
+            key so all instances share one index.
+    """
+
     type: IndexType
     index_key: str = ""
 
 
 @dataclass(frozen=True)
 class Attribute(Generic[ValueT]):
+    """Define a typed, durable singleton value owned by a Flow.
+
+    Declare Attributes once in a Flow's ``PersistenceSchema`` and reuse the same
+    definition from Steps, RPCs, and Client calls. Values are read and written
+    through a handler :class:`Context`; Client methods provide external access.
+
+    Attributes:
+        name: The non-empty logical Attribute name, unique within its Flow.
+        value_type: The Python type used to encode and decode values.
+        index: Optional search-index configuration; ``None`` disables indexing.
+
+    Examples:
+        >>> status = Attribute("status", str, AttributeIndex(IndexType.KEYWORD))
+        >>> status.set(context, "paid")
+        >>> status.get(context)
+        'paid'
+    """
+
     name: str
     value_type: type[ValueT]
     index: AttributeIndex | None = None
@@ -46,20 +85,71 @@ class Attribute(Generic[ValueT]):
         require_name(self.name)
 
     def get(self, context: Context) -> ValueT:
+        """Return the current value from a Step or RPC Context.
+
+        Args:
+            context: The current handler Context.
+
+        Returns:
+            The decoded value.
+
+        Raises:
+            KeyError: If the Attribute has no value.
+            TypeError: If the stored value cannot be decoded as ``value_type``.
+        """
         return context._get_attribute(self, None)
 
     def set(self, context: Context, value: ValueT) -> None:
+        """Stage a value to persist with the current handler decision.
+
+        Args:
+            context: The current handler Context.
+            value: A value compatible with ``value_type``.
+
+        Raises:
+            TypeError: If ``value`` cannot be encoded as ``value_type``.
+        """
         context._set_attribute(self, None, value)
 
     def delete(self, context: Context) -> None:
+        """Stage deletion of this Attribute in the current handler decision.
+
+        Args:
+            context: The current handler Context.
+        """
         context._delete_attribute(cast(Attribute[object], self), None)
 
     def lock(self) -> AttributeLock:
+        """Return a lock request for this Attribute.
+
+        Use the result in Step or RPC lock options to serialize handlers that
+        access the same value.
+
+        Returns:
+            An immutable lock descriptor for this Attribute.
+        """
         return AttributeLock(self)
 
 
 @dataclass(frozen=True)
 class AttributeMap(Generic[ValueT]):
+    """Define a typed family of durable values keyed by map instance.
+
+    AttributeMap instances share one schema definition while retaining independent
+    values and locks. Declare the map in ``PersistenceSchema`` before using it.
+
+    Attributes:
+        name: The non-empty logical Attribute name, unique within its Flow.
+        value_type: The Python type used for every map instance.
+        index: Optional shared search-index configuration.
+
+    Examples:
+        >>> balances = AttributeMap("balance", int)
+        >>> balances.set(context, "merchant-7", 1200)
+        >>> balances.get(context, "merchant-7")
+        1200
+    """
+
     name: str
     value_type: type[ValueT]
     index: AttributeIndex | None = None
@@ -68,20 +158,64 @@ class AttributeMap(Generic[ValueT]):
         require_name(self.name)
 
     def get(self, context: Context, instance: str) -> ValueT:
+        """Return one map instance from a Step or RPC Context.
+
+        Args:
+            context: The current handler Context.
+            instance: The non-empty logical map key.
+
+        Returns:
+            The decoded instance value.
+
+        Raises:
+            KeyError: If the instance has no value.
+            ValueError: If ``instance`` is empty.
+        """
         return context._get_attribute(self, instance)
 
     def set(self, context: Context, instance: str, value: ValueT) -> None:
+        """Stage one map-instance value for the current handler decision.
+
+        Args:
+            context: The current handler Context.
+            instance: The non-empty logical map key.
+            value: A value compatible with ``value_type``.
+        """
         context._set_attribute(self, instance, value)
 
     def delete(self, context: Context, instance: str) -> None:
+        """Stage deletion of one map instance.
+
+        Args:
+            context: The current handler Context.
+            instance: The non-empty logical map key.
+        """
         context._delete_attribute(cast(AttributeMap[object], self), instance)
 
     def lock(self, instance: str) -> AttributeLock:
+        """Return a lock request for one map instance.
+
+        Args:
+            instance: The non-empty logical map key.
+
+        Returns:
+            An immutable lock descriptor scoped to ``instance``.
+
+        Raises:
+            ValueError: If ``instance`` is empty.
+        """
         require_name(instance)
         return AttributeLock(self, instance)
 
 
 @dataclass(frozen=True)
 class AttributeLock:
+    """Describe an Attribute lock acquired for a Step or RPC handler.
+
+    Attributes:
+        attribute: The singleton Attribute or AttributeMap definition to lock.
+        instance: The AttributeMap instance, or ``None`` for a singleton Attribute.
+    """
+
     attribute: Attribute[Any] | AttributeMap[Any]
     instance: str | None = None

--- a/sdk-python/dex/attribute.py
+++ b/sdk-python/dex/attribute.py
@@ -126,7 +126,7 @@ class Attribute(Generic[ValueT]):
         access the same value.
 
         Returns:
-            An immutable lock descriptor for this Attribute.
+            A lock for this Attribute.
         """
         return AttributeLock(self)
 
@@ -135,7 +135,7 @@ class Attribute(Generic[ValueT]):
 class AttributeMap(Generic[ValueT]):
     """Define a typed family of durable values keyed by map instance.
 
-    AttributeMap instances share one schema definition while retaining independent
+    AttributeMap instances share one schema definition while keeping independent
     values and locks. Declare the map in ``PersistenceSchema`` before using it.
 
     Attributes:
@@ -199,7 +199,7 @@ class AttributeMap(Generic[ValueT]):
             instance: The non-empty logical map key.
 
         Returns:
-            An immutable lock descriptor scoped to ``instance``.
+            A lock for ``instance``.
 
         Raises:
             ValueError: If ``instance`` is empty.

--- a/sdk-python/dex/blob_cache.py
+++ b/sdk-python/dex/blob_cache.py
@@ -14,6 +14,15 @@ from dex._native import NativeBlobCache
 
 @dataclass(frozen=True)
 class BlobCacheConfig:
+    """Configure the local persistent cache for large Dex values.
+
+    Attributes:
+        directory: The writable directory that stores cache data and metadata.
+        max_bytes: The positive maximum on-disk payload size in bytes.
+        frequency_counters: Admission-policy counter count. Zero selects the default
+            of 10,000; larger values improve frequency estimates at a memory cost.
+    """
+
     directory: str
     max_bytes: int
     frequency_counters: int = 10_000
@@ -30,18 +39,62 @@ class BlobCacheConfig:
 
 
 class BlobCache(Protocol):
+    """Provide local, bounded storage for content-addressed Dex blobs.
+
+    Implementations may be called concurrently by Clients and Workers. Blob IDs are
+    opaque server identifiers; callers should not derive their own IDs.
+    """
+
     @property
-    def config(self) -> BlobCacheConfig: ...
+    def config(self) -> BlobCacheConfig:
+        """Return the immutable configuration used to open this cache.
 
-    def get(self, blob_id: str) -> bytes | None: ...
+        Returns:
+            The effective cache configuration.
+        """
+        ...
 
-    def put(self, blob_id: str, payload: bytes) -> bool: ...
+    def get(self, blob_id: str) -> bytes | None:
+        """Read a cached payload without contacting Dex.
 
-    def delete(self, blob_id: str) -> None: ...
+        Args:
+            blob_id: The non-empty, opaque blob identifier.
 
-    def delete_all(self) -> None: ...
+        Returns:
+            The payload bytes, or ``None`` when the entry is absent.
+        """
+        ...
 
-    def close(self) -> None: ...
+    def put(self, blob_id: str, payload: bytes) -> bool:
+        """Offer a payload to the bounded cache.
+
+        Args:
+            blob_id: The non-empty, opaque blob identifier.
+            payload: The bytes to retain; the cache does not take mutable ownership.
+
+        Returns:
+            ``True`` when admitted, or ``False`` when the policy rejects the entry.
+        """
+        ...
+
+    def delete(self, blob_id: str) -> None:
+        """Delete one cached payload if present.
+
+        Args:
+            blob_id: The opaque identifier to remove.
+        """
+        ...
+
+    def delete_all(self) -> None:
+        """Delete every cached payload while keeping the cache open."""
+        ...
+
+    def close(self) -> None:
+        """Flush metadata and release native cache resources.
+
+        Repeated calls are safe; other methods must not be used after close.
+        """
+        ...
 
 
 class _RustBlobCache:
@@ -70,4 +123,23 @@ class _RustBlobCache:
 
 
 def open_blob_cache(config: BlobCacheConfig) -> BlobCache:
+    """Open or create a native BlobCache.
+
+    Args:
+        config: Valid directory, byte capacity, and admission-policy settings.
+
+    Returns:
+        An open cache owned by the caller; call :meth:`BlobCache.close` at shutdown.
+
+    Raises:
+        ValueError: If a configuration value is invalid.
+        OSError: If the directory cannot be created, locked, or opened.
+
+    Examples:
+        >>> cache = open_blob_cache(BlobCacheConfig(".dex-cache", 64 * 1024**2))
+        >>> try:
+        ...     cache.put("blob-1", b"payload")
+        ... finally:
+        ...     cache.close()
+    """
     return _RustBlobCache(config)

--- a/sdk-python/dex/blob_cache.py
+++ b/sdk-python/dex/blob_cache.py
@@ -47,7 +47,7 @@ class BlobCache(Protocol):
 
     @property
     def config(self) -> BlobCacheConfig:
-        """Return the immutable configuration used to open this cache.
+        """Return the configuration used to open this cache.
 
         Returns:
             The effective cache configuration.

--- a/sdk-python/dex/channel.py
+++ b/sdk-python/dex/channel.py
@@ -146,7 +146,7 @@ class Channel(Generic[ValueT]):
     ) -> Condition:
         """Create a bounded condition for queued Channel values.
 
-        At least one bound must be supplied. When both are present, ``at_least``
+        At least one bound is required. When both are present, ``at_least``
         cannot exceed ``at_most``. The condition is evaluated durably by Dex.
 
         Args:

--- a/sdk-python/dex/channel.py
+++ b/sdk-python/dex/channel.py
@@ -22,6 +22,22 @@ ValueT = TypeVar("ValueT")
 
 @dataclass(frozen=True)
 class Channel(Generic[ValueT]):
+    """Define a typed, durable singleton message stream owned by a Flow.
+
+    Add the Channel to the Flow's ``PersistenceSchema``. Publishers append values;
+    Steps use the condition factories to wait for a count and then inspect the
+    selected values through ``results``.
+
+    Attributes:
+        name: The non-empty Channel name, unique within its Flow.
+        value_type: The Python type of every published value.
+
+    Examples:
+        >>> approvals = Channel("approvals", str)
+        >>> wait = Wait.until(approvals.for_n(2, condition_id="two-approvals"))
+        >>> approvals.publish(context, "reviewer@example.com")
+    """
+
     name: str
     value_type: type[ValueT]
 
@@ -29,18 +45,58 @@ class Channel(Generic[ValueT]):
         require_name(self.name)
 
     def publish(self, context: Context, value: ValueT) -> None:
+        """Stage one value to append with the current handler decision.
+
+        Args:
+            context: The current Step or RPC Context.
+            value: A value compatible with ``value_type``.
+        """
         context._publish_channel(self, None, value)
 
     def size(self, context: Context) -> int:
+        """Return the current number of queued values.
+
+        Args:
+            context: The current Step or RPC Context.
+
+        Returns:
+            The non-negative number of queued Channel values.
+        """
         return context._channel_size(cast(Channel[object], self), None)
 
     def results(self, context: Context) -> Sequence[ValueT]:
+        """Return values selected by the Step's satisfied Channel condition.
+
+        Args:
+            context: The current Step Context.
+
+        Returns:
+            An ordered, read-only sequence for this Step execution; it is empty
+            when the Step did not wait on this Channel.
+        """
         return context._channel_results(self, None)
 
     def for_one(self, *, condition_id: str | None = None) -> Condition:
+        """Create a condition that consumes exactly one value.
+
+        Args:
+            condition_id: Optional stable identifier used by Timer and wait APIs.
+
+        Returns:
+            A Channel condition equivalent to ``for_range(at_least=1, at_most=1)``.
+        """
         return self.for_range(at_least=1, at_most=1, condition_id=condition_id)
 
     def for_n(self, count: int, *, condition_id: str | None = None) -> Condition:
+        """Create a condition that consumes exactly ``count`` values.
+
+        Args:
+            count: The required non-negative value count.
+            condition_id: Optional stable condition identifier.
+
+        Returns:
+            A Channel condition with equal lower and upper bounds.
+        """
         return self.for_range(
             at_least=count,
             at_most=count,
@@ -53,6 +109,15 @@ class Channel(Generic[ValueT]):
         *,
         condition_id: str | None = None,
     ) -> Condition:
+        """Create a condition requiring at least ``count`` values.
+
+        Args:
+            count: The inclusive, non-negative lower bound.
+            condition_id: Optional stable condition identifier.
+
+        Returns:
+            A Channel condition with no upper bound.
+        """
         return self.for_range(at_least=count, condition_id=condition_id)
 
     def at_most(
@@ -61,6 +126,15 @@ class Channel(Generic[ValueT]):
         *,
         condition_id: str | None = None,
     ) -> Condition:
+        """Create a condition consuming at most ``count`` available values.
+
+        Args:
+            count: The inclusive, non-negative upper bound.
+            condition_id: Optional stable condition identifier.
+
+        Returns:
+            A Channel condition with no positive lower bound.
+        """
         return self.for_range(at_most=count, condition_id=condition_id)
 
     def for_range(
@@ -70,6 +144,19 @@ class Channel(Generic[ValueT]):
         at_most: int | None = None,
         condition_id: str | None = None,
     ) -> Condition:
+        """Create a bounded condition for queued Channel values.
+
+        At least one bound must be supplied. When both are present, ``at_least``
+        cannot exceed ``at_most``. The condition is evaluated durably by Dex.
+
+        Args:
+            at_least: Optional inclusive lower bound.
+            at_most: Optional inclusive upper bound.
+            condition_id: Optional stable identifier unique within the Wait tree.
+
+        Returns:
+            A condition accepted by :class:`Wait` factories.
+        """
         return ChannelCondition(
             condition_id=condition_id,
             channel=self,
@@ -80,6 +167,21 @@ class Channel(Generic[ValueT]):
 
 @dataclass(frozen=True)
 class ChannelMap(Generic[ValueT]):
+    """Define keyed Channel instances that share one typed schema.
+
+    Each ``instance`` has an independent queue and may be waited on separately.
+    Add the ChannelMap definition to the Flow's ``PersistenceSchema``.
+
+    Attributes:
+        name: The non-empty Channel name, unique within its Flow.
+        value_type: The Python type of every published value.
+
+    Examples:
+        >>> events = ChannelMap("events", dict[str, str])
+        >>> events.publish(context, "customer-42", {"kind": "paid"})
+        >>> wait = Wait.until(events.for_one("customer-42"))
+    """
+
     name: str
     value_type: type[ValueT]
 
@@ -87,12 +189,37 @@ class ChannelMap(Generic[ValueT]):
         require_name(self.name)
 
     def publish(self, context: Context, instance: str, value: ValueT) -> None:
+        """Stage a value to append to one ChannelMap instance.
+
+        Args:
+            context: The current Step or RPC Context.
+            instance: The non-empty logical map key.
+            value: A value compatible with ``value_type``.
+        """
         context._publish_channel(self, instance, value)
 
     def size(self, context: Context, instance: str) -> int:
+        """Return the queued value count for one instance.
+
+        Args:
+            context: The current Step or RPC Context.
+            instance: The non-empty logical map key.
+
+        Returns:
+            The non-negative number of queued values for ``instance``.
+        """
         return context._channel_size(cast(ChannelMap[object], self), instance)
 
     def results(self, context: Context, instance: str) -> Sequence[ValueT]:
+        """Return values selected for one instance by the satisfied condition.
+
+        Args:
+            context: The current Step Context.
+            instance: The non-empty logical map key.
+
+        Returns:
+            An ordered, read-only sequence for this Step execution.
+        """
         return context._channel_results(self, instance)
 
     def for_one(
@@ -101,6 +228,15 @@ class ChannelMap(Generic[ValueT]):
         *,
         condition_id: str | None = None,
     ) -> Condition:
+        """Create an instance condition that consumes exactly one value.
+
+        Args:
+            instance: The non-empty logical map key.
+            condition_id: Optional stable condition identifier.
+
+        Returns:
+            A ChannelMap condition for one value.
+        """
         return self.for_range(
             instance,
             at_least=1,
@@ -115,6 +251,16 @@ class ChannelMap(Generic[ValueT]):
         *,
         condition_id: str | None = None,
     ) -> Condition:
+        """Create an instance condition that consumes exactly ``count`` values.
+
+        Args:
+            instance: The non-empty logical map key.
+            count: The required non-negative value count.
+            condition_id: Optional stable condition identifier.
+
+        Returns:
+            A condition with equal lower and upper bounds.
+        """
         return self.for_range(
             instance,
             at_least=count,
@@ -129,6 +275,16 @@ class ChannelMap(Generic[ValueT]):
         *,
         condition_id: str | None = None,
     ) -> Condition:
+        """Create an instance condition requiring at least ``count`` values.
+
+        Args:
+            instance: The non-empty logical map key.
+            count: The inclusive, non-negative lower bound.
+            condition_id: Optional stable condition identifier.
+
+        Returns:
+            A condition with no upper bound.
+        """
         return self.for_range(
             instance,
             at_least=count,
@@ -142,6 +298,16 @@ class ChannelMap(Generic[ValueT]):
         *,
         condition_id: str | None = None,
     ) -> Condition:
+        """Create an instance condition consuming at most ``count`` values.
+
+        Args:
+            instance: The non-empty logical map key.
+            count: The inclusive, non-negative upper bound.
+            condition_id: Optional stable condition identifier.
+
+        Returns:
+            A condition with no positive lower bound.
+        """
         return self.for_range(
             instance,
             at_most=count,
@@ -156,6 +322,17 @@ class ChannelMap(Generic[ValueT]):
         at_most: int | None = None,
         condition_id: str | None = None,
     ) -> Condition:
+        """Create a bounded condition for one ChannelMap instance.
+
+        Args:
+            instance: The non-empty logical map key.
+            at_least: Optional inclusive lower bound.
+            at_most: Optional inclusive upper bound.
+            condition_id: Optional stable identifier unique within the Wait tree.
+
+        Returns:
+            A condition accepted by :class:`Wait` factories.
+        """
         return ChannelCondition(
             condition_id=condition_id,
             channel=self,

--- a/sdk-python/dex/client.py
+++ b/sdk-python/dex/client.py
@@ -60,7 +60,7 @@ class Client:
     shutdown. The Client owns its gRPC channel but not the Registry or BlobCache.
 
     Attributes:
-        registry: The immutable definitions used to validate typed calls.
+        registry: Flow definitions used to validate typed calls.
         blob_cache: The open cache used to hydrate large values.
         options: The effective ClientOptions.
 
@@ -140,7 +140,7 @@ class Client:
             flow: The registered Flow instance to start.
             flow_id: A non-empty application ID stable across runs.
             input: The starting Step input, or ``None`` when no starting Step exists.
-            options: Immutable start configuration.
+            options: Settings for the new Flow execution.
 
         Returns:
             The server-assigned run ID.
@@ -464,7 +464,7 @@ class Client:
             run_id: Optional exact run; ``""`` targets the active run.
 
         Raises:
-            ValueError: If no value is supplied or a required name is empty.
+            ValueError: If no value is passed or a required name is empty.
             TypeError: If map arguments or value types are invalid.
             ValueMappingError: If a value cannot be encoded.
             FlowNotActiveError: If the selected Flow run is closed.
@@ -788,7 +788,7 @@ class Client:
     def update_flow_config(self, flow_id: str, config: FlowConfig) -> None:
         """Replace mutable configuration for an active Flow.
 
-        The update affects subsequent decisions and does not recall work already
+        The update affects later decisions and does not recall work already
         dispatched.
 
         Args:

--- a/sdk-python/dex/client.py
+++ b/sdk-python/dex/client.py
@@ -53,12 +53,36 @@ ValueT = TypeVar("ValueT")
 
 
 class Client:
+    """Call Dex FlowService through registered, typed Flow definitions.
+
+    Client methods are synchronous and may block on network I/O. Create one Client
+    per Registry, share it across calling threads, and close it at application
+    shutdown. The Client owns its gRPC channel but not the Registry or BlobCache.
+
+    Attributes:
+        registry: The immutable definitions used to validate typed calls.
+        blob_cache: The open cache used to hydrate large values.
+        options: The effective ClientOptions.
+
+    Examples:
+        >>> with Client(registry, cache) as client:
+        ...     run_id = client.start_flow(orders, "order-42", OrderInput("42"))
+        ...     result = client.wait_for_flow("order-42", OrderResult)
+    """
+
     def __init__(
         self,
         registry: Registry,
         blob_cache: BlobCache,
         options: ClientOptions | None = None,
     ) -> None:
+        """Construct a Client and its lazy plaintext gRPC channel.
+
+        Args:
+            registry: The Flow Registry used for call validation and codecs.
+            blob_cache: An open cache used to hydrate large response values.
+            options: Service address and default Worker target; ``None`` uses defaults.
+        """
         self.registry = registry
         self.blob_cache = blob_cache
         self.options = options or ClientOptions()
@@ -76,6 +100,11 @@ class Client:
         self._closed = False
 
     def __enter__(self) -> Client:
+        """Return this open Client for context-manager use.
+
+        Returns:
+            This Client instance.
+        """
         return self
 
     def __exit__(
@@ -84,6 +113,13 @@ class Client:
         exception: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
+        """Close the Client when leaving a context-manager block.
+
+        Args:
+            exception_type: The active exception type, if any.
+            exception: The active exception value, if any.
+            traceback: The active traceback, if any.
+        """
         self.close()
 
     def start_flow(
@@ -93,6 +129,28 @@ class Client:
         input: InputT,
         options: StartFlowOptions = StartFlowOptions(),
     ) -> str:
+        """Start a Flow and return its server-assigned run ID.
+
+        The call returns after Dex accepts the Flow, not after completion. ``flow``
+        must be the exact instance registered with this Client, and ``input`` must
+        match its starting Step annotation. Options control timeout, reuse, retries,
+        configuration, idempotency, and initial Attributes.
+
+        Args:
+            flow: The registered Flow instance to start.
+            flow_id: A non-empty application ID stable across runs.
+            input: The starting Step input, or ``None`` when no starting Step exists.
+            options: Immutable start configuration.
+
+        Returns:
+            The server-assigned run ID.
+
+        Raises:
+            FlowAlreadyStartedError: If reuse policy rejects an existing Flow ID.
+            FlowDefinitionError: If ``flow`` is not registered.
+            ValueMappingError: If ``input`` or an initial Attribute cannot be encoded.
+            DexServiceError: If FlowService rejects or cannot perform the request.
+        """
         registered = self.registry._flow_for_instance(flow)
         request = pb.StartFlowRequest(
             flow_id=require_name(flow_id),
@@ -167,6 +225,28 @@ class Client:
         *,
         run_id: str = "",
     ) -> Any:
+        """Synchronously invoke a registered RPC on an active Flow.
+
+        Pass the bound method from the same registered Flow instance. RPC timeout and
+        Attribute locks come from its ``@rpc`` decorator. The call blocks until the
+        handler returns, fails, or times out.
+
+        Args:
+            rpc_method: A bound method decorated with ``@rpc``.
+            flow_id: The non-empty target Flow ID.
+            input: The annotated RPC input, or ``None`` for an input-free RPC.
+            run_id: Optional exact run; ``""`` targets the active run.
+
+        Returns:
+            The decoded ``RPCResult.output``, or ``None`` for a no-output RPC.
+
+        Raises:
+            FlowDefinitionError: If the method is not registered.
+            RpcLockConflictError: If requested Attribute locks cannot be acquired.
+            WorkerInvocationError: If the application handler fails.
+            ValueMappingError: If input or output mapping fails.
+            DexServiceError: If the Flow is inactive or the service call fails.
+        """
         _, rpc = self.registry._rpc_for_method(rpc_method)
         encoded_input = (
             self._values.encode(input, rpc.input_codec)
@@ -230,6 +310,23 @@ class Client:
         *,
         run_id: str = "",
     ) -> Any:
+        """Return one decoded Attribute or AttributeMap instance.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            attribute: A typed singleton Attribute or AttributeMap definition.
+            instance: The non-empty map key; omit for a singleton Attribute.
+            run_id: Optional exact run; ``""`` targets the current run.
+
+        Returns:
+            The decoded value, or ``None`` when the Attribute is unset.
+
+        Raises:
+            TypeError: If singleton/map arguments do not match the definition.
+            ValueMappingError: If the stored value cannot be decoded.
+            FlowNotFoundError: If ``flow_id`` does not exist.
+            DexServiceError: If FlowService cannot perform the request.
+        """
         key = self._definition_name(attribute, instance)
         response = cast(
             pb.GetAttributesResponse,
@@ -281,6 +378,23 @@ class Client:
         *args: object,
         run_id: str = "",
     ) -> None:
+        """Write one Attribute or AttributeMap instance on an active Flow.
+
+        Singleton form is ``set_attribute(flow_id, attribute, value)``; map form is
+        ``set_attribute(flow_id, attribute_map, instance, value)``.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            attribute: A typed singleton Attribute or AttributeMap definition.
+            *args: The value, or a map instance followed by its value.
+            run_id: Optional exact run; ``""`` targets the active run.
+
+        Raises:
+            TypeError: If arguments do not match the definition or value type.
+            ValueMappingError: If the value cannot be encoded.
+            FlowNotActiveError: If the selected Flow run is closed.
+            DexServiceError: If FlowService cannot apply the write.
+        """
         instance, value = self._definition_value(attribute, args)
         write = pb.AttributeWrite(
             key=self._definition_name(attribute, instance),
@@ -337,6 +451,25 @@ class Client:
         *args: object,
         run_id: str = "",
     ) -> None:
+        """Append one or more typed values to a Channel.
+
+        Singleton form is ``publish(flow_id, channel, *values)``; map form is
+        ``publish(flow_id, channel_map, instance, *values)``. Values are appended in
+        argument order as one service request.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            channel: A typed singleton Channel or ChannelMap definition.
+            *args: Values, or a map instance followed by one or more values.
+            run_id: Optional exact run; ``""`` targets the active run.
+
+        Raises:
+            ValueError: If no value is supplied or a required name is empty.
+            TypeError: If map arguments or value types are invalid.
+            ValueMappingError: If a value cannot be encoded.
+            FlowNotActiveError: If the selected Flow run is closed.
+            DexServiceError: If FlowService cannot publish the batch.
+        """
         if isinstance(channel, ChannelMap):
             if len(args) < 2 or not isinstance(args[0], str):
                 raise TypeError("ChannelMap publish requires instance and values")
@@ -384,6 +517,27 @@ class Client:
         output_type: type[Any] | None = None,
         timeout: timedelta | None = None,
     ) -> Any:
+        """Block until a Flow closes and optionally decode its latest Step output.
+
+        ``timeout`` is the server-side long-poll duration. A long-poll timeout is
+        retryable by calling this method again. Successful completion without a
+        matching Step output returns ``None``.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            output_type: Optional Python type for the latest completed Step output.
+            timeout: Optional non-negative server-side wait duration.
+
+        Returns:
+            The decoded latest output, or ``None`` when no output type/value exists.
+
+        Raises:
+            LongPollTimeoutError: If the Flow remains open when the wait expires.
+            FlowUncompletedError: If the Flow closes without successful completion.
+            FlowNotFoundError: If ``flow_id`` does not exist.
+            ValueMappingError: If a requested output cannot be decoded.
+            DexServiceError: If FlowService cannot perform the wait.
+        """
         response = self._wait_for_flow_response(flow_id, timeout)
         if output_type is None:
             return None
@@ -401,6 +555,19 @@ class Client:
         flow_id: str,
         options: StopFlowOptions = StopFlowOptions(),
     ) -> None:
+        """Request cancellation, termination, or failure of an active Flow.
+
+        The call returns after Dex accepts the request and does not wait for terminal
+        status.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            options: Stop mode and optional recorded reason.
+
+        Raises:
+            FlowNotActiveError: If no active run exists.
+            DexServiceError: If FlowService rejects or cannot perform the request.
+        """
         self._call(
             self._service.StopFlow,
             pb.StopFlowRequest(
@@ -418,6 +585,18 @@ class Client:
         )
 
     def describe_flow(self, flow_id: str) -> FlowInfo:
+        """Return summary metadata for the current or latest Flow run.
+
+        Args:
+            flow_id: The non-empty Flow ID to describe.
+
+        Returns:
+            Flow ID, run ID, Flow type, status, and UTC start time.
+
+        Raises:
+            FlowNotFoundError: If ``flow_id`` does not exist.
+            DexServiceError: If FlowService cannot return the summary.
+        """
         response = cast(
             pb.GetFlowSummaryResponse,
             self._call(
@@ -442,6 +621,21 @@ class Client:
         page_size: int,
         next_page_token: str = "",
     ) -> SearchFlowsPage:
+        """Return one page of Flow runs matching a visibility query.
+
+        Args:
+            query: A Dex visibility query; an empty string matches server defaults.
+            page_size: The non-negative maximum result count requested.
+            next_page_token: Opaque token from the preceding page, or ``""`` first.
+
+        Returns:
+            Server-ordered entries with hydrated indexed Attributes and a next token.
+
+        Raises:
+            ValueError: If ``page_size`` is negative.
+            ValueMappingError: If an indexed Attribute cannot be hydrated.
+            DexServiceError: If FlowService cannot execute the query.
+        """
         if page_size < 0:
             raise ValueError("search page size must not be negative")
         response = cast(
@@ -482,6 +676,20 @@ class Client:
         )
 
     def reset_flow(self, flow_id: str, options: ResetFlowOptions) -> str:
+        """Create a new run from a selected point in existing Flow history.
+
+        Args:
+            flow_id: The non-empty Flow ID whose history is reset.
+            options: Reset selector, reason, and replay controls.
+
+        Returns:
+            The new server-assigned run ID; the Flow ID is unchanged.
+
+        Raises:
+            FlowNotFoundError: If ``flow_id`` does not exist.
+            ValueError: If reset selector fields are invalid.
+            DexServiceError: If FlowService cannot reset the Flow.
+        """
         request = pb.ResetFlowRequest(
             flow_id=require_name(flow_id),
             reset_type={
@@ -521,6 +729,18 @@ class Client:
         step_execution_id: StepExecutionId,
         timer_id: TimerId,
     ) -> None:
+        """Make one waiting Timer condition immediately ready.
+
+        Args:
+            flow_id: The non-empty active Flow ID.
+            step_execution_id: The Step type and positive execution number.
+            timer_id: Exactly one Timer condition ID or zero-based index.
+
+        Raises:
+            FlowNotActiveError: If the Flow is closed.
+            ValueError: If an identifier is invalid.
+            DexServiceError: If FlowService cannot skip the Timer.
+        """
         request = pb.SkipTimerRequest(
             flow_id=require_name(flow_id),
             step_execution_id=(
@@ -539,6 +759,18 @@ class Client:
         step_execution_id: StepExecutionId,
         timeout: timedelta,
     ) -> None:
+        """Block until one Step execution completes or the long poll expires.
+
+        Args:
+            flow_id: The non-empty active Flow ID.
+            step_execution_id: The Step type and positive execution number.
+            timeout: The non-negative server-side wait duration.
+
+        Raises:
+            LongPollTimeoutError: If completion is not observed before ``timeout``.
+            FlowNotActiveError: If the Flow closes first.
+            DexServiceError: If FlowService cannot perform the wait.
+        """
         self._call(
             self._service.WaitForStepCompletion,
             pb.WaitForStepCompletionRequest(
@@ -554,6 +786,20 @@ class Client:
         )
 
     def update_flow_config(self, flow_id: str, config: FlowConfig) -> None:
+        """Replace mutable configuration for an active Flow.
+
+        The update affects subsequent decisions and does not recall work already
+        dispatched.
+
+        Args:
+            flow_id: The non-empty active Flow ID.
+            config: The new optional configuration fields.
+
+        Raises:
+            FlowNotActiveError: If the Flow is closed.
+            ValueError: If a configuration value is invalid.
+            DexServiceError: If FlowService cannot apply the update.
+        """
         self._call(
             self._service.UpdateFlowConfig,
             pb.UpdateFlowConfigRequest(
@@ -566,6 +812,18 @@ class Client:
         )
 
     def trigger_continue_as_new(self, flow_id: str) -> None:
+        """Ask an active Flow to roll history into a new run.
+
+        The request returns after acceptance; the Flow ID remains stable and the run
+        ID changes when rollover occurs.
+
+        Args:
+            flow_id: The non-empty active Flow ID.
+
+        Raises:
+            FlowNotActiveError: If the Flow is closed.
+            DexServiceError: If FlowService cannot accept the request.
+        """
         self._call(
             self._service.TriggerContinueAsNew,
             pb.TriggerContinueAsNewRequest(flow_id=require_name(flow_id)),
@@ -575,6 +833,14 @@ class Client:
         )
 
     def health_check(self) -> bool:
+        """Call the FlowService health endpoint.
+
+        Returns:
+            ``True`` when the service returns successfully.
+
+        Raises:
+            DexServiceError: If the service is unhealthy or unreachable.
+        """
         from google.protobuf import empty_pb2
 
         self._call(
@@ -587,6 +853,11 @@ class Client:
         return True
 
     def close(self) -> None:
+        """Close the owned gRPC channel.
+
+        ``close`` is idempotent. Other Client methods must not be called afterward.
+        The Registry and BlobCache remain owned by the caller.
+        """
         if self._closed:
             return
         self._closed = True

--- a/sdk-python/dex/client_options.py
+++ b/sdk-python/dex/client_options.py
@@ -15,5 +15,14 @@ from dex.worker_options import WorkerTarget
 
 @dataclass(frozen=True)
 class ClientOptions:
+    """Configure FlowService connectivity and default Flow routing.
+
+    Attributes:
+        server_address: The plaintext gRPC target for Dex. Defaults to
+            ``"localhost:8801"`` and must not include an HTTP scheme.
+        worker_target: The Worker target advertised by ``start_flow`` when the Flow
+            does not override it, or ``None`` to omit a Client-level default.
+    """
+
     server_address: str = "localhost:8801"
     worker_target: WorkerTarget | None = None

--- a/sdk-python/dex/codec.py
+++ b/sdk-python/dex/codec.py
@@ -110,7 +110,7 @@ class Codec(Protocol[ValueT]):
             value: The validated Value to decode.
 
         Returns:
-            The reconstructed application value.
+            The decoded application value.
 
         Raises:
             TypeError: If the wire kind or payload is incompatible.

--- a/sdk-python/dex/codec.py
+++ b/sdk-python/dex/codec.py
@@ -31,6 +31,17 @@ ValueT = TypeVar("ValueT")
 
 
 class WireKind(Enum):
+    """Identify the protocol representation carried by an encoded Value.
+
+    Attributes:
+        STRING: A UTF-8 string scalar.
+        BOOL: A Boolean scalar.
+        INT64: A signed 64-bit integer scalar.
+        DOUBLE: A finite IEEE-754 double scalar.
+        BYTES: An uninterpreted byte sequence.
+        JSON: A canonical JSON document stored as text.
+    """
+
     STRING = "string"
     BOOL = "bool"
     INT64 = "int64"
@@ -41,20 +52,71 @@ class WireKind(Enum):
 
 @dataclass(frozen=True)
 class Value:
+    """Contain one validated SDK value before protocol mapping.
+
+    Attributes:
+        kind: The wire representation used for ``data``.
+        data: The scalar, bytes, or JSON text payload compatible with ``kind``.
+    """
+
     kind: WireKind
     data: str | bool | int | float | bytes
 
 
 class Codec(Protocol[ValueT]):
-    @property
-    def type_name(self) -> str: ...
+    """Define bidirectional conversion between a Python type and Dex Values.
+
+    Custom codecs must be deterministic: equivalent inputs should produce the same
+    Value so durable replays observe identical data.
+    """
 
     @property
-    def wire_kind(self) -> WireKind: ...
+    def type_name(self) -> str:
+        """Return the application-facing type name used in error messages.
 
-    def encode(self, value: ValueT) -> Value: ...
+        Returns:
+            A stable, non-empty type name.
+        """
+        ...
 
-    def decode(self, value: Value) -> ValueT: ...
+    @property
+    def wire_kind(self) -> WireKind:
+        """Return the single wire kind emitted and accepted by this codec.
+
+        Returns:
+            The codec's protocol representation.
+        """
+        ...
+
+    def encode(self, value: ValueT) -> Value:
+        """Encode one typed Python value.
+
+        Args:
+            value: The application value to encode.
+
+        Returns:
+            A Value whose kind equals ``wire_kind``.
+
+        Raises:
+            TypeError: If ``value`` is incompatible with the codec.
+            ValueError: If the value is not representable by Dex.
+        """
+        ...
+
+    def decode(self, value: Value) -> ValueT:
+        """Decode one protocol Value into the application type.
+
+        Args:
+            value: The validated Value to decode.
+
+        Returns:
+            The reconstructed application value.
+
+        Raises:
+            TypeError: If the wire kind or payload is incompatible.
+            ValueError: If the payload is malformed.
+        """
+        ...
 
 
 @dataclass(frozen=True)
@@ -98,10 +160,15 @@ def _validate_double(value: float) -> None:
         raise ValueError("non-finite floating-point values are unsupported")
 
 
+#: The built-in UTF-8 ``str`` codec.
 STRING: Codec[str] = _ScalarCodec("str", WireKind.STRING, str)
+#: The built-in strict ``bool`` codec; integers are not accepted as Booleans.
 BOOL: Codec[bool] = _ScalarCodec("bool", WireKind.BOOL, bool)
+#: The built-in signed 64-bit ``int`` codec; larger values raise OverflowError.
 INT64: Codec[int] = _ScalarCodec("int", WireKind.INT64, int, _validate_int64)
+#: The built-in finite ``float`` codec; NaN and infinities are rejected.
 DOUBLE: Codec[float] = _ScalarCodec("float", WireKind.DOUBLE, float, _validate_double)
+#: The built-in raw ``bytes`` codec.
 BYTES: Codec[bytes] = _ScalarCodec("bytes", WireKind.BYTES, bytes)
 
 
@@ -143,6 +210,25 @@ _DATETIME: Codec[datetime] = _DateTimeCodec()
 
 @dataclass(frozen=True)
 class JsonCodec(Generic[ValueT]):
+    """Encode an application type as deterministic JSON text.
+
+    ``encoder`` first converts the typed value to JSON-compatible data; ``decoder``
+    performs the reverse conversion. JSON is emitted with sorted keys, compact
+    separators, and no NaN or infinity values.
+
+    Attributes:
+        type_name: The stable type name used in diagnostics.
+        decoder: A callable from parsed JSON-compatible data to ``ValueT``.
+        encoder: A callable from ``ValueT`` to JSON-compatible data.
+        expected_type: Optional runtime type hint validated before encoding.
+        wire_kind: Always :attr:`WireKind.JSON`.
+
+    Examples:
+        >>> codec = JsonCodec("Point", lambda data: Point(**data), vars, Point)
+        >>> codec.decode(codec.encode(Point(x=1, y=2)))
+        Point(x=1, y=2)
+    """
+
     type_name: str
     decoder: Callable[[Any], ValueT]
     encoder: Callable[[ValueT], Any] = field(default=lambda value: value)
@@ -150,6 +236,18 @@ class JsonCodec(Generic[ValueT]):
     wire_kind: WireKind = field(default=WireKind.JSON, init=False)
 
     def encode(self, value: ValueT) -> Value:
+        """Encode a typed value as canonical JSON.
+
+        Args:
+            value: The application value accepted by ``encoder``.
+
+        Returns:
+            A JSON-kind Value containing compact, sorted JSON text.
+
+        Raises:
+            TypeError: If ``expected_type`` does not match.
+            ValueError: If the encoded data contains unsupported JSON values.
+        """
         if self.expected_type is not None and not _matches_type(
             value, self.expected_type
         ):
@@ -166,16 +264,57 @@ class JsonCodec(Generic[ValueT]):
         return Value(WireKind.JSON, payload)
 
     def decode(self, value: Value) -> ValueT:
+        """Decode JSON text with this codec's decoder.
+
+        Args:
+            value: A JSON-kind Value containing valid JSON text.
+
+        Returns:
+            The application value returned by ``decoder``.
+
+        Raises:
+            TypeError: If ``value`` is not a JSON Value.
+            ValueError: If its JSON text is malformed.
+        """
         if value.kind is not WireKind.JSON or not isinstance(value.data, str):
             raise TypeError(f"{self.type_name} requires a JSON value")
         return self.decoder(json.loads(value.data))
 
 
 class CodecRegistry:
+    """Resolve codecs for type hints used by registered SDK definitions.
+
+    Explicit registrations take precedence over built-ins. The default registry
+    supports scalar types, ``None``, ``datetime``, dataclasses, enums, and typed
+    list, tuple, mapping, and sequence containers.
+
+    Examples:
+        >>> registry = CodecRegistry({Money: money_codec})
+        >>> registry.resolve(Money) is money_codec
+        True
+    """
+
     def __init__(self, codecs: Mapping[object, Codec[Any]] | None = None) -> None:
+        """Create a registry with optional custom type-hint mappings.
+
+        Args:
+            codecs: Custom codecs keyed by the exact type hint used in definitions.
+                The mapping is copied and may be mutated after construction.
+        """
         self._codecs = dict(codecs or {})
 
     def resolve(self, type_hint: object) -> Codec[Any]:
+        """Return the codec for an exact type hint.
+
+        Args:
+            type_hint: A runtime type or supported parameterized type hint.
+
+        Returns:
+            The registered, built-in, or automatically derived codec.
+
+        Raises:
+            TypeError: If no codec can represent ``type_hint``.
+        """
         custom = self._codecs.get(type_hint)
         if custom is not None:
             return custom

--- a/sdk-python/dex/condition.py
+++ b/sdk-python/dex/condition.py
@@ -67,8 +67,25 @@ class ChannelCondition(Condition, Generic[ValueT]):
 
 @dataclass(frozen=True)
 class ConditionCombination:
+    """Group Conditions that must become ready together.
+
+    Pass combinations to :meth:`Wait.any_combination_of` when several alternative
+    groups are acceptable.
+
+    Attributes:
+        conditions: The ordered Conditions in this all-of group.
+    """
+
     conditions: tuple[Condition, ...]
 
     @staticmethod
     def of(*conditions: Condition) -> ConditionCombination:
+        """Create a combination from one or more Conditions.
+
+        Args:
+            *conditions: Conditions that must all become ready together.
+
+        Returns:
+            An immutable combination preserving argument order.
+        """
         return ConditionCombination(conditions)

--- a/sdk-python/dex/condition.py
+++ b/sdk-python/dex/condition.py
@@ -86,6 +86,6 @@ class ConditionCombination:
             *conditions: Conditions that must all become ready together.
 
         Returns:
-            An immutable combination preserving argument order.
+            A combination with Conditions in argument order.
         """
         return ConditionCombination(conditions)

--- a/sdk-python/dex/context.py
+++ b/sdk-python/dex/context.py
@@ -20,7 +20,7 @@ ValueT = TypeVar("ValueT")
 
 
 class Context(Protocol):
-    """Expose immutable execution metadata and decision-local Step operations.
+    """Expose execution metadata and decision-local Step operations.
 
     Dex supplies a Context to every ``wait_for`` and ``execute`` call. Do not retain
     it after the handler returns. Attribute and Channel definition methods provide

--- a/sdk-python/dex/context.py
+++ b/sdk-python/dex/context.py
@@ -20,32 +20,115 @@ ValueT = TypeVar("ValueT")
 
 
 class Context(Protocol):
-    @property
-    def flow_id(self) -> str: ...
+    """Expose immutable execution metadata and decision-local Step operations.
+
+    Dex supplies a Context to every ``wait_for`` and ``execute`` call. Do not retain
+    it after the handler returns. Attribute and Channel definition methods provide
+    the typed persistence API; the methods below expose execution diagnostics and
+    per-attempt local state.
+    """
 
     @property
-    def run_id(self) -> str: ...
+    def flow_id(self) -> str:
+        """Return the stable Flow ID shared by all runs.
+
+        Returns:
+            The application-assigned Flow ID.
+        """
+        ...
 
     @property
-    def step_execution_id(self) -> str: ...
+    def run_id(self) -> str:
+        """Return the current server-assigned run ID.
+
+        Returns:
+            The run ID, which changes after reset or continue-as-new.
+        """
+        ...
 
     @property
-    def from_step_execution_id(self) -> str: ...
+    def step_execution_id(self) -> str:
+        """Return the current Step execution's protocol identifier.
+
+        Returns:
+            The Step type and execution number encoded by Dex.
+        """
+        ...
 
     @property
-    def attempt(self) -> int: ...
+    def from_step_execution_id(self) -> str:
+        """Return the predecessor Step execution identifier.
 
-    def has_timer_fired(self, index: int | None = None) -> bool: ...
+        Returns:
+            The originating identifier, or an empty string at Flow start.
+        """
+        ...
 
-    def wait_for_method_failed(self) -> bool: ...
+    @property
+    def attempt(self) -> int:
+        """Return the one-based handler retry attempt.
 
-    def set_step_execution_local(self, key: str, value: object) -> None: ...
+        Returns:
+            ``1`` for the initial attempt and a larger value after retries.
+        """
+        ...
+
+    def has_timer_fired(self, index: int | None = None) -> bool:
+        """Report whether a Timer made the current Wait ready.
+
+        Args:
+            index: Optional zero-based Timer index; ``None`` checks any Timer.
+
+        Returns:
+            ``True`` when the selected Timer fired for this execution.
+        """
+        ...
+
+    def wait_for_method_failed(self) -> bool:
+        """Report whether ``wait_for`` failed before this ``execute`` call.
+
+        Returns:
+            ``True`` when the Step's failure policy proceeded after a wait error.
+        """
+        ...
+
+    def set_step_execution_local(self, key: str, value: object) -> None:
+        """Store process-local data for this Step execution.
+
+        Local data is not persisted, replicated, or available after worker restart;
+        use Attributes for durable state.
+
+        Args:
+            key: A non-empty key scoped to the Step execution.
+            value: The in-memory object to retain by reference.
+        """
+        ...
 
     def get_step_execution_local(
         self, key: str, value_type: type[ValueT]
-    ) -> ValueT | None: ...
+    ) -> ValueT | None:
+        """Return typed process-local data for this Step execution.
 
-    def record_event(self, name: str, value: object) -> None: ...
+        Args:
+            key: The key passed to ``set_step_execution_local``.
+            value_type: The required runtime type.
+
+        Returns:
+            The stored object, or ``None`` when the key is absent.
+
+        Raises:
+            TypeError: If the stored object is not an instance of ``value_type``.
+        """
+        ...
+
+    def record_event(self, name: str, value: object) -> None:
+        """Stage an application event in the current handler result.
+
+        Args:
+            name: The non-empty event name used for diagnostics.
+            value: A codec-supported event payload.
+        """
+        ...
 
     def _get_attribute(
         self,

--- a/sdk-python/dex/flow.py
+++ b/sdk-python/dex/flow.py
@@ -73,6 +73,31 @@ def rpc(
     timeout: timedelta | None = None,
     lock_attributes: Sequence[AttributeLock] = (),
 ) -> CallableT | Callable[[CallableT], CallableT]:
+    """Mark a Flow method as a typed RPC handler.
+
+    Use ``@rpc`` with defaults or call ``@rpc(...)`` with configuration. A handler
+    receives Context plus zero or one typed input and returns ``RPCResult[T]`` or
+    ``None``. Registry construction validates annotations and Attribute locks.
+
+    Args:
+        handler: The decorated bound-method function when used as ``@rpc``.
+        name: Optional protocol RPC name; defaults to the method name.
+        timeout: Optional non-negative handler timeout.
+        lock_attributes: Attribute locks held for the entire handler invocation.
+
+    Returns:
+        The original handler, or a decorator that returns it after attaching options.
+
+    Raises:
+        ValueError: If ``name`` is empty or ``timeout`` is negative.
+
+    Examples:
+        >>> class Orders(Flow[None]):
+        ...     @rpc(timeout=timedelta(seconds=10), lock_attributes=(status.lock(),))
+        ...     def cancel(self, context: Context, reason: str) -> RPCResult[bool]:
+        ...         status.set(context, "canceled")
+        ...         return RPCResult(True)
+    """
     if name is not None:
         require_name(name)
     if timeout is not None and timeout < timedelta(0):
@@ -93,17 +118,47 @@ def rpc(
 
 @dataclass(frozen=True)
 class RPCResult(Generic[OutputT]):
+    """Return a typed RPC output and optional next-Step movements.
+
+    Attributes:
+        output: The value decoded into the Client caller's expected output type.
+        next_steps: Step movements applied atomically with handler persistence writes.
+    """
+
     output: OutputT
     next_steps: tuple[StepMovement[Any], ...] = ()
 
 
 @dataclass(frozen=True)
 class PersistenceSchema:
+    """Declare the Attributes and Channels owned by a Flow type.
+
+    Definitions must have unique names and are immutable after Registry creation.
+
+    Attributes:
+        attributes: Singleton and map Attribute definitions.
+        channels: Singleton and map Channel definitions.
+
+    Examples:
+        >>> schema = PersistenceSchema.of(status, balances, approvals, events)
+    """
+
     attributes: tuple[Attribute[Any] | AttributeMap[Any], ...] = ()
     channels: tuple[Channel[Any] | ChannelMap[Any], ...] = ()
 
     @staticmethod
     def of(*definitions: _PersistenceDefinition) -> PersistenceSchema:
+        """Partition persistence definitions into Attributes and Channels.
+
+        Args:
+            *definitions: Attribute, AttributeMap, Channel, or ChannelMap definitions.
+
+        Returns:
+            An immutable schema preserving relative order within each category.
+
+        Raises:
+            TypeError: If a value is not a supported persistence definition.
+        """
         attributes: list[Attribute[Any] | AttributeMap[Any]] = []
         channels: list[Channel[Any] | ChannelMap[Any]] = []
         for definition in definitions:
@@ -117,13 +172,37 @@ class PersistenceSchema:
 
 
 class Flow(Generic[StartT], ABC):
+    """Define a durable application Flow and its registered API surface.
+
+    Subclasses return their Steps and persistence schema and may expose methods
+    decorated with :func:`rpc`. Construct one Flow instance and pass it to Registry;
+    Client calls must use that same registered instance.
+    """
+
     def get_flow_type(self) -> str:
+        """Return the protocol Flow type used by Client and Dex.
+
+        Override it to decouple the type from the Python class name.
+
+        Returns:
+            A non-empty Flow type unique within the Registry.
+        """
         return type(self).__name__
 
     def get_steps(self) -> StepList[StartT]:
+        """Return the immutable Step definitions for this Flow.
+
+        Returns:
+            A StepList with zero or one starting Step and all reachable Steps.
+        """
         return StepList.empty()
 
     def get_persistence_schema(self) -> PersistenceSchema:
+        """Return the Attributes and Channels owned by this Flow.
+
+        Returns:
+            The persistence schema; the default is empty.
+        """
         return PersistenceSchema.of()
 
 
@@ -174,6 +253,21 @@ class _RegisteredFlow:
 
 @dataclass(frozen=True)
 class Registry:
+    """Validate and store immutable Flow definitions shared by Client and Worker.
+
+    Registry construction inspects Step and RPC signatures, resolves codecs, checks
+    names and locks, and assembles Attribute indexes atomically. The result is safe
+    for concurrent reads.
+
+    Attributes:
+        flows: The registered Flow instances in input order.
+        codec_registry: The codec registry used for every handler and persistence type.
+
+    Examples:
+        >>> orders = Orders()
+        >>> registry = Registry([orders], CodecRegistry({Money: money_codec}))
+    """
+
     flows: tuple[Flow[Any], ...]
     codec_registry: CodecRegistry
     _steps: tuple[_RegisteredStep, ...]
@@ -188,6 +282,19 @@ class Registry:
         *,
         allow_async_handlers: bool = False,
     ) -> None:
+        """Validate and assemble a set of Flow definitions.
+
+        Args:
+            flows: Flow instances with unique Flow types.
+            codec_registry: Optional custom codecs; defaults to ``CodecRegistry()``.
+            allow_async_handlers: Accept ``async def`` Step and RPC handlers. Sync
+                Client/Worker construction leaves this ``False``; Async variants use
+                ``True``.
+
+        Raises:
+            FlowDefinitionError: If any Flow, Step, RPC, persistence definition,
+                annotation, codec, lock, or index is invalid.
+        """
         immutable_flows = tuple(flows)
         resolved_codecs = codec_registry or CodecRegistry()
         try:
@@ -519,6 +626,18 @@ class Registry:
 
     @staticmethod
     def physical_name(name: str, instance: str) -> str:
+        """Return the escaped physical name for a map definition instance.
+
+        Args:
+            name: The logical AttributeMap or ChannelMap name.
+            instance: The non-empty logical instance key.
+
+        Returns:
+            ``name`` followed by a slash and percent-encoded instance.
+
+        Raises:
+            ValueError: If ``instance`` is empty.
+        """
         require_name(instance)
         return f"{name}/{quote(instance, safe='')}"
 

--- a/sdk-python/dex/flow.py
+++ b/sdk-python/dex/flow.py
@@ -154,7 +154,7 @@ class PersistenceSchema:
             *definitions: Attribute, AttributeMap, Channel, or ChannelMap definitions.
 
         Returns:
-            An immutable schema preserving relative order within each category.
+            A schema with each category kept in argument order.
 
         Raises:
             TypeError: If a value is not a supported persistence definition.
@@ -190,7 +190,7 @@ class Flow(Generic[StartT], ABC):
         return type(self).__name__
 
     def get_steps(self) -> StepList[StartT]:
-        """Return the immutable Step definitions for this Flow.
+        """Return the Step definitions for this Flow.
 
         Returns:
             A StepList with zero or one starting Step and all reachable Steps.
@@ -253,7 +253,7 @@ class _RegisteredFlow:
 
 @dataclass(frozen=True)
 class Registry:
-    """Validate and store immutable Flow definitions shared by Client and Worker.
+    """Validate and store Flow definitions shared by Client and Worker.
 
     Registry construction inspects Step and RPC signatures, resolves codecs, checks
     names and locks, and assembles Attribute indexes atomically. The result is safe

--- a/sdk-python/dex/flow_config.py
+++ b/sdk-python/dex/flow_config.py
@@ -14,6 +14,15 @@ from dex.worker_options import WorkerTarget
 
 
 class ActiveStepSearchMode(Enum):
+    """Control which active Steps are included in Flow search indexing.
+
+    Attributes:
+        DEFAULT: Use the Dex server's current default policy.
+        ALL: Index every active Step.
+        WITH_WAIT_FOR: Index only active Steps that define ``wait_for``.
+        DISABLED: Do not index active Steps.
+    """
+
     DEFAULT = "default"
     ALL = "all"
     WITH_WAIT_FOR = "with_wait_for"
@@ -22,6 +31,21 @@ class ActiveStepSearchMode(Enum):
 
 @dataclass(frozen=True)
 class FlowConfig:
+    """Override server behavior for one Flow execution.
+
+    Every ``None`` field delegates to the registered or server default. Config may
+    be supplied at start time or replaced on an active Flow through the Client.
+
+    Attributes:
+        active_step_search_mode: Optional active-Step visibility indexing policy.
+        continue_as_new_threshold: Optional positive history-event threshold that
+            requests continue-as-new.
+        continue_as_new_page_size_bytes: Optional positive history page-size budget
+            in bytes used by continue-as-new decisions.
+        step_durability: Optional default durability for Step handlers.
+        worker_target: Optional Worker endpoint for subsequent handler dispatch.
+    """
+
     active_step_search_mode: ActiveStepSearchMode | None = None
     continue_as_new_threshold: int | None = None
     continue_as_new_page_size_bytes: int | None = None

--- a/sdk-python/dex/flow_config.py
+++ b/sdk-python/dex/flow_config.py
@@ -33,8 +33,8 @@ class ActiveStepSearchMode(Enum):
 class FlowConfig:
     """Override server behavior for one Flow execution.
 
-    Every ``None`` field delegates to the registered or server default. Config may
-    be supplied at start time or replaced on an active Flow through the Client.
+    Every ``None`` field uses the registered or server default. Config may be set
+    at start time or replaced on an active Flow through the Client.
 
     Attributes:
         active_step_search_mode: Optional active-Step visibility indexing policy.
@@ -43,7 +43,7 @@ class FlowConfig:
         continue_as_new_page_size_bytes: Optional positive history page-size budget
             in bytes used by continue-as-new decisions.
         step_durability: Optional default durability for Step handlers.
-        worker_target: Optional Worker endpoint for subsequent handler dispatch.
+        worker_target: Optional Worker endpoint for later handler calls.
     """
 
     active_step_search_mode: ActiveStepSearchMode | None = None

--- a/sdk-python/dex/flow_info.py
+++ b/sdk-python/dex/flow_info.py
@@ -15,6 +15,18 @@ from dex.codec import Value
 
 
 class FlowStatus(Enum):
+    """Describe the lifecycle state of a Flow run.
+
+    Attributes:
+        RUNNING: The Flow can still accept work and state changes.
+        COMPLETED: The Flow completed successfully.
+        FAILED: The Flow ended because application or worker processing failed.
+        CANCELED: The Flow cooperatively accepted a cancellation request.
+        TERMINATED: The Flow was forcibly terminated.
+        TIMED_OUT: The Flow exceeded its configured timeout.
+        CONTINUED_AS_NEW: This run rolled forward into a new run.
+    """
+
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
@@ -26,6 +38,16 @@ class FlowStatus(Enum):
 
 @dataclass(frozen=True)
 class FlowInfo:
+    """Summarize the current or latest run of one Flow ID.
+
+    Attributes:
+        flow_id: The stable application-assigned Flow ID.
+        run_id: The server-assigned run ID.
+        flow_type: The registered Flow type name.
+        status: The run's current lifecycle status.
+        started_at: The timezone-aware server start timestamp.
+    """
+
     flow_id: str
     run_id: str
     flow_type: str
@@ -35,6 +57,14 @@ class FlowInfo:
 
 @dataclass(frozen=True)
 class HealthInfo:
+    """Describe one FlowService health-check response.
+
+    Attributes:
+        condition: The service-reported health condition.
+        hostname: The hostname of the responding Dex server.
+        duration_seconds: The server-reported response duration in seconds.
+    """
+
     condition: str
     hostname: str
     duration_seconds: int
@@ -42,6 +72,18 @@ class HealthInfo:
 
 @dataclass(frozen=True)
 class SearchFlowEntry:
+    """Represent one indexed Flow run returned by ``search_flows``.
+
+    Attributes:
+        flow_id: The stable application-assigned Flow ID.
+        run_id: The server-assigned run ID for this result.
+        flow_type: The registered Flow type name.
+        status: The indexed run status.
+        started_at: The timezone-aware start timestamp.
+        closed_at: The close timestamp, or ``None`` for open or unknown runs.
+        indexed_attributes: Hydrated Values keyed by physical search-index name.
+    """
+
     flow_id: str
     run_id: str
     flow_type: str
@@ -53,5 +95,13 @@ class SearchFlowEntry:
 
 @dataclass(frozen=True)
 class SearchFlowsPage:
+    """Contain one server-ordered page of Flow search results.
+
+    Attributes:
+        flows: The result entries in server-defined query order.
+        next_page_token: An opaque token for the next request, or ``""`` on the
+            final page.
+    """
+
     flows: Sequence[SearchFlowEntry]
     next_page_token: str

--- a/sdk-python/dex/flow_options.py
+++ b/sdk-python/dex/flow_options.py
@@ -52,9 +52,8 @@ class _AttributeInitialization:
 class StartFlowOptions:
     """Configure creation of a new Flow execution.
 
-    Durations are :class:`datetime.timedelta` values. ``None`` delegates to the
-    registered Flow or server default. Use :meth:`with_attribute` to build immutable
-    initial Attribute writes.
+    Durations are :class:`datetime.timedelta` values. ``None`` uses the registered
+    Flow or server default. Use :meth:`with_attribute` to add initial Attribute writes.
 
     Attributes:
         timeout: Optional maximum lifetime of the Flow.
@@ -163,7 +162,7 @@ class ResetType(Enum):
 class ResetFlowOptions:
     """Configure creation of a new run from existing Flow history.
 
-    Exactly the selector corresponding to ``type`` should be supplied. The Client
+    Exactly one selector matching ``type`` must be set. The Client
     validates combinations before sending the request.
 
     Attributes:
@@ -194,7 +193,7 @@ class StopType(Enum):
     Attributes:
         CANCEL: Request cooperative cancellation.
         TERMINATE: Force immediate termination.
-        FAIL: Close the Flow as failed with the supplied reason.
+        FAIL: Close the Flow as failed with the reason in :class:`StopFlowOptions`.
     """
 
     CANCEL = "cancel"

--- a/sdk-python/dex/flow_options.py
+++ b/sdk-python/dex/flow_options.py
@@ -24,6 +24,16 @@ ValueT = TypeVar("ValueT")
 
 
 class IdReusePolicy(Enum):
+    """Control whether ``start_flow`` may reuse an existing Flow ID.
+
+    Attributes:
+        DEFAULT: Use the Dex server's default reuse policy.
+        ALLOW_IF_PREVIOUS_FAILED: Reuse only after an unsuccessful closed run.
+        ALLOW_IF_NOT_RUNNING: Reuse after any closed run.
+        ALLOW_TERMINATE_IF_RUNNING: Terminate an active run and start the new run.
+        DISALLOW: Reject every previously used Flow ID.
+    """
+
     DEFAULT = "default"
     ALLOW_IF_PREVIOUS_FAILED = "allow_if_previous_failed"
     ALLOW_IF_NOT_RUNNING = "allow_if_not_running"
@@ -40,6 +50,31 @@ class _AttributeInitialization:
 
 @dataclass(frozen=True)
 class StartFlowOptions:
+    """Configure creation of a new Flow execution.
+
+    Durations are :class:`datetime.timedelta` values. ``None`` delegates to the
+    registered Flow or server default. Use :meth:`with_attribute` to build immutable
+    initial Attribute writes.
+
+    Attributes:
+        timeout: Optional maximum lifetime of the Flow.
+        start_delay: Optional delay before the starting Step becomes eligible.
+        id_reuse_policy: Flow ID reuse policy; defaults to ``DEFAULT``.
+        cron_schedule: Optional server-supported cron expression for recurring runs.
+        retry_policy: Optional Flow-level retry policy.
+        config_override: Optional FlowConfig applied over registered defaults.
+        ignore_already_started: Return the existing run rather than raising
+            ``FlowAlreadyStartedError`` when supported by the server.
+        request_id: Optional non-empty idempotency key. ``None`` generates one.
+
+    Examples:
+        >>> options = (
+        ...     StartFlowOptions(timeout=timedelta(hours=1))
+        ...     .with_attribute(status, "pending")
+        ...     .with_attribute(balances, "merchant-7", 1200)
+        ... )
+    """
+
     timeout: timedelta | None = None
     start_delay: timedelta | None = None
     id_reuse_policy: IdReusePolicy = IdReusePolicy.DEFAULT
@@ -73,6 +108,22 @@ class StartFlowOptions:
         /,
         *args: object,
     ) -> StartFlowOptions:
+        """Return a copy with one initial Attribute value appended.
+
+        Singleton Attributes take ``(attribute, value)``; AttributeMaps take
+        ``(attribute, instance, value)``. Calls preserve initialization order.
+
+        Args:
+            attribute: A registered Attribute or AttributeMap definition.
+            *args: The value, or the AttributeMap instance followed by its value.
+
+        Returns:
+            A new options object containing the additional initialization.
+
+        Raises:
+            TypeError: If arguments do not match either supported form.
+            ValueError: If an AttributeMap instance is empty.
+        """
         if isinstance(attribute, Attribute) and len(args) == 1:
             initialization = _AttributeInitialization(attribute, None, args[0])
         elif isinstance(attribute, AttributeMap) and len(args) == 2:
@@ -91,6 +142,16 @@ class StartFlowOptions:
 
 
 class ResetType(Enum):
+    """Select the history point from which a Flow reset should resume.
+
+    Attributes:
+        BEGINNING: Restart from the beginning of the Flow.
+        HISTORY_EVENT_ID: Resume at a specific history event ID.
+        HISTORY_EVENT_TIME: Resume at the first event at or after a timestamp.
+        STEP_TYPE: Resume at the latest execution of a Step type.
+        STEP_EXECUTION_ID: Resume at one exact Step execution ID.
+    """
+
     BEGINNING = "beginning"
     HISTORY_EVENT_ID = "history_event_id"
     HISTORY_EVENT_TIME = "history_event_time"
@@ -100,6 +161,23 @@ class ResetType(Enum):
 
 @dataclass(frozen=True)
 class ResetFlowOptions:
+    """Configure creation of a new run from existing Flow history.
+
+    Exactly the selector corresponding to ``type`` should be supplied. The Client
+    validates combinations before sending the request.
+
+    Attributes:
+        type: The reset-point selector kind.
+        history_event_id: Event ID used by ``HISTORY_EVENT_ID``.
+        history_event_time: Timestamp used by ``HISTORY_EVENT_TIME``.
+        step_type: Registered Step type used by ``STEP_TYPE``.
+        step_execution_id: Exact execution ID used by ``STEP_EXECUTION_ID``.
+        reason: Optional operator-readable reset reason.
+        skip_channel_messages_reapply: Do not replay Channel publications after the
+            reset point.
+        skip_locking_rpc_reapply: Do not replay locking RPC effects after the point.
+    """
+
     type: ResetType
     history_event_id: int | None = None
     history_event_time: datetime | None = None
@@ -111,6 +189,14 @@ class ResetFlowOptions:
 
 
 class StopType(Enum):
+    """Select how an active Flow should close.
+
+    Attributes:
+        CANCEL: Request cooperative cancellation.
+        TERMINATE: Force immediate termination.
+        FAIL: Close the Flow as failed with the supplied reason.
+    """
+
     CANCEL = "cancel"
     TERMINATE = "terminate"
     FAIL = "fail"
@@ -118,5 +204,12 @@ class StopType(Enum):
 
 @dataclass(frozen=True)
 class StopFlowOptions:
+    """Configure a ``stop_flow`` request.
+
+    Attributes:
+        type: The stop behavior; defaults to cooperative cancellation.
+        reason: Optional operator-readable reason recorded by Dex.
+    """
+
     type: StopType = StopType.CANCEL
     reason: str | None = None

--- a/sdk-python/dex/runtime_errors.py
+++ b/sdk-python/dex/runtime_errors.py
@@ -24,7 +24,7 @@ class ErrorSubStatus(Enum):
     """Classify a FlowService error more precisely than its gRPC status.
 
     Attributes:
-        UNCATEGORIZED: No stable Dex-specific classification was supplied.
+        UNCATEGORIZED: Dex returned no specific classification.
         FLOW_ALREADY_STARTED: The requested Flow ID conflicts with an existing run.
         FLOW_NOT_EXISTS: No Flow with the requested ID exists.
         WORKER_API_ERROR: An application Worker rejected or failed an invocation.
@@ -143,7 +143,7 @@ class WorkerInvocationError(DexServiceError):
             detail: The outer service detail.
             operation: The Client operation name.
             flow_id: The targeted Flow ID, if any.
-            worker_code: The nested Worker gRPC status, if supplied.
+            worker_code: The nested Worker gRPC status, if available.
             worker_error_type: The nested application error type.
             worker_error_detail: The nested human-readable detail.
         """
@@ -237,7 +237,7 @@ class FlowUncompletedError(RuntimeError):
     Attributes:
         run_id: The terminal server-assigned run ID.
         status: The non-completed terminal Flow status.
-        error_type: The terminal failure category, if Dex supplied one.
+        error_type: The terminal failure category, if Dex returned one.
         results: The ordered, opaque Step completion outputs.
     """
 
@@ -255,7 +255,7 @@ class FlowUncompletedError(RuntimeError):
         Args:
             run_id: The terminal server-assigned run ID.
             status: The non-completed terminal status.
-            error_type: The failure category, if supplied.
+            error_type: The failure category, if available.
             message: Optional human-readable terminal message.
             results: Raw Step completion outputs in server order.
             values: The mapper used to decode outputs on demand.

--- a/sdk-python/dex/runtime_errors.py
+++ b/sdk-python/dex/runtime_errors.py
@@ -21,6 +21,16 @@ if TYPE_CHECKING:
 
 
 class ErrorSubStatus(Enum):
+    """Classify a FlowService error more precisely than its gRPC status.
+
+    Attributes:
+        UNCATEGORIZED: No stable Dex-specific classification was supplied.
+        FLOW_ALREADY_STARTED: The requested Flow ID conflicts with an existing run.
+        FLOW_NOT_EXISTS: No Flow with the requested ID exists.
+        WORKER_API_ERROR: An application Worker rejected or failed an invocation.
+        LONG_POLL_TIMEOUT: A wait ended without observing its condition.
+    """
+
     UNCATEGORIZED = "uncategorized"
     FLOW_ALREADY_STARTED = "flow_already_started"
     FLOW_NOT_EXISTS = "flow_not_exists"
@@ -29,6 +39,16 @@ class ErrorSubStatus(Enum):
 
 
 class FlowErrorType(Enum):
+    """Identify the terminal failure category reported for a Flow.
+
+    Attributes:
+        STEP_DECISION_FAILED: A Step decision could not be applied.
+        CLIENT_API_FAILED: A Client-originated operation failed the Flow.
+        WORKER_API_FAILED: A Worker handler or dispatch failed.
+        INVALID_USER_FLOW_CODE: Application Flow definitions or results were invalid.
+        INTERNAL: Dex encountered an internal invariant or infrastructure failure.
+    """
+
     STEP_DECISION_FAILED = "step_decision_failed"
     CLIENT_API_FAILED = "client_api_failed"
     WORKER_API_FAILED = "worker_api_failed"
@@ -37,6 +57,16 @@ class FlowErrorType(Enum):
 
 
 class DexServiceError(RuntimeError):
+    """Represent a structured error returned by a Dex FlowService operation.
+
+    Attributes:
+        code: The outer gRPC status code.
+        sub_status: The stable Dex-specific error classification.
+        detail: The human-readable service detail.
+        operation: The Client operation that failed.
+        flow_id: The targeted Flow ID, or ``None`` for service-wide calls.
+    """
+
     def __init__(
         self,
         code: grpc.StatusCode,
@@ -45,6 +75,15 @@ class DexServiceError(RuntimeError):
         operation: str,
         flow_id: str | None,
     ) -> None:
+        """Create a structured FlowService error.
+
+        Args:
+            code: The outer gRPC status code.
+            sub_status: The Dex-specific classification.
+            detail: Human-readable error detail.
+            operation: The Client operation name.
+            flow_id: The targeted Flow ID, if any.
+        """
         super().__init__(detail)
         self.code = code
         self.sub_status = sub_status
@@ -54,18 +93,37 @@ class DexServiceError(RuntimeError):
 
 
 class FlowAlreadyStartedError(DexServiceError):
+    """Indicate that ``start_flow`` conflicts with an existing Flow ID."""
+
     pass
 
 
 class FlowNotFoundError(DexServiceError):
+    """Indicate that an operation targeted a Flow ID that does not exist."""
+
     pass
 
 
 class FlowNotActiveError(DexServiceError):
+    """Indicate that an operation requires an active but already closed Flow."""
+
     pass
 
 
 class WorkerInvocationError(DexServiceError):
+    """Expose both FlowService and nested WorkerService failure details.
+
+    Attributes:
+        code: The outer FlowService gRPC status.
+        sub_status: Usually ``WORKER_API_ERROR``.
+        detail: The outer service detail.
+        operation: The Client operation that invoked the Worker.
+        flow_id: The targeted Flow ID, if available.
+        worker_code: The nested Worker gRPC status, or ``None`` when unavailable.
+        worker_error_type: The Worker-reported application error type.
+        worker_error_detail: The Worker-reported human-readable detail.
+    """
+
     def __init__(
         self,
         code: grpc.StatusCode,
@@ -77,6 +135,18 @@ class WorkerInvocationError(DexServiceError):
         worker_error_type: str,
         worker_error_detail: str,
     ) -> None:
+        """Create an error from outer and nested Worker failure metadata.
+
+        Args:
+            code: The outer FlowService gRPC status.
+            sub_status: The Dex-specific classification.
+            detail: The outer service detail.
+            operation: The Client operation name.
+            flow_id: The targeted Flow ID, if any.
+            worker_code: The nested Worker gRPC status, if supplied.
+            worker_error_type: The nested application error type.
+            worker_error_detail: The nested human-readable detail.
+        """
         super().__init__(code, sub_status, detail, operation, flow_id)
         self.worker_code = worker_code
         self.worker_error_type = worker_error_type
@@ -84,18 +154,33 @@ class WorkerInvocationError(DexServiceError):
 
 
 class RpcLockConflictError(DexServiceError):
+    """Indicate that an RPC could not acquire all requested Attribute locks."""
+
     pass
 
 
 class LongPollTimeoutError(DexServiceError):
+    """Indicate that a retryable long poll ended before its condition was observed."""
+
     pass
 
 
 class FlowDefinitionError(RuntimeError):
+    """Indicate that Registry construction found an invalid Flow definition."""
+
     pass
 
 
 class InvalidStepResultError(FlowDefinitionError):
+    """Identify a Step or RPC handler result that violates the SDK contract.
+
+    Attributes:
+        flow_type: The containing Flow type.
+        step_type: The Step type, or ``None`` for an RPC.
+        method: The handler method that returned the invalid value.
+        detail: A precise description of the contract violation.
+    """
+
     def __init__(
         self,
         flow_type: str,
@@ -103,6 +188,14 @@ class InvalidStepResultError(FlowDefinitionError):
         method: Literal["wait_for", "execute", "rpc"],
         detail: str,
     ) -> None:
+        """Create an invalid-result definition error.
+
+        Args:
+            flow_type: The containing Flow type.
+            step_type: The Step type, or ``None`` for an RPC.
+            method: ``"wait_for"``, ``"execute"``, or ``"rpc"``.
+            detail: A precise description of the invalid result.
+        """
         target = (
             f"Flow {flow_type} Step {step_type}"
             if step_type is not None
@@ -116,13 +209,38 @@ class InvalidStepResultError(FlowDefinitionError):
 
 
 class ValueMappingError(RuntimeError):
+    """Report an application-value encoding or decoding failure.
+
+    Attributes:
+        operation: The mapping operation, such as ``"encode"`` or ``"decode"``.
+        detail: The incompatible type, wire kind, or malformed payload detail.
+    """
+
     def __init__(self, operation: str, detail: str) -> None:
+        """Create a mapping error with stable operation context.
+
+        Args:
+            operation: The attempted mapping operation.
+            detail: The human-readable failure detail.
+        """
         super().__init__(f"Cannot {operation} Dex Value: {detail}")
         self.operation = operation
         self.detail = detail
 
 
 class FlowUncompletedError(RuntimeError):
+    """Report that ``wait_for_flow`` observed a non-successful terminal status.
+
+    Completed Step outputs remain available through :meth:`result` when the request
+    asked Dex to include them.
+
+    Attributes:
+        run_id: The terminal server-assigned run ID.
+        status: The non-completed terminal Flow status.
+        error_type: The terminal failure category, if Dex supplied one.
+        results: The ordered, opaque Step completion outputs.
+    """
+
     def __init__(
         self,
         run_id: str,
@@ -132,6 +250,16 @@ class FlowUncompletedError(RuntimeError):
         results: list[pb.StepCompletionOutput],
         values: ValueMapper,
     ) -> None:
+        """Create an uncompleted-Flow error with lazy result decoding.
+
+        Args:
+            run_id: The terminal server-assigned run ID.
+            status: The non-completed terminal status.
+            error_type: The failure category, if supplied.
+            message: Optional human-readable terminal message.
+            results: Raw Step completion outputs in server order.
+            values: The mapper used to decode outputs on demand.
+        """
         super().__init__(message)
         self.run_id = run_id
         self.status = status
@@ -140,5 +268,18 @@ class FlowUncompletedError(RuntimeError):
         self._values = values
 
     def result(self, index: int, result_type: type[Any]) -> Any:
+        """Decode one completed Step output by zero-based index.
+
+        Args:
+            index: The zero-based position in ``results``.
+            result_type: The Python type expected by the caller.
+
+        Returns:
+            The decoded Step output.
+
+        Raises:
+            IndexError: If ``index`` is outside the available results.
+            ValueMappingError: If the output cannot be decoded as ``result_type``.
+        """
         value = self.results[index].completed_step_output
         return self._values.decode(value, self._values.codec(result_type))

--- a/sdk-python/dex/step.py
+++ b/sdk-python/dex/step.py
@@ -55,7 +55,7 @@ class WaitForFailurePolicy(Enum):
 class RetryPolicy:
     """Configure exponential retries for a Step handler or Flow.
 
-    A ``None`` duration or zero numeric value delegates to the server default.
+    A ``None`` duration or zero numeric value uses the server default.
     Attempts include the initial call. Retries stop at the first configured limit.
 
     Attributes:
@@ -77,7 +77,7 @@ class RetryPolicy:
 class StepOptions:
     """Configure timeouts, retries, durability, locks, and failure routing for a Step.
 
-    Fields set to ``None`` or ``DEFAULT`` delegate to Flow or server policy. Attribute
+    Fields set to ``None`` or ``DEFAULT`` use Flow or server policy. Attribute
     locks are acquired separately for ``wait_for`` and ``execute`` and must reference
     definitions in the containing Flow's ``PersistenceSchema``.
 
@@ -150,7 +150,7 @@ class Step(Generic[InputT], ABC):
 
         Args:
             context: Execution metadata and decision-local persistence operations.
-            input: The decoded value supplied by the incoming Step movement.
+            input: The decoded value passed by the incoming Step movement.
 
         Returns:
             A StepDecision describing movements or Flow completion.
@@ -204,7 +204,7 @@ class _StepDef:
 
 @dataclass(frozen=True)
 class StepList(Generic[StartT]):
-    """Build the immutable ordered Step definitions for a Flow.
+    """Build the ordered Step definitions for a Flow.
 
     A Flow may have zero or one starting Step. Other Steps are reachable only through
     decisions, RPC results, or failure routing.
@@ -217,7 +217,7 @@ class StepList(Generic[StartT]):
         """Create a StepList with no starting or other Steps.
 
         Returns:
-            An empty immutable StepList.
+            An empty StepList.
         """
         return cls(())
 
@@ -252,7 +252,7 @@ class StepList(Generic[StartT]):
             *steps: Steps to append in registration order.
 
         Returns:
-            A new immutable StepList.
+            A new StepList.
         """
         return StepList(
             self._definitions + tuple(_StepDef(step, False) for step in steps)
@@ -262,7 +262,7 @@ class StepList(Generic[StartT]):
         """Iterate internal definitions in stable registration order.
 
         Returns:
-            An iterator over immutable Step definitions.
+            An iterator over the registered Step definitions.
         """
         return iter(self._definitions)
 
@@ -296,7 +296,7 @@ class StepMovement(Generic[InputT]):
             options: Optional per-movement options.
 
         Returns:
-            An immutable StepMovement.
+            A StepMovement.
         """
         return StepMovement(step, input, options)
 
@@ -354,7 +354,7 @@ def go_to_multi(*movements: StepMovement[Any]) -> StepDecision:
         *movements: Typed destination movements applied in argument order.
 
     Returns:
-        A next decision containing every supplied movement.
+        A next decision with all movements.
     """
     return StepDecision(DecisionKind.NEXT, movements=movements)
 

--- a/sdk-python/dex/step.py
+++ b/sdk-python/dex/step.py
@@ -26,18 +26,46 @@ StartT = TypeVar("StartT")
 
 
 class StepDurability(Enum):
+    """Control when a Step handler result is durably acknowledged.
+
+    Attributes:
+        DEFAULT: Use the Flow or server durability policy.
+        SYNC: Persist the result before acknowledging the Worker call.
+        ASYNC: Allow acknowledgement before persistence completes.
+    """
+
     DEFAULT = "default"
     SYNC = "sync"
     ASYNC = "async"
 
 
 class WaitForFailurePolicy(Enum):
+    """Control what Dex does when a Step's ``wait_for`` method fails.
+
+    Attributes:
+        FAIL_FLOW: Fail the Flow without invoking ``execute``.
+        PROCEED: Invoke ``execute`` and expose the failure through Context.
+    """
+
     FAIL_FLOW = "fail_flow"
     PROCEED = "proceed"
 
 
 @dataclass(frozen=True)
 class RetryPolicy:
+    """Configure exponential retries for a Step handler or Flow.
+
+    A ``None`` duration or zero numeric value delegates to the server default.
+    Attempts include the initial call. Retries stop at the first configured limit.
+
+    Attributes:
+        initial_interval: Delay before the first retry.
+        backoff_coefficient: Interval multiplier; zero uses the server default.
+        maximum_interval: Upper bound for one retry delay.
+        maximum_attempts: Total attempt limit; zero uses the server default.
+        total_duration: Overall elapsed-time limit for all attempts.
+    """
+
     initial_interval: timedelta | None = None
     backoff_coefficient: float = 0.0
     maximum_interval: timedelta | None = None
@@ -47,6 +75,24 @@ class RetryPolicy:
 
 @dataclass(frozen=True)
 class StepOptions:
+    """Configure timeouts, retries, durability, locks, and failure routing for a Step.
+
+    Fields set to ``None`` or ``DEFAULT`` delegate to Flow or server policy. Attribute
+    locks are acquired separately for ``wait_for`` and ``execute`` and must reference
+    definitions in the containing Flow's ``PersistenceSchema``.
+
+    Attributes:
+        wait_for_method_timeout: Maximum duration of one ``wait_for`` attempt.
+        execute_method_timeout: Maximum duration of one ``execute`` attempt.
+        wait_for_retry: Optional retry policy for ``wait_for``.
+        execute_retry: Optional retry policy for ``execute``.
+        wait_for_failure: Behavior after all ``wait_for`` attempts fail.
+        wait_for_durability: Durability used for the ``wait_for`` result.
+        execute_durability: Durability used for the ``execute`` result.
+        wait_for_lock_attributes: Attribute locks held during ``wait_for``.
+        execute_lock_attributes: Attribute locks held during ``execute``.
+    """
+
     wait_for_method_timeout: timedelta | None = None
     execute_method_timeout: timedelta | None = None
     wait_for_retry: RetryPolicy | None = None
@@ -64,6 +110,15 @@ class StepOptions:
         step: Step[Any],
         options: StepOptions | None = None,
     ) -> StepOptions:
+        """Return a copy that routes exhausted ``execute`` retries to another Step.
+
+        Args:
+            step: The registered fallback Step.
+            options: Optional options applied to the fallback movement.
+
+        Returns:
+            A new StepOptions object with failure routing configured.
+        """
         return replace(
             self,
             _execute_failure_target=step,
@@ -72,22 +127,72 @@ class StepOptions:
 
 
 class Step(Generic[InputT], ABC):
+    """Define one typed unit of durable Flow application logic.
+
+    Subclasses implement ``execute`` and may implement ``wait_for``. Handler methods
+    must remain deterministic with respect to their inputs and Context state; external
+    side effects belong behind idempotent application integrations.
+
+    Examples:
+        >>> class Charge(Step[ChargeInput]):
+        ...     def execute(self, context: Context, input: ChargeInput) -> StepDecision:
+        ...         status.set(context, "charged")
+        ...         return graceful_complete(input.order_id)
+    """
+
     @abstractmethod
     def execute(
         self,
         context: Context,
         input: InputT,
     ) -> StepDecision:
+        """Execute application logic and return the next durable decision.
+
+        Args:
+            context: Execution metadata and decision-local persistence operations.
+            input: The decoded value supplied by the incoming Step movement.
+
+        Returns:
+            A StepDecision describing movements or Flow completion.
+
+        Raises:
+            Exception: Application exceptions are retried according to StepOptions
+                and may ultimately fail or reroute the Flow.
+        """
         raise NotImplementedError
 
     def wait_for(self, context: Context, input: InputT) -> Wait:
+        """Describe durable conditions that must be ready before ``execute``.
+
+        Override this method only when the Step waits. Dex skips the base
+        implementation and invokes ``execute`` immediately.
+
+        Args:
+            context: Execution metadata and decision-local persistence operations.
+            input: The same decoded input later passed to ``execute``.
+
+        Returns:
+            A durable Wait condition tree.
+        """
         del context, input
         raise RuntimeError("framework must skip the default wait_for")
 
     def get_step_type(self) -> str:
+        """Return the name used to register and address this Step.
+
+        Override it to decouple the protocol Step type from the Python class name.
+
+        Returns:
+            A non-empty name unique within the containing Flow.
+        """
         return type(self).__name__
 
     def get_step_options(self) -> StepOptions | None:
+        """Return this Step's static execution options.
+
+        Returns:
+            Step-specific options, or ``None`` to use Flow and server defaults.
+        """
         return None
 
 
@@ -99,31 +204,79 @@ class _StepDef:
 
 @dataclass(frozen=True)
 class StepList(Generic[StartT]):
+    """Build the immutable ordered Step definitions for a Flow.
+
+    A Flow may have zero or one starting Step. Other Steps are reachable only through
+    decisions, RPC results, or failure routing.
+    """
+
     _definitions: tuple[_StepDef, ...]
 
     @classmethod
     def empty(cls) -> StepList[StartT]:
+        """Create a StepList with no starting or other Steps.
+
+        Returns:
+            An empty immutable StepList.
+        """
         return cls(())
 
     @staticmethod
     def start_step(step: Step[StartT]) -> StepList[StartT]:
+        """Create a StepList whose first definition is the Flow starting Step.
+
+        Args:
+            step: The Step receiving ``start_flow`` input.
+
+        Returns:
+            A StepList with exactly one starting Step.
+        """
         return StepList((_StepDef(step, True),))
 
     @classmethod
     def without_start_step(cls, *steps: Step[Any]) -> StepList[StartT]:
+        """Create a StepList with only non-starting Steps.
+
+        Args:
+            *steps: Registered Steps reachable through other entry paths.
+
+        Returns:
+            A StepList that requires ``None`` start input.
+        """
         return cls(tuple(_StepDef(step, False) for step in steps))
 
     def other_steps(self, *steps: Step[Any]) -> StepList[StartT]:
+        """Return a copy with additional non-starting Steps appended.
+
+        Args:
+            *steps: Steps to append in registration order.
+
+        Returns:
+            A new immutable StepList.
+        """
         return StepList(
             self._definitions + tuple(_StepDef(step, False) for step in steps)
         )
 
     def __iter__(self) -> Iterator[_StepDef]:
+        """Iterate internal definitions in stable registration order.
+
+        Returns:
+            An iterator over immutable Step definitions.
+        """
         return iter(self._definitions)
 
 
 @dataclass(frozen=True)
 class StepMovement(Generic[InputT]):
+    """Schedule one registered Step with typed input and optional options.
+
+    Attributes:
+        step: The destination Step instance from the containing Registry.
+        input: The value decoded by the destination Step's input codec.
+        options: Optional per-movement StepOptions override.
+    """
+
     step: Step[InputT]
     input: InputT
     options: StepOptions | None = None
@@ -135,6 +288,16 @@ class StepMovement(Generic[InputT]):
         *,
         options: StepOptions | None = None,
     ) -> StepMovement[InputT]:
+        """Create a typed movement to a Step.
+
+        Args:
+            step: The registered destination Step.
+            input: A value compatible with the Step's input annotation.
+            options: Optional per-movement options.
+
+        Returns:
+            An immutable StepMovement.
+        """
         return StepMovement(step, input, options)
 
 
@@ -149,6 +312,20 @@ class DecisionKind(Enum):
 
 @dataclass(frozen=True)
 class StepDecision:
+    """Describe the durable state transition returned by ``Step.execute``.
+
+    Prefer the module-level factory functions instead of constructing this class
+    directly; they populate the fields required for each decision kind.
+
+    Attributes:
+        kind: The transition behavior interpreted by Dex.
+        movements: Destination Steps for a next decision.
+        output: Optional Flow completion value.
+        reason: Human-readable force-failure reason.
+        empty_channels: Channels that must be empty for conditional completion.
+        fallback: Movement used when conditional completion cannot proceed.
+    """
+
     kind: DecisionKind
     movements: tuple[StepMovement[Any], ...] = ()
     output: object | None = None
@@ -158,18 +335,51 @@ class StepDecision:
 
 
 def go_to(step: Step[InputT], input: InputT) -> StepDecision:
+    """Create a decision that schedules one next Step.
+
+    Args:
+        step: The registered destination Step.
+        input: A value compatible with the destination input annotation.
+
+    Returns:
+        A next decision containing one StepMovement.
+    """
     return go_to_multi(StepMovement.of(step, input))
 
 
 def go_to_multi(*movements: StepMovement[Any]) -> StepDecision:
+    """Create a decision that schedules several next Steps.
+
+    Args:
+        *movements: Typed destination movements applied in argument order.
+
+    Returns:
+        A next decision containing every supplied movement.
+    """
     return StepDecision(DecisionKind.NEXT, movements=movements)
 
 
 def graceful_complete(output: object | None = None) -> StepDecision:
+    """Request successful completion after already-scheduled Steps finish.
+
+    Args:
+        output: Optional codec-supported Flow result.
+
+    Returns:
+        A graceful-completion decision.
+    """
     return StepDecision(DecisionKind.GRACEFUL_COMPLETE, output=output)
 
 
 def force_complete(output: object | None = None) -> StepDecision:
+    """Request immediate successful completion of the Flow.
+
+    Args:
+        output: Optional codec-supported Flow result.
+
+    Returns:
+        A force-completion decision that does not await other active Steps.
+    """
     return StepDecision(DecisionKind.FORCE_COMPLETE, output=output)
 
 
@@ -178,6 +388,16 @@ def force_complete_when_channels_empty(
     fallback: StepMovement[Any],
     *channels: Channel[Any] | ChannelMap[Any],
 ) -> StepDecision:
+    """Complete only when selected Channels are empty, otherwise schedule fallback.
+
+    Args:
+        output: The codec-supported completion result.
+        fallback: Movement scheduled when any selected Channel is non-empty.
+        *channels: Registered Channel or ChannelMap definitions to inspect.
+
+    Returns:
+        A conditional force-completion decision.
+    """
     return StepDecision(
         DecisionKind.FORCE_COMPLETE_IF_CHANNELS_EMPTY,
         output=output,
@@ -187,8 +407,21 @@ def force_complete_when_channels_empty(
 
 
 def force_fail(reason: str) -> StepDecision:
+    """Request immediate Flow failure with an application reason.
+
+    Args:
+        reason: Non-empty human-readable failure detail.
+
+    Returns:
+        A force-failure decision.
+    """
     return StepDecision(DecisionKind.FORCE_FAIL, reason=reason)
 
 
 def dead_end() -> StepDecision:
+    """End this execution path without scheduling work or closing the Flow.
+
+    Returns:
+        A dead-end decision; other active paths may continue.
+    """
     return StepDecision(DecisionKind.DEAD_END)

--- a/sdk-python/dex/step_execution.py
+++ b/sdk-python/dex/step_execution.py
@@ -17,12 +17,29 @@ from dex._utils import require_name
 
 @dataclass(frozen=True)
 class StepExecutionId:
+    """Identify one numbered execution of a Step type.
+
+    Attributes:
+        step_type: The registered Step type name.
+        number: The positive execution number; defaults to the first execution.
+    """
+
     step_type: str
     number: int = 1
 
 
 @dataclass(frozen=True)
 class TimerId:
+    """Select a Timer condition within a Step execution.
+
+    Exactly one selector must be set. Prefer ``condition_id`` for definitions that
+    can evolve; ``condition_index`` is zero-based and follows flattened Wait order.
+
+    Attributes:
+        condition_id: A stable Timer condition identifier, or ``None``.
+        condition_index: A zero-based Timer condition index, or ``None``.
+    """
+
     condition_id: str | None = None
     condition_index: int | None = None
 
@@ -34,9 +51,28 @@ class TimerId:
 
     @staticmethod
     def by_condition_id(condition_id: str) -> TimerId:
+        """Select a Timer by its stable condition ID.
+
+        Args:
+            condition_id: The non-empty ID assigned by ``Timer.by_duration``.
+
+        Returns:
+            A TimerId using the ID selector.
+        """
         require_name(condition_id)
         return TimerId(condition_id=condition_id)
 
     @staticmethod
     def by_condition_index(condition_index: int) -> TimerId:
+        """Select a Timer by zero-based Wait-tree position.
+
+        Args:
+            condition_index: The non-negative flattened Timer index.
+
+        Returns:
+            A TimerId using the index selector.
+
+        Raises:
+            ValueError: If ``condition_index`` is negative.
+        """
         return TimerId(condition_index=condition_index)

--- a/sdk-python/dex/timer.py
+++ b/sdk-python/dex/timer.py
@@ -12,10 +12,33 @@ from dex.condition import Condition, TimerCondition
 
 
 class Timer:
+    """Create durable Timer conditions for Step waits.
+
+    Timer conditions measure durable workflow time rather than blocking a Python
+    worker thread. Use a stable ``condition_id`` when external code may skip the
+    Timer by ID.
+    """
+
     @staticmethod
     def by_duration(
         duration: timedelta,
         *,
         condition_id: str | None = None,
     ) -> Condition:
+        """Create a Timer that becomes ready after ``duration``.
+
+        Args:
+            duration: A non-negative delay measured from the wait's start.
+            condition_id: Optional stable identifier unique within the Wait tree.
+
+        Returns:
+            A durable Timer condition accepted by :class:`Wait`.
+
+        Raises:
+            ValueError: If ``duration`` is negative or the identifier is invalid.
+
+        Examples:
+            >>> reminder = Timer.by_duration(timedelta(minutes=15), condition_id="remind")
+            >>> wait = Wait.until(reminder)
+        """
         return TimerCondition(condition_id=condition_id, duration=duration)

--- a/sdk-python/dex/wait.py
+++ b/sdk-python/dex/wait.py
@@ -25,28 +25,83 @@ class WaitKind(Enum):
 
 @dataclass(frozen=True)
 class Wait:
+    """Describe the durable conditions evaluated before a Step executes.
+
+    A Step returns a Wait from ``wait_for``. Dex persists the condition tree and
+    invokes ``execute`` only when the selected readiness rule succeeds.
+
+    Attributes:
+        kind: The combination rule applied by Dex.
+        conditions: Direct Conditions for all-of or any-of waits.
+        combinations: Alternative all-of groups for any-combination waits.
+
+    Examples:
+        >>> wait = Wait.any_of(
+        ...     replies.for_one(condition_id="reply"),
+        ...     Timer.by_duration(timedelta(hours=1), condition_id="timeout"),
+        ... )
+    """
+
     kind: WaitKind
     conditions: tuple[Condition, ...] = ()
     combinations: tuple[ConditionCombination, ...] = ()
 
     @staticmethod
     def skip_immediately() -> Wait:
+        """Create a Wait that proceeds to ``execute`` immediately.
+
+        Returns:
+            A Wait with no Conditions.
+        """
         return Wait(WaitKind.SKIP_IMMEDIATELY)
 
     @staticmethod
     def until(condition: Condition) -> Wait:
+        """Create a Wait for one Condition.
+
+        Args:
+            condition: The sole readiness condition.
+
+        Returns:
+            An all-of Wait containing ``condition``.
+        """
         return Wait.all_of(condition)
 
     @staticmethod
     def all_of(*conditions: Condition) -> Wait:
+        """Create a Wait that requires every supplied Condition.
+
+        Args:
+            *conditions: Conditions evaluated as one all-of group.
+
+        Returns:
+            An immutable all-of Wait preserving argument order.
+        """
         return Wait(WaitKind.ALL_OF, conditions)
 
     @staticmethod
     def any_of(*conditions: Condition) -> Wait:
+        """Create a Wait that proceeds when any supplied Condition is ready.
+
+        Args:
+            *conditions: Alternative readiness Conditions.
+
+        Returns:
+            An immutable any-of Wait preserving argument order.
+        """
         return Wait(WaitKind.ANY_OF, conditions)
 
     @staticmethod
     def any_combination_of(*combinations: ConditionCombination) -> Wait:
+        """Create a Wait that accepts any complete Condition combination.
+
+        Args:
+            *combinations: Alternative all-of groups created with
+                :meth:`ConditionCombination.of`.
+
+        Returns:
+            An immutable Wait containing the alternative groups.
+        """
         return Wait(
             WaitKind.ANY_COMBINATION_OF,
             combinations=combinations,

--- a/sdk-python/dex/wait.py
+++ b/sdk-python/dex/wait.py
@@ -60,34 +60,34 @@ class Wait:
         """Create a Wait for one Condition.
 
         Args:
-            condition: The sole readiness condition.
+            condition: The only readiness condition.
 
         Returns:
-            An all-of Wait containing ``condition``.
+            An all-of Wait with ``condition``.
         """
         return Wait.all_of(condition)
 
     @staticmethod
     def all_of(*conditions: Condition) -> Wait:
-        """Create a Wait that requires every supplied Condition.
+        """Create a Wait that requires every Condition.
 
         Args:
             *conditions: Conditions evaluated as one all-of group.
 
         Returns:
-            An immutable all-of Wait preserving argument order.
+            An all-of Wait with Conditions in argument order.
         """
         return Wait(WaitKind.ALL_OF, conditions)
 
     @staticmethod
     def any_of(*conditions: Condition) -> Wait:
-        """Create a Wait that proceeds when any supplied Condition is ready.
+        """Create a Wait that continues when any Condition is ready.
 
         Args:
             *conditions: Alternative readiness Conditions.
 
         Returns:
-            An immutable any-of Wait preserving argument order.
+            An any-of Wait with Conditions in argument order.
         """
         return Wait(WaitKind.ANY_OF, conditions)
 
@@ -100,7 +100,7 @@ class Wait:
                 :meth:`ConditionCombination.of`.
 
         Returns:
-            An immutable Wait containing the alternative groups.
+            A Wait containing the alternative groups.
         """
         return Wait(
             WaitKind.ANY_COMBINATION_OF,

--- a/sdk-python/dex/worker.py
+++ b/sdk-python/dex/worker.py
@@ -29,12 +29,42 @@ from dex.worker_options import WorkerOptions, WorkerTarget
 
 
 class Worker:
+    """Host synchronous registered Step and RPC handlers over WorkerService.
+
+    A Worker is one-shot. Call ``start`` on a dedicated thread because it blocks,
+    then call ``stop`` or ``close`` during shutdown. Handlers run concurrently in a
+    bounded thread pool and must synchronize shared application state.
+
+    Attributes:
+        registry: The immutable Flow Registry served by this Worker.
+        blob_cache: The shared cache used to hydrate large values.
+        options: The effective WorkerOptions.
+
+    Examples:
+        >>> worker = Worker(registry, cache)
+        >>> thread = threading.Thread(target=worker.start, daemon=True)
+        >>> thread.start()
+        >>> worker.worker_target.address
+        'localhost:8803'
+        >>> worker.stop()
+    """
+
     def __init__(
         self,
         registry: Registry,
         blob_cache: BlobCache,
         options: WorkerOptions | None = None,
     ) -> None:
+        """Construct a Worker without starting its listener.
+
+        Args:
+            registry: A Registry created for synchronous handlers.
+            blob_cache: An open cache shared for value hydration.
+            options: Networking and startup options; ``None`` uses defaults.
+
+        Raises:
+            ValueError: If a configured target or bind address is malformed.
+        """
         self.registry = registry
         self.blob_cache = blob_cache
         self.options = options or WorkerOptions()
@@ -69,10 +99,25 @@ class Worker:
         )
 
     def __enter__(self) -> Worker:
+        """Return this Worker for synchronous context-manager use.
+
+        Entering does not call ``start``.
+
+        Returns:
+            This Worker instance.
+        """
         return self
 
     @property
     def worker_target(self) -> WorkerTarget:
+        """Return the effective endpoint advertised to Dex.
+
+        Before ``start``, an ephemeral bind port may not yet be resolved. After
+        binding, the property contains the actual selected port.
+
+        Returns:
+            The immutable advertised WorkerTarget.
+        """
         return self._worker_target
 
     def __exit__(
@@ -81,9 +126,25 @@ class Worker:
         exception: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
+        """Close the Worker when leaving a context-manager block.
+
+        Args:
+            exception_type: The active exception type, if any.
+            exception: The active exception value, if any.
+            traceback: The active traceback, if any.
+        """
         self.close()
 
     def start(self) -> None:
+        """Synchronize Attribute indexes, serve WorkerService, and block.
+
+        ``start`` may be called exactly once. It first contacts FlowService using the
+        configured synchronization timeout, then binds the listener and waits until
+        ``stop`` shuts the server down.
+
+        Raises:
+            RuntimeError: If lifecycle state, index synchronization, or binding fails.
+        """
         with self._lock:
             if self._state != "created":
                 raise RuntimeError(f"Worker cannot start from state {self._state}")
@@ -116,6 +177,11 @@ class Worker:
         self._server.wait_for_termination()
 
     def stop(self) -> None:
+        """Drain handlers for five seconds and release Worker resources.
+
+        Calls before ``start`` and repeated calls after shutdown are safe. Remaining
+        handler futures are canceled after the gRPC grace period.
+        """
         with self._lock:
             if self._state in ("stopped", "closed"):
                 return
@@ -128,6 +194,10 @@ class Worker:
                 self._state = "stopped"
 
     def close(self) -> None:
+        """Stop the Worker and permanently mark it closed.
+
+        ``close`` is idempotent; a closed Worker cannot be started again.
+        """
         self.stop()
         with self._lock:
             self._state = "closed"

--- a/sdk-python/dex/worker.py
+++ b/sdk-python/dex/worker.py
@@ -36,7 +36,7 @@ class Worker:
     bounded thread pool and must synchronize shared application state.
 
     Attributes:
-        registry: The immutable Flow Registry served by this Worker.
+        registry: The Flow Registry served by this Worker.
         blob_cache: The shared cache used to hydrate large values.
         options: The effective WorkerOptions.
 
@@ -116,7 +116,7 @@ class Worker:
         binding, the property contains the actual selected port.
 
         Returns:
-            The immutable advertised WorkerTarget.
+            The advertised WorkerTarget.
         """
         return self._worker_target
 

--- a/sdk-python/dex/worker_options.py
+++ b/sdk-python/dex/worker_options.py
@@ -12,6 +12,14 @@ from datetime import timedelta
 
 @dataclass(frozen=True)
 class WorkerTarget:
+    """Identify the application Worker endpoint advertised to Dex.
+
+    Attributes:
+        address: A plaintext gRPC target. Headless targets must use ``host:port``.
+        headless: Whether Dex should connect directly without service discovery.
+            Defaults to ``False``.
+    """
+
     address: str
     headless: bool = False
 
@@ -22,6 +30,16 @@ class WorkerOptions:
 
     ``attribute_index_sync_timeout`` is the RPC deadline used before the Worker
     opens its listener. It defaults to two minutes and must be positive.
+
+    Attributes:
+        bind_address: The local plaintext WorkerService listener in ``host:port``
+            form. Defaults to ``":8803"``.
+        worker_target: The endpoint advertised to Dex. ``None`` derives an address
+            from ``bind_address``.
+        server_address: The Dex FlowService target used for startup synchronization
+            and blob hydration. Defaults to ``"localhost:8801"``.
+        attribute_index_sync_timeout: Maximum duration for startup Attribute index
+            synchronization. Defaults to two minutes and must be positive.
     """
 
     bind_address: str = ":8803"

--- a/sdk-python/scripts/check_public_docs.py
+++ b/sdk-python/scripts/check_public_docs.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Super Durable Source License 1.0.
+# You may not use this file except in compliance with the License.
+# See the LICENSE file in the repository root.
+#
+# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PACKAGE = Path("dex")
+PUBLIC_DUNDERS = {
+    "__aenter__",
+    "__aexit__",
+    "__call__",
+    "__enter__",
+    "__exit__",
+    "__init__",
+    "__iter__",
+    "__next__",
+}
+
+
+@dataclass(frozen=True)
+class Issue:
+    path: Path
+    line: int
+    message: str
+
+
+@dataclass(frozen=True)
+class Definition:
+    path: Path
+    source: str
+    node: ast.AST
+
+
+def main() -> int:
+    issues = inspect_public_api()
+    for issue in issues:
+        print(f"{issue.path}:{issue.line}: {issue.message}", file=sys.stderr)
+    if issues:
+        print(
+            f"public API documentation check failed with {len(issues)} issue(s)",
+            file=sys.stderr,
+        )
+        return 1
+    print("all hand-written Python SDK public APIs are documented")
+    return 0
+
+
+def inspect_public_api() -> list[Issue]:
+    init_path = PACKAGE / "__init__.py"
+    init_source = init_path.read_text(encoding="utf-8")
+    init_tree = ast.parse(init_source, filename=str(init_path))
+    exports = exported_names(init_tree)
+    definitions = imported_definitions(init_tree)
+    issues: list[Issue] = []
+    for name in sorted(exports):
+        definition = definitions.get(name)
+        if definition is None:
+            issues.append(Issue(init_path, 1, f"cannot resolve exported API {name}"))
+            continue
+        issues.extend(inspect_definition(name, definition))
+    return issues
+
+
+def exported_names(tree: ast.Module) -> set[str]:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "__all__"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, (ast.List, ast.Tuple)):
+            raise ValueError("dex.__all__ must be a literal list or tuple")
+        return {
+            element.value
+            for element in node.value.elts
+            if isinstance(element, ast.Constant) and isinstance(element.value, str)
+        }
+    raise ValueError("dex.__all__ is required")
+
+
+def imported_definitions(tree: ast.Module) -> dict[str, Definition]:
+    definitions: dict[str, Definition] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.ImportFrom) or node.module is None:
+            continue
+        module_path = Path(*node.module.split("."))
+        path = module_path.with_suffix(".py")
+        if not path.exists():
+            path = module_path.with_suffix(".pyi")
+        source = path.read_text(encoding="utf-8")
+        module_tree = ast.parse(source, filename=str(path))
+        module_definitions = definitions_by_name(module_tree)
+        for imported in node.names:
+            exported_name = imported.asname or imported.name
+            definition = module_definitions.get(imported.name)
+            if definition is not None:
+                definitions[exported_name] = Definition(path, source, definition)
+    return definitions
+
+
+def definitions_by_name(tree: ast.Module) -> dict[str, ast.AST]:
+    definitions: dict[str, ast.AST] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            definitions[node.name] = node
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    definitions[target.id] = node
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            definitions[node.target.id] = node
+    return definitions
+
+
+def inspect_definition(name: str, definition: Definition) -> list[Issue]:
+    node = definition.node
+    if isinstance(node, ast.ClassDef):
+        return inspect_class(definition)
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return inspect_function(definition.path, node)
+    if isinstance(node, (ast.Assign, ast.AnnAssign)):
+        if has_sphinx_attribute_doc(definition.source, node.lineno):
+            return []
+        return [
+            Issue(
+                definition.path,
+                node.lineno,
+                f"exported constant {name} needs a preceding '#:' documentation comment",
+            )
+        ]
+    return [Issue(definition.path, node.lineno, f"unsupported exported API {name}")]
+
+
+def inspect_class(definition: Definition) -> list[Issue]:
+    node = definition.node
+    assert isinstance(node, ast.ClassDef)
+    issues = require_docstring(definition.path, node, f"class {node.name}")
+    class_doc = ast.get_docstring(node, clean=True) or ""
+    for member in node.body:
+        if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if is_documented_public_method(member):
+                issues.extend(inspect_function(definition.path, member))
+        elif isinstance(member, (ast.Assign, ast.AnnAssign)):
+            for field_name in assignment_names(member):
+                if field_name.startswith("_"):
+                    continue
+                if not documents_attribute(class_doc, field_name):
+                    issues.append(
+                        Issue(
+                            definition.path,
+                            member.lineno,
+                            f"class {node.name} docstring must document attribute {field_name}",
+                        )
+                    )
+    for field_name, line in instance_attribute_names(node).items():
+        if not documents_attribute(class_doc, field_name):
+            issues.append(
+                Issue(
+                    definition.path,
+                    line,
+                    f"class {node.name} docstring must document attribute {field_name}",
+                )
+            )
+    return issues
+
+
+def inspect_function(
+    path: Path,
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[Issue]:
+    if has_decorator(node, "overload"):
+        return []
+    label = f"method {node.name}" if node.col_offset else f"function {node.name}"
+    issues = require_docstring(path, node, label)
+    doc = ast.get_docstring(node, clean=True)
+    if doc is None:
+        return issues
+    for argument in documented_arguments(node):
+        if not documents_argument(doc, argument):
+            issues.append(
+                Issue(
+                    path,
+                    node.lineno,
+                    f"{label} docstring must document argument {argument}",
+                )
+            )
+    if returns_value(node) and not has_section(doc, "Returns"):
+        issues.append(
+            Issue(
+                path, node.lineno, f"{label} docstring must include a Returns section"
+            )
+        )
+    return issues
+
+
+def require_docstring(
+    path: Path,
+    node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef,
+    label: str,
+) -> list[Issue]:
+    doc = ast.get_docstring(node, clean=True)
+    if doc is None:
+        return [Issue(path, node.lineno, f"exported {label} has no docstring")]
+    summary = next((line.strip() for line in doc.splitlines() if line.strip()), "")
+    if not summary.endswith((".", "!", "?")):
+        return [Issue(path, node.lineno, f"{label} summary must end with punctuation")]
+    return []
+
+
+def is_documented_public_method(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    return not node.name.startswith("_") or node.name in PUBLIC_DUNDERS
+
+
+def documented_arguments(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    arguments = [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]
+    names = [
+        argument.arg for argument in arguments if argument.arg not in {"self", "cls"}
+    ]
+    if node.args.vararg is not None:
+        names.append(node.args.vararg.arg)
+    if node.args.kwarg is not None:
+        names.append(node.args.kwarg.arg)
+    return names
+
+
+def documents_argument(doc: str, name: str) -> bool:
+    return (
+        re.search(
+            rf"^\s{{4,}}\*{{0,2}}{re.escape(name)}(?:\s*\([^)]*\))?:\s+\S",
+            doc,
+            re.MULTILINE,
+        )
+        is not None
+    )
+
+
+def documents_attribute(doc: str, name: str) -> bool:
+    return (
+        re.search(
+            rf"^\s{{4,}}{re.escape(name)}(?:\s*\([^)]*\))?:\s+\S", doc, re.MULTILINE
+        )
+        is not None
+    )
+
+
+def has_section(doc: str, name: str) -> bool:
+    return re.search(rf"^{re.escape(name)}:\s*$", doc, re.MULTILINE) is not None
+
+
+def returns_value(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    if node.name in {"__init__", "__exit__", "__aexit__"}:
+        return False
+    annotation = node.returns
+    if annotation is None:
+        return False
+    return ast.unparse(annotation) not in {"None", "NoReturn", "Never"}
+
+
+def assignment_names(node: ast.Assign | ast.AnnAssign) -> list[str]:
+    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+    return [target.id for target in targets if isinstance(target, ast.Name)]
+
+
+def instance_attribute_names(node: ast.ClassDef) -> dict[str, int]:
+    attributes: dict[str, int] = {}
+    for member in node.body:
+        if not isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for descendant in ast.walk(member):
+            targets: list[ast.expr] = []
+            if isinstance(descendant, ast.Assign):
+                targets.extend(descendant.targets)
+            elif isinstance(descendant, ast.AnnAssign):
+                targets.append(descendant.target)
+            for target in targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                    and not target.attr.startswith("_")
+                ):
+                    attributes.setdefault(target.attr, descendant.lineno)
+    return attributes
+
+
+def has_sphinx_attribute_doc(source: str, line: int) -> bool:
+    lines = source.splitlines()
+    index = line - 2
+    while index >= 0 and not lines[index].strip():
+        index -= 1
+    return index >= 0 and lines[index].lstrip().startswith("#:")
+
+
+def has_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef, name: str) -> bool:
+    return any(
+        (isinstance(decorator, ast.Name) and decorator.id == name)
+        or (isinstance(decorator, ast.Attribute) and decorator.attr == name)
+        for decorator in node.decorator_list
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk-rust/Makefile
+++ b/sdk-rust/Makefile
@@ -1,4 +1,8 @@
-.PHONY: fmt integration-test lint test
+.PHONY: docs-check fmt integration-test lint test
+
+docs-check:
+	RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps -p dex-sdk -p dex-blob-cache
+	cargo test --locked -p dex-sdk -p dex-blob-cache --doc
 
 fmt:
 	cargo fmt --all --check

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -138,7 +138,14 @@ Format and test the workspace:
 make fmt
 make lint
 make test
+make docs-check
 ```
+
+`docs-check` denies missing rustdoc and rustdoc warnings for the hand-written
+`dex-sdk` and `dex-blob-cache` public APIs, then compiles every documentation
+example as a doctest. Generated protocol and language-binding crates are not
+part of that public SDK surface. Generated HTML starts at
+`target/doc/dex_sdk/index.html` and `target/doc/dex_blob_cache/index.html`.
 
 Run the SDK integration suite against a fresh local `dexcli dev` stack:
 

--- a/sdk-rust/crates/dex-blob-cache/src/config.rs
+++ b/sdk-rust/crates/dex-blob-cache/src/config.rs
@@ -14,6 +14,11 @@ pub(crate) const MAX_BLOB_ID_BYTES: usize = 1 << 20;
 const DEFAULT_FREQUENCY_COUNTERS: i64 = 10_000;
 
 #[derive(Clone, Debug)]
+/// Configures one persistent [`crate::BlobCache`].
+///
+/// The directory contains cache-owned files and must not be shared with unrelated data. The byte
+/// limit bounds admitted payloads. Frequency counters tune admission accuracy; pass `0` to use the
+/// default of 10,000.
 pub struct BlobCacheConfig {
     directory: PathBuf,
     max_bytes: i64,
@@ -21,6 +26,29 @@ pub struct BlobCacheConfig {
 }
 
 impl BlobCacheConfig {
+    /// Validates and creates a cache configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `directory` - Cache-owned filesystem directory.
+    /// * `max_bytes` - Positive maximum number of payload bytes admitted to the cache.
+    /// * `frequency_counters` - Admission-policy counters, or `0` for the 10,000 default.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BlobCacheError::InvalidConfig`] when the directory is empty, the byte limit is not
+    /// positive, the counter count is negative, or the count cannot fit in [`usize`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dex_blob_cache::BlobCacheConfig;
+    ///
+    /// let config = BlobCacheConfig::new("/tmp/dex-blobs", 64 * 1024 * 1024, 0)?;
+    /// assert_eq!(config.max_bytes(), 64 * 1024 * 1024);
+    /// assert_eq!(config.frequency_counters(), 10_000);
+    /// # Ok::<(), dex_blob_cache::BlobCacheError>(())
+    /// ```
     pub fn new(
         directory: impl Into<PathBuf>,
         max_bytes: i64,
@@ -58,14 +86,17 @@ impl BlobCacheConfig {
         })
     }
 
+    /// Returns the cache-owned filesystem directory.
     pub fn directory(&self) -> &Path {
         &self.directory
     }
 
+    /// Returns the maximum admitted payload bytes.
     pub fn max_bytes(&self) -> i64 {
         self.max_bytes
     }
 
+    /// Returns the admission-policy frequency counter count.
     pub fn frequency_counters(&self) -> usize {
         self.frequency_counters
     }

--- a/sdk-rust/crates/dex-blob-cache/src/error.rs
+++ b/sdk-rust/crates/dex-blob-cache/src/error.rs
@@ -11,16 +11,27 @@ use std::fmt::{Display, Formatter};
 use std::io;
 
 #[derive(Debug)]
+/// Reports configuration, lifecycle, storage, or policy failures from [`crate::BlobCache`].
 pub enum BlobCacheError {
+    /// The operation requires an open cache, but [`crate::BlobCache::close`] already completed.
     Closed,
+    /// Cache construction received an invalid directory, byte limit, or frequency counter count.
     InvalidConfig(String),
+    /// A blob ID is empty, too large, or otherwise invalid.
     InvalidBlob(String),
+    /// Existing content for a blob ID differs from the new immutable payload.
     ContentMismatch(String),
+    /// A committed cache entry is malformed or fails integrity validation.
     Corrupt(String),
+    /// On-disk state and the in-memory eviction policy could not be reconciled.
     Reconciliation(String),
+    /// The admission or eviction policy failed.
     Policy(String),
+    /// A filesystem operation failed.
     Io {
+        /// Describes the filesystem operation that failed.
         operation: String,
+        /// Preserves the underlying I/O error.
         source: io::Error,
     },
 }

--- a/sdk-rust/crates/dex-blob-cache/src/lib.rs
+++ b/sdk-rust/crates/dex-blob-cache/src/lib.rs
@@ -6,6 +6,13 @@
 //
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
+//! Persistent, bounded local cache for Dex blob payloads.
+//!
+//! [`BlobCache`] stores immutable payloads by blob ID and uses an admission and eviction policy to
+//! keep committed files within the configured byte budget.
+
+#![deny(missing_docs)]
+
 mod config;
 mod entry;
 mod error;
@@ -24,6 +31,24 @@ use format::{FileMetadata, calculate_metadata};
 use policy::{DiskPolicyCallback, PolicyCache, new_policy};
 use store::LocalFileStore;
 
+/// Stores immutable Dex blob payloads in a bounded local directory.
+///
+/// A cache is thread-safe. Reads and writes may run concurrently, while deletion and close
+/// coordinate with in-flight operations. Payloads survive process restarts; [`BlobCache::open`]
+/// recovers valid committed entries and removes interrupted writes.
+///
+/// # Examples
+///
+/// ```no_run
+/// use dex_blob_cache::{BlobCache, BlobCacheConfig};
+///
+/// let config = BlobCacheConfig::new("/tmp/dex-blobs", 64 * 1024 * 1024, 0)?;
+/// let cache = BlobCache::open(config)?;
+/// assert!(cache.put("orders/123", b"payload")?);
+/// assert_eq!(cache.get("orders/123")?, Some(b"payload".to_vec()));
+/// cache.close()?;
+/// # Ok::<(), dex_blob_cache::BlobCacheError>(())
+/// ```
 pub struct BlobCache {
     config: BlobCacheConfig,
     store: LocalFileStore,
@@ -40,6 +65,15 @@ enum ExistingEntry {
 }
 
 impl BlobCache {
+    /// Opens a cache and recovers its committed entries.
+    ///
+    /// `config` supplies the owned directory, byte budget, and admission-policy sizing. The call
+    /// creates the directory when needed and returns only after recovery completes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BlobCacheError`] when the directory cannot be prepared, recovery finds an
+    /// unrecoverable storage failure, or the admission policy cannot be initialized.
     pub fn open(config: BlobCacheConfig) -> Result<Self, BlobCacheError> {
         let store = LocalFileStore::new(config.directory())?;
         store.prepare()?;
@@ -61,6 +95,15 @@ impl BlobCache {
         Ok(cache)
     }
 
+    /// Reads one payload and records an admission-policy access.
+    ///
+    /// Returns `Ok(Some(payload))` for a valid entry and `Ok(None)` when the ID is absent or its
+    /// file disappeared or became corrupt. Corrupt entries are invalidated before returning.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BlobCacheError::InvalidBlob`] for an invalid ID, [`BlobCacheError::Closed`] after
+    /// close, or a storage/policy error that cannot be treated as a cache miss.
     pub fn get(&self, blob_id: &str) -> Result<Option<Vec<u8>>, BlobCacheError> {
         validate_blob_id(blob_id)?;
         let _lifecycle = self
@@ -95,6 +138,16 @@ impl BlobCache {
         }
     }
 
+    /// Attempts to admit an immutable payload under `blob_id`.
+    ///
+    /// Returns `Ok(true)` when the payload is committed or the identical payload already exists.
+    /// Returns `Ok(false)` when the payload exceeds the byte budget or the policy rejects it.
+    /// Reusing an ID for different bytes is an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BlobCacheError`] for invalid IDs, content mismatches, closed lifecycle, or failed
+    /// filesystem and policy operations.
     pub fn put(&self, blob_id: &str, payload: &[u8]) -> Result<bool, BlobCacheError> {
         validate_blob_id(blob_id)?;
         let _lifecycle = self
@@ -153,6 +206,14 @@ impl BlobCache {
         Ok(true)
     }
 
+    /// Deletes one blob if present.
+    ///
+    /// Missing IDs succeed, making deletion idempotent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BlobCacheError`] for an invalid ID, a closed cache, or a failed storage/policy
+    /// operation.
     pub fn delete(&self, blob_id: &str) -> Result<(), BlobCacheError> {
         validate_blob_id(blob_id)?;
         let _lifecycle = self
@@ -187,6 +248,14 @@ impl BlobCache {
         self.wait_for_policy()
     }
 
+    /// Removes every cache entry while keeping the cache open.
+    ///
+    /// The call excludes concurrent cache operations until both policy and disk state are cleared.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BlobCacheError::Closed`] after close or a reconciliation/storage failure when the
+    /// cache cannot fully purge its state.
     pub fn delete_all(&self) -> Result<(), BlobCacheError> {
         let _lifecycle = self
             .lifecycle
@@ -219,6 +288,13 @@ impl BlobCache {
         Ok(())
     }
 
+    /// Releases policy resources and rejects future operations.
+    ///
+    /// Close is idempotent and preserves committed files for the next [`BlobCache::open`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a cleanup error after closing when a previously deferred file removal still fails.
     pub fn close(&self) -> Result<(), BlobCacheError> {
         let _lifecycle = self
             .lifecycle

--- a/sdk-rust/crates/dex-sdk/src/attribute.rs
+++ b/sdk-rust/crates/dex-sdk/src/attribute.rs
@@ -12,6 +12,20 @@ use dex_protocol::dex::IndexConfig;
 
 use crate::{Context, HandlerError, HandlerResult, Value};
 
+/// Defines one durable, typed value stored with a Flow.
+///
+/// Declare Attributes on the Flow, add them to [`crate::PersistenceSchema`], and reuse the same
+/// definition from Step and RPC code. Values use Serde serialization. `get` distinguishes a missing
+/// value with `None`; `get_required` converts absence into [`HandlerError`].
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::{Attribute, AttributeIndex};
+///
+/// let status = Attribute::<String>::new("status")
+///     .indexed(AttributeIndex::keyword());
+/// ```
 pub struct Attribute<T> {
     name: String,
     index: Option<AttributeIndex>,
@@ -19,6 +33,7 @@ pub struct Attribute<T> {
 }
 
 impl<T> Attribute<T> {
+    /// Defines an unindexed Attribute with stable `name`.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -27,11 +42,19 @@ impl<T> Attribute<T> {
         }
     }
 
+    /// Enables Flow-search indexing with the supplied representation.
     pub fn indexed(mut self, index: AttributeIndex) -> Self {
         self.index = Some(index);
         self
     }
 
+    /// Reads the current value from a Step or RPC invocation.
+    ///
+    /// Returns `Ok(None)` when no value is stored.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] when the payload cannot be decoded.
     pub fn get(&self, context: &Context) -> HandlerResult<Option<T>>
     where
         T: Value,
@@ -39,6 +62,11 @@ impl<T> Attribute<T> {
         context.get_attribute(self)
     }
 
+    /// Reads the current value and treats absence as an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] when the Attribute is missing or cannot be decoded.
     pub fn get_required(&self, context: &Context) -> HandlerResult<T>
     where
         T: Value,
@@ -47,6 +75,11 @@ impl<T> Attribute<T> {
             .ok_or_else(|| HandlerError::new(format!("attribute {} is missing", self.name)))
     }
 
+    /// Stages `value` for durable persistence in the current invocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] when the value cannot be encoded or indexed.
     pub fn set(&self, context: &mut Context, value: T) -> HandlerResult<()>
     where
         T: Value,
@@ -54,10 +87,14 @@ impl<T> Attribute<T> {
         context.set_attribute(self, value)
     }
 
+    /// Stages deletion of the current value.
+    ///
+    /// Deleting a missing Attribute is valid.
     pub fn delete(&self, context: &mut Context) -> HandlerResult<()> {
         context.delete_attribute(self)
     }
 
+    /// Creates a lock request for Step options or an RPC definition.
     pub fn lock(&self) -> AttributeLock {
         AttributeLock {
             attribute: self.name.clone(),
@@ -84,6 +121,10 @@ impl<T> Clone for Attribute<T> {
     }
 }
 
+/// Defines keyed durable values sharing one Attribute name.
+///
+/// Each `instance` identifies an independent stored value and lock. Add the map definition once to
+/// [`crate::PersistenceSchema`]; instance names are supplied at access time.
 pub struct AttributeMap<T> {
     name: String,
     index: Option<AttributeIndex>,
@@ -91,6 +132,7 @@ pub struct AttributeMap<T> {
 }
 
 impl<T> AttributeMap<T> {
+    /// Defines an unindexed Attribute map with stable `name`.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -99,11 +141,17 @@ impl<T> AttributeMap<T> {
         }
     }
 
+    /// Enables search indexing for every instance using the supplied representation.
     pub fn indexed(mut self, index: AttributeIndex) -> Self {
         self.index = Some(index);
         self
     }
 
+    /// Reads one instance, returning `Ok(None)` when it is absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] when the payload cannot be decoded.
     pub fn get(&self, context: &Context, instance: &str) -> HandlerResult<Option<T>>
     where
         T: Value,
@@ -111,6 +159,11 @@ impl<T> AttributeMap<T> {
         context.get_attribute_map(self, instance)
     }
 
+    /// Reads one instance and treats absence as an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] when the instance is missing or cannot be decoded.
     pub fn get_required(&self, context: &Context, instance: &str) -> HandlerResult<T>
     where
         T: Value,
@@ -120,6 +173,11 @@ impl<T> AttributeMap<T> {
         })
     }
 
+    /// Stages one instance value for durable persistence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] when the value cannot be encoded or indexed.
     pub fn set(&self, context: &mut Context, instance: &str, value: T) -> HandlerResult<()>
     where
         T: Value,
@@ -127,10 +185,12 @@ impl<T> AttributeMap<T> {
         context.set_attribute_map(self, instance, value)
     }
 
+    /// Stages deletion of one instance; missing instances are valid.
     pub fn delete(&self, context: &mut Context, instance: &str) -> HandlerResult<()> {
         context.delete_attribute_map(self, instance)
     }
 
+    /// Creates a lock request scoped to one map instance.
     pub fn lock(&self, instance: impl Into<String>) -> AttributeLock {
         AttributeLock {
             attribute: self.name.clone(),
@@ -158,6 +218,10 @@ impl<T> Clone for AttributeMap<T> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Describes how Dex projects an Attribute value into its Flow-search index.
+///
+/// Without [`Self::with_key`], a single Attribute uses its name as the physical key. Attribute maps
+/// derive per-instance physical keys unless an explicit key is supplied.
 pub struct AttributeIndex {
     kind: AttributeIndexKind,
     key: Option<String>,
@@ -168,34 +232,42 @@ impl AttributeIndex {
         Self { kind, key: None }
     }
 
+    /// Indexes one exact UTF-8 string for equality and aggregation queries.
     pub fn keyword() -> Self {
         Self::new(AttributeIndexKind::Keyword)
     }
 
+    /// Indexes analyzed UTF-8 text for full-text queries.
     pub fn full_text() -> Self {
         Self::new(AttributeIndexKind::FullText)
     }
 
+    /// Indexes an array of exact UTF-8 strings.
     pub fn keyword_array() -> Self {
         Self::new(AttributeIndexKind::KeywordArray)
     }
 
+    /// Indexes a signed 64-bit integer.
     pub fn int() -> Self {
         Self::new(AttributeIndexKind::Int)
     }
 
+    /// Indexes a finite 64-bit floating-point number.
     pub fn double() -> Self {
         Self::new(AttributeIndexKind::Double)
     }
 
+    /// Indexes a Boolean value.
     pub fn bool() -> Self {
         Self::new(AttributeIndexKind::Bool)
     }
 
+    /// Indexes an RFC 3339 date-time value.
     pub fn date_time() -> Self {
         Self::new(AttributeIndexKind::DateTime)
     }
 
+    /// Uses an explicit physical search-index key instead of the default Attribute-derived key.
     pub fn with_key(mut self, key: impl Into<String>) -> Self {
         self.key = Some(key.into());
         self
@@ -214,6 +286,10 @@ pub(crate) enum AttributeIndexKind {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Identifies an Attribute or Attribute-map instance lock.
+///
+/// Create locks with [`Attribute::lock`] or [`AttributeMap::lock`], then attach them to
+/// [`crate::StepOptions`] or [`crate::RpcDefinition`](crate::Rpc).
 pub struct AttributeLock {
     attribute: String,
     instance: Option<String>,

--- a/sdk-rust/crates/dex-sdk/src/attribute.rs
+++ b/sdk-rust/crates/dex-sdk/src/attribute.rs
@@ -42,7 +42,7 @@ impl<T> Attribute<T> {
         }
     }
 
-    /// Enables Flow-search indexing with the supplied representation.
+    /// Enables Flow-search indexing with the selected index type.
     pub fn indexed(mut self, index: AttributeIndex) -> Self {
         self.index = Some(index);
         self
@@ -124,7 +124,7 @@ impl<T> Clone for Attribute<T> {
 /// Defines keyed durable values sharing one Attribute name.
 ///
 /// Each `instance` identifies an independent stored value and lock. Add the map definition once to
-/// [`crate::PersistenceSchema`]; instance names are supplied at access time.
+/// [`crate::PersistenceSchema`]; pass an instance name on each access.
 pub struct AttributeMap<T> {
     name: String,
     index: Option<AttributeIndex>,
@@ -141,7 +141,7 @@ impl<T> AttributeMap<T> {
         }
     }
 
-    /// Enables search indexing for every instance using the supplied representation.
+    /// Enables search indexing for every instance using the selected index type.
     pub fn indexed(mut self, index: AttributeIndex) -> Self {
         self.index = Some(index);
         self
@@ -221,7 +221,7 @@ impl<T> Clone for AttributeMap<T> {
 /// Describes how Dex projects an Attribute value into its Flow-search index.
 ///
 /// Without [`Self::with_key`], a single Attribute uses its name as the physical key. Attribute maps
-/// derive per-instance physical keys unless an explicit key is supplied.
+/// derive per-instance physical keys unless an explicit key is set.
 pub struct AttributeIndex {
     kind: AttributeIndexKind,
     key: Option<String>,

--- a/sdk-rust/crates/dex-sdk/src/channel.rs
+++ b/sdk-rust/crates/dex-sdk/src/channel.rs
@@ -10,7 +10,7 @@ use std::marker::PhantomData;
 
 use crate::{Condition, Context, HandlerResult, Value};
 
-/// Defines one durable FIFO stream of typed messages.
+/// Defines one durable FIFO queue of typed messages.
 ///
 /// Add the Channel to [`crate::PersistenceSchema`]. Clients and handlers may publish messages;
 /// Steps create [`Condition`] values that wait for queue-size bounds and read the messages consumed

--- a/sdk-rust/crates/dex-sdk/src/channel.rs
+++ b/sdk-rust/crates/dex-sdk/src/channel.rs
@@ -10,12 +10,27 @@ use std::marker::PhantomData;
 
 use crate::{Condition, Context, HandlerResult, Value};
 
+/// Defines one durable FIFO stream of typed messages.
+///
+/// Add the Channel to [`crate::PersistenceSchema`]. Clients and handlers may publish messages;
+/// Steps create [`Condition`] values that wait for queue-size bounds and read the messages consumed
+/// by the satisfied condition.
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::{Channel, Wait};
+///
+/// let approvals = Channel::<String>::new("approvals");
+/// let wait = Wait::until(approvals.for_one());
+/// ```
 pub struct Channel<T> {
     name: String,
     marker: PhantomData<fn() -> T>,
 }
 
 impl<T> Channel<T> {
+    /// Defines a Channel with stable `name`.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -23,6 +38,11 @@ impl<T> Channel<T> {
         }
     }
 
+    /// Stages one message from the current Step or RPC invocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`crate::HandlerError`] when `value` cannot be encoded.
     pub fn publish(&self, context: &mut Context, value: T) -> HandlerResult<()>
     where
         T: Value,
@@ -30,10 +50,16 @@ impl<T> Channel<T> {
         context.publish(self, value)
     }
 
+    /// Returns the invocation snapshot's queued-message count.
     pub fn size(&self, context: &Context) -> HandlerResult<usize> {
         context.channel_size(self)
     }
 
+    /// Decodes messages consumed by this Channel's satisfied condition.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`crate::HandlerError`] when a message cannot be decoded.
     pub fn condition_results(&self, context: &Context) -> HandlerResult<Vec<T>>
     where
         T: Value,
@@ -41,26 +67,32 @@ impl<T> Channel<T> {
         context.channel_results(self)
     }
 
+    /// Creates a condition that consumes exactly one queued message.
     pub fn for_one(&self) -> Condition {
         self.range(Some(1), Some(1))
     }
 
+    /// Creates a condition that consumes exactly `count` queued messages.
     pub fn for_n(&self, count: usize) -> Condition {
         self.range(Some(count), Some(count))
     }
 
+    /// Creates a condition satisfied when at least `count` messages are queued.
     pub fn at_least(&self, count: usize) -> Condition {
         self.range(Some(count), None)
     }
 
+    /// Creates a condition satisfied when no more than `count` messages are queued.
     pub fn at_most(&self, count: usize) -> Condition {
         self.range(None, Some(count))
     }
 
+    /// Creates a condition with optional inclusive lower and upper queue-size bounds.
     pub fn range(&self, at_least: Option<usize>, at_most: Option<usize>) -> Condition {
         Condition::channel(self.name.clone(), None, at_least, at_most)
     }
 
+    /// Creates a guard used by conditional Flow completion to require an empty queue.
     pub fn when_empty(&self) -> ChannelGuard {
         ChannelGuard {
             name: self.name.clone(),
@@ -82,12 +114,17 @@ impl<T> Clone for Channel<T> {
     }
 }
 
+/// Defines independently queued Channel instances under one name.
+///
+/// Supply an instance string for every publish, read, condition, and completion guard. Add the map
+/// definition once to [`crate::PersistenceSchema`].
 pub struct ChannelMap<T> {
     name: String,
     marker: PhantomData<fn() -> T>,
 }
 
 impl<T> ChannelMap<T> {
+    /// Defines a Channel map with stable `name`.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -95,6 +132,11 @@ impl<T> ChannelMap<T> {
         }
     }
 
+    /// Stages one message for `instance` from the current invocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`crate::HandlerError`] when `value` cannot be encoded.
     pub fn publish(&self, context: &mut Context, instance: &str, value: T) -> HandlerResult<()>
     where
         T: Value,
@@ -102,10 +144,16 @@ impl<T> ChannelMap<T> {
         context.publish_map(self, instance, value)
     }
 
+    /// Returns the invocation snapshot's message count for `instance`.
     pub fn size(&self, context: &Context, instance: &str) -> HandlerResult<usize> {
         context.channel_map_size(self, instance)
     }
 
+    /// Decodes messages consumed by `instance`'s satisfied condition.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`crate::HandlerError`] when a message cannot be decoded.
     pub fn condition_results(&self, context: &Context, instance: &str) -> HandlerResult<Vec<T>>
     where
         T: Value,
@@ -113,22 +161,27 @@ impl<T> ChannelMap<T> {
         context.channel_map_results(self, instance)
     }
 
+    /// Creates an `instance` condition that consumes exactly one message.
     pub fn for_one(&self, instance: &str) -> Condition {
         self.range(instance, Some(1), Some(1))
     }
 
+    /// Creates an `instance` condition that consumes exactly `count` messages.
     pub fn for_n(&self, instance: &str, count: usize) -> Condition {
         self.range(instance, Some(count), Some(count))
     }
 
+    /// Creates an `instance` condition with an inclusive lower queue-size bound.
     pub fn at_least(&self, instance: &str, count: usize) -> Condition {
         self.range(instance, Some(count), None)
     }
 
+    /// Creates an `instance` condition with an inclusive upper queue-size bound.
     pub fn at_most(&self, instance: &str, count: usize) -> Condition {
         self.range(instance, None, Some(count))
     }
 
+    /// Creates an `instance` condition with optional inclusive lower and upper bounds.
     pub fn range(
         &self,
         instance: &str,
@@ -143,6 +196,7 @@ impl<T> ChannelMap<T> {
         )
     }
 
+    /// Creates a conditional-completion guard requiring `instance` to be empty.
     pub fn when_empty(&self, instance: &str) -> ChannelGuard {
         ChannelGuard {
             name: self.name.clone(),
@@ -165,6 +219,7 @@ impl<T> Clone for ChannelMap<T> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Identifies a Channel or Channel-map instance that must be empty before conditional completion.
 pub struct ChannelGuard {
     name: String,
     instance: Option<String>,

--- a/sdk-rust/crates/dex-sdk/src/client.rs
+++ b/sdk-rust/crates/dex-sdk/src/client.rs
@@ -40,6 +40,25 @@ use crate::{
     WorkerTarget,
 };
 
+/// Provides blocking, typed control of registered Dex Flows.
+///
+/// Client methods block the calling thread while an internal Tokio runtime performs gRPC and blob
+/// hydration. The Client owns its transport resources; dropping it releases them. Flow, Step, RPC,
+/// Attribute, and Channel arguments are checked against the supplied [`Registry`].
+///
+/// # Examples
+///
+/// ```no_run
+/// use dex_sdk::{BlobCache, BlobCacheConfig, Client, ClientOptions, Registry};
+/// use std::sync::Arc;
+///
+/// let cache = Arc::new(BlobCache::open(BlobCacheConfig::new(
+///     "/tmp/dex-blobs", 64 * 1024 * 1024, 0,
+/// )?)?);
+/// let client = Client::try_new(Registry::new(), cache, ClientOptions::new())?;
+/// client.health_check()?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 pub struct Client {
     runtime: Runtime,
     registry: Registry,
@@ -49,11 +68,24 @@ pub struct Client {
 }
 
 impl Client {
+    /// Creates a Client or panics when runtime or endpoint initialization fails.
+    ///
+    /// Prefer [`Self::try_new`] when the application can recover from startup configuration errors.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a Tokio runtime cannot be created or the server address is invalid.
     pub fn new(registry: Registry, blob_cache: Arc<BlobCache>, options: ClientOptions) -> Self {
         Self::try_new(registry, blob_cache, options)
             .unwrap_or_else(|error| panic!("cannot create Dex Client: {error}"))
     }
 
+    /// Creates a Client from validated definitions, a shared BlobCache, and connection options.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError::Service`] if runtime or endpoint initialization fails. The transport
+    /// connects lazily, so server availability is checked by the first operation.
     pub fn try_new(
         registry: Registry,
         blob_cache: Arc<BlobCache>,
@@ -76,6 +108,14 @@ impl Client {
         })
     }
 
+    /// Starts a registered Flow with server-default options.
+    ///
+    /// Returns the server-assigned run ID. `input` is encoded for the registered starting Step.
+    ///
+    /// # Errors
+    ///
+    /// Returns a definition or mapping error locally, [`SdkError::FlowAlreadyStarted`] for a reuse
+    /// conflict, or another service-backed [`SdkError`] when Dex rejects the request.
     pub fn start_flow<SomeFlow: Flow>(
         &self,
         flow: &SomeFlow,
@@ -85,6 +125,14 @@ impl Client {
         self.start_flow_with_options(flow, flow_id, input, StartFlowOptions::new())
     }
 
+    /// Starts a registered Flow with explicit lifecycle, retry, and initial persistence options.
+    ///
+    /// Returns the server-assigned run ID. A missing request ID is replaced with a generated UUID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError`] for invalid IDs, unregistered or mismatched Flow types, encoding
+    /// failures, invalid option durations, reuse conflicts, and service failures.
     pub fn start_flow_with_options<SomeFlow: Flow>(
         &self,
         flow: &SomeFlow,
@@ -149,6 +197,12 @@ impl Client {
         })
     }
 
+    /// Invokes a registered RPC with typed input and decodes its typed output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError::RpcLockConflict`] when locks cannot be acquired, WorkerInvocation for a
+    /// handler failure, FlowNotActive for a terminal Flow, or a mapping/service error.
     pub fn invoke_rpc<Input: Value, Output: Value>(
         &self,
         flow_id: &str,
@@ -158,6 +212,9 @@ impl Client {
         self.do_invoke_rpc(flow_id, rpc.name(), &input)
     }
 
+    /// Invokes a registered no-input RPC and decodes its typed output.
+    ///
+    /// Errors use the same specialized variants as [`Self::invoke_rpc`].
     pub fn invoke_rpc_without_input<Output: Value>(
         &self,
         flow_id: &str,
@@ -166,6 +223,9 @@ impl Client {
         self.do_invoke_rpc(flow_id, rpc.name(), &())
     }
 
+    /// Reads one Attribute from the current run.
+    ///
+    /// Returns `Ok(None)` when no value is stored.
     pub fn get_attribute<T: Value>(
         &self,
         flow_id: &str,
@@ -174,6 +234,9 @@ impl Client {
         self.get_attribute_value(flow_id, attribute.name())
     }
 
+    /// Reads one Attribute-map instance from the current run.
+    ///
+    /// Returns `Ok(None)` when the instance is absent.
     pub fn get_attribute_map<T: Value>(
         &self,
         flow_id: &str,
@@ -186,6 +249,11 @@ impl Client {
         )
     }
 
+    /// Writes one Attribute on an active Flow.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError::FlowNotActive`], a value-mapping error, or a service failure.
     pub fn set_attribute<T: Value>(
         &self,
         flow_id: &str,
@@ -200,6 +268,11 @@ impl Client {
         )
     }
 
+    /// Writes one Attribute-map instance on an active Flow.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError::FlowNotActive`], a value-mapping error, or a service failure.
     pub fn set_attribute_map<T: Value>(
         &self,
         flow_id: &str,
@@ -215,6 +288,7 @@ impl Client {
         )
     }
 
+    /// Publishes one typed message to a Channel on an active Flow.
     pub fn publish<T: Value>(
         &self,
         flow_id: &str,
@@ -224,6 +298,7 @@ impl Client {
         self.publish_values(flow_id, channel.name(), [value])
     }
 
+    /// Publishes an ordered batch of typed messages to one Channel atomically.
     pub fn publish_many<T: Value>(
         &self,
         flow_id: &str,
@@ -233,6 +308,7 @@ impl Client {
         self.publish_values(flow_id, channel.name(), values)
     }
 
+    /// Publishes an ordered batch to one Channel-map instance atomically.
     pub fn publish_map<T: Value>(
         &self,
         flow_id: &str,
@@ -247,11 +323,23 @@ impl Client {
         )
     }
 
+    /// Blocks until a Flow completes successfully and decodes its first completion output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError::FlowUncompleted`] for other terminal statuses, FlowNotFound for an
+    /// unknown ID, or a mapping/service error. This overload has no client-side timeout.
     pub fn wait_for_flow<Output: Value>(&self, flow_id: &str) -> SdkResult<Output> {
         self.wait_for_flow_response(flow_id, None)
             .and_then(|response| self.decode_flow_output(response))
     }
 
+    /// Blocks up to `timeout` for successful Flow completion and decodes its output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError::LongPollTimeout`] when the timeout elapses while the Flow remains active;
+    /// other errors match [`Self::wait_for_flow`].
     pub fn wait_for_flow_with_timeout<Output: Value>(
         &self,
         flow_id: &str,
@@ -261,6 +349,11 @@ impl Client {
             .and_then(|response| self.decode_flow_output(response))
     }
 
+    /// Returns current identity, status, type, and start time for the latest run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError::FlowNotFound`] for an unknown ID or a service/protocol error.
     pub fn describe_flow(&self, flow_id: &str) -> SdkResult<FlowInfo> {
         let mut service = self.service.clone();
         let response = self.runtime.block_on(async {
@@ -294,10 +387,18 @@ impl Client {
         })
     }
 
+    /// Executes a server search query and returns its first page.
+    ///
+    /// `page_size` must be non-negative; zero uses the server default. Indexed values are hydrated
+    /// and decoded as [`serde_json::Value`].
     pub fn search_flows(&self, query: &str, page_size: i32) -> SdkResult<SearchFlowsPage> {
         self.search_flows_page(query, page_size, "")
     }
 
+    /// Continues a search with the opaque token returned by a previous page.
+    ///
+    /// Keep `query` and `page_size` consistent across pages. An empty returned token marks the last
+    /// page.
     pub fn search_flows_page(
         &self,
         query: &str,
@@ -358,6 +459,11 @@ impl Client {
         })
     }
 
+    /// Cancels, terminates, or fails an active Flow according to `options`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError::FlowNotActive`] when no active run exists or another service error.
     pub fn stop_flow(&self, flow_id: &str, options: StopFlowOptions) -> SdkResult<()> {
         let stop_type = match options.stop_type {
             StopType::Cancel => ProtoStopType::Cancel,
@@ -381,6 +487,14 @@ impl Client {
         )
     }
 
+    /// Creates a new run by replaying an existing Flow from the selected historical point.
+    ///
+    /// Returns the new server-assigned run ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns InvalidArgument for an unrepresentable history ID or time, FlowNotFound for an
+    /// unknown ID, or another service error.
     pub fn reset_flow(&self, flow_id: &str, options: ResetFlowOptions) -> SdkResult<String> {
         let mut request = ResetFlowRequest {
             flow_id: flow_id.to_string(),
@@ -432,6 +546,12 @@ impl Client {
         })
     }
 
+    /// Marks one timer in an active Step execution as satisfied immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns InvalidArgument for an oversized index, FlowNotActive for a terminal Flow, or a
+    /// service error when the Step execution or timer cannot be targeted.
     pub fn skip_timer(
         &self,
         flow_id: &str,
@@ -466,6 +586,12 @@ impl Client {
         )
     }
 
+    /// Blocks until one Step execution completes or `timeout` elapses.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError::LongPollTimeout`] on timeout, FlowNotActive when appropriate, or another
+    /// service error. Successful completion returns `()` and does not decode Step output.
     pub fn wait_for_step_completion(
         &self,
         flow_id: &str,
@@ -491,6 +617,9 @@ impl Client {
         )
     }
 
+    /// Replaces mutable runtime configuration fields on an active Flow.
+    ///
+    /// Unset fields retain server-defined behavior.
     pub fn update_flow_config(&self, flow_id: &str, config: FlowConfig) -> SdkResult<()> {
         let flow_config = self.map_flow_config(Some(&config))?;
         self.call_empty(
@@ -509,6 +638,7 @@ impl Client {
         )
     }
 
+    /// Requests that an active Flow roll its history into a successor run.
     pub fn trigger_continue_as_new(&self, flow_id: &str) -> SdkResult<()> {
         self.call_empty(
             "trigger_continue_as_new",
@@ -525,6 +655,9 @@ impl Client {
         )
     }
 
+    /// Verifies that Dex FlowService responds successfully.
+    ///
+    /// Returns `Ok(())` for a healthy service and a service-backed [`SdkError`] otherwise.
     pub fn health_check(&self) -> SdkResult<()> {
         self.call_empty(
             "health_check",

--- a/sdk-rust/crates/dex-sdk/src/client.rs
+++ b/sdk-rust/crates/dex-sdk/src/client.rs
@@ -44,7 +44,7 @@ use crate::{
 ///
 /// Client methods block the calling thread while an internal Tokio runtime performs gRPC and blob
 /// hydration. The Client owns its transport resources; dropping it releases them. Flow, Step, RPC,
-/// Attribute, and Channel arguments are checked against the supplied [`Registry`].
+/// Attribute, and Channel arguments are checked against the [`Registry`].
 ///
 /// # Examples
 ///
@@ -214,7 +214,7 @@ impl Client {
 
     /// Invokes a registered no-input RPC and decodes its typed output.
     ///
-    /// Errors use the same specialized variants as [`Self::invoke_rpc`].
+    /// Returns the same errors as [`Self::invoke_rpc`].
     pub fn invoke_rpc_without_input<Output: Value>(
         &self,
         flow_id: &str,

--- a/sdk-rust/crates/dex-sdk/src/client_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/client_options.rs
@@ -9,12 +9,17 @@
 use crate::WorkerTarget;
 
 #[derive(Clone, Debug)]
+/// Configures how a [`crate::Client`] reaches Dex and identifies application workers.
+///
+/// [`ClientOptions::new`] connects to `127.0.0.1:8801` over plaintext gRPC and supplies no default
+/// worker target. A per-Flow [`crate::FlowConfig`] can override the target.
 pub struct ClientOptions {
     server_address: String,
     worker_target: Option<WorkerTarget>,
 }
 
 impl ClientOptions {
+    /// Creates options with the local Dex server default and no worker target.
     pub fn new() -> Self {
         Self {
             server_address: "127.0.0.1:8801".to_string(),
@@ -22,11 +27,13 @@ impl ClientOptions {
         }
     }
 
+    /// Sets the plaintext gRPC `host:port` used for every client request.
     pub fn server_address(mut self, value: impl Into<String>) -> Self {
         self.server_address = value.into();
         self
     }
 
+    /// Sets the WorkerService target advertised by newly started Flows.
     pub fn worker_target(mut self, value: WorkerTarget) -> Self {
         self.worker_target = Some(value);
         self

--- a/sdk-rust/crates/dex-sdk/src/context.rs
+++ b/sdk-rust/crates/dex-sdk/src/context.rs
@@ -28,7 +28,7 @@ pub(crate) enum InvocationMethod {
     Rpc,
 }
 
-/// Provides immutable invocation metadata and staged durable mutations to Step and RPC handlers.
+/// Provides invocation metadata and staged durable changes to Step and RPC handlers.
 ///
 /// A Context belongs to one handler attempt and must not outlive the call. Attribute writes,
 /// Channel publications, locals, and events become visible atomically only when the handler returns

--- a/sdk-rust/crates/dex-sdk/src/context.rs
+++ b/sdk-rust/crates/dex-sdk/src/context.rs
@@ -28,6 +28,11 @@ pub(crate) enum InvocationMethod {
     Rpc,
 }
 
+/// Provides immutable invocation metadata and staged durable mutations to Step and RPC handlers.
+///
+/// A Context belongs to one handler attempt and must not outlive the call. Attribute writes,
+/// Channel publications, locals, and events become visible atomically only when the handler returns
+/// successfully. Application values are freshly decoded and owned by the invocation.
 pub struct Context {
     method: InvocationMethod,
     flow: RegisteredFlow,
@@ -45,34 +50,42 @@ pub struct Context {
 }
 
 impl Context {
+    /// Returns the application-assigned Flow ID.
     pub fn flow_id(&self) -> &str {
         &self.metadata.flow_id
     }
 
+    /// Returns the server-assigned run ID for this execution.
     pub fn run_id(&self) -> &str {
         &self.metadata.run_id
     }
 
+    /// Returns when the current Flow run started.
     pub fn flow_started_at(&self) -> SystemTime {
         system_time(self.metadata.flow_started_timestamp)
     }
 
+    /// Returns the current Step execution ID, or an empty string for an RPC.
     pub fn step_execution_id(&self) -> &str {
         &self.metadata.step_execution_id
     }
 
+    /// Returns the predecessor Step execution ID, or an empty string when absent.
     pub fn from_step_execution_id(&self) -> &str {
         &self.metadata.from_step_execution_id
     }
 
+    /// Returns when the first attempt of this handler invocation started.
     pub fn first_attempt_at(&self) -> SystemTime {
         system_time(self.metadata.first_attempt_timestamp)
     }
 
+    /// Returns the one-based handler attempt number.
     pub fn attempt(&self) -> u32 {
         u32::try_from(self.metadata.attempt).unwrap_or_default()
     }
 
+    /// Returns whether any timer condition completed for this `execute` invocation.
     pub fn has_any_timer_fired(&self) -> bool {
         self.condition_results.as_ref().is_some_and(|results| {
             results
@@ -82,6 +95,9 @@ impl Context {
         })
     }
 
+    /// Returns whether the zero-based timer at `index` completed.
+    ///
+    /// Missing indexes return `false`.
     pub fn has_timer_fired(&self, index: usize) -> bool {
         self.condition_results
             .as_ref()
@@ -89,20 +105,30 @@ impl Context {
             .is_some_and(|timer| timer.condition_status == ConditionStatus::Completed as i32)
     }
 
+    /// Returns whether `execute` is running because `wait_for` exhausted retries with Proceed.
     pub fn wait_for_method_failed(&self) -> bool {
         self.condition_results
             .as_ref()
             .is_some_and(|results| results.wait_for_failed)
     }
 
+    /// Blocks the current thread until Dex cancels this handler attempt.
+    ///
+    /// Use this only for interruptible application work; ordinary handlers should return normally.
     pub fn wait_for_cancellation(&self) {
         self.cancellation.wait();
     }
 
+    /// Returns immediately with the current handler-cancellation state.
     pub fn is_cancelled(&self) -> bool {
         self.cancellation.is_cancelled()
     }
 
+    /// Stages a Step-execution-local value visible to later attempts of the same execution.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] for an empty key or an encoding failure.
     pub fn set_step_execution_local<T: Value>(&mut self, key: &str, value: T) -> HandlerResult<()> {
         require_name(key, "step-execution local key")?;
         let value = value_mapper::encode_handler(&value)?;
@@ -116,6 +142,11 @@ impl Context {
         Ok(())
     }
 
+    /// Reads a required Step-execution-local value, including writes staged by this attempt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] for an empty key, a missing value, or a decoding failure.
     pub fn step_execution_local<T: Value>(&self, key: &str) -> HandlerResult<T> {
         require_name(key, "step-execution local key")?;
         let value = self
@@ -127,6 +158,13 @@ impl Context {
         value_mapper::decode_handler(value)
     }
 
+    /// Records one named diagnostic event with a typed payload.
+    ///
+    /// Event names must be unique within the invocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] for an empty or duplicate name or an encoding failure.
     pub fn record_event<T: Value>(&mut self, name: &str, value: T) -> HandlerResult<()> {
         require_name(name, "event name")?;
         if !self.event_names.insert(name.to_string()) {
@@ -141,10 +179,12 @@ impl Context {
         Ok(())
     }
 
+    /// Reads an Attribute value, including writes staged by this invocation.
     pub fn get_attribute<T: Value>(&self, attribute: &Attribute<T>) -> HandlerResult<Option<T>> {
         self.get_attribute_value(attribute.name(), PersistenceKind::Attribute, None)
     }
 
+    /// Reads one Attribute-map instance, including staged writes.
     pub fn get_attribute_map<T: Value>(
         &self,
         attribute: &AttributeMap<T>,
@@ -157,6 +197,7 @@ impl Context {
         )
     }
 
+    /// Stages a typed Attribute write.
     pub fn set_attribute<T: Value>(
         &mut self,
         attribute: &Attribute<T>,
@@ -171,6 +212,7 @@ impl Context {
         )
     }
 
+    /// Stages a typed write for one Attribute-map instance.
     pub fn set_attribute_map<T: Value>(
         &mut self,
         attribute: &AttributeMap<T>,
@@ -186,6 +228,7 @@ impl Context {
         )
     }
 
+    /// Stages deletion of an Attribute value.
     pub fn delete_attribute<T>(&mut self, attribute: &Attribute<T>) -> HandlerResult<()> {
         self.set_attribute_value(
             attribute.name(),
@@ -196,6 +239,7 @@ impl Context {
         )
     }
 
+    /// Stages deletion of one Attribute-map instance.
     pub fn delete_attribute_map<T>(
         &mut self,
         attribute: &AttributeMap<T>,
@@ -210,6 +254,7 @@ impl Context {
         )
     }
 
+    /// Stages one typed Channel publication.
     pub fn publish<T: Value>(&mut self, channel: &Channel<T>, value: T) -> HandlerResult<()> {
         self.publish_value(
             channel.name(),
@@ -219,6 +264,7 @@ impl Context {
         )
     }
 
+    /// Stages one typed publication to a Channel-map instance.
     pub fn publish_map<T: Value>(
         &mut self,
         channel: &ChannelMap<T>,
@@ -233,10 +279,12 @@ impl Context {
         )
     }
 
+    /// Returns the current invocation snapshot's Channel queue size.
     pub fn channel_size<T>(&self, channel: &Channel<T>) -> HandlerResult<usize> {
         self.channel_size_value(channel.name(), PersistenceKind::Channel, None)
     }
 
+    /// Returns one Channel-map instance's queue size.
     pub fn channel_map_size<T>(
         &self,
         channel: &ChannelMap<T>,
@@ -245,10 +293,12 @@ impl Context {
         self.channel_size_value(channel.name(), PersistenceKind::ChannelMap, Some(instance))
     }
 
+    /// Decodes the messages consumed by a satisfied Channel condition.
     pub fn channel_results<T: Value>(&self, channel: &Channel<T>) -> HandlerResult<Vec<T>> {
         self.channel_results_value(channel.name(), PersistenceKind::Channel, None)
     }
 
+    /// Decodes messages consumed by one satisfied Channel-map condition.
     pub fn channel_map_results<T: Value>(
         &self,
         channel: &ChannelMap<T>,

--- a/sdk-rust/crates/dex-sdk/src/flow.rs
+++ b/sdk-rust/crates/dex-sdk/src/flow.rs
@@ -8,21 +8,59 @@
 
 use crate::{PersistenceSchema, RpcList, StepList, Value, short_type_name};
 
+/// Defines a durable application Flow and its registered API surface.
+///
+/// A Flow owns a typed start input, Step list, persistence schema, and RPC list. Implementations are
+/// registered as owned values in [`crate::Registry`] and shared safely across Worker invocations.
+/// Keep [`Self::flow_type`] and all subordinate names stable while any execution is running.
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::{Flow, StepList};
+///
+/// struct OrderFlow;
+///
+/// impl Flow for OrderFlow {
+///     type StartInput = String;
+///
+///     fn flow_type(&self) -> &'static str {
+///         "OrderFlow"
+///     }
+///
+///     fn steps(&self) -> StepList<'_, Self::StartInput> {
+///         StepList::empty()
+///     }
+/// }
+/// ```
 pub trait Flow: Send + Sync + 'static {
+    /// Value accepted by [`crate::Client::start_flow`] and the starting Step.
     type StartInput: Value;
 
+    /// Returns the stable Flow type sent to Dex.
+    ///
+    /// The default is the final Rust type-name segment.
     fn flow_type(&self) -> &'static str {
         short_type_name::<Self>()
     }
 
+    /// Returns the starting Step and all other Step definitions.
+    ///
+    /// The default is an empty list, which is valid only for Flows driven entirely by RPCs.
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::empty()
     }
 
+    /// Declares every Attribute and Channel used by this Flow.
+    ///
+    /// The default schema is empty.
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
     }
 
+    /// Binds public RPC names to methods on this Flow implementation.
+    ///
+    /// The default list is empty.
     fn rpcs(&self) -> RpcList<Self>
     where
         Self: Sized,

--- a/sdk-rust/crates/dex-sdk/src/flow_config.rs
+++ b/sdk-rust/crates/dex-sdk/src/flow_config.rs
@@ -9,6 +9,10 @@
 use crate::{StepDurability, WorkerTarget};
 
 #[derive(Clone, Debug, Default)]
+/// Overrides runtime behavior for one Flow.
+///
+/// Omitted fields use Dex server defaults. Pass a value to [`crate::StartFlowOptions::config_override`]
+/// for one execution or to [`crate::Client::update_flow_config`] for an active Flow.
 pub struct FlowConfig {
     pub(crate) active_step_search_mode: Option<ActiveStepSearchMode>,
     pub(crate) continue_as_new_threshold: Option<u32>,
@@ -18,30 +22,36 @@ pub struct FlowConfig {
 }
 
 impl FlowConfig {
+    /// Creates a config with every field delegated to server defaults.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Controls which active Step types Dex places in the search index.
     pub fn active_step_search_mode(mut self, value: ActiveStepSearchMode) -> Self {
         self.active_step_search_mode = Some(value);
         self
     }
 
+    /// Sets the event-count threshold that triggers Continue-As-New.
     pub fn continue_as_new_threshold(mut self, value: u32) -> Self {
         self.continue_as_new_threshold = Some(value);
         self
     }
 
+    /// Sets the maximum history page size, in bytes, carried into Continue-As-New.
     pub fn continue_as_new_page_size_bytes(mut self, value: u32) -> Self {
         self.continue_as_new_page_size_bytes = Some(value);
         self
     }
 
+    /// Sets the default persistence durability for Step handler writes.
     pub fn step_durability(mut self, value: StepDurability) -> Self {
         self.step_durability = Some(value);
         self
     }
 
+    /// Routes future Step and RPC invocations to this WorkerService target.
     pub fn worker_target(mut self, value: WorkerTarget) -> Self {
         self.worker_target = Some(value);
         self
@@ -49,8 +59,12 @@ impl FlowConfig {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Controls which active Step types Dex indexes for Flow search.
 pub enum ActiveStepSearchMode {
+    /// Indexes every active Step type, including execute-only Steps.
     All,
+    /// Indexes a Step type only after its `wait_for` handler runs.
     WithWaitFor,
+    /// Disables active-Step indexing for the Flow.
     Disabled,
 }

--- a/sdk-rust/crates/dex-sdk/src/flow_info.rs
+++ b/sdk-rust/crates/dex-sdk/src/flow_info.rs
@@ -10,48 +10,78 @@ use std::collections::BTreeMap;
 use std::time::SystemTime;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Describes the current or terminal state of a Flow run.
 pub enum FlowStatus {
+    /// The Flow can still execute Steps or receive RPCs and Channel messages.
     Running,
+    /// The Flow completed successfully.
     Completed,
+    /// The Flow ended because a Step, RPC, or user-code failure was not recovered.
     Failed,
+    /// The Flow exceeded its configured timeout.
     TimedOut,
+    /// An operator terminated the Flow immediately.
     Terminated,
+    /// The Flow completed cooperative cancellation.
     Canceled,
+    /// The run rolled its history into a successor run.
     ContinuedAsNew,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Categorizes the failure recorded for an uncompleted Flow.
 pub enum FlowErrorType {
+    /// A Step returned an invalid or failing decision.
     StepDecisionFailed,
+    /// A client API operation failed the Flow.
     ClientApiFailed,
+    /// A Worker Step or RPC handler failed.
     WorkerApiFailed,
+    /// The registered Flow or Step definition violated an SDK contract.
     InvalidUserFlowCode,
+    /// Dex encountered an internal failure.
     Internal,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Summarizes one Flow run returned by [`crate::Client::describe_flow`].
 pub struct FlowInfo {
+    /// Application-assigned Flow ID.
     pub flow_id: String,
+    /// Server-assigned run ID for the described execution.
     pub run_id: String,
+    /// Registered Flow type name.
     pub flow_type: String,
+    /// Current or terminal status.
     pub status: FlowStatus,
+    /// Server-recorded start time.
     pub started_at: SystemTime,
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// Contains one Flow row returned by a search query.
 pub struct SearchFlowEntry {
+    /// Application-assigned Flow ID.
     pub flow_id: String,
+    /// Server-assigned run ID.
     pub run_id: String,
+    /// Registered Flow type name.
     pub flow_type: String,
+    /// Status captured by the search index.
     pub status: FlowStatus,
+    /// Indexed start time, or `None` when unavailable.
     pub started_at: Option<SystemTime>,
+    /// Indexed close time, or `None` while open or unavailable.
     pub closed_at: Option<SystemTime>,
     /// Values keyed by their physical Indexed Attribute names.
     pub indexed_attributes: BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// Contains one page of [`crate::Client::search_flows`] results.
 pub struct SearchFlowsPage {
+    /// Flow rows in server-defined query order.
     pub flows: Vec<SearchFlowEntry>,
+    /// Opaque token for [`crate::Client::search_flows_page`], or empty on the last page.
     pub next_page_token: String,
 }

--- a/sdk-rust/crates/dex-sdk/src/handler_error.rs
+++ b/sdk-rust/crates/dex-sdk/src/handler_error.rs
@@ -9,15 +9,21 @@
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 
+/// Result returned by application Step and RPC handlers.
 pub type HandlerResult<T> = Result<T, HandlerError>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Reports an application-defined Step or RPC failure to Dex.
+///
+/// Return this error from [`crate::Step::wait_for`], [`crate::Step::execute`], or an RPC handler.
+/// Dex records the message and applies the configured retry or failure policy.
 pub struct HandlerError {
     message: String,
     error_type: String,
 }
 
 impl HandlerError {
+    /// Creates a handler error with a developer-facing message.
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),

--- a/sdk-rust/crates/dex-sdk/src/lib.rs
+++ b/sdk-rust/crates/dex-sdk/src/lib.rs
@@ -6,6 +6,14 @@
 //
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
+//! Strongly typed Rust client and worker APIs for durable Dex Flows.
+//!
+//! Define [`Flow`] and [`Step`] implementations, register them with [`Registry`], host them with
+//! [`Worker`], and control executions with [`Client`]. The crate also exposes typed Attributes,
+//! Channels, waits, decisions, RPCs, lifecycle options, and structured errors.
+
+#![deny(missing_docs)]
+
 mod attribute;
 mod channel;
 mod client;
@@ -36,7 +44,7 @@ mod worker_dispatcher;
 mod worker_options;
 
 pub use attribute::{Attribute, AttributeIndex, AttributeMap};
-pub use channel::{Channel, ChannelMap};
+pub use channel::{Channel, ChannelGuard, ChannelMap};
 pub use client::Client;
 pub use client_options::ClientOptions;
 pub use context::Context;
@@ -49,7 +57,7 @@ pub use persistence::PersistenceSchema;
 pub use registry::Registry;
 pub use reset_flow_options::ResetFlowOptions;
 pub use retry_policy::RetryPolicy;
-pub use rpc::{Rpc, RpcList, RpcResult};
+pub use rpc::{Rpc, RpcDefinition, RpcList, RpcResult};
 pub use sdk_error::{ErrorSubStatus, SdkError, SdkResult, ServiceError, WorkerError};
 pub use start_flow_options::{IdReusePolicy, StartFlowOptions};
 pub use step::{Step, StepDecision, StepList, StepMovement};

--- a/sdk-rust/crates/dex-sdk/src/persistence.rs
+++ b/sdk-rust/crates/dex-sdk/src/persistence.rs
@@ -9,6 +9,20 @@
 use crate::{Attribute, AttributeIndex, AttributeMap, Channel, ChannelMap};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+/// Declares the Attributes and Channels a Flow persists.
+///
+/// Return a schema from [`crate::Flow::persistence`]. Definitions must have unique names,
+/// and all values accessed by Step or RPC code must appear in the schema.
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::{Attribute, Channel, PersistenceSchema};
+///
+/// let status = Attribute::<String>::new("status");
+/// let commands = Channel::<String>::new("commands");
+/// let schema = PersistenceSchema::new().attribute(&status).channel(&commands);
+/// ```
 pub struct PersistenceSchema {
     definitions: Vec<PersistenceDefinition>,
 }
@@ -29,10 +43,12 @@ pub(crate) enum PersistenceKind {
 }
 
 impl PersistenceSchema {
+    /// Creates an empty schema.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Adds one single-value Attribute definition.
     pub fn attribute<T>(mut self, attribute: &Attribute<T>) -> Self {
         self.add(
             attribute.name(),
@@ -42,6 +58,7 @@ impl PersistenceSchema {
         self
     }
 
+    /// Adds one keyed Attribute-map definition.
     pub fn attribute_map<T>(mut self, attribute: &AttributeMap<T>) -> Self {
         self.add(
             attribute.name(),
@@ -51,11 +68,13 @@ impl PersistenceSchema {
         self
     }
 
+    /// Adds one Channel definition.
     pub fn channel<T>(mut self, channel: &Channel<T>) -> Self {
         self.add(channel.name(), PersistenceKind::Channel, None);
         self
     }
 
+    /// Adds one keyed Channel-map definition.
     pub fn channel_map<T>(mut self, channel: &ChannelMap<T>) -> Self {
         self.add(channel.name(), PersistenceKind::ChannelMap, None);
         self

--- a/sdk-rust/crates/dex-sdk/src/registry.rs
+++ b/sdk-rust/crates/dex-sdk/src/registry.rs
@@ -21,8 +21,8 @@ use dex_protocol::dex::Value as ProtoValue;
 /// Validates and stores all Flow definitions used by a Client or Worker.
 ///
 /// Registration checks unique Flow, Step, RPC, and persistence names; starting-Step constraints;
-/// Attribute index consistency; RPC locks; and handler options. Cloning is cheap because immutable
-/// registrations are shared.
+/// Attribute index consistency; RPC locks; and handler options. Cloning is cheap because it shares
+/// the registered data.
 ///
 /// # Examples
 ///

--- a/sdk-rust/crates/dex-sdk/src/registry.rs
+++ b/sdk-rust/crates/dex-sdk/src/registry.rs
@@ -18,6 +18,23 @@ use crate::{Context, Flow, HandlerResult, SdkError, SdkResult, StepDecision, Wai
 use dex_protocol::dex::Value as ProtoValue;
 
 #[derive(Clone, Default)]
+/// Validates and stores all Flow definitions used by a Client or Worker.
+///
+/// Registration checks unique Flow, Step, RPC, and persistence names; starting-Step constraints;
+/// Attribute index consistency; RPC locks; and handler options. Cloning is cheap because immutable
+/// registrations are shared.
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::{Flow, Registry};
+///
+/// struct OrderFlow;
+/// impl Flow for OrderFlow { type StartInput = String; }
+///
+/// let registry = Registry::new().register(OrderFlow)?;
+/// # Ok::<(), dex_sdk::SdkError>(())
+/// ```
 pub struct Registry {
     inner: Arc<RegistryInner>,
 }
@@ -40,10 +57,17 @@ pub(crate) struct RegisteredFlow {
 }
 
 impl Registry {
+    /// Creates an empty registry.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Validates and adds one owned Flow definition.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError::FlowDefinition`] for invalid or conflicting names, schemas, indexes,
+    /// Steps, RPCs, locks, or options.
     pub fn register<SomeFlow: Flow>(mut self, flow: SomeFlow) -> SdkResult<Self> {
         let flow = Arc::new(flow);
         let name = require_static_name(flow.flow_type(), "Flow type")?;

--- a/sdk-rust/crates/dex-sdk/src/reset_flow_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/reset_flow_options.rs
@@ -11,6 +11,11 @@ use std::time::SystemTime;
 use crate::{Step, StepExecutionId};
 
 #[derive(Clone, Debug)]
+/// Selects a historical point from which [`crate::Client::reset_flow`] creates a new run.
+///
+/// Constructors identify exactly one reset point. Builder methods add an audit reason and control
+/// whether Channel messages and locking RPCs are reapplied. Both reapply switches default to
+/// `false`, so historical operations are reapplied.
 pub struct ResetFlowOptions {
     pub(crate) point: ResetPoint,
     pub(crate) reason: Option<String>,
@@ -28,36 +33,44 @@ pub(crate) enum ResetPoint {
 }
 
 impl ResetFlowOptions {
+    /// Resets before the first workflow-history event.
     pub fn from_beginning() -> Self {
         Self::new(ResetPoint::Beginning)
     }
 
+    /// Resets at the specified server workflow-history event ID.
     pub fn from_history_event_id(event_id: i64) -> Self {
         Self::new(ResetPoint::HistoryEventId(event_id))
     }
 
+    /// Resets at the last eligible history event at or before `event_time`.
     pub fn from_history_event_time(event_time: SystemTime) -> Self {
         Self::new(ResetPoint::HistoryEventTime(event_time))
     }
 
+    /// Resets before the first execution of the supplied Step type.
     pub fn from_step<SomeStep: Step>(step: &SomeStep) -> Self {
         Self::new(ResetPoint::StepType(step.step_type()))
     }
 
+    /// Resets before the exact Step execution identified by `step_execution`.
     pub fn from_step_execution(step_execution: StepExecutionId) -> Self {
         Self::new(ResetPoint::StepExecution(step_execution))
     }
 
+    /// Adds an operator-facing reason recorded with the reset.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason = Some(reason.into());
         self
     }
 
+    /// Controls whether post-reset Channel messages are skipped instead of reapplied.
     pub fn skip_channel_messages_reapply(mut self, skip: bool) -> Self {
         self.skip_channel_messages_reapply = skip;
         self
     }
 
+    /// Controls whether post-reset locking RPCs are skipped instead of reapplied.
     pub fn skip_locking_rpc_reapply(mut self, skip: bool) -> Self {
         self.skip_locking_rpc_reapply = skip;
         self

--- a/sdk-rust/crates/dex-sdk/src/reset_flow_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/reset_flow_options.rs
@@ -48,7 +48,7 @@ impl ResetFlowOptions {
         Self::new(ResetPoint::HistoryEventTime(event_time))
     }
 
-    /// Resets before the first execution of the supplied Step type.
+    /// Resets before the first execution of the selected Step type.
     pub fn from_step<SomeStep: Step>(step: &SomeStep) -> Self {
         Self::new(ResetPoint::StepType(step.step_type()))
     }

--- a/sdk-rust/crates/dex-sdk/src/retry_policy.rs
+++ b/sdk-rust/crates/dex-sdk/src/retry_policy.rs
@@ -9,6 +9,24 @@
 use std::time::Duration;
 
 #[derive(Clone, Debug, Default, PartialEq)]
+/// Overrides Dex retry timing for a Flow, `wait_for`, or `execute` operation.
+///
+/// Unset fields use server defaults. Intervals and total duration use [`Duration`]; maximum
+/// attempts counts the initial attempt. A zero maximum attempts value delegates to server
+/// semantics.
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::RetryPolicy;
+/// use std::time::Duration;
+///
+/// let retry = RetryPolicy::new()
+///     .initial_interval(Duration::from_secs(1))
+///     .backoff_coefficient(2.0)
+///     .maximum_interval(Duration::from_secs(30))
+///     .maximum_attempts(5);
+/// ```
 pub struct RetryPolicy {
     pub(crate) initial_interval: Option<Duration>,
     pub(crate) backoff_coefficient: Option<f64>,
@@ -18,30 +36,36 @@ pub struct RetryPolicy {
 }
 
 impl RetryPolicy {
+    /// Creates an empty policy that preserves every server default.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets the delay before the first retry.
     pub fn initial_interval(mut self, value: Duration) -> Self {
         self.initial_interval = Some(value);
         self
     }
 
+    /// Sets the multiplier applied to each successive retry interval.
     pub fn backoff_coefficient(mut self, value: f64) -> Self {
         self.backoff_coefficient = Some(value);
         self
     }
 
+    /// Caps the delay between retries.
     pub fn maximum_interval(mut self, value: Duration) -> Self {
         self.maximum_interval = Some(value);
         self
     }
 
+    /// Sets the total attempt limit, including the initial attempt.
     pub fn maximum_attempts(mut self, value: u32) -> Self {
         self.maximum_attempts = Some(value);
         self
     }
 
+    /// Sets the total elapsed-time limit for all attempts.
     pub fn total_duration(mut self, value: Duration) -> Self {
         self.total_duration = Some(value);
         self

--- a/sdk-rust/crates/dex-sdk/src/retry_policy.rs
+++ b/sdk-rust/crates/dex-sdk/src/retry_policy.rs
@@ -12,8 +12,7 @@ use std::time::Duration;
 /// Overrides Dex retry timing for a Flow, `wait_for`, or `execute` operation.
 ///
 /// Unset fields use server defaults. Intervals and total duration use [`Duration`]; maximum
-/// attempts counts the initial attempt. A zero maximum attempts value delegates to server
-/// semantics.
+/// attempts counts the initial attempt. A zero maximum attempts value uses the server behavior.
 ///
 /// # Examples
 ///

--- a/sdk-rust/crates/dex-sdk/src/rpc.rs
+++ b/sdk-rust/crates/dex-sdk/src/rpc.rs
@@ -17,12 +17,41 @@ use crate::step::{ErasedValue, TypedValue};
 use crate::value_mapper;
 use crate::{Context, HandlerResult, SdkResult, StepMovement, Value};
 
+/// Names one typed RPC exposed by a Flow.
+///
+/// Use the same value when binding the handler in [`RpcList`] and invoking it through
+/// [`crate::Client`]. Input and output types must implement [`Value`]. The stable name becomes part
+/// of the protocol and must remain compatible with running Flows.
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::{Context, Flow, HandlerResult, Rpc, RpcList, RpcResult};
+///
+/// const STATUS: Rpc<(), String> = Rpc::new("status");
+/// struct OrderFlow;
+///
+/// impl OrderFlow {
+///     fn status(&self, _context: &mut Context) -> HandlerResult<RpcResult<String>> {
+///         Ok(RpcResult::new("ready".to_owned()))
+///     }
+/// }
+///
+/// impl Flow for OrderFlow {
+///     type StartInput = ();
+///
+///     fn rpcs(&self) -> RpcList<Self> {
+///         RpcList::new().function_without_input(STATUS, Self::status)
+///     }
+/// }
+/// ```
 pub struct Rpc<Input, Output> {
     name: &'static str,
     marker: PhantomData<fn(Input) -> Output>,
 }
 
 impl<Input, Output> Rpc<Input, Output> {
+    /// Defines an RPC with a stable protocol `name` and no option overrides.
     pub const fn new(name: &'static str) -> Self {
         Self {
             name,
@@ -30,10 +59,12 @@ impl<Input, Output> Rpc<Input, Output> {
         }
     }
 
+    /// Converts this RPC into a definition with a handler execution timeout.
     pub fn timeout(self, timeout: Duration) -> RpcDefinition<Input, Output> {
         RpcDefinition::from(self).timeout(timeout)
     }
 
+    /// Converts this RPC into a definition holding one Attribute lock during invocation.
     pub fn lock(self, lock: AttributeLock) -> RpcDefinition<Input, Output> {
         RpcDefinition::from(self).lock(lock)
     }
@@ -51,6 +82,10 @@ impl<Input, Output> Clone for Rpc<Input, Output> {
 
 impl<Input, Output> Copy for Rpc<Input, Output> {}
 
+/// Adds execution options to a typed [`Rpc`] before handler binding.
+///
+/// Definitions are created implicitly from `Rpc` or explicitly through [`Rpc::timeout`] and
+/// [`Rpc::lock`]. Multiple locks are acquired together for the invocation.
 pub struct RpcDefinition<Input, Output> {
     rpc: Rpc<Input, Output>,
     timeout: Option<Duration>,
@@ -58,11 +93,13 @@ pub struct RpcDefinition<Input, Output> {
 }
 
 impl<Input, Output> RpcDefinition<Input, Output> {
+    /// Sets the maximum duration of one RPC handler attempt.
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
         self
     }
 
+    /// Adds an Attribute or Attribute-map instance lock.
     pub fn lock(mut self, lock: AttributeLock) -> Self {
         self.locks.push(lock);
         self
@@ -79,6 +116,10 @@ impl<Input, Output> From<Rpc<Input, Output>> for RpcDefinition<Input, Output> {
     }
 }
 
+/// Binds typed RPC definitions to methods on one Flow type.
+///
+/// Return the completed list from [`crate::Flow::rpcs`]. Handler signatures encode whether input or
+/// output is present, preventing invalid calls at compile time.
 pub struct RpcList<FlowType> {
     definitions: Vec<Box<dyn RpcBinder<FlowType>>>,
 }
@@ -87,12 +128,16 @@ impl<FlowType> RpcList<FlowType>
 where
     FlowType: Send + Sync + 'static,
 {
+    /// Creates an empty RPC list.
     pub fn new() -> Self {
         Self {
             definitions: Vec::new(),
         }
     }
 
+    /// Binds an RPC that accepts typed input and returns typed output plus optional Step movements.
+    ///
+    /// Handler errors are returned to Dex and follow RPC failure semantics.
     pub fn function<Input, Output>(
         mut self,
         definition: impl Into<RpcDefinition<Input, Output>>,
@@ -109,6 +154,7 @@ where
         self
     }
 
+    /// Binds an RPC without input that returns typed output and optional Step movements.
     pub fn function_without_input<Output>(
         mut self,
         definition: impl Into<RpcDefinition<(), Output>>,
@@ -124,6 +170,7 @@ where
         self
     }
 
+    /// Binds an RPC that accepts typed input and returns no output.
     pub fn procedure<Input>(
         mut self,
         definition: impl Into<RpcDefinition<Input, ()>>,
@@ -139,6 +186,7 @@ where
         self
     }
 
+    /// Binds an RPC with neither input nor output.
     pub fn procedure_without_input(
         mut self,
         definition: impl Into<RpcDefinition<(), ()>>,
@@ -168,12 +216,16 @@ where
     }
 }
 
+/// Carries a typed RPC output and optional Step movements.
+///
+/// [`Self::then`] may be called repeatedly to schedule multiple active Steps after the RPC commits.
 pub struct RpcResult<Output> {
     output: Output,
     next_steps: Vec<StepMovement>,
 }
 
 impl<Output: Value> RpcResult<Output> {
+    /// Creates a result with `output` and no Step movements.
     pub fn new(output: Output) -> Self {
         Self {
             output,
@@ -181,15 +233,18 @@ impl<Output: Value> RpcResult<Output> {
         }
     }
 
+    /// Appends one Step movement executed after the RPC succeeds.
     pub fn then(mut self, movement: StepMovement) -> Self {
         self.next_steps.push(movement);
         self
     }
 
+    /// Returns the typed output by reference.
     pub fn output(&self) -> &Output {
         &self.output
     }
 
+    /// Returns the scheduled Step movements in insertion order.
     pub fn next_steps(&self) -> &[StepMovement] {
         &self.next_steps
     }

--- a/sdk-rust/crates/dex-sdk/src/sdk_error.rs
+++ b/sdk-rust/crates/dex-sdk/src/sdk_error.rs
@@ -22,7 +22,7 @@ pub type SdkResult<T> = Result<T, SdkError>;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 /// Provides Dex-specific detail beyond a gRPC status code.
 pub enum ErrorSubStatus {
-    /// Dex supplied no recognized specialized status.
+    /// Dex returned no specific status.
     Uncategorized,
     /// A start request targeted an already-existing Flow ID.
     FlowAlreadyStarted,
@@ -105,7 +105,7 @@ pub struct WorkerError {
 }
 
 impl WorkerError {
-    /// Returns the Worker gRPC status when supplied.
+    /// Returns the Worker gRPC status when available.
     pub fn code(&self) -> Option<GrpcCode> {
         self.code
     }
@@ -124,7 +124,7 @@ impl WorkerError {
 #[derive(Debug)]
 /// Reports service, definition, value, handler, and Flow-completion failures.
 ///
-/// Match specialized variants when recovery differs. [`Self::service_error`] extracts common gRPC
+/// Match specific variants when recovery differs. [`Self::service_error`] extracts common gRPC
 /// metadata from every service-backed variant.
 pub enum SdkError {
     /// A general Dex service or transport call failed.
@@ -170,9 +170,9 @@ pub enum SdkError {
         run_id: String,
         /// Terminal Flow status.
         status: FlowStatus,
-        /// Dex failure category, when supplied.
+        /// Dex failure category, when available.
         error_type: Option<FlowErrorType>,
-        /// Server completion detail, when supplied.
+        /// Server completion detail, when available.
         message: Option<String>,
         /// Number of completed Step outputs returned with the failure.
         result_count: usize,

--- a/sdk-rust/crates/dex-sdk/src/sdk_error.rs
+++ b/sdk-rust/crates/dex-sdk/src/sdk_error.rs
@@ -16,18 +16,26 @@ use tonic::Status;
 
 use crate::{FlowErrorType, FlowStatus, GrpcCode};
 
+/// Result returned by fallible Dex SDK operations.
 pub type SdkResult<T> = Result<T, SdkError>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Provides Dex-specific detail beyond a gRPC status code.
 pub enum ErrorSubStatus {
+    /// Dex supplied no recognized specialized status.
     Uncategorized,
+    /// A start request targeted an already-existing Flow ID.
     FlowAlreadyStarted,
+    /// The requested Flow does not exist or is no longer active.
     FlowNotExists,
+    /// A Worker Step or RPC invocation failed.
     WorkerApiError,
+    /// A long-poll deadline elapsed while the Flow remained active.
     LongPollTimeout,
 }
 
 #[derive(Debug)]
+/// Preserves one failed Dex service operation and its transport source.
 pub struct ServiceError {
     code: GrpcCode,
     sub_status: ErrorSubStatus,
@@ -38,22 +46,27 @@ pub struct ServiceError {
 }
 
 impl ServiceError {
+    /// Returns the outer gRPC status code.
     pub fn code(&self) -> GrpcCode {
         self.code
     }
 
+    /// Returns the decoded Dex-specific status.
     pub fn sub_status(&self) -> ErrorSubStatus {
         self.sub_status
     }
 
+    /// Returns the most specific server or transport detail available.
     pub fn detail(&self) -> &str {
         &self.detail
     }
 
+    /// Returns the SDK operation name that failed.
     pub fn operation(&self) -> &str {
         self.operation
     }
 
+    /// Returns the targeted Flow ID when the operation had one.
     pub fn flow_id(&self) -> Option<&str> {
         self.flow_id.as_deref()
     }
@@ -84,6 +97,7 @@ impl Error for ServiceError {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Preserves the original Worker-side error carried by a service failure.
 pub struct WorkerError {
     code: Option<GrpcCode>,
     error_type: String,
@@ -91,62 +105,100 @@ pub struct WorkerError {
 }
 
 impl WorkerError {
+    /// Returns the Worker gRPC status when supplied.
     pub fn code(&self) -> Option<GrpcCode> {
         self.code
     }
 
+    /// Returns the Worker exception or error type name.
     pub fn error_type(&self) -> &str {
         &self.error_type
     }
 
+    /// Returns the Worker-provided failure detail.
     pub fn detail(&self) -> &str {
         &self.detail
     }
 }
 
 #[derive(Debug)]
+/// Reports service, definition, value, handler, and Flow-completion failures.
+///
+/// Match specialized variants when recovery differs. [`Self::service_error`] extracts common gRPC
+/// metadata from every service-backed variant.
 pub enum SdkError {
+    /// A general Dex service or transport call failed.
     Service {
+        /// Structured service failure.
         service: ServiceError,
     },
+    /// Starting a Flow conflicted with an existing Flow ID.
     FlowAlreadyStarted {
+        /// Structured start-operation failure.
         service: ServiceError,
     },
+    /// An operation requiring an existing Flow targeted an unknown ID.
     FlowNotFound {
+        /// Structured lookup failure.
         service: ServiceError,
     },
+    /// An operation requiring an active Flow targeted a terminal or unknown ID.
     FlowNotActive {
+        /// Structured active-Flow failure.
         service: ServiceError,
     },
+    /// A Worker Step or RPC handler failed.
     WorkerInvocation {
+        /// Outer Dex service failure.
         service: ServiceError,
+        /// Original Worker-side failure metadata.
         worker: Box<WorkerError>,
     },
+    /// A locking RPC could not acquire all requested Attribute locks.
     RpcLockConflict {
+        /// Structured aborted-operation failure.
         service: ServiceError,
     },
+    /// A long-poll timeout elapsed without indicating a Flow failure.
     LongPollTimeout {
+        /// Structured timeout failure.
         service: ServiceError,
     },
+    /// A waited Flow reached a terminal status other than Completed.
     FlowUncompleted {
+        /// Run ID that reached the terminal status.
         run_id: String,
+        /// Terminal Flow status.
         status: FlowStatus,
+        /// Dex failure category, when supplied.
         error_type: Option<FlowErrorType>,
+        /// Server completion detail, when supplied.
         message: Option<String>,
+        /// Number of completed Step outputs returned with the failure.
         result_count: usize,
     },
+    /// A registered Flow, Step, RPC, or persistence definition is invalid.
     FlowDefinition {
+        /// Developer-actionable contract violation.
         message: String,
     },
+    /// An SDK method received an invalid argument.
     InvalidArgument {
+        /// Developer-actionable argument violation.
         message: String,
     },
+    /// An application value could not be serialized or decoded.
     ValueMapping {
+        /// Developer-actionable mapping failure.
         message: String,
     },
+    /// A Step returned a value that violates its handler contract.
     InvalidStepResult {
+        /// Flow type containing the Step.
         flow_type: String,
+        /// Step type that returned the invalid value.
         step_type: String,
+        /// Developer-actionable result violation.
         detail: String,
     },
 }
@@ -180,6 +232,10 @@ impl Error for SdkError {
 }
 
 impl SdkError {
+    /// Returns shared service metadata for service-backed variants.
+    ///
+    /// Local definition, argument, mapping, invalid-result, and uncompleted-Flow errors return
+    /// `None`.
     pub fn service_error(&self) -> Option<&ServiceError> {
         match self {
             Self::Service { service }

--- a/sdk-rust/crates/dex-sdk/src/start_flow_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/start_flow_options.rs
@@ -17,15 +17,39 @@ use crate::step::{ErasedValue, TypedValue};
 use crate::{Attribute, AttributeMap, FlowConfig, RetryPolicy, Value};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Controls whether [`crate::Client::start_flow_with_options`] may reuse a Flow ID.
 pub enum IdReusePolicy {
+    /// Uses the Dex server's configured reuse policy.
     Default,
+    /// Allows reuse only when the previous run failed.
     AllowIfPreviousFailed,
+    /// Allows reuse when no run with the ID is currently active.
     AllowIfNotRunning,
+    /// Rejects reuse regardless of the previous run status.
     Disallow,
+    /// Terminates an active run before starting the replacement.
     TerminateIfRunning,
 }
 
 #[derive(Clone)]
+/// Configures a new Flow execution.
+///
+/// All optional fields are absent by default. Initial Attribute values are encoded when the start
+/// request is sent. Use a stable request ID to make retries of the same logical request idempotent.
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::{Attribute, IdReusePolicy, StartFlowOptions};
+/// use std::time::Duration;
+///
+/// let customer = Attribute::<String>::new("customer");
+/// let options = StartFlowOptions::new()
+///     .timeout(Duration::from_secs(3_600))
+///     .id_reuse_policy(IdReusePolicy::AllowIfNotRunning)
+///     .initial_attribute(&customer, "customer-42".to_owned())
+///     .request_id("create-order-42");
+/// ```
 pub struct StartFlowOptions {
     pub(crate) timeout: Option<Duration>,
     pub(crate) start_delay: Option<Duration>,
@@ -46,6 +70,7 @@ pub(crate) struct InitialAttribute {
 }
 
 impl StartFlowOptions {
+    /// Creates start options that preserve all server defaults.
     pub fn new() -> Self {
         Self {
             timeout: None,
@@ -60,31 +85,37 @@ impl StartFlowOptions {
         }
     }
 
+    /// Sets the maximum total Flow execution duration.
     pub fn timeout(mut self, value: Duration) -> Self {
         self.timeout = Some(value);
         self
     }
 
+    /// Delays the first Step after the server accepts the Flow.
     pub fn start_delay(mut self, value: Duration) -> Self {
         self.start_delay = Some(value);
         self
     }
 
+    /// Sets how the server handles an existing Flow with the same ID.
     pub fn id_reuse_policy(mut self, value: IdReusePolicy) -> Self {
         self.id_reuse_policy = value;
         self
     }
 
+    /// Sets the server cron expression used to schedule recurring runs.
     pub fn cron_schedule(mut self, value: impl Into<String>) -> Self {
         self.cron_schedule = Some(value.into());
         self
     }
 
+    /// Sets the whole-Flow retry policy after a terminal failure.
     pub fn retry_policy(mut self, value: RetryPolicy) -> Self {
         self.retry_policy = Some(value);
         self
     }
 
+    /// Adds an initial value for a declared Attribute.
     pub fn initial_attribute<T: Value>(mut self, attribute: &Attribute<T>, value: T) -> Self {
         self.attributes.push(InitialAttribute {
             key: attribute.name().to_string(),
@@ -94,6 +125,7 @@ impl StartFlowOptions {
         self
     }
 
+    /// Adds an initial value for one Attribute-map instance.
     pub fn initial_attribute_map<T: Value>(
         mut self,
         attribute: &AttributeMap<T>,
@@ -108,16 +140,19 @@ impl StartFlowOptions {
         self
     }
 
+    /// Overrides the registered Flow configuration for this execution.
     pub fn config_override(mut self, value: FlowConfig) -> Self {
         self.config_override = Some(value);
         self
     }
 
+    /// Returns the existing run ID instead of an error when the Flow already exists.
     pub fn ignore_already_started(mut self, value: bool) -> Self {
         self.ignore_already_started = value;
         self
     }
 
+    /// Sets the idempotency key for this start request.
     pub fn request_id(mut self, value: impl Into<String>) -> Self {
         self.request_id = Some(value.into());
         self

--- a/sdk-rust/crates/dex-sdk/src/step.rs
+++ b/sdk-rust/crates/dex-sdk/src/step.rs
@@ -210,7 +210,7 @@ impl StepDecision {
         Self::go_to_many([StepMovement::to(step, input)])
     }
 
-    /// Moves to every supplied target, enabling concurrent active Steps.
+    /// Moves to all targets, enabling concurrent active Steps.
     pub fn go_to_many(movements: impl IntoIterator<Item = StepMovement>) -> Self {
         Self {
             kind: StepDecisionKind::Next(movements.into_iter().collect()),

--- a/sdk-rust/crates/dex-sdk/src/step.rs
+++ b/sdk-rust/crates/dex-sdk/src/step.rs
@@ -15,30 +15,76 @@ use crate::step_options::ErasedStepOptions;
 use crate::value_mapper;
 use crate::{Context, HandlerResult, SdkResult, StepOptions, Value, Wait, short_type_name};
 
+/// Defines one durable state transition in a Flow.
+///
+/// Dex calls [`Self::wait_for`] to obtain durable conditions, then calls [`Self::execute`] after the
+/// wait is satisfied. The default `wait_for` skips immediately, making execute-only Steps concise.
+/// Handler code may read and stage persistence changes through [`Context`].
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::{Context, HandlerResult, Step, StepDecision};
+///
+/// struct CompleteOrder;
+///
+/// impl Step for CompleteOrder {
+///     type Input = String;
+///
+///     fn execute(
+///         &self,
+///         _context: &mut Context,
+///         order_id: Self::Input,
+///     ) -> HandlerResult<StepDecision> {
+///         Ok(StepDecision::graceful_complete(order_id))
+///     }
+/// }
+/// ```
 pub trait Step: Send + Sync + 'static {
+    /// Value decoded for both `wait_for` and `execute`.
     type Input: Value;
 
+    /// Produces the next movement or terminal Flow decision.
+    ///
+    /// `context` represents one isolated invocation and `input` is a newly decoded owned value.
+    /// Returning [`HandlerError`](crate::HandlerError) activates the configured execute retry and
+    /// failure behavior.
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision>;
 
+    /// Returns the durable conditions Dex must satisfy before `execute`.
+    ///
+    /// The default returns [`Wait::skip_immediately`]. Returning an error activates the configured
+    /// `wait_for` retry and failure behavior.
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::skip_immediately())
     }
 
+    /// Returns the stable Step type sent to Dex.
+    ///
+    /// The default is the final Rust type-name segment.
     fn step_type(&self) -> &'static str {
         short_type_name::<Self>()
     }
 
+    /// Returns timeouts, retries, locks, durability, and failure behavior for this Step.
+    ///
+    /// The default preserves server defaults and fails the Flow when `wait_for` exhausts retries.
     fn options(&self) -> StepOptions<Self::Input> {
         StepOptions::new()
     }
 }
 
+/// Collects a Flow's starting Step and remaining Step definitions.
+///
+/// The lifetime ties registered definitions to Step values owned by the Flow. A list may contain at
+/// most one starting Step; [`Self::and`] adds non-starting Steps with arbitrary input types.
 pub struct StepList<'a, StartInput> {
     definitions: Vec<StepDefinition<'a>>,
     marker: PhantomData<fn(StartInput)>,
 }
 
 impl<'a, StartInput: Value> StepList<'a, StartInput> {
+    /// Creates a list without a starting Step.
     pub fn empty() -> Self {
         Self {
             definitions: Vec::new(),
@@ -46,6 +92,7 @@ impl<'a, StartInput: Value> StepList<'a, StartInput> {
         }
     }
 
+    /// Creates a list whose starting Step accepts the Flow's start input.
     pub fn start<StartStep>(step: &'a StartStep) -> Self
     where
         StartStep: Step<Input = StartInput>,
@@ -56,6 +103,7 @@ impl<'a, StartInput: Value> StepList<'a, StartInput> {
         }
     }
 
+    /// Adds a non-starting Step and returns the updated list.
     pub fn and<OtherStep>(mut self, step: &'a OtherStep) -> Self
     where
         OtherStep: Step,
@@ -88,6 +136,10 @@ impl<StartInput: Value> Default for StepList<'_, StartInput> {
     }
 }
 
+/// Targets a Step with encoded input and an optional per-movement options override.
+///
+/// Create movements with [`Self::to`] or [`Self::to_with_options`], then pass them to
+/// [`StepDecision::go_to_many`], [`crate::RpcResult::then`], or conditional completion.
 pub struct StepMovement {
     pub(crate) target_step_type: &'static str,
     input: Box<dyn ErasedValue>,
@@ -95,6 +147,7 @@ pub struct StepMovement {
 }
 
 impl StepMovement {
+    /// Targets `step` with typed `input` and the Step's registered options.
     pub fn to<TargetStep>(step: &TargetStep, input: TargetStep::Input) -> Self
     where
         TargetStep: Step,
@@ -106,6 +159,7 @@ impl StepMovement {
         }
     }
 
+    /// Targets `step` with typed input and options used only for this movement.
     pub fn to_with_options<TargetStep>(
         step: &TargetStep,
         input: TargetStep::Input,
@@ -126,6 +180,10 @@ impl StepMovement {
     }
 }
 
+/// Describes the durable outcome of one successful Step execution.
+///
+/// A decision moves to one or more Steps, completes or fails the Flow, waits for Channels to empty,
+/// or deliberately leaves the Flow at a dead end.
 pub struct StepDecision {
     pub(crate) kind: StepDecisionKind,
 }
@@ -144,6 +202,7 @@ pub(crate) enum StepDecisionKind {
 }
 
 impl StepDecision {
+    /// Moves to one typed target Step.
     pub fn go_to<TargetStep>(step: &TargetStep, input: TargetStep::Input) -> Self
     where
         TargetStep: Step,
@@ -151,24 +210,28 @@ impl StepDecision {
         Self::go_to_many([StepMovement::to(step, input)])
     }
 
+    /// Moves to every supplied target, enabling concurrent active Steps.
     pub fn go_to_many(movements: impl IntoIterator<Item = StepMovement>) -> Self {
         Self {
             kind: StepDecisionKind::Next(movements.into_iter().collect()),
         }
     }
 
+    /// Completes only after all other active Steps finish, returning `output`.
     pub fn graceful_complete<Output: Value>(output: Output) -> Self {
         Self {
             kind: StepDecisionKind::GracefulComplete(Box::new(TypedValue(output))),
         }
     }
 
+    /// Completes immediately, abandoning other active Steps and returning `output`.
     pub fn force_complete<Output: Value>(output: Output) -> Self {
         Self {
             kind: StepDecisionKind::ForceComplete(Box::new(TypedValue(output))),
         }
     }
 
+    /// Completes with `output` when every guard is empty; otherwise follows `fallback`.
     pub fn force_complete_when_channels_empty<Output: Value>(
         output: Output,
         fallback: StepMovement,
@@ -183,12 +246,16 @@ impl StepDecision {
         }
     }
 
+    /// Fails the Flow immediately with an application-provided reason.
     pub fn force_fail(reason: impl Into<String>) -> Self {
         Self {
             kind: StepDecisionKind::ForceFail(reason.into()),
         }
     }
 
+    /// Leaves the Flow running with no next Step.
+    ///
+    /// Use this only when an RPC or external operation will resume the Flow later.
     pub fn dead_end() -> Self {
         Self {
             kind: StepDecisionKind::DeadEnd,

--- a/sdk-rust/crates/dex-sdk/src/step_execution.rs
+++ b/sdk-rust/crates/dex-sdk/src/step_execution.rs
@@ -9,12 +9,16 @@
 use crate::Step;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Identifies one execution of a Step type within a Flow run.
+///
+/// Execution numbers are one-based and default to `1`.
 pub struct StepExecutionId {
     pub(crate) step_type: &'static str,
     pub(crate) execution_number: u32,
 }
 
 impl StepExecutionId {
+    /// Targets the first execution of `step`.
     pub fn of<SomeStep: Step>(step: &SomeStep) -> Self {
         Self {
             step_type: step.step_type(),
@@ -22,6 +26,7 @@ impl StepExecutionId {
         }
     }
 
+    /// Selects a one-based execution number for repeated Step executions.
     pub fn execution_number(mut self, execution_number: u32) -> Self {
         self.execution_number = execution_number;
         self

--- a/sdk-rust/crates/dex-sdk/src/step_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/step_options.rs
@@ -15,8 +15,8 @@ use crate::{RetryPolicy, Step, Value};
 /// Configures one Step's handler execution and persistence behavior.
 ///
 /// New options preserve server timeout, retry, and durability defaults. `wait_for` failures fail the
-/// Flow by default. Attribute locks apply only to their respective handler invocation. The input
-/// type ensures an execute-failure recovery Step accepts the same value.
+/// Flow by default. Attribute locks apply only to the matching handler call. The type system checks
+/// that an execute-failure recovery Step accepts the same input type.
 ///
 /// # Examples
 ///

--- a/sdk-rust/crates/dex-sdk/src/step_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/step_options.rs
@@ -12,6 +12,25 @@ use std::time::Duration;
 use crate::attribute::AttributeLock;
 use crate::{RetryPolicy, Step, Value};
 
+/// Configures one Step's handler execution and persistence behavior.
+///
+/// New options preserve server timeout, retry, and durability defaults. `wait_for` failures fail the
+/// Flow by default. Attribute locks apply only to their respective handler invocation. The input
+/// type ensures an execute-failure recovery Step accepts the same value.
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::{Attribute, RetryPolicy, StepOptions, WaitForFailurePolicy};
+/// use std::time::Duration;
+///
+/// let balance = Attribute::<i64>::new("balance");
+/// let options = StepOptions::<String>::new()
+///     .execute_method_timeout(Duration::from_secs(30))
+///     .execute_retry(RetryPolicy::new().maximum_attempts(3))
+///     .wait_for_failure(WaitForFailurePolicy::Proceed)
+///     .execute_lock(balance.lock());
+/// ```
 pub struct StepOptions<Input> {
     pub(crate) wait_for_method_timeout: Option<Duration>,
     pub(crate) execute_method_timeout: Option<Duration>,
@@ -58,6 +77,7 @@ impl<Input> From<StepOptions<Input>> for ErasedStepOptions {
 }
 
 impl<Input: Value> StepOptions<Input> {
+    /// Creates options that preserve server defaults and fail on exhausted `wait_for` retries.
     pub fn new() -> Self {
         Self {
             wait_for_method_timeout: None,
@@ -74,31 +94,37 @@ impl<Input: Value> StepOptions<Input> {
         }
     }
 
+    /// Sets the maximum duration of one `wait_for` handler attempt.
     pub fn wait_for_method_timeout(mut self, value: Duration) -> Self {
         self.wait_for_method_timeout = Some(value);
         self
     }
 
+    /// Sets the maximum duration of one `execute` handler attempt.
     pub fn execute_method_timeout(mut self, value: Duration) -> Self {
         self.execute_method_timeout = Some(value);
         self
     }
 
+    /// Sets the retry policy for failed `wait_for` attempts.
     pub fn wait_for_retry(mut self, value: RetryPolicy) -> Self {
         self.wait_for_retry = Some(value);
         self
     }
 
+    /// Sets the retry policy for failed `execute` attempts.
     pub fn execute_retry(mut self, value: RetryPolicy) -> Self {
         self.execute_retry = Some(value);
         self
     }
 
+    /// Selects whether exhausted `wait_for` retries fail or advance the Flow.
     pub fn wait_for_failure(mut self, value: WaitForFailurePolicy) -> Self {
         self.wait_for_failure = value;
         self
     }
 
+    /// Routes exhausted `execute` failures to a recovery Step with the same input type.
     pub fn on_execute_failure_proceed_to<RecoveryStep>(mut self, step: &RecoveryStep) -> Self
     where
         RecoveryStep: Step<Input = Input>,
@@ -107,21 +133,25 @@ impl<Input: Value> StepOptions<Input> {
         self
     }
 
+    /// Overrides persistence durability for writes staged by `wait_for`.
     pub fn wait_for_durability(mut self, value: StepDurability) -> Self {
         self.wait_for_durability = value;
         self
     }
 
+    /// Overrides persistence durability for writes staged by `execute`.
     pub fn execute_durability(mut self, value: StepDurability) -> Self {
         self.execute_durability = value;
         self
     }
 
+    /// Adds an Attribute lock held for the `wait_for` invocation.
     pub fn wait_for_lock(mut self, value: AttributeLock) -> Self {
         self.wait_for_locks.push(value);
         self
     }
 
+    /// Adds an Attribute lock held for the `execute` invocation.
     pub fn execute_lock(mut self, value: AttributeLock) -> Self {
         self.execute_locks.push(value);
         self
@@ -135,14 +165,21 @@ impl<Input: Value> Default for StepOptions<Input> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Selects the terminal behavior after `wait_for` exhausts its retry policy.
 pub enum WaitForFailurePolicy {
+    /// Fails the Flow.
     FailFlow,
+    /// Skips the failed wait and invokes `execute` with failure visible in [`crate::Context`].
     Proceed,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Controls when staged Step persistence must be durably acknowledged.
 pub enum StepDurability {
+    /// Uses the Flow or server default.
     Default,
+    /// Waits for durable persistence before completing the handler request.
     Sync,
+    /// Allows asynchronous persistence after accepting the handler result.
     Async,
 }

--- a/sdk-rust/crates/dex-sdk/src/stop_flow_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/stop_flow_options.rs
@@ -41,7 +41,7 @@ impl StopFlowOptions {
         Self::new(StopType::Terminate)
     }
 
-    /// Marks the Flow failed with the supplied reason.
+    /// Marks the Flow failed with the reason set by [`Self::reason`].
     pub fn fail() -> Self {
         Self::new(StopType::Fail)
     }

--- a/sdk-rust/crates/dex-sdk/src/stop_flow_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/stop_flow_options.rs
@@ -14,6 +14,10 @@ pub(crate) enum StopType {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Selects how [`crate::Client::stop_flow`] ends an active Flow.
+///
+/// Construct a value with [`Self::cancel`], [`Self::terminate`], or [`Self::fail`], then optionally
+/// attach an operator-facing reason.
 pub struct StopFlowOptions {
     pub(crate) stop_type: StopType,
     pub(crate) reason: Option<String>,
@@ -27,18 +31,22 @@ impl StopFlowOptions {
         }
     }
 
+    /// Requests cooperative cancellation so application cleanup can run.
     pub fn cancel() -> Self {
         Self::new(StopType::Cancel)
     }
 
+    /// Terminates the Flow immediately without cooperative cleanup.
     pub fn terminate() -> Self {
         Self::new(StopType::Terminate)
     }
 
+    /// Marks the Flow failed with the supplied reason.
     pub fn fail() -> Self {
         Self::new(StopType::Fail)
     }
 
+    /// Attaches a reason recorded with the stop operation.
     pub fn reason(mut self, value: impl Into<String>) -> Self {
         self.reason = Some(value.into());
         self

--- a/sdk-rust/crates/dex-sdk/src/timer.rs
+++ b/sdk-rust/crates/dex-sdk/src/timer.rs
@@ -10,25 +10,34 @@ use std::time::Duration;
 
 use crate::Condition;
 
+/// Creates durable timer conditions for Step waits.
 pub struct Timer;
 
 impl Timer {
+    /// Returns a condition that becomes true after `duration` elapses.
+    ///
+    /// Timer duration is measured by Dex workflow time and survives Worker restarts.
     pub fn by_duration(duration: Duration) -> Condition {
         Condition::timer(duration)
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Selects one timer from a Step execution for [`crate::Client::skip_timer`].
 pub enum TimerId {
+    /// Targets the condition carrying this explicit condition ID.
     ConditionId(String),
+    /// Targets the zero-based timer-condition index within the wait result.
     ConditionIndex(usize),
 }
 
 impl TimerId {
+    /// Selects a timer by the ID assigned with [`Condition::with_id`].
     pub fn by_condition_id(id: impl Into<String>) -> Self {
         Self::ConditionId(id.into())
     }
 
+    /// Selects a timer by its zero-based condition index.
     pub fn by_condition_index(index: usize) -> Self {
         Self::ConditionIndex(index)
     }

--- a/sdk-rust/crates/dex-sdk/src/value.rs
+++ b/sdk-rust/crates/dex-sdk/src/value.rs
@@ -9,6 +9,11 @@
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
+/// Marks application values that Dex can serialize as JSON and move across handler boundaries.
+///
+/// The blanket implementation accepts owned, thread-safe Serde values. Keep serialized shapes
+/// backward compatible for running Flows, because persisted Attributes, Channel messages, Step
+/// inputs, and RPC payloads may outlive a deployment.
 pub trait Value: DeserializeOwned + Send + Serialize + Sync + 'static {}
 
 impl<T> Value for T where T: DeserializeOwned + Send + Serialize + Sync + 'static {}

--- a/sdk-rust/crates/dex-sdk/src/wait.rs
+++ b/sdk-rust/crates/dex-sdk/src/wait.rs
@@ -8,6 +8,23 @@
 
 use std::time::Duration;
 
+/// Describes when Dex may invoke a Step's `execute` handler.
+///
+/// Build waits from durable timer and Channel [`Condition`] values. Combinators consume their
+/// inputs and preserve order, which determines timer indexes used by [`crate::TimerId`].
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::{Channel, Timer, Wait};
+/// use std::time::Duration;
+///
+/// let approvals = Channel::<String>::new("approvals");
+/// let wait = Wait::any_of([
+///     approvals.for_one().with_id("approved"),
+///     Timer::by_duration(Duration::from_secs(300)).with_id("timeout"),
+/// ]);
+/// ```
 pub struct Wait {
     pub(crate) kind: WaitKind,
 }
@@ -20,28 +37,33 @@ pub(crate) enum WaitKind {
 }
 
 impl Wait {
+    /// Skips `wait_for` and asks Dex to invoke `execute` immediately.
     pub fn skip_immediately() -> Self {
         Self {
             kind: WaitKind::SkipImmediately,
         }
     }
 
+    /// Waits until one condition is satisfied.
     pub fn until(condition: Condition) -> Self {
         Self::all_of([condition])
     }
 
+    /// Waits until every supplied condition is satisfied.
     pub fn all_of(conditions: impl IntoIterator<Item = Condition>) -> Self {
         Self {
             kind: WaitKind::AllOf(conditions.into_iter().collect()),
         }
     }
 
+    /// Waits until at least one supplied condition is satisfied.
     pub fn any_of(conditions: impl IntoIterator<Item = Condition>) -> Self {
         Self {
             kind: WaitKind::AnyOf(conditions.into_iter().collect()),
         }
     }
 
+    /// Waits until every condition in at least one combination is satisfied.
     pub fn any_combination_of(
         combinations: impl IntoIterator<Item = ConditionCombination>,
     ) -> Self {
@@ -51,6 +73,10 @@ impl Wait {
     }
 }
 
+/// Represents one durable timer or Channel predicate.
+///
+/// Conditions are created by [`crate::Timer`], [`crate::Channel`], or [`crate::ChannelMap`]. Assign
+/// an ID when application code must identify a timer independently of its position.
 pub struct Condition {
     pub(crate) id: Option<String>,
     pub(crate) kind: ConditionKind,
@@ -91,17 +117,20 @@ impl Condition {
         }
     }
 
+    /// Assigns a stable ID used by [`crate::TimerId::by_condition_id`].
     pub fn with_id(mut self, id: impl Into<String>) -> Self {
         self.id = Some(id.into());
         self
     }
 }
 
+/// Groups conditions that must all succeed as one branch of [`Wait::any_combination_of`].
 pub struct ConditionCombination {
     pub(crate) conditions: Vec<Condition>,
 }
 
 impl ConditionCombination {
+    /// Creates a branch satisfied only when all `conditions` are satisfied.
     pub fn all_of(conditions: impl IntoIterator<Item = Condition>) -> Self {
         Self {
             conditions: conditions.into_iter().collect(),

--- a/sdk-rust/crates/dex-sdk/src/wait.rs
+++ b/sdk-rust/crates/dex-sdk/src/wait.rs
@@ -49,14 +49,14 @@ impl Wait {
         Self::all_of([condition])
     }
 
-    /// Waits until every supplied condition is satisfied.
+    /// Waits until every condition is satisfied.
     pub fn all_of(conditions: impl IntoIterator<Item = Condition>) -> Self {
         Self {
             kind: WaitKind::AllOf(conditions.into_iter().collect()),
         }
     }
 
-    /// Waits until at least one supplied condition is satisfied.
+    /// Waits until at least one condition is satisfied.
     pub fn any_of(conditions: impl IntoIterator<Item = Condition>) -> Self {
         Self {
             kind: WaitKind::AnyOf(conditions.into_iter().collect()),

--- a/sdk-rust/crates/dex-sdk/src/worker.rs
+++ b/sdk-rust/crates/dex-sdk/src/worker.rs
@@ -34,6 +34,26 @@ const CREATED: u8 = 0;
 const RUNNING: u8 = 1;
 const STOPPED: u8 = 2;
 
+/// Hosts registered Flow Step and RPC handlers over application WorkerService.
+///
+/// A Worker owns an internal Tokio runtime and is one-shot. [`Self::start`] first synchronizes
+/// Attribute indexes with Dex, then blocks the calling thread while serving gRPC. Call [`Self::stop`]
+/// from another thread to request graceful server shutdown.
+///
+/// # Examples
+///
+/// ```no_run
+/// use dex_sdk::{BlobCache, BlobCacheConfig, Registry, Worker, WorkerOptions};
+/// use std::sync::Arc;
+///
+/// let cache = Arc::new(BlobCache::open(BlobCacheConfig::new(
+///     "/tmp/dex-blobs", 64 * 1024 * 1024, 0,
+/// )?)?);
+/// let worker = Worker::try_new(Registry::new(), cache, WorkerOptions::new())?;
+/// println!("advertise {}", worker.worker_target().address());
+/// worker.start()?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 pub struct Worker {
     runtime: Runtime,
     service: RustWorkerService,
@@ -47,11 +67,23 @@ pub struct Worker {
 }
 
 impl Worker {
+    /// Creates a Worker or panics when options or runtime initialization are invalid.
+    ///
+    /// # Panics
+    ///
+    /// Panics for an invalid bind address, zero index-sync timeout, invalid Dex endpoint, or Tokio
+    /// runtime creation failure. Prefer [`Self::try_new`] for recoverable startup.
     pub fn new(registry: Registry, blob_cache: Arc<BlobCache>, options: WorkerOptions) -> Self {
         Self::try_new(registry, blob_cache, options)
             .unwrap_or_else(|error| panic!("cannot create Rust Worker: {error}"))
     }
 
+    /// Creates a one-shot Worker without binding its listener.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SdkError::FlowDefinition`] for invalid Worker options or Service for runtime and
+    /// endpoint initialization failures. The Dex connection is lazy.
     pub fn try_new(
         registry: Registry,
         blob_cache: Arc<BlobCache>,
@@ -100,10 +132,17 @@ impl Worker {
         })
     }
 
+    /// Returns the resolved WorkerService target that Clients should advertise to Dex.
     pub fn worker_target(&self) -> &WorkerTarget {
         &self.worker_target
     }
 
+    /// Synchronizes Attribute indexes, serves WorkerService, and blocks until stopped or failed.
+    ///
+    /// # Errors
+    ///
+    /// Returns FlowDefinition if called more than once, or Service for index synchronization,
+    /// timeout, bind, and server failures.
     pub fn start(&self) -> SdkResult<()> {
         self.state
             .compare_exchange(CREATED, RUNNING, Ordering::AcqRel, Ordering::Acquire)
@@ -143,6 +182,9 @@ impl Worker {
         result.map_err(service_error)
     }
 
+    /// Requests shutdown of a running Worker and returns immediately.
+    ///
+    /// Calling `stop` before or after `start` is safe; [`Self::start`] observes the shutdown signal.
     pub fn stop(&self) {
         let _ = self.shutdown.send(true);
     }

--- a/sdk-rust/crates/dex-sdk/src/worker_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/worker_options.rs
@@ -9,12 +9,17 @@
 use std::time::Duration;
 
 #[derive(Clone, Debug)]
+/// Identifies the application WorkerService endpoint Dex should call.
+///
+/// The address is advertised, not bound locally. Headless targets must be direct `host:port`
+/// addresses; non-headless targets may use resolver-supported gRPC target syntax.
 pub struct WorkerTarget {
     address: String,
     headless: bool,
 }
 
 impl WorkerTarget {
+    /// Creates a non-headless target at `address`.
     pub fn new(address: impl Into<String>) -> Self {
         Self {
             address: address.into(),
@@ -22,21 +27,28 @@ impl WorkerTarget {
         }
     }
 
+    /// Enables direct headless routing when `value` is `true`.
     pub fn headless(mut self, value: bool) -> Self {
         self.headless = value;
         self
     }
 
+    /// Returns the advertised gRPC target address.
     pub fn address(&self) -> &str {
         &self.address
     }
 
+    /// Returns whether Dex should bypass service discovery.
     pub fn is_headless(&self) -> bool {
         self.headless
     }
 }
 
 #[derive(Clone, Debug)]
+/// Configures a [`crate::Worker`] listener and its Dex connection.
+///
+/// Defaults bind WorkerService on `0.0.0.0:8803`, connect to Dex at `127.0.0.1:8801`, derive an
+/// advertised target from the listener, and allow two minutes for Attribute-index synchronization.
 pub struct WorkerOptions {
     bind_address: String,
     server_address: String,
@@ -45,6 +57,7 @@ pub struct WorkerOptions {
 }
 
 impl WorkerOptions {
+    /// Creates Worker options with local development defaults.
     pub fn new() -> Self {
         Self {
             bind_address: "0.0.0.0:8803".to_string(),
@@ -54,16 +67,19 @@ impl WorkerOptions {
         }
     }
 
+    /// Sets the local plaintext WorkerService listener address.
     pub fn bind_address(mut self, value: impl Into<String>) -> Self {
         self.bind_address = value.into();
         self
     }
 
+    /// Sets the plaintext Dex FlowService `host:port` used by the Worker.
     pub fn server_address(mut self, value: impl Into<String>) -> Self {
         self.server_address = value.into();
         self
     }
 
+    /// Overrides the WorkerService target advertised to Dex.
     pub fn worker_target(mut self, value: WorkerTarget) -> Self {
         self.worker_target = Some(value);
         self

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -145,8 +145,14 @@ continue importing only from `@superdurable/dex`.
 - `gen/`: checked-in protobuf and grpc-js bindings
 
 Run `npm run build:native` once to stage the DXBC Node addon for the current
-platform, then `npm test` for runtime contracts and `npm run typecheck` for
-strict static contracts. Run `./run-integration-tests.sh` for all 58 IWF
+platform, then `npm test` for runtime contracts, `npm run typecheck` for strict
+static contracts, and `npm run docs:check` for public API documentation. The
+documentation check follows the actual exports of `src/index.ts` and requires
+JSDoc for every public class, interface, type, overload, member, object-style
+enum value, type parameter, input, and output; generated sources are excluded.
+The comments appear in TypeScript language-service and IDE hovers.
+
+Run `./run-integration-tests.sh` for all 58 IWF
 compatibility scenarios against an isolated `dexcli dev` environment. Run
 `npm run generate:proto` after changing `protos/dex.proto`; `protoc` and its
 standard protobuf includes must be installed.

--- a/sdk-typescript/package.json
+++ b/sdk-typescript/package.json
@@ -35,6 +35,7 @@
     "build": "tsc -p tsconfig.json",
     "build:native": "node scripts/build-native.mjs",
     "coverage:integration": "./run-integration-tests.sh --coverage",
+    "docs:check": "node scripts/check-public-docs.mjs",
     "generate:proto": "node scripts/generate-proto.mjs",
     "prepack": "npm run build:native && npm run build",
     "test:integration": "npm run build:native && npm run build && node --test --test-concurrency=1 dist/test/integ/*.integration.test.js",

--- a/sdk-typescript/scripts/check-public-docs.mjs
+++ b/sdk-typescript/scripts/check-public-docs.mjs
@@ -1,0 +1,303 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+import ts from "typescript";
+
+const configPath = ts.findConfigFile(".", ts.sys.fileExists, "tsconfig.json");
+if (configPath === undefined) {
+  throw new Error("tsconfig.json not found");
+}
+const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+if (configFile.error !== undefined) {
+  throw new Error(ts.flattenDiagnosticMessageText(configFile.error.messageText, "\n"));
+}
+const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, ".");
+const program = ts.createProgram(parsed.fileNames, parsed.options);
+const checker = program.getTypeChecker();
+const entrypoint = program.getSourceFile("src/index.ts");
+if (entrypoint === undefined) {
+  throw new Error("src/index.ts not found in the TypeScript program");
+}
+const entrypointSymbol = checker.getSymbolAtLocation(entrypoint);
+if (entrypointSymbol === undefined) {
+  throw new Error("cannot resolve the TypeScript SDK entrypoint");
+}
+
+const issues = [];
+const visited = new Set();
+for (const exported of checker.getExportsOfModule(entrypointSymbol)) {
+  const symbol = exported.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(exported) : exported;
+  for (const declaration of symbol.declarations ?? []) {
+    inspectDeclaration(declaration, symbol.name);
+  }
+}
+issues.sort((left, right) => left.file.localeCompare(right.file) || left.line - right.line);
+for (const issue of issues) {
+  process.stderr.write(`${issue.file}:${issue.line}: ${issue.message}\n`);
+}
+if (issues.length > 0) {
+  process.stderr.write(`public API documentation check failed with ${issues.length} issue(s)\n`);
+  process.exitCode = 1;
+} else {
+  process.stdout.write("all hand-written TypeScript SDK public APIs are documented\n");
+}
+
+function inspectDeclaration(node, fallbackName) {
+  if (node.getSourceFile().fileName.includes("/gen/") || node.getSourceFile().isDeclarationFile) {
+    return;
+  }
+  const key = `${node.getSourceFile().fileName}:${node.pos}:${node.end}`;
+  if (visited.has(key)) {
+    return;
+  }
+  visited.add(key);
+
+  if (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) {
+    const name = node.name?.text ?? fallbackName;
+    requireDoc(node, `${ts.isClassDeclaration(node) ? "class" : "interface"} ${name}`, typeParameters(node));
+    for (const member of node.members) {
+      if (isPublicMember(member)) {
+        inspectMember(member, name);
+      }
+    }
+    return;
+  }
+  if (ts.isTypeAliasDeclaration(node)) {
+    requireDoc(node, `type ${node.name.text}`, typeParameters(node));
+    inspectTypeNode(node.type, `type ${node.name.text}`);
+    return;
+  }
+  if (ts.isFunctionDeclaration(node)) {
+    inspectCallable(node, `function ${node.name?.text ?? fallbackName}`);
+    return;
+  }
+  if (ts.isVariableDeclaration(node)) {
+    const name = ts.isIdentifier(node.name) ? node.name.text : fallbackName;
+    const callable = callableInitializer(node.initializer);
+    if (callable !== undefined) {
+      inspectCallable(callable, `constant function ${name}`, documentationNode(node));
+    } else {
+      requireDoc(documentationNode(node), `constant ${name}`, []);
+      if (node.type === undefined) {
+        inspectObjectInitializer(node.initializer, `constant ${name}`);
+      }
+    }
+    if (node.type !== undefined) {
+      inspectTypeNode(node.type, `constant ${name}`);
+    }
+  }
+}
+
+function inspectMember(member, owner) {
+  const name = memberName(member.name) ?? "constructor";
+  const label = `${owner}.${name}`;
+  if (
+    ts.isMethodDeclaration(member) ||
+    ts.isMethodSignature(member) ||
+    ts.isConstructorDeclaration(member) ||
+    ts.isGetAccessorDeclaration(member) ||
+    ts.isSetAccessorDeclaration(member) ||
+    ts.isCallSignatureDeclaration(member)
+  ) {
+    inspectCallable(member, label);
+    return;
+  }
+  if (ts.isPropertyDeclaration(member) || ts.isPropertySignature(member)) {
+    requireDoc(member, `property ${label}`, typeParameters(member));
+    if (member.type !== undefined) {
+      inspectTypeNode(member.type, `property ${label}`);
+    }
+    return;
+  }
+  if (ts.isConstructSignatureDeclaration(member)) {
+    inspectCallable(member, `${owner}.new`);
+  }
+}
+
+function inspectCallable(callable, label, docNode = callable) {
+  const docs = requireDoc(docNode, label, typeParameters(callable));
+  if (docs === undefined) {
+    return;
+  }
+  for (const parameter of callable.parameters ?? []) {
+    if (ts.isIdentifier(parameter.name) && !hasTag(docs, "param", parameter.name.text)) {
+      report(docNode, `${label} must document parameter ${parameter.name.text} with @param`);
+    }
+    if (parameter.type !== undefined) {
+      inspectTypeNode(parameter.type, `${label} parameter ${parameter.name.getText()}`);
+    }
+  }
+  if (returnsValue(callable) && !hasTag(docs, "returns")) {
+    report(docNode, `${label} must document its output with @returns`);
+  }
+}
+
+function inspectTypeNode(typeNode, owner) {
+  if (ts.isTypeLiteralNode(typeNode)) {
+    for (const member of typeNode.members) {
+      inspectMember(member, owner);
+    }
+    return;
+  }
+  if (ts.isUnionTypeNode(typeNode) || ts.isIntersectionTypeNode(typeNode)) {
+    for (const type of typeNode.types) {
+      inspectTypeNode(type, owner);
+    }
+    return;
+  }
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    inspectTypeNode(typeNode.type, owner);
+    return;
+  }
+  if (ts.isTypeOperatorNode(typeNode)) {
+    inspectTypeNode(typeNode.type, owner);
+    return;
+  }
+  if (ts.isTypeReferenceNode(typeNode)) {
+    for (const argument of typeNode.typeArguments ?? []) {
+      inspectTypeNode(argument, owner);
+    }
+  }
+}
+
+function inspectObjectInitializer(initializer, owner) {
+  let object = unwrapExpression(initializer);
+  if (ts.isCallExpression(object) && object.arguments.length > 0) {
+    object = unwrapExpression(object.arguments[0]);
+  }
+  if (!ts.isObjectLiteralExpression(object)) {
+    return;
+  }
+  for (const property of object.properties) {
+    if (ts.isSpreadAssignment(property)) {
+      continue;
+    }
+    const name = memberName(property.name) ?? "member";
+    if (ts.isMethodDeclaration(property)) {
+      inspectCallable(property, `${owner}.${name}`);
+    } else {
+      requireDoc(property, `property ${owner}.${name}`, []);
+    }
+  }
+}
+
+function unwrapExpression(expression) {
+  let current = expression;
+  while (
+    current !== undefined &&
+    (ts.isAsExpression(current) ||
+      ts.isTypeAssertionExpression(current) ||
+      ts.isSatisfiesExpression(current) ||
+      ts.isParenthesizedExpression(current))
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function requireDoc(node, label, parameters) {
+  const docs = jsDoc(node);
+  if (docs === undefined) {
+    report(node, `exported ${label} has no JSDoc comment`);
+    return undefined;
+  }
+  const summary = docs.description.split(/\r?\n/, 1)[0].trim();
+  if (!/[.!?]$/.test(summary)) {
+    report(node, `${label} summary must end with punctuation`);
+  }
+  for (const parameter of parameters) {
+    if (parameter.name !== undefined && !hasTag(docs, "typeParam", parameter.name.text)) {
+      report(node, `${label} must document type parameter ${parameter.name.text} with @typeParam`);
+    }
+  }
+  return docs;
+}
+
+function jsDoc(node) {
+  const sourceFile = node.getSourceFile();
+  const ranges = ts.getLeadingCommentRanges(sourceFile.text, node.getFullStart()) ?? [];
+  const range = [...ranges].reverse().find((candidate) =>
+    sourceFile.text.slice(candidate.pos, candidate.pos + 3) === "/**",
+  );
+  if (range === undefined) {
+    return undefined;
+  }
+  const raw = sourceFile.text.slice(range.pos + 3, range.end - 2);
+  const lines = raw.split(/\r?\n/).map((line) => line.replace(/^\s*\* ?/, ""));
+  const description = lines.filter((line) => !line.trimStart().startsWith("@")).join("\n").trim();
+  const tags = [];
+  for (const line of lines) {
+    const match = /^@(\w+)\s*(?:\{[^}]*\}\s*)?([^\s-]+)?\s*(?:-\s*)?(.*)$/.exec(line.trim());
+    if (match !== null) {
+      tags.push({ name: match[1], target: match[2], description: match[3] });
+    }
+  }
+  return { description, tags };
+}
+
+function hasTag(docs, name, target) {
+  return docs.tags.some((tag) =>
+    tag.name === name &&
+    (target === undefined || tag.target === target || tag.target === `<${target}>`) &&
+    tag.description.trim().length > 0,
+  );
+}
+
+function returnsValue(callable) {
+  if (ts.isConstructorDeclaration(callable) || ts.isConstructSignatureDeclaration(callable)) {
+    return false;
+  }
+  const type = callable.type;
+  if (type === undefined) {
+    return false;
+  }
+  const text = type.getText();
+  return text !== "void" && text !== "never" && text !== "Promise<void>";
+}
+
+function typeParameters(node) {
+  return [...(node.typeParameters ?? [])];
+}
+
+function callableInitializer(initializer) {
+  if (initializer !== undefined && (ts.isArrowFunction(initializer) || ts.isFunctionExpression(initializer))) {
+    return initializer;
+  }
+  return undefined;
+}
+
+function documentationNode(node) {
+  if (ts.isVariableDeclaration(node) && ts.isVariableDeclarationList(node.parent)) {
+    return node.parent.parent;
+  }
+  return node;
+}
+
+function isPublicMember(member) {
+  return !hasModifier(member, ts.SyntaxKind.PrivateKeyword) && !hasModifier(member, ts.SyntaxKind.ProtectedKeyword);
+}
+
+function hasModifier(node, kind) {
+  return node.modifiers?.some((modifier) => modifier.kind === kind) ?? false;
+}
+
+function memberName(name) {
+  if (name === undefined) {
+    return undefined;
+  }
+  if (ts.isIdentifier(name) || ts.isPrivateIdentifier(name) || ts.isStringLiteral(name)) {
+    return name.text;
+  }
+  return name.getText();
+}
+
+function report(node, message) {
+  const sourceFile = node.getSourceFile();
+  const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+  issues.push({ file: sourceFile.fileName, line: position.line + 1, message });
+}

--- a/sdk-typescript/src/blob-cache.ts
+++ b/sdk-typescript/src/blob-cache.ts
@@ -16,13 +16,13 @@ export interface BlobCacheConfig {
   readonly directory: string;
   /** Positive maximum on-disk payload size in bytes. */
   readonly maxBytes: number;
-  /** Admission-policy counter count; zero or omission selects the native default. */
+  /** Admission-policy counter count; zero or `undefined` uses the native default. */
   readonly frequencyCounters?: number;
 }
 
 /** Provides concurrent, bounded storage for content-addressed Dex blobs. */
 export interface BlobCache {
-  /** Immutable effective configuration. */
+  /** Effective configuration used by this cache. */
   readonly config: BlobCacheConfig;
   /**
    * Reads a cached payload without contacting Dex.

--- a/sdk-typescript/src/blob-cache.ts
+++ b/sdk-typescript/src/blob-cache.ts
@@ -10,18 +10,41 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+/** Configures the local persistent cache for large Dex values. */
 export interface BlobCacheConfig {
+  /** Writable directory used for cache payloads and metadata. */
   readonly directory: string;
+  /** Positive maximum on-disk payload size in bytes. */
   readonly maxBytes: number;
+  /** Admission-policy counter count; zero or omission selects the native default. */
   readonly frequencyCounters?: number;
 }
 
+/** Provides concurrent, bounded storage for content-addressed Dex blobs. */
 export interface BlobCache {
+  /** Immutable effective configuration. */
   readonly config: BlobCacheConfig;
+  /**
+   * Reads a cached payload without contacting Dex.
+   * @param blobId - Opaque server-assigned blob identifier.
+   * @returns A copied payload, or `undefined` when absent.
+   */
   get(blobId: string): Uint8Array | undefined;
+  /**
+   * Offers a payload to the bounded cache.
+   * @param blobId - Opaque server-assigned blob identifier.
+   * @param payload - Bytes copied into native storage.
+   * @returns `true` when admitted or `false` when rejected by policy.
+   */
   put(blobId: string, payload: Uint8Array): boolean;
+  /**
+   * Deletes one cached payload when present.
+   * @param blobId - Opaque identifier to remove.
+   */
   delete(blobId: string): void;
+  /** Deletes every payload while keeping the cache open. */
   deleteAll(): void;
+  /** Flushes metadata and releases native resources; repeated calls are safe. */
   close(): void;
 }
 
@@ -48,6 +71,19 @@ interface NativeModule {
 const require = createRequire(import.meta.url);
 let nativeModule: NativeModule | undefined;
 
+/**
+ * Opens or creates a native BlobCache owned by the caller.
+ *
+ * @example
+ * ```ts
+ * const cache = openBlobCache({ directory: ".dex-cache", maxBytes: 64 * 1024 ** 2 });
+ * try { cache.put("blob-1", new Uint8Array([1, 2])); } finally { cache.close(); }
+ * ```
+ * @param config - Directory, positive byte capacity, and optional counter count.
+ * @returns An open cache that must be closed at application shutdown.
+ * @throws {@link TypeError} when the directory is empty.
+ * @throws {@link RangeError} when a numeric setting is invalid.
+ */
 export function openBlobCache(config: BlobCacheConfig): BlobCache {
   if (config.directory.length === 0) {
     throw new TypeError("blob cache directory is required");

--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -178,7 +178,7 @@ export class Client {
    * @param rpcMethod - Bound method decorated with `rpc` on the registered Flow.
    * @param flowId - Non-empty target Flow ID.
    * @param input - Typed handler input.
-   * @param runId - Optional exact run; omission targets the active run.
+   * @param runId - Optional exact run; targets the active run when omitted.
    * @returns The decoded RPCResult output.
    */
   public invokeRPC<Input, Output>(
@@ -196,7 +196,7 @@ export class Client {
    * @typeParam Output - RPC output type.
    * @param rpcMethod - Bound method decorated with `rpc` on the registered Flow.
    * @param flowId - Non-empty target Flow ID.
-   * @param runId - Optional exact run; omission targets the active run.
+   * @param runId - Optional exact run; targets the active run when omitted.
    * @returns The decoded RPCResult output.
    */
   public invokeRPC<Output>(
@@ -211,7 +211,7 @@ export class Client {
    * @param rpcMethod - Bound method decorated with `rpc` on the registered Flow.
    * @param flowId - Non-empty target Flow ID.
    * @param input - Typed handler input.
-   * @param runId - Optional exact run; omission targets the active run.
+   * @param runId - Optional exact run; targets the active run when omitted.
    * @returns A promise resolved after successful handler completion.
    */
   public invokeRPC<Input>(
@@ -225,7 +225,7 @@ export class Client {
    * Invokes an input-free, output-free RPC.
    * @param rpcMethod - Bound method decorated with `rpc` on the registered Flow.
    * @param flowId - Non-empty target Flow ID.
-   * @param runId - Optional exact run; omission targets the active run.
+   * @param runId - Optional exact run; targets the active run when omitted.
    * @returns A promise resolved after successful handler completion.
    */
   public invokeRPC(
@@ -239,7 +239,7 @@ export class Client {
    * @param rpcMethod - Bound registered RPC method.
    * @param flowId - Non-empty target Flow ID.
    * @param inputOrRunId - Typed input, or run ID for an input-free RPC.
-   * @param runId - Exact run for an input-bearing RPC; omission targets active.
+   * @param runId - Exact run for an input-bearing RPC; targets the active run when omitted.
    * @returns Decoded output, or `undefined` for an output-free RPC.
    * @throws {@link RpcLockConflictError} when locks cannot be acquired.
    * @throws {@link WorkerInvocationError} when the application handler fails.
@@ -283,7 +283,7 @@ export class Client {
    * @typeParam T - Attribute value type.
    * @param flowId - Non-empty existing Flow ID.
    * @param attribute - Typed singleton Attribute definition.
-   * @param runId - Optional exact run; omission targets the current run.
+   * @param runId - Optional exact run; targets the current run when omitted.
    * @returns The decoded value, or `undefined` when unset.
    */
   public getAttribute<T>(
@@ -298,7 +298,7 @@ export class Client {
    * @param flowId - Non-empty existing Flow ID.
    * @param attribute - Typed AttributeMap definition.
    * @param instance - Non-empty logical map key.
-   * @param runId - Optional exact run; omission targets the current run.
+   * @param runId - Optional exact run; targets the current run when omitted.
    * @returns The decoded value, or `undefined` when unset.
    */
   public getAttribute<T>(
@@ -349,7 +349,7 @@ export class Client {
    * @param flowId - Non-empty active Flow ID.
    * @param attribute - Typed singleton Attribute definition.
    * @param value - Value encoded by the Attribute codec.
-   * @param runId - Optional exact run; omission targets the active run.
+   * @param runId - Optional exact run; targets the active run when omitted.
    * @returns A promise resolved after Dex applies the write.
    */
   public setAttribute<T>(
@@ -366,7 +366,7 @@ export class Client {
    * @param attribute - Typed AttributeMap definition.
    * @param instance - Non-empty logical map key.
    * @param value - Value encoded by the Attribute codec.
-   * @param runId - Optional exact run; omission targets the active run.
+   * @param runId - Optional exact run; targets the active run when omitted.
    * @returns A promise resolved after Dex applies the write.
    */
   public setAttribute<T>(
@@ -723,7 +723,7 @@ export class Client {
 
   /**
    * Replaces mutable configuration for an active Flow.
-   * The update affects subsequent decisions and does not recall dispatched work.
+   * The update affects later decisions and does not recall dispatched work.
    * @param flowId - Non-empty active Flow ID.
    * @param config - New optional Flow configuration fields.
    */

--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -74,10 +74,31 @@ import { ChannelMap, type Channel } from "./wait.js";
 
 const defaultServerAddress = "localhost:8801";
 
+/**
+ * Calls Dex FlowService through registered, typed Flow definitions.
+ *
+ * Methods perform asynchronous gRPC I/O. A Client owns its service connection but
+ * not its Registry or BlobCache; call `close` during application shutdown.
+ *
+ * @example
+ * ```ts
+ * const client = new Client(registry, cache);
+ * try {
+ *   const runId = await client.startFlow(orders, "order-42", input);
+ *   const result = await client.waitForFlow("order-42", orderResultCodec);
+ * } finally { await client.close(); }
+ * ```
+ */
 export class Client {
   private readonly service: FlowServiceClientType;
   private readonly hydrator: ValueHydrator;
 
+  /**
+   * Constructs a Client and lazy plaintext gRPC connection.
+   * @param registry - Flow definitions used for validation and routing.
+   * @param blobCache - Open cache used to hydrate large response values.
+   * @param options - Service address and default Worker target.
+   */
   public constructor(
     public readonly registry: Registry,
     public readonly blobCache: BlobCache,
@@ -90,6 +111,17 @@ export class Client {
     this.hydrator = new ValueHydrator(this.service, blobCache);
   }
 
+  /**
+   * Starts a Flow and returns after Dex accepts it.
+   * @typeParam StartInput - Starting Step input type.
+   * @param flow - Exact Flow instance registered with this Client.
+   * @param flowId - Non-empty application ID stable across runs.
+   * @param input - Starting Step input, or `undefined` when no start Step exists.
+   * @param options - Timeout, reuse, retry, configuration, and initial state.
+   * @returns The server-assigned run ID.
+   * @throws {@link FlowAlreadyStartedError} when reuse policy rejects the Flow ID.
+   * @throws {@link FlowDefinitionError} when `flow` is not registered.
+   */
   public async startFlow<StartInput>(
     flow: Flow<StartInput>,
     flowId: string,
@@ -139,6 +171,16 @@ export class Client {
       .runId;
   }
 
+  /**
+   * Invokes an RPC with typed input and output.
+   * @typeParam Input - RPC input type.
+   * @typeParam Output - RPC output type.
+   * @param rpcMethod - Bound method decorated with `rpc` on the registered Flow.
+   * @param flowId - Non-empty target Flow ID.
+   * @param input - Typed handler input.
+   * @param runId - Optional exact run; omission targets the active run.
+   * @returns The decoded RPCResult output.
+   */
   public invokeRPC<Input, Output>(
     rpcMethod: (
       context: Context,
@@ -149,12 +191,29 @@ export class Client {
     runId?: string,
   ): Promise<Output>;
 
+  /**
+   * Invokes an input-free RPC with typed output.
+   * @typeParam Output - RPC output type.
+   * @param rpcMethod - Bound method decorated with `rpc` on the registered Flow.
+   * @param flowId - Non-empty target Flow ID.
+   * @param runId - Optional exact run; omission targets the active run.
+   * @returns The decoded RPCResult output.
+   */
   public invokeRPC<Output>(
     rpcMethod: (context: Context) => RPCResult<Output> | Promise<RPCResult<Output>>,
     flowId: string,
     runId?: string,
   ): Promise<Output>;
 
+  /**
+   * Invokes a typed-input RPC that returns no output.
+   * @typeParam Input - RPC input type.
+   * @param rpcMethod - Bound method decorated with `rpc` on the registered Flow.
+   * @param flowId - Non-empty target Flow ID.
+   * @param input - Typed handler input.
+   * @param runId - Optional exact run; omission targets the active run.
+   * @returns A promise resolved after successful handler completion.
+   */
   public invokeRPC<Input>(
     rpcMethod: (context: Context, input: Input) => void | Promise<void>,
     flowId: string,
@@ -162,12 +221,29 @@ export class Client {
     runId?: string,
   ): Promise<void>;
 
+  /**
+   * Invokes an input-free, output-free RPC.
+   * @param rpcMethod - Bound method decorated with `rpc` on the registered Flow.
+   * @param flowId - Non-empty target Flow ID.
+   * @param runId - Optional exact run; omission targets the active run.
+   * @returns A promise resolved after successful handler completion.
+   */
   public invokeRPC(
     rpcMethod: (context: Context) => void | Promise<void>,
     flowId: string,
     runId?: string,
   ): Promise<void>;
 
+  /**
+   * Dispatches a registered RPC using its decorator codecs and locks.
+   * @param rpcMethod - Bound registered RPC method.
+   * @param flowId - Non-empty target Flow ID.
+   * @param inputOrRunId - Typed input, or run ID for an input-free RPC.
+   * @param runId - Exact run for an input-bearing RPC; omission targets active.
+   * @returns Decoded output, or `undefined` for an output-free RPC.
+   * @throws {@link RpcLockConflictError} when locks cannot be acquired.
+   * @throws {@link WorkerInvocationError} when the application handler fails.
+   */
   public async invokeRPC(
     rpcMethod: Function,
     flowId: string,
@@ -202,12 +278,29 @@ export class Client {
     return decodeValue(rpc.options.outputCodec, await this.hydrator.hydrate(response.output));
   }
 
+  /**
+   * Reads a singleton Attribute.
+   * @typeParam T - Attribute value type.
+   * @param flowId - Non-empty existing Flow ID.
+   * @param attribute - Typed singleton Attribute definition.
+   * @param runId - Optional exact run; omission targets the current run.
+   * @returns The decoded value, or `undefined` when unset.
+   */
   public getAttribute<T>(
     flowId: string,
     attribute: Attribute<T>,
     runId?: string,
   ): Promise<T | undefined>;
 
+  /**
+   * Reads one AttributeMap instance.
+   * @typeParam T - Attribute value type.
+   * @param flowId - Non-empty existing Flow ID.
+   * @param attribute - Typed AttributeMap definition.
+   * @param instance - Non-empty logical map key.
+   * @param runId - Optional exact run; omission targets the current run.
+   * @returns The decoded value, or `undefined` when unset.
+   */
   public getAttribute<T>(
     flowId: string,
     attribute: AttributeMap<T>,
@@ -215,6 +308,14 @@ export class Client {
     runId?: string,
   ): Promise<T | undefined>;
 
+  /**
+   * Reads and decodes a singleton or map Attribute.
+   * @param flowId - Non-empty existing Flow ID.
+   * @param attribute - Typed Attribute definition.
+   * @param instanceOrRunId - Map instance, or singleton run ID.
+   * @param runId - Exact run for a map read.
+   * @returns The decoded value, or `undefined` when unset.
+   */
   public async getAttribute(
     flowId: string,
     attribute: Attribute<unknown> | AttributeMap<unknown>,
@@ -242,6 +343,15 @@ export class Client {
     return decodeValue(attribute.codec, await this.hydrator.hydrate(value));
   }
 
+  /**
+   * Writes a singleton Attribute on an active Flow.
+   * @typeParam T - Attribute value type.
+   * @param flowId - Non-empty active Flow ID.
+   * @param attribute - Typed singleton Attribute definition.
+   * @param value - Value encoded by the Attribute codec.
+   * @param runId - Optional exact run; omission targets the active run.
+   * @returns A promise resolved after Dex applies the write.
+   */
   public setAttribute<T>(
     flowId: string,
     attribute: Attribute<T>,
@@ -249,6 +359,16 @@ export class Client {
     runId?: string,
   ): Promise<void>;
 
+  /**
+   * Writes one AttributeMap instance on an active Flow.
+   * @typeParam T - Attribute value type.
+   * @param flowId - Non-empty active Flow ID.
+   * @param attribute - Typed AttributeMap definition.
+   * @param instance - Non-empty logical map key.
+   * @param value - Value encoded by the Attribute codec.
+   * @param runId - Optional exact run; omission targets the active run.
+   * @returns A promise resolved after Dex applies the write.
+   */
   public setAttribute<T>(
     flowId: string,
     attribute: AttributeMap<T>,
@@ -257,6 +377,15 @@ export class Client {
     runId?: string,
   ): Promise<void>;
 
+  /**
+   * Encodes and writes a singleton or map Attribute.
+   * @param flowId - Non-empty active Flow ID.
+   * @param attribute - Typed Attribute definition.
+   * @param instanceOrValue - Map instance or singleton value.
+   * @param valueOrRunId - Map value or singleton run ID.
+   * @param runId - Exact run for a map write.
+   * @returns A promise resolved after Dex applies the write.
+   */
   public async setAttribute(
     flowId: string,
     attribute: Attribute<unknown> | AttributeMap<unknown>,
@@ -289,8 +418,25 @@ export class Client {
     );
   }
 
+  /**
+   * Publishes one or more values to a singleton Channel.
+   * @typeParam T - Channel element type.
+   * @param flowId - Non-empty active Flow ID.
+   * @param channel - Typed singleton Channel definition.
+   * @param values - Values appended in argument order.
+   * @returns A promise resolved after Dex accepts the batch.
+   */
   public publish<T>(flowId: string, channel: Channel<T>, ...values: readonly T[]): Promise<void>;
 
+  /**
+   * Publishes one or more values to a ChannelMap instance.
+   * @typeParam T - Channel element type.
+   * @param flowId - Non-empty active Flow ID.
+   * @param channel - Typed ChannelMap definition.
+   * @param instance - Non-empty logical map key.
+   * @param values - Values appended in argument order.
+   * @returns A promise resolved after Dex accepts the batch.
+   */
   public publish<T>(
     flowId: string,
     channel: ChannelMap<T>,
@@ -298,6 +444,13 @@ export class Client {
     ...values: readonly T[]
   ): Promise<void>;
 
+  /**
+   * Encodes and publishes a singleton or map Channel batch.
+   * @param flowId - Non-empty active Flow ID.
+   * @param channel - Typed Channel definition.
+   * @param instanceAndValues - Optional map instance followed by values.
+   * @returns A promise resolved after Dex accepts the batch.
+   */
   public async publish(
     flowId: string,
     channel: Channel<unknown> | ChannelMap<unknown>,
@@ -323,14 +476,36 @@ export class Client {
     );
   }
 
+  /**
+   * Waits for successful Flow completion without decoding output.
+   * @param flowId - Non-empty existing Flow ID.
+   * @returns A promise resolved on successful completion.
+   */
   public waitForFlow(flowId: string): Promise<void>;
 
+  /**
+   * Waits for successful Flow completion and decodes the latest Step output.
+   * @typeParam Output - Expected completion output type.
+   * @param flowId - Non-empty existing Flow ID.
+   * @param outputCodec - Codec for the expected output.
+   * @param timeoutMs - Optional server-side long-poll duration in milliseconds.
+   * @returns The decoded latest completed Step output.
+   */
   public waitForFlow<Output>(
     flowId: string,
     outputCodec: Codec<Output>,
     timeoutMs?: number,
   ): Promise<Output>;
 
+  /**
+   * Long-polls until a Flow closes and optionally decodes output.
+   * @param flowId - Non-empty existing Flow ID.
+   * @param outputCodec - Optional codec for the latest output.
+   * @param timeoutMs - Optional server-side long-poll duration in milliseconds.
+   * @returns Decoded output, or `undefined` when no codec was requested.
+   * @throws {@link LongPollTimeoutError} when the Flow remains open at timeout.
+   * @throws {@link FlowUncompletedError} for a non-successful terminal status.
+   */
   public async waitForFlow(
     flowId: string,
     outputCodec?: Codec<unknown>,
@@ -374,6 +549,12 @@ export class Client {
     throw new TypeError(`Flow ${flowId} completed without an output`);
   }
 
+  /**
+   * Requests cancellation, termination, or failure of an active Flow.
+   * The promise resolves after acceptance and does not await terminal status.
+   * @param flowId - Non-empty active Flow ID.
+   * @param options - Stop mode and optional recorded reason.
+   */
   public async stopFlow(flowId: string, options: StopFlowOptions = {}): Promise<void> {
     await unary<Empty>(
       { operation: "stopFlow", flowId, requirement: "active" },
@@ -390,6 +571,11 @@ export class Client {
     );
   }
 
+  /**
+   * Returns summary metadata for the current or latest Flow run.
+   * @param flowId - Non-empty existing Flow ID.
+   * @returns Flow ID, run ID, type, status, and UTC start time.
+   */
   public async describeFlow(flowId: string): Promise<FlowInfo> {
     const response = await unary<GetFlowSummaryResponse>(
       { operation: "describeFlow", flowId, requirement: "existing" },
@@ -407,6 +593,13 @@ export class Client {
     };
   }
 
+  /**
+   * Returns one page of Flow runs matching a visibility query.
+   * @param query - Dex visibility query; empty uses server defaults.
+   * @param pageSize - Non-negative requested maximum result count.
+   * @param nextPageToken - Opaque token from the preceding page, or empty first.
+   * @returns Server-ordered entries and the next-page token.
+   */
   public async searchFlows(
     query: string,
     pageSize: number,
@@ -444,6 +637,12 @@ export class Client {
     };
   }
 
+  /**
+   * Creates a new run from a selected point in existing Flow history.
+   * @param flowId - Non-empty Flow ID whose history is reset.
+   * @param options - Reset selector, reason, and replay controls.
+   * @returns The new server-assigned run ID; the Flow ID remains unchanged.
+   */
   public async resetFlow(flowId: string, options: ResetFlowOptions): Promise<string> {
     const response = await unary<ResetFlowResponse>(
       { operation: "resetFlow", flowId, requirement: "existing" },
@@ -467,6 +666,12 @@ export class Client {
     return response.runId;
   }
 
+  /**
+   * Makes one waiting Timer condition immediately ready.
+   * @param flowId - Non-empty active Flow ID.
+   * @param stepExecutionId - Step type and positive execution number.
+   * @param timerId - Exactly one Timer condition ID or zero-based index.
+   */
   public async skipTimer(
     flowId: string,
     stepExecutionId: StepExecutionId,
@@ -488,6 +693,13 @@ export class Client {
     );
   }
 
+  /**
+   * Long-polls until one Step execution completes.
+   * @param flowId - Non-empty active Flow ID.
+   * @param stepExecutionId - Step type and positive execution number.
+   * @param timeoutMs - Non-negative server-side wait duration in milliseconds.
+   * @throws {@link LongPollTimeoutError} when completion is not observed in time.
+   */
   public async waitForStepCompletion(
     flowId: string,
     stepExecutionId: StepExecutionId,
@@ -509,6 +721,12 @@ export class Client {
     );
   }
 
+  /**
+   * Replaces mutable configuration for an active Flow.
+   * The update affects subsequent decisions and does not recall dispatched work.
+   * @param flowId - Non-empty active Flow ID.
+   * @param config - New optional Flow configuration fields.
+   */
   public async updateFlowConfig(flowId: string, config: FlowConfig): Promise<void> {
     await unary<Empty>(
       { operation: "updateFlowConfig", flowId, requirement: "active" },
@@ -524,6 +742,10 @@ export class Client {
     );
   }
 
+  /**
+   * Closes the owned FlowService connection.
+   * Registry and BlobCache ownership remains with the caller.
+   */
   public async close(): Promise<void> {
     this.service.close();
   }

--- a/sdk-typescript/src/codec.ts
+++ b/sdk-typescript/src/codec.ts
@@ -83,7 +83,7 @@ export interface Codec<T> {
   /**
    * Decodes one protocol value.
    * @param value - Value to validate and decode.
-   * @returns The reconstructed application value.
+   * @returns The decoded application value.
    */
   decode(value: Value): T;
 }

--- a/sdk-typescript/src/codec.ts
+++ b/sdk-typescript/src/codec.ts
@@ -6,23 +6,89 @@
 //
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
+/** Identifies the protocol representation carried by an encoded {@link Value}. */
 export type WireKind = "string" | "bool" | "int64" | "double" | "bytes" | "json";
 
+/** Contains one validated SDK value before protocol mapping. */
 export type Value =
-  | Readonly<{ kind: "string"; data: string }>
-  | Readonly<{ kind: "bool"; data: boolean }>
-  | Readonly<{ kind: "int64"; data: bigint }>
-  | Readonly<{ kind: "double"; data: number }>
-  | Readonly<{ kind: "bytes"; data: Uint8Array }>
-  | Readonly<{ kind: "json"; data: string }>;
+  | Readonly<{
+      /** String wire discriminator. */
+      kind: "string";
+      /** Valid UTF-8 application text. */
+      data: string;
+    }>
+  | Readonly<{
+      /** Boolean wire discriminator. */
+      kind: "bool";
+      /** Boolean scalar payload. */
+      data: boolean;
+    }>
+  | Readonly<{
+      /** Signed-integer wire discriminator. */
+      kind: "int64";
+      /** Signed 64-bit integer payload. */
+      data: bigint;
+    }>
+  | Readonly<{
+      /** Floating-point wire discriminator. */
+      kind: "double";
+      /** Finite IEEE-754 number payload. */
+      data: number;
+    }>
+  | Readonly<{
+      /** Raw-bytes wire discriminator. */
+      kind: "bytes";
+      /** Uninterpreted byte payload. */
+      data: Uint8Array;
+    }>
+  | Readonly<{
+      /** JSON wire discriminator. */
+      kind: "json";
+      /** Valid JSON document text. */
+      data: string;
+    }>;
 
+/**
+ * Converts between an application type and one Dex wire representation.
+ * Implementations should be deterministic so durable replay sees identical values.
+ *
+ * @example
+ * ```ts
+ * type Order = { id: string };
+ * const orderCodec = jsonCodec<Order>({
+ *   typeName: "Order",
+ *   decode(value) {
+ *     if (typeof value !== "object" || value === null ||
+ *         !("id" in value) || typeof value.id !== "string") {
+ *       throw new TypeError("invalid Order");
+ *     }
+ *     return { id: value.id };
+ *   },
+ * });
+ * const encoded = orderCodec.encode({ id: "order-42" });
+ * ```
+ * @typeParam T - Application value type encoded by this codec.
+ */
 export interface Codec<T> {
+  /** Stable application-facing name used in mapping errors. */
   readonly typeName: string;
+  /** Wire kind normally emitted and accepted by the codec. */
   readonly wireKind: WireKind;
+  /**
+   * Encodes one application value.
+   * @param value - Typed value to encode.
+   * @returns A validated Dex Value.
+   */
   encode(value: T): Value;
+  /**
+   * Decodes one protocol value.
+   * @param value - Value to validate and decode.
+   * @returns The reconstructed application value.
+   */
   decode(value: Value): T;
 }
 
+/** Built-in UTF-8 string codec. */
 export const stringCodec: Codec<string> = {
   typeName: "string",
   wireKind: "string",
@@ -30,6 +96,7 @@ export const stringCodec: Codec<string> = {
   decode: (value) => requireKind(value, "string").data,
 };
 
+/** Built-in strict Boolean codec. */
 export const booleanCodec: Codec<boolean> = {
   typeName: "boolean",
   wireKind: "bool",
@@ -37,6 +104,7 @@ export const booleanCodec: Codec<boolean> = {
   decode: (value) => requireKind(value, "bool").data,
 };
 
+/** Built-in signed 64-bit bigint codec. */
 export const int64Codec: Codec<bigint> = {
   typeName: "bigint",
   wireKind: "int64",
@@ -49,6 +117,7 @@ export const int64Codec: Codec<bigint> = {
   decode: (value) => requireKind(value, "int64").data,
 };
 
+/** Built-in finite IEEE-754 number codec. */
 export const doubleCodec: Codec<number> = {
   typeName: "number",
   wireKind: "double",
@@ -61,6 +130,7 @@ export const doubleCodec: Codec<number> = {
   decode: (value) => requireKind(value, "double").data,
 };
 
+/** Built-in byte-array codec that copies values in both directions. */
 export const bytesCodec: Codec<Uint8Array> = {
   typeName: "Uint8Array",
   wireKind: "bytes",
@@ -68,6 +138,7 @@ export const bytesCodec: Codec<Uint8Array> = {
   decode: (value) => requireKind(value, "bytes").data.slice(),
 };
 
+/** Built-in void codec represented as JSON `null`. */
 export const voidCodec: Codec<void> = {
   typeName: "void",
   wireKind: "json",
@@ -79,6 +150,12 @@ export const voidCodec: Codec<void> = {
   },
 };
 
+/**
+ * Wraps a codec so JSON `null` represents `undefined`.
+ * @typeParam T - Defined application value type.
+ * @param codec - Codec used for defined values.
+ * @returns A codec accepting the original type or `undefined`.
+ */
 export function optionalCodec<T>(codec: Codec<T>): Codec<T | undefined> {
   return {
     typeName: `${codec.typeName} | undefined`,
@@ -88,9 +165,23 @@ export function optionalCodec<T>(codec: Codec<T>): Codec<T | undefined> {
   };
 }
 
+/**
+ * Creates a deterministic JSON codec with application conversion hooks.
+ *
+ * JSON.stringify semantics apply; `undefined`, cycles, and unsupported bigint values
+ * fail during encoding. The decoder receives parsed, untrusted JSON data.
+ *
+ * @typeParam T - Application value type.
+ * @param options - Stable name plus JSON conversion hooks.
+ * @returns A JSON-wire codec for `T`.
+ * @throws {@link TypeError} when encoding produces `undefined`.
+ */
 export function jsonCodec<T>(options: {
+  /** Stable type name used in mapping errors. */
   readonly typeName: string;
+  /** Validates and converts parsed JSON-compatible data. */
   readonly decode: (value: unknown) => T;
+  /** Converts an application value to JSON-compatible data; identity by default. */
   readonly encode?: (value: T) => unknown;
 }): Codec<T> {
   return {

--- a/sdk-typescript/src/context.ts
+++ b/sdk-typescript/src/context.ts
@@ -10,23 +10,103 @@ import type { Attribute, AttributeMap } from "./persistence.js";
 import type { Channel, ChannelMap } from "./wait.js";
 import type { Codec } from "./codec.js";
 
+/**
+ * Exposes immutable execution metadata and decision-local persistence operations.
+ * Dex supplies a Context to each Step or RPC handler; do not retain it afterward.
+ */
 export interface Context {
+  /** Stable application Flow ID shared across runs. */
   readonly flowId: string;
+  /** Current server-assigned run ID. */
   readonly runId: string;
+  /** UTC timestamp at which the current Flow run started. */
   readonly flowStartedAt: Date;
+  /** Current Step type and execution number encoded by Dex. */
   readonly stepExecutionId: string;
+  /** Predecessor Step execution ID, or an empty string at Flow start. */
   readonly fromStepExecutionId: string;
+  /** UTC timestamp of the first handler attempt. */
   readonly firstAttemptAt: Date;
+  /** One-based handler retry attempt number. */
   readonly attempt: number;
+  /**
+   * Reports whether a Timer made the current Wait ready.
+   * @param index - Optional zero-based Timer index; omission checks any Timer.
+   * @returns Whether the selected Timer fired.
+   */
   hasTimerFired(index?: number): boolean;
+  /**
+   * Reports whether `waitFor` failed before the current `execute` call.
+   * @returns Whether failure policy proceeded to execution.
+   */
   waitForMethodFailed(): boolean;
+  /**
+   * Stores process-local data for this Step execution; it is not durable.
+   * @typeParam T - Local value type.
+   * @param key - Non-empty execution-scoped key.
+   * @param value - Value retained in worker memory.
+   * @param codec - Codec used to serialize the local value when required.
+   */
   setStepExecutionLocal<T>(key: string, value: T, codec: Codec<T>): void;
+  /**
+   * Reads process-local data for this Step execution.
+   * @typeParam T - Expected local value type.
+   * @param key - Key used when storing the value.
+   * @param codec - Codec used to reconstruct the value.
+   * @returns The value, or `undefined` after absence or worker restart.
+   */
   getStepExecutionLocal<T>(key: string, codec: Codec<T>): T | undefined;
+  /**
+   * Stages an application event in the current handler result.
+   * @typeParam T - Event payload type.
+   * @param name - Non-empty diagnostic event name.
+   * @param value - Event payload.
+   * @param codec - Payload codec.
+   */
   recordEvent<T>(name: string, value: T, codec: Codec<T>): void;
+  /**
+   * Reads a typed Attribute from decision state.
+   * @typeParam T - Attribute value type.
+   * @param attribute - Registered singleton or map definition.
+   * @param instance - Required AttributeMap instance; omitted for a singleton.
+   * @returns The decoded current value.
+   */
   getAttribute<T>(attribute: Attribute<T> | AttributeMap<T>, instance?: string): T;
+  /**
+   * Stages an Attribute write in the current decision.
+   * @typeParam T - Attribute value type.
+   * @param attribute - Registered singleton or map definition.
+   * @param value - Typed value to persist.
+   * @param instance - Required AttributeMap instance; omitted for a singleton.
+   */
   setAttribute<T>(attribute: Attribute<T> | AttributeMap<T>, value: T, instance?: string): void;
+  /**
+   * Stages deletion of an Attribute value.
+   * @param attribute - Registered singleton or map definition.
+   * @param instance - Required AttributeMap instance; omitted for a singleton.
+   */
   deleteAttribute(attribute: Attribute<unknown> | AttributeMap<unknown>, instance?: string): void;
+  /**
+   * Stages one typed Channel publication.
+   * @typeParam T - Channel element type.
+   * @param channel - Registered singleton or map definition.
+   * @param value - Value to append.
+   * @param instance - Required ChannelMap instance; omitted for a singleton.
+   */
   publish<T>(channel: Channel<T> | ChannelMap<T>, value: T, instance?: string): void;
+  /**
+   * Returns a Channel's current queued value count.
+   * @param channel - Registered singleton or map definition.
+   * @param instance - Required ChannelMap instance; omitted for a singleton.
+   * @returns Non-negative queued value count.
+   */
   channelSize(channel: Channel<unknown> | ChannelMap<unknown>, instance?: string): number;
+  /**
+   * Returns values selected by the satisfied Channel condition.
+   * @typeParam T - Channel element type.
+   * @param channel - Registered singleton or map definition.
+   * @param instance - Required ChannelMap instance; omitted for a singleton.
+   * @returns Ordered values for this Step execution.
+   */
   channelResults<T>(channel: Channel<T> | ChannelMap<T>, instance?: string): readonly T[];
 }

--- a/sdk-typescript/src/context.ts
+++ b/sdk-typescript/src/context.ts
@@ -11,7 +11,7 @@ import type { Channel, ChannelMap } from "./wait.js";
 import type { Codec } from "./codec.js";
 
 /**
- * Exposes immutable execution metadata and decision-local persistence operations.
+ * Exposes execution metadata and decision-local persistence operations.
  * Dex supplies a Context to each Step or RPC handler; do not retain it afterward.
  */
 export interface Context {
@@ -31,7 +31,7 @@ export interface Context {
   readonly attempt: number;
   /**
    * Reports whether a Timer made the current Wait ready.
-   * @param index - Optional zero-based Timer index; omission checks any Timer.
+   * @param index - Optional zero-based Timer index; checks any Timer when omitted.
    * @returns Whether the selected Timer fired.
    */
   hasTimerFired(index?: number): boolean;
@@ -52,7 +52,7 @@ export interface Context {
    * Reads process-local data for this Step execution.
    * @typeParam T - Expected local value type.
    * @param key - Key used when storing the value.
-   * @param codec - Codec used to reconstruct the value.
+   * @param codec - Codec used to decode the value.
    * @returns The value, or `undefined` after absence or worker restart.
    */
   getStepExecutionLocal<T>(key: string, codec: Codec<T>): T | undefined;

--- a/sdk-typescript/src/errors.ts
+++ b/sdk-typescript/src/errors.ts
@@ -18,7 +18,7 @@ export class PhaseNotImplementedError extends Error {}
 
 /** Provides stable Dex-specific classifications beyond gRPC status codes. */
 export const ErrorSubStatus = Object.freeze({
-  /** No more precise stable classification was supplied. */
+  /** Dex returned no more specific classification. */
   UNCATEGORIZED: "uncategorized",
   /** A start request conflicted with an existing Flow ID. */
   FLOW_ALREADY_STARTED: "flowAlreadyStarted",
@@ -174,10 +174,10 @@ export class ValueMappingError extends Error {
 /** Reports that `waitForFlow` observed a non-successful terminal status. */
 export class FlowUncompletedError extends Error {
   /**
-   * Creates an error retaining completed Step outputs for typed decoding.
+   * Creates an error that keeps completed Step outputs for typed decoding.
    * @param runId - Terminal server-assigned run ID.
    * @param status - Non-completed terminal status.
-   * @param errorType - Terminal failure category, when supplied.
+   * @param errorType - Terminal failure category, when available.
    * @param message - Human-readable terminal detail.
    * @param results - Hydrated Step outputs in server order.
    */

--- a/sdk-typescript/src/errors.ts
+++ b/sdk-typescript/src/errors.ts
@@ -13,29 +13,54 @@ import type { Value } from "./gen/dex.js";
 import type { FlowStatus } from "./options.js";
 import { decodeValue } from "./value-mapper.js";
 
+/** Indicates that an API is intentionally unavailable in the current SDK phase. */
 export class PhaseNotImplementedError extends Error {}
 
+/** Provides stable Dex-specific classifications beyond gRPC status codes. */
 export const ErrorSubStatus = Object.freeze({
+  /** No more precise stable classification was supplied. */
   UNCATEGORIZED: "uncategorized",
+  /** A start request conflicted with an existing Flow ID. */
   FLOW_ALREADY_STARTED: "flowAlreadyStarted",
+  /** No Flow exists for the requested ID. */
   FLOW_NOT_EXISTS: "flowNotExists",
+  /** A nested application Worker invocation failed. */
   WORKER_API_ERROR: "workerApiError",
+  /** A retryable long poll ended without observing its condition. */
   LONG_POLL_TIMEOUT: "longPollTimeout",
 } as const);
 
+/** Represents a value from {@link ErrorSubStatus}. */
 export type ErrorSubStatus = (typeof ErrorSubStatus)[keyof typeof ErrorSubStatus];
 
+/** Provides terminal Flow failure categories returned by Dex. */
 export const FlowErrorType = Object.freeze({
+  /** A Step decision could not be applied. */
   STEP_DECISION_FAILED: "stepDecisionFailed",
+  /** A Client-originated operation failed the Flow. */
   CLIENT_API_FAILED: "clientApiFailed",
+  /** Worker dispatch or application handler execution failed. */
   WORKER_API_FAILED: "workerApiFailed",
+  /** Application Flow code returned an invalid definition or result. */
   INVALID_USER_FLOW_CODE: "invalidUserFlowCode",
+  /** Dex encountered an internal invariant or infrastructure failure. */
   INTERNAL: "internal",
 } as const);
 
+/** Represents a value from {@link FlowErrorType}. */
 export type FlowErrorType = (typeof FlowErrorType)[keyof typeof FlowErrorType];
 
+/** Exposes structured metadata returned by a failed FlowService operation. */
 export class DexServiceError extends Error {
+  /**
+   * Creates a structured service error.
+   * @param code - Outer gRPC status code.
+   * @param subStatus - Stable Dex-specific classification.
+   * @param detail - Human-readable service detail.
+   * @param operation - Client operation that failed.
+   * @param flowId - Target Flow ID, or `undefined` for service-wide calls.
+   * @param options - Standard Error construction options.
+   */
   public constructor(
     public readonly code: status,
     public readonly subStatus: ErrorSubStatus,
@@ -49,13 +74,29 @@ export class DexServiceError extends Error {
   }
 }
 
+/** Indicates that `startFlow` conflicts with an existing Flow ID. */
 export class FlowAlreadyStartedError extends DexServiceError {}
 
+/** Indicates that an operation targeted a Flow ID that does not exist. */
 export class FlowNotFoundError extends DexServiceError {}
 
+/** Indicates that an operation requires an active but already closed Flow. */
 export class FlowNotActiveError extends DexServiceError {}
 
+/** Exposes both outer FlowService and nested WorkerService failure details. */
 export class WorkerInvocationError extends DexServiceError {
+  /**
+   * Creates an error from outer and nested Worker metadata.
+   * @param code - Outer FlowService gRPC status.
+   * @param subStatus - Dex-specific classification.
+   * @param detail - Outer human-readable detail.
+   * @param operation - Client operation that invoked the Worker.
+   * @param flowId - Target Flow ID, when available.
+   * @param workerCode - Nested Worker gRPC status, when available.
+   * @param workerErrorType - Worker-reported application error type.
+   * @param workerErrorDetail - Worker-reported human-readable detail.
+   * @param options - Standard Error construction options.
+   */
   public constructor(
     code: status,
     subStatus: ErrorSubStatus,
@@ -71,18 +112,35 @@ export class WorkerInvocationError extends DexServiceError {
   }
 }
 
+/** Indicates that an RPC could not acquire all requested Attribute locks. */
 export class RpcLockConflictError extends DexServiceError {}
 
+/** Indicates that a retryable long poll ended before its condition was observed. */
 export class LongPollTimeoutError extends DexServiceError {}
 
+/** Indicates that Registry construction found an invalid Flow definition. */
 export class FlowDefinitionError extends Error {
+  /**
+   * Creates a Flow definition error.
+   * @param message - Precise validation failure detail.
+   * @param options - Standard Error construction options.
+   */
   public constructor(message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = new.target.name;
   }
 }
 
+/** Identifies a Step or RPC result that violates the SDK contract. */
 export class InvalidStepResultError extends FlowDefinitionError {
+  /**
+   * Creates an invalid-handler-result error.
+   * @param flowType - Containing Flow type.
+   * @param stepType - Step type, or `undefined` for an RPC.
+   * @param method - Handler method that returned the invalid value.
+   * @param detail - Precise contract violation.
+   * @param options - Standard Error construction options.
+   */
   public constructor(
     public readonly flowType: string,
     public readonly stepType: string | undefined,
@@ -95,7 +153,14 @@ export class InvalidStepResultError extends FlowDefinitionError {
   }
 }
 
+/** Reports an application value encoding, decoding, or hydration failure. */
 export class ValueMappingError extends Error {
+  /**
+   * Creates a value-mapping error.
+   * @param operation - Mapping phase that failed.
+   * @param detail - Incompatible type, wire kind, or malformed payload detail.
+   * @param options - Standard Error construction options.
+   */
   public constructor(
     public readonly operation: "encode" | "decode" | "hydrate",
     detail: string,
@@ -106,7 +171,16 @@ export class ValueMappingError extends Error {
   }
 }
 
+/** Reports that `waitForFlow` observed a non-successful terminal status. */
 export class FlowUncompletedError extends Error {
+  /**
+   * Creates an error retaining completed Step outputs for typed decoding.
+   * @param runId - Terminal server-assigned run ID.
+   * @param status - Non-completed terminal status.
+   * @param errorType - Terminal failure category, when supplied.
+   * @param message - Human-readable terminal detail.
+   * @param results - Hydrated Step outputs in server order.
+   */
   public constructor(
     public readonly runId: string,
     public readonly status: FlowStatus,
@@ -117,10 +191,22 @@ export class FlowUncompletedError extends Error {
     super(message);
   }
 
+  /**
+   * Returns the number of retained Step completion outputs.
+   * @returns A non-negative result count.
+   */
   public get resultCount(): number {
     return this.results.length;
   }
 
+  /**
+   * Decodes one completed Step output.
+   * @typeParam T - Expected output type.
+   * @param index - Zero-based output position.
+   * @param codec - Codec for the expected output type.
+   * @returns The decoded Step output.
+   * @throws {@link RangeError} when the index is outside the retained outputs.
+   */
   public getResult<T>(index: number, codec: Codec<T>): T {
     const value = this.results[index];
     if (value === undefined) {
@@ -130,6 +216,11 @@ export class FlowUncompletedError extends Error {
   }
 }
 
+/**
+ * Creates a consistent error for an API planned in a later implementation phase.
+ * @param component - Human-readable unavailable component name.
+ * @returns A new PhaseNotImplementedError.
+ */
 export function laterPhase(component: string): PhaseNotImplementedError {
   return new PhaseNotImplementedError(`${component} belongs to a later phase`);
 }

--- a/sdk-typescript/src/flow.ts
+++ b/sdk-typescript/src/flow.ts
@@ -14,15 +14,48 @@ import { StepList, type Step } from "./step.js";
 import { requireName } from "./validation.js";
 import type { Channel, ChannelMap } from "./wait.js";
 
+/**
+ * Defines one durable application Flow and its registered API surface.
+ * @typeParam StartInput - Value accepted by the optional starting Step.
+ */
 export interface Flow<StartInput = void> {
+  /**
+   * Returns the protocol Flow type.
+   * @returns A non-empty Flow type unique within the Registry.
+   */
   getFlowType(): string;
+  /**
+   * Returns this Flow's Step definitions.
+   * @returns Zero or one starting Step plus all other registered Steps.
+   */
   getSteps(): StepList<StartInput>;
+  /**
+   * Returns this Flow's persistence definitions.
+   * @returns Attributes and Channels owned by this Flow; omission means empty.
+   */
   getPersistenceSchema?(): PersistenceSchema;
 }
 
+/**
+ * Validates and stores immutable Flow definitions shared by Client and Worker.
+ * Construction checks names, Step/RPC signatures, persistence definitions, locks,
+ * and Attribute indexes atomically.
+ *
+ * @example
+ * ```ts
+ * const orders = new OrdersFlow();
+ * const registry = new Registry([orders]);
+ * ```
+ */
 export class Registry {
+  /** Registered Flow instances in input order. */
   public readonly flows: readonly Flow<any>[];
 
+  /**
+   * Creates an immutable Registry.
+   * @param flows - Flow instances with unique Flow types.
+   * @throws {@link FlowDefinitionError} when any public definition is invalid.
+   */
   public constructor(flows: readonly Flow<any>[]) {
     const flowsByInstance = new Map<Flow<any>, RegisteredFlow>();
     const flowsByName = new Map<string, RegisteredFlow>();

--- a/sdk-typescript/src/flow.ts
+++ b/sdk-typescript/src/flow.ts
@@ -31,13 +31,13 @@ export interface Flow<StartInput = void> {
   getSteps(): StepList<StartInput>;
   /**
    * Returns this Flow's persistence definitions.
-   * @returns Attributes and Channels owned by this Flow; omission means empty.
+   * @returns Attributes and Channels owned by this Flow. Flows without this method have none.
    */
   getPersistenceSchema?(): PersistenceSchema;
 }
 
 /**
- * Validates and stores immutable Flow definitions shared by Client and Worker.
+ * Validates and stores Flow definitions shared by Client and Worker.
  * Construction checks names, Step/RPC signatures, persistence definitions, locks,
  * and Attribute indexes atomically.
  *
@@ -52,7 +52,7 @@ export class Registry {
   public readonly flows: readonly Flow<any>[];
 
   /**
-   * Creates an immutable Registry.
+   * Creates a Registry.
    * @param flows - Flow instances with unique Flow types.
    * @throws {@link FlowDefinitionError} when any public definition is invalid.
    */

--- a/sdk-typescript/src/options.ts
+++ b/sdk-typescript/src/options.ts
@@ -55,9 +55,9 @@ export interface FlowConfig {
   readonly continueAsNewThreshold?: number;
   /** Positive history page-size budget in bytes for continue-as-new. */
   readonly continueAsNewPageSizeBytes?: number;
-  /** Default durability for subsequent Step handler results. */
+  /** Default durability for later Step handler results. */
   readonly stepDurability?: StepDurability;
-  /** Worker endpoint used for subsequent handler dispatch. */
+  /** Worker endpoint used for later handler calls. */
   readonly workerTarget?: WorkerTarget;
 }
 
@@ -81,7 +81,7 @@ export const InitialAttribute = Object.freeze({
    * @typeParam T - Attribute value type.
    * @param attribute - Registered singleton Attribute.
    * @param value - Typed initial value.
-   * @returns An immutable initialization descriptor.
+   * @returns The Attribute initialization value.
    */
   of<T>(attribute: Attribute<T>, value: T): InitialAttribute<T> {
     return { attribute, value };
@@ -92,7 +92,7 @@ export const InitialAttribute = Object.freeze({
    * @param attribute - Registered AttributeMap.
    * @param instance - Non-empty logical map key.
    * @param value - Typed initial value.
-   * @returns An immutable initialization descriptor.
+   * @returns The AttributeMap initialization value.
    */
   mapValue<T>(
     attribute: AttributeMap<T>,
@@ -119,11 +119,11 @@ export const InitialAttribute = Object.freeze({
  * ```
  */
 export interface StartFlowOptions {
-  /** Maximum Flow lifetime in milliseconds; omission uses registered defaults. */
+  /** Maximum Flow lifetime in milliseconds; uses registered defaults when omitted. */
   readonly timeoutMs?: number;
   /** Delay before the starting Step becomes eligible, in milliseconds. */
   readonly startDelayMs?: number;
-  /** Flow ID reuse policy; omission uses `DEFAULT`. */
+  /** Flow ID reuse policy; uses `DEFAULT` when omitted. */
   readonly idReusePolicy?: IdReusePolicy;
   /** Server-supported cron expression for recurring runs. */
   readonly cronSchedule?: string;
@@ -135,7 +135,7 @@ export interface StartFlowOptions {
   readonly configOverride?: FlowConfig;
   /** Returns the existing run instead of raising an already-started error. */
   readonly ignoreAlreadyStarted?: boolean;
-  /** Non-empty idempotency key; omission generates a UUID. */
+  /** Non-empty idempotency key; generates a UUID when omitted. */
   readonly requestId?: string;
 }
 
@@ -193,7 +193,7 @@ export interface SearchFlowsPage {
 export interface StepExecutionId {
   /** Registered Step type. */
   readonly stepType: string;
-  /** Positive execution number; omission means the first execution. */
+  /** Positive execution number; defaults to the first execution. */
   readonly number?: number;
 }
 
@@ -291,7 +291,7 @@ export type StopType = (typeof StopType)[keyof typeof StopType];
 
 /** Configures a `stopFlow` request. */
 export interface StopFlowOptions {
-  /** Stop behavior; omission requests cooperative cancellation. */
+  /** Stop behavior; defaults to cooperative cancellation. */
   readonly type?: StopType;
   /** Optional operator-readable reason recorded by Dex. */
   readonly reason?: string;
@@ -301,7 +301,7 @@ export interface StopFlowOptions {
 export interface WorkerOptions {
   /** Local plaintext WorkerService listener; defaults to `:8803`. */
   readonly bindAddress?: string;
-  /** Endpoint advertised to Dex; omission derives it from `bindAddress`. */
+  /** Endpoint advertised to Dex; derived from `bindAddress` when omitted. */
   readonly workerTarget?: WorkerTarget;
   /** Dex FlowService target; defaults to `localhost:8801`. */
   readonly serverAddress?: string;

--- a/sdk-typescript/src/options.ts
+++ b/sdk-typescript/src/options.ts
@@ -10,47 +10,90 @@ import type { Attribute, AttributeMap } from "./persistence.js";
 import type { RetryPolicy, StepDurability } from "./step.js";
 import { requireName } from "./validation.js";
 
+/** Configures FlowService connectivity and default Flow routing. */
 export interface ClientOptions {
+  /** Plaintext Dex gRPC target; defaults to `localhost:8801`. */
   readonly serverAddress?: string;
+  /** Worker endpoint advertised by `startFlow` unless a Flow overrides it. */
   readonly workerTarget?: WorkerTarget;
 }
 
+/** Controls which active Steps are included in Flow search indexing. */
 export const ActiveStepSearchMode = Object.freeze({
+  /** Uses the Dex server's current default policy. */
   DEFAULT: "default",
+  /** Indexes every active Step. */
   ALL: "all",
 } as const);
 
+/** Represents a value from {@link ActiveStepSearchMode}. */
 export type ActiveStepSearchMode =
   (typeof ActiveStepSearchMode)[keyof typeof ActiveStepSearchMode];
 
+/** Controls whether `startFlow` may reuse a previously used Flow ID. */
 export const IdReusePolicy = Object.freeze({
+  /** Uses the Dex server's default reuse policy. */
   DEFAULT: "default",
+  /** Reuses an ID only after an unsuccessful closed run. */
   ALLOW_IF_PREVIOUS_FAILED: "allowIfPreviousFailed",
+  /** Reuses an ID after any closed run. */
   ALLOW_IF_NOT_RUNNING: "allowIfNotRunning",
+  /** Terminates an active run before starting the replacement. */
   ALLOW_TERMINATE_IF_RUNNING: "allowTerminateIfRunning",
+  /** Rejects every previously used Flow ID. */
   DISALLOW: "disallow",
 } as const);
 
+/** Represents a value from {@link IdReusePolicy}. */
 export type IdReusePolicy = (typeof IdReusePolicy)[keyof typeof IdReusePolicy];
 
+/** Overrides mutable server behavior for one Flow execution. */
 export interface FlowConfig {
+  /** Optional active-Step visibility indexing policy. */
   readonly activeStepSearchMode?: ActiveStepSearchMode;
+  /** Positive history-event threshold requesting continue-as-new. */
   readonly continueAsNewThreshold?: number;
+  /** Positive history page-size budget in bytes for continue-as-new. */
   readonly continueAsNewPageSizeBytes?: number;
+  /** Default durability for subsequent Step handler results. */
   readonly stepDurability?: StepDurability;
+  /** Worker endpoint used for subsequent handler dispatch. */
   readonly workerTarget?: WorkerTarget;
 }
 
+/**
+ * Describes one Attribute value written atomically when a Flow starts.
+ * @typeParam T - Attribute value type.
+ */
 export interface InitialAttribute<T> {
+  /** Registered singleton Attribute or AttributeMap definition. */
   readonly attribute: Attribute<T> | AttributeMap<T>;
+  /** Required non-empty map key; omitted for a singleton Attribute. */
   readonly instance?: string;
+  /** Typed initial value. */
   readonly value: T;
 }
 
+/** Creates type-safe initial Attribute writes for {@link StartFlowOptions}. */
 export const InitialAttribute = Object.freeze({
+  /**
+   * Creates a singleton Attribute initialization.
+   * @typeParam T - Attribute value type.
+   * @param attribute - Registered singleton Attribute.
+   * @param value - Typed initial value.
+   * @returns An immutable initialization descriptor.
+   */
   of<T>(attribute: Attribute<T>, value: T): InitialAttribute<T> {
     return { attribute, value };
   },
+  /**
+   * Creates an AttributeMap instance initialization.
+   * @typeParam T - Attribute value type.
+   * @param attribute - Registered AttributeMap.
+   * @param instance - Non-empty logical map key.
+   * @param value - Typed initial value.
+   * @returns An immutable initialization descriptor.
+   */
   mapValue<T>(
     attribute: AttributeMap<T>,
     instance: string,
@@ -61,18 +104,42 @@ export const InitialAttribute = Object.freeze({
   },
 });
 
+/**
+ * Configures creation of a new Flow execution. All durations use milliseconds.
+ *
+ * @example
+ * ```ts
+ * const status = new Attribute("status", stringCodec);
+ * const options: StartFlowOptions = {
+ *   timeoutMs: 30 * 60_000,
+ *   idReusePolicy: IdReusePolicy.ALLOW_IF_NOT_RUNNING,
+ *   attributes: [InitialAttribute.of(status, "queued")],
+ *   configOverride: { activeStepSearchMode: ActiveStepSearchMode.ALL },
+ * };
+ * ```
+ */
 export interface StartFlowOptions {
+  /** Maximum Flow lifetime in milliseconds; omission uses registered defaults. */
   readonly timeoutMs?: number;
+  /** Delay before the starting Step becomes eligible, in milliseconds. */
   readonly startDelayMs?: number;
+  /** Flow ID reuse policy; omission uses `DEFAULT`. */
   readonly idReusePolicy?: IdReusePolicy;
+  /** Server-supported cron expression for recurring runs. */
   readonly cronSchedule?: string;
+  /** Optional Flow-level retry policy. */
   readonly retryPolicy?: RetryPolicy;
+  /** Initial Attribute writes applied atomically with Flow creation. */
   readonly attributes?: readonly InitialAttribute<any>[];
+  /** Flow configuration applied over registered defaults. */
   readonly configOverride?: FlowConfig;
+  /** Returns the existing run instead of raising an already-started error. */
   readonly ignoreAlreadyStarted?: boolean;
+  /** Non-empty idempotency key; omission generates a UUID. */
   readonly requestId?: string;
 }
 
+/** Describes the lifecycle state of one Flow run. */
 export type FlowStatus =
   | "running"
   | "completed"
@@ -82,98 +149,170 @@ export type FlowStatus =
   | "timedOut"
   | "continuedAsNew";
 
+/** Summarizes the current or latest run for one Flow ID. */
 export interface FlowInfo {
+  /** Stable application-assigned Flow ID. */
   readonly flowId: string;
+  /** Server-assigned run ID. */
   readonly runId: string;
+  /** Registered Flow type. */
   readonly flowType: string;
+  /** Current lifecycle state. */
   readonly status: FlowStatus;
+  /** UTC run start timestamp. */
   readonly startedAt: Date;
 }
 
+/** Represents one indexed Flow run returned by `searchFlows`. */
 export interface SearchFlowEntry {
+  /** Stable application-assigned Flow ID. */
   readonly flowId: string;
+  /** Server-assigned run ID for this entry. */
   readonly runId: string;
+  /** Registered Flow type. */
   readonly flowType: string;
+  /** Indexed lifecycle state. */
   readonly status: FlowStatus;
+  /** UTC start timestamp. */
   readonly startedAt: Date;
+  /** UTC close timestamp, or `undefined` for open or unknown runs. */
   readonly closedAt: Date | undefined;
+  /** Hydrated values keyed by physical search-index name. */
   readonly indexedAttributes: ReadonlyMap<string, unknown>;
 }
 
+/** Contains one server-ordered page of Flow search results. */
 export interface SearchFlowsPage {
+  /** Result entries in server-defined query order. */
   readonly flows: readonly SearchFlowEntry[];
+  /** Opaque next-page token, or an empty string on the final page. */
   readonly nextPageToken: string;
 }
 
+/** Identifies one numbered execution of a registered Step type. */
 export interface StepExecutionId {
+  /** Registered Step type. */
   readonly stepType: string;
+  /** Positive execution number; omission means the first execution. */
   readonly number?: number;
 }
 
+/** Creates normalized {@link StepExecutionId} values. */
 export const StepExecutionId = Object.freeze({
+  /**
+   * Creates a Step execution identifier.
+   * @param stepType - Non-empty registered Step type.
+   * @param number - Positive execution number; defaults to one.
+   * @returns The normalized identifier.
+   */
   of(stepType: string, number?: number): StepExecutionId {
     return { stepType, number: number ?? 1 };
   },
 });
 
+/** Selects one Timer condition within a Step execution. */
 export interface TimerId {
+  /** Stable condition ID, mutually exclusive with `conditionIndex`. */
   readonly conditionId?: string;
+  /** Zero-based condition index, mutually exclusive with `conditionId`. */
   readonly conditionIndex?: number;
 }
 
+/** Creates Timer selectors by stable ID or Wait-tree position. */
 export const TimerId = Object.freeze({
+  /**
+   * Selects a Timer by stable condition ID.
+   * @param conditionId - Non-empty ID assigned by `Timer.byDuration`.
+   * @returns An ID-based Timer selector.
+   */
   byConditionId(conditionId: string): TimerId {
     requireName(conditionId);
     return { conditionId };
   },
+  /**
+   * Selects a Timer by zero-based Wait-tree position.
+   * @param conditionIndex - Non-negative flattened Timer index.
+   * @returns An index-based Timer selector.
+   */
   byConditionIndex(conditionIndex: number): TimerId {
     return { conditionIndex };
   },
 });
 
+/** Selects the history point from which a Flow reset resumes. */
 export const ResetType = Object.freeze({
+  /** Restarts from the beginning of the Flow. */
   BEGINNING: "beginning",
+  /** Resumes at a specific history event ID. */
   HISTORY_EVENT_ID: "historyEventId",
+  /** Resumes at the first event at or after a timestamp. */
   HISTORY_EVENT_TIME: "historyEventTime",
+  /** Resumes at the latest execution of a Step type. */
   STEP_TYPE: "stepType",
+  /** Resumes at one exact Step execution ID. */
   STEP_EXECUTION_ID: "stepExecutionId",
 } as const);
 
+/** Represents a value from {@link ResetType}. */
 export type ResetType = (typeof ResetType)[keyof typeof ResetType];
 
+/** Configures creation of a new run from existing Flow history. */
 export interface ResetFlowOptions {
+  /** Reset-point selector kind. */
   readonly type: ResetType;
+  /** Event ID used with `HISTORY_EVENT_ID`. */
   readonly historyEventId?: bigint;
+  /** Timestamp used with `HISTORY_EVENT_TIME`. */
   readonly historyEventTime?: Date;
+  /** Registered Step type used with `STEP_TYPE`. */
   readonly stepType?: string;
+  /** Exact execution ID used with `STEP_EXECUTION_ID`. */
   readonly stepExecutionId?: string;
+  /** Optional operator-readable reset reason. */
   readonly reason?: string;
+  /** Prevents reapplication of Channel messages after the reset point. */
   readonly skipChannelMessagesReapply?: boolean;
+  /** Prevents reapplication of locking RPC effects after the reset point. */
   readonly skipLockingRpcReapply?: boolean;
 }
 
+/** Selects how an active Flow should close. */
 export const StopType = Object.freeze({
+  /** Requests cooperative cancellation. */
   CANCEL: "cancel",
+  /** Forces immediate termination. */
   TERMINATE: "terminate",
+  /** Closes the Flow as failed. */
   FAIL: "fail",
 } as const);
 
+/** Represents a value from {@link StopType}. */
 export type StopType = (typeof StopType)[keyof typeof StopType];
 
+/** Configures a `stopFlow` request. */
 export interface StopFlowOptions {
+  /** Stop behavior; omission requests cooperative cancellation. */
   readonly type?: StopType;
+  /** Optional operator-readable reason recorded by Dex. */
   readonly reason?: string;
 }
 
+/** Configures Worker networking and startup synchronization. */
 export interface WorkerOptions {
+  /** Local plaintext WorkerService listener; defaults to `:8803`. */
   readonly bindAddress?: string;
+  /** Endpoint advertised to Dex; omission derives it from `bindAddress`. */
   readonly workerTarget?: WorkerTarget;
+  /** Dex FlowService target; defaults to `localhost:8801`. */
   readonly serverAddress?: string;
   /** Startup Indexed Attribute synchronization deadline in milliseconds. Defaults to 120000. */
   readonly attributeIndexSyncTimeoutMs?: number;
 }
 
+/** Identifies the application Worker endpoint advertised to Dex. */
 export interface WorkerTarget {
+  /** Plaintext gRPC target; headless targets must use `host:port`. */
   readonly address: string;
+  /** Whether Dex connects directly without service discovery. */
   readonly headless?: boolean;
 }

--- a/sdk-typescript/src/persistence.ts
+++ b/sdk-typescript/src/persistence.ts
@@ -44,7 +44,7 @@ export interface AttributeIndex {
 export interface AttributeLock {
   /** Singleton Attribute or AttributeMap definition to lock. */
   readonly attribute: Attribute<unknown> | AttributeMap<unknown>;
-  /** AttributeMap instance, or omission for a singleton Attribute. */
+  /** AttributeMap instance; omitted for a singleton Attribute. */
   readonly instance?: string;
 }
 
@@ -103,7 +103,7 @@ export class Attribute<T> {
 
   /**
    * Creates a lock request for this Attribute.
-   * @returns An immutable lock descriptor for this singleton Attribute.
+   * @returns A lock for this singleton Attribute.
    */
   public lock(): AttributeLock {
     return { attribute: this as Attribute<unknown> };
@@ -161,7 +161,7 @@ export class AttributeMap<T> {
   /**
    * Creates a lock request scoped to one map instance.
    * @param instance - Non-empty logical map key.
-   * @returns An immutable instance lock descriptor.
+   * @returns A lock for the requested instance.
    */
   public lock(instance: string): AttributeLock {
     requireName(instance);

--- a/sdk-typescript/src/persistence.ts
+++ b/sdk-typescript/src/persistence.ts
@@ -11,29 +11,62 @@ import type { Codec } from "./codec.js";
 import type { Context } from "./context.js";
 import { requireName } from "./validation.js";
 
+/** Selects how Dex indexes an Attribute for Flow search. */
 export const IndexType = Object.freeze({
+  /** Indexes an exact string value. */
   KEYWORD: "keyword",
+  /** Indexes a string for tokenized full-text matching. */
   FULL_TEXT: "fullText",
+  /** Indexes every string in an array as a keyword. */
   KEYWORD_ARRAY: "keywordArray",
+  /** Indexes a signed 64-bit integer. */
   INT: "int",
+  /** Indexes a finite floating-point number. */
   DOUBLE: "double",
+  /** Indexes a Boolean value. */
   BOOL: "bool",
+  /** Indexes a JavaScript Date value. */
   DATETIME: "datetime",
 } as const);
 
+/** Represents a value from {@link IndexType}. */
 export type IndexType = (typeof IndexType)[keyof typeof IndexType];
 
+/** Configures the search index for an Attribute or AttributeMap. */
 export interface AttributeIndex {
+  /** Value representation accepted by the search index. */
   readonly type: IndexType;
+  /** Physical search key; indexed AttributeMaps require an explicit key. */
   readonly indexKey?: string;
 }
 
+/** Describes an Attribute lock acquired for a Step or RPC handler. */
 export interface AttributeLock {
+  /** Singleton Attribute or AttributeMap definition to lock. */
   readonly attribute: Attribute<unknown> | AttributeMap<unknown>;
+  /** AttributeMap instance, or omission for a singleton Attribute. */
   readonly instance?: string;
 }
 
+/**
+ * Defines a typed, durable singleton value owned by a Flow.
+ *
+ * @example
+ * ```ts
+ * const status = new Attribute("status", stringCodec, {
+ *   type: IndexType.KEYWORD,
+ * });
+ * const persistence: PersistenceSchema = { attributes: [status] };
+ * ```
+ * @typeParam T - Value encoded by the Attribute's codec.
+ */
 export class Attribute<T> {
+  /**
+   * Creates an Attribute definition for a PersistenceSchema.
+   * @param name - Non-empty logical name unique within the Flow.
+   * @param codec - Value codec used by handlers and Client calls.
+   * @param index - Optional visibility search index.
+   */
   public constructor(
     public readonly name: string,
     public readonly codec: Codec<T>,
@@ -42,24 +75,52 @@ export class Attribute<T> {
     requireName(name);
   }
 
+  /**
+   * Reads the current value from handler decision state.
+   * @param context - Current Step or RPC Context.
+   * @returns The decoded Attribute value.
+   */
   public get(context: Context): T {
     return context.getAttribute(this);
   }
 
+  /**
+   * Stages a value to persist with the current decision.
+   * @param context - Current Step or RPC Context.
+   * @param value - Typed value to persist.
+   */
   public set(context: Context, value: T): void {
     context.setAttribute(this, value);
   }
 
+  /**
+   * Stages deletion in the current decision.
+   * @param context - Current Step or RPC Context.
+   */
   public delete(context: Context): void {
     context.deleteAttribute(this as Attribute<unknown>);
   }
 
+  /**
+   * Creates a lock request for this Attribute.
+   * @returns An immutable lock descriptor for this singleton Attribute.
+   */
   public lock(): AttributeLock {
     return { attribute: this as Attribute<unknown> };
   }
 }
 
+/**
+ * Defines a typed family of durable values keyed by map instance.
+ * @typeParam T - Value encoded for every map instance.
+ */
 export class AttributeMap<T> {
+  /**
+   * Creates an AttributeMap definition for a PersistenceSchema.
+   * @param name - Non-empty logical name unique within the Flow.
+   * @param codec - Value codec shared by every instance.
+   * @param index - Optional shared visibility search index.
+   */
   public constructor(
     public readonly name: string,
     public readonly codec: Codec<T>,
@@ -68,25 +129,50 @@ export class AttributeMap<T> {
     requireName(name);
   }
 
+  /**
+   * Reads one map instance from handler decision state.
+   * @param context - Current Step or RPC Context.
+   * @param instance - Non-empty logical map key.
+   * @returns The decoded instance value.
+   */
   public get(context: Context, instance: string): T {
     return context.getAttribute(this, instance);
   }
 
+  /**
+   * Stages one map-instance write.
+   * @param context - Current Step or RPC Context.
+   * @param instance - Non-empty logical map key.
+   * @param value - Typed value to persist.
+   */
   public set(context: Context, instance: string, value: T): void {
     context.setAttribute(this, value, instance);
   }
 
+  /**
+   * Stages deletion of one map instance.
+   * @param context - Current Step or RPC Context.
+   * @param instance - Non-empty logical map key.
+   */
   public delete(context: Context, instance: string): void {
     context.deleteAttribute(this as AttributeMap<unknown>, instance);
   }
 
+  /**
+   * Creates a lock request scoped to one map instance.
+   * @param instance - Non-empty logical map key.
+   * @returns An immutable instance lock descriptor.
+   */
   public lock(instance: string): AttributeLock {
     requireName(instance);
     return { attribute: this as AttributeMap<unknown>, instance };
   }
 }
 
+/** Declares the Attributes and Channels owned by a Flow type. */
 export interface PersistenceSchema {
+  /** Singleton and map Attribute definitions with unique names. */
   readonly attributes?: readonly (Attribute<unknown> | AttributeMap<unknown>)[];
+  /** Singleton and map Channel definitions with unique names. */
   readonly channels?: readonly (Channel<unknown> | ChannelMap<unknown>)[];
 }

--- a/sdk-typescript/src/rpc.ts
+++ b/sdk-typescript/src/rpc.ts
@@ -40,7 +40,7 @@ export type RPC<Input, Output> = (
  * @typeParam Output - Handler output type.
  */
 export interface RPCOptions<Input = unknown, Output = unknown> {
-  /** Protocol RPC name; omission uses the decorated method name. */
+  /** Protocol RPC name; uses the decorated method name when omitted. */
   readonly name?: string;
   /** Required input codec for handlers that accept an input. */
   readonly inputCodec?: Codec<Input>;

--- a/sdk-typescript/src/rpc.ts
+++ b/sdk-typescript/src/rpc.ts
@@ -13,21 +13,42 @@ import type { AttributeLock } from "./persistence.js";
 import type { StepMovement } from "./step.js";
 import { requireName } from "./validation.js";
 
+/**
+ * Contains a typed RPC output and optional next-Step movements.
+ * @typeParam Output - Value decoded for the Client caller.
+ */
 export interface RPCResult<Output> {
+  /** Typed application result. */
   readonly output: Output;
+  /** Step movements applied atomically with handler persistence writes. */
   readonly nextSteps?: readonly StepMovement<unknown>[];
 }
 
+/**
+ * Describes a typed, possibly asynchronous RPC handler.
+ * @typeParam Input - Handler input type.
+ * @typeParam Output - Handler output type.
+ */
 export type RPC<Input, Output> = (
   context: Context,
   input: Input,
 ) => RPCResult<Output> | Promise<RPCResult<Output>>;
 
+/**
+ * Configures an RPC decorator's name, codecs, timeout, and Attribute locks.
+ * @typeParam Input - Handler input type.
+ * @typeParam Output - Handler output type.
+ */
 export interface RPCOptions<Input = unknown, Output = unknown> {
+  /** Protocol RPC name; omission uses the decorated method name. */
   readonly name?: string;
+  /** Required input codec for handlers that accept an input. */
   readonly inputCodec?: Codec<Input>;
+  /** Required output codec for handlers returning RPCResult. */
   readonly outputCodec?: Codec<Output>;
+  /** Non-negative handler timeout in milliseconds. */
   readonly timeoutMs?: number;
+  /** Attribute locks held for the entire invocation. */
   readonly lockAttributes?: readonly AttributeLock[];
 }
 
@@ -39,8 +60,17 @@ export interface RegisteredRPC {
 
 const rpcOptions = new WeakMap<Function, RPCOptions<any, any>>();
 
+/**
+ * Decorates an RPC with both typed input and output.
+ * @typeParam Input - Handler input type.
+ * @typeParam Output - Handler output type.
+ * @param options - Required input/output codecs and optional RPC settings.
+ * @returns A stage-3 method decorator validated during Registry construction.
+ */
 export function rpc<Input, Output>(options: RPCOptions<Input, Output> & {
+  /** Required codec for the handler input. */
   readonly inputCodec: Codec<Input>;
+  /** Required codec for the RPCResult output. */
   readonly outputCodec: Codec<Output>;
 }): <This>(
   method: (
@@ -58,8 +88,16 @@ export function rpc<Input, Output>(options: RPCOptions<Input, Output> & {
   >,
 ) => void;
 
+/**
+ * Decorates an input-free RPC with typed output.
+ * @typeParam Output - Handler output type.
+ * @param options - Required output codec and optional RPC settings.
+ * @returns A stage-3 method decorator validated during Registry construction.
+ */
 export function rpc<Output>(options: RPCOptions<never, Output> & {
+  /** Input codecs are forbidden for an input-free handler. */
   readonly inputCodec?: never;
+  /** Required codec for the RPCResult output. */
   readonly outputCodec: Codec<Output>;
 }): <This>(
   method: (this: This, context: Context) => RPCResult<Output> | Promise<RPCResult<Output>>,
@@ -69,8 +107,16 @@ export function rpc<Output>(options: RPCOptions<never, Output> & {
   >,
 ) => void;
 
+/**
+ * Decorates a typed-input RPC with no output.
+ * @typeParam Input - Handler input type.
+ * @param options - Required input codec and optional RPC settings.
+ * @returns A stage-3 method decorator validated during Registry construction.
+ */
 export function rpc<Input>(options: RPCOptions<Input, never> & {
+  /** Required codec for the handler input. */
   readonly inputCodec: Codec<Input>;
+  /** Output codecs are forbidden for a void handler. */
   readonly outputCodec?: never;
 }): <This>(
   method: (this: This, context: Context, input: Input) => void | Promise<void>,
@@ -80,14 +126,38 @@ export function rpc<Input>(options: RPCOptions<Input, never> & {
   >,
 ) => void;
 
+/**
+ * Decorates an input-free, output-free RPC.
+ * @param options - Optional name, timeout, and Attribute locks.
+ * @returns A stage-3 method decorator validated during Registry construction.
+ */
 export function rpc(options?: RPCOptions<never, never> & {
+  /** Input codecs are forbidden for an input-free handler. */
   readonly inputCodec?: never;
+  /** Output codecs are forbidden for a void handler. */
   readonly outputCodec?: never;
 }): <This>(
   method: (this: This, context: Context) => void | Promise<void>,
   context: ClassMethodDecoratorContext<This, (this: This, context: Context) => void | Promise<void>>,
 ) => void;
 
+/**
+ * Creates a typed RPC method decorator.
+ *
+ * Registry construction validates handler shape, codecs, unique names, and locks.
+ * The handler receives Context and optional input, then returns RPCResult or void.
+ *
+ * @example
+ * ```ts
+ * @rpc({ inputCodec: stringCodec, outputCodec: booleanCodec, timeoutMs: 10_000 })
+ * async cancel(context: Context, reason: string): Promise<RPCResult<boolean>> {
+ *   return { output: true };
+ * }
+ * ```
+ * @param options - Codecs and optional name, timeout, and lock settings.
+ * @returns A stage-3 method decorator.
+ * @throws {@link RangeError} when `timeoutMs` is negative.
+ */
 export function rpc(options: RPCOptions<any, any> = {}) {
   if (options.name !== undefined) {
     requireName(options.name);

--- a/sdk-typescript/src/step.ts
+++ b/sdk-typescript/src/step.ts
@@ -11,23 +11,42 @@ import type { Context } from "./context.js";
 import type { AttributeLock } from "./persistence.js";
 import type { Channel, ChannelMap, Wait } from "./wait.js";
 
+/** Controls when a Step handler result is durably acknowledged. */
 export type StepDurability = "sync" | "async";
+/** Controls whether exhausted `waitFor` failures fail the Flow or run `execute`. */
 export type WaitForFailurePolicy = "failFlow" | "proceed";
 
+/** Configures exponential retries for a Step handler or Flow. */
 export interface RetryPolicy {
+  /** Delay before the first retry in milliseconds. */
   readonly initialIntervalMs?: number;
+  /** Retry-delay multiplier; omission uses the server default. */
   readonly backoffCoefficient?: number;
+  /** Upper bound for one retry delay in milliseconds. */
   readonly maximumIntervalMs?: number;
+  /** Total attempt limit including the initial call. */
   readonly maximumAttempts?: number;
+  /** Overall elapsed-time limit in milliseconds. */
   readonly totalDurationMs?: number;
 }
 
+/** Routes exhausted `execute` retries to a fallback Step. */
 export interface ExecuteFailure {
+  /** Registered fallback Step. */
   readonly step: Step<unknown>;
+  /** Options applied to the fallback movement. */
   readonly options?: StepOptions;
 }
 
+/** Creates execute-failure routing descriptors. */
 export const ExecuteFailure = Object.freeze({
+  /**
+   * Routes exhausted execution retries to another Step.
+   * @typeParam Input - Fallback Step input type.
+   * @param step - Registered fallback Step.
+   * @param options - Optional options for the fallback movement.
+   * @returns An immutable failure-routing descriptor.
+   */
   proceedTo<Input>(step: Step<Input>, options?: StepOptions): ExecuteFailure {
     return {
       step: step as Step<unknown>,
@@ -36,24 +55,70 @@ export const ExecuteFailure = Object.freeze({
   },
 });
 
+/** Configures timeouts, retries, durability, locks, and failure routing for a Step. */
 export interface StepOptions {
+  /** Maximum duration of one `waitFor` attempt in milliseconds. */
   readonly waitForMethodTimeoutMs?: number;
+  /** Maximum duration of one `execute` attempt in milliseconds. */
   readonly executeMethodTimeoutMs?: number;
+  /** Optional retry policy for `waitFor`. */
   readonly waitForRetry?: RetryPolicy;
+  /** Optional retry policy for `execute`. */
   readonly executeRetry?: RetryPolicy;
+  /** Behavior after all `waitFor` attempts fail. */
   readonly waitForFailure?: WaitForFailurePolicy;
+  /** Durability used for the `waitFor` result. */
   readonly waitForDurability?: StepDurability;
+  /** Durability used for the `execute` result. */
   readonly executeDurability?: StepDurability;
+  /** Attribute locks held during `waitFor`. */
   readonly waitForLockAttributes?: readonly AttributeLock[];
+  /** Attribute locks held during `execute`. */
   readonly executeLockAttributes?: readonly AttributeLock[];
+  /** Fallback routing after exhausted `execute` retries. */
   readonly executeFailure?: ExecuteFailure;
 }
 
+/**
+ * Defines one typed unit of durable Flow application logic.
+ *
+ * @example
+ * ```ts
+ * const confirm: Step<string> = {
+ *   inputCodec: stringCodec,
+ *   getStepType: () => "Confirm",
+ *   waitFor: () => Wait.until(Timer.byDuration(1_000)),
+ *   execute: (_context, input) => forceComplete(input),
+ * };
+ * ```
+ * @typeParam Input - Value supplied by an incoming Step movement.
+ */
 export interface Step<Input> {
+  /** Codec used for every incoming input value. */
   readonly inputCodec: Codec<Input>;
+  /**
+   * Returns the protocol Step type.
+   * @returns A non-empty Step type unique within the containing Flow.
+   */
   getStepType(): string;
+  /**
+   * Returns this Step's static options.
+   * @returns Static options, or `undefined` for Flow and server defaults.
+   */
   getStepOptions?(): StepOptions | undefined;
+  /**
+   * Describes durable conditions required before execution.
+   * @param context - Current execution metadata and persistence operations.
+   * @param input - Decoded Step input.
+   * @returns A Wait or promise resolving to one.
+   */
   waitFor?(context: Context, input: Input): Wait | Promise<Wait>;
+  /**
+   * Runs application logic and produces the next durable decision.
+   * @param context - Current execution metadata and persistence operations.
+   * @param input - Decoded Step input.
+   * @returns A StepDecision or promise resolving to one.
+   */
   execute(context: Context, input: Input): StepDecision | Promise<StepDecision>;
 }
 
@@ -71,7 +136,12 @@ type StepDefinition = StartStepDefinition<unknown> | NonStartStepDefinition;
 
 declare const startInputType: unique symbol;
 
+/**
+ * Builds immutable Step definitions for a Flow.
+ * @typeParam StartInput - Input type of the optional starting Step.
+ */
 export class StepList<StartInput> {
+  /** Compile-time brand preserving the starting input type. */
   public declare readonly [startInputType]: (input: StartInput) => StartInput;
 
   private readonly definitions: readonly StepDefinition[];
@@ -80,20 +150,42 @@ export class StepList<StartInput> {
     this.definitions = Object.freeze([...definitions]);
   }
 
+  /**
+   * Creates a StepList with no Steps.
+   * @typeParam StartInput - Declared Flow start input type.
+   * @returns An empty immutable StepList.
+   */
   public static empty<StartInput = void>(): StepList<StartInput> {
     return new StepList([]);
   }
 
+  /**
+   * Creates a StepList with one starting Step.
+   * @typeParam StartInput - Starting Step input type.
+   * @param step - Step receiving `startFlow` input.
+   * @returns A StepList with exactly one starting Step.
+   */
   public static startStep<StartInput>(step: Step<StartInput>): StepList<StartInput> {
     return new StepList([{ step: step as Step<unknown>, isStartStep: true }]);
   }
 
+  /**
+   * Creates a StepList containing only non-starting Steps.
+   * @typeParam StartInput - Declared start input; defaults to `never`.
+   * @param steps - Steps reachable through decisions, RPCs, or failure routing.
+   * @returns A StepList without a starting Step.
+   */
   public static withoutStartStep<StartInput = never>(
     ...steps: readonly Step<any>[]
   ): StepList<StartInput> {
     return new StepList(steps.map((step) => ({ step: step as Step<unknown>, isStartStep: false })));
   }
 
+  /**
+   * Returns a copy with non-starting Steps appended.
+   * @param steps - Registered Steps appended in argument order.
+   * @returns A new immutable StepList.
+   */
   public otherSteps(...steps: readonly Step<any>[]): StepList<StartInput> {
     return new StepList([
       ...this.definitions,
@@ -101,18 +193,38 @@ export class StepList<StartInput> {
     ]);
   }
 
+  /**
+   * Iterates Step definitions in registration order.
+   * @returns An iterator over immutable internal definitions.
+   */
   public [Symbol.iterator](): Iterator<StepDefinition> {
     return this.definitions[Symbol.iterator]();
   }
 }
 
+/**
+ * Schedules one registered Step with typed input and optional options.
+ * @typeParam Input - Destination Step input type.
+ */
 export interface StepMovement<Input> {
+  /** Registered destination Step. */
   readonly step: Step<Input>;
+  /** Value encoded for the destination Step. */
   readonly input: Input;
+  /** Optional per-movement Step options. */
   readonly options?: StepOptions;
 }
 
+/** Creates typed Step movements. */
 export const StepMovement = Object.freeze({
+  /**
+   * Creates a movement to one Step.
+   * @typeParam Input - Destination Step input type.
+   * @param step - Registered destination Step.
+   * @param input - Typed destination input.
+   * @param options - Optional per-movement options.
+   * @returns An immutable movement descriptor.
+   */
   of<Input>(step: Step<Input>, input: Input, options?: StepOptions): StepMovement<Input> {
     return {
       step,
@@ -122,39 +234,100 @@ export const StepMovement = Object.freeze({
   },
 });
 
+/** Describes the durable transition returned by `Step.execute`. */
 export type StepDecision =
-  | Readonly<{ kind: "next"; movements: readonly StepMovement<unknown>[] }>
-  | Readonly<{ kind: "gracefulComplete" | "forceComplete"; output: unknown }>
   | Readonly<{
-      kind: "forceCompleteIfChannelsEmpty";
+      /** Schedules next Step movements. */
+      kind: "next";
+      /** Ordered destination movements. */
+      movements: readonly StepMovement<unknown>[];
+    }>
+  | Readonly<{
+      /** Requests graceful or immediate successful completion. */
+      kind: "gracefulComplete" | "forceComplete";
+      /** Codec-supported Flow result. */
       output: unknown;
+    }>
+  | Readonly<{
+      /** Completes only when selected Channels are empty. */
+      kind: "forceCompleteIfChannelsEmpty";
+      /** Codec-supported Flow result. */
+      output: unknown;
+      /** Movement scheduled when any selected Channel is non-empty. */
       fallback: StepMovement<unknown>;
+      /** Registered Channels inspected for emptiness. */
       channels: readonly (Channel<unknown> | ChannelMap<unknown>)[];
     }>
-  | Readonly<{ kind: "forceFail"; reason: string }>
-  | Readonly<{ kind: "deadEnd" }>;
+  | Readonly<{
+      /** Requests immediate Flow failure. */
+      kind: "forceFail";
+      /** Application-readable failure detail. */
+      reason: string;
+    }>
+  | Readonly<{
+      /** Ends this path without scheduling work or closing the Flow. */
+      kind: "deadEnd";
+    }>;
 
+/**
+ * Creates a decision scheduling one next Step.
+ * @typeParam Input - Destination Step input type.
+ * @param step - Registered destination Step.
+ * @param input - Typed destination input.
+ * @returns A next decision containing one movement.
+ */
 export const goTo = <Input>(step: Step<Input>, input: Input): StepDecision =>
   goToMulti(StepMovement.of(step, input));
 
+/**
+ * Creates a decision scheduling several next Steps.
+ * @param movements - Typed movements applied in argument order.
+ * @returns A next decision containing every movement.
+ */
 export const goToMulti = (...movements: readonly StepMovement<unknown>[]): StepDecision => ({
   kind: "next",
   movements,
 });
 
+/**
+ * Requests successful completion after already-scheduled Steps finish.
+ * @param output - Optional codec-supported Flow result.
+ * @returns A graceful-completion decision.
+ */
 export const gracefulComplete = (output?: unknown): StepDecision => ({
   kind: "gracefulComplete",
   output,
 });
 
+/**
+ * Requests immediate successful completion.
+ * @param output - Optional codec-supported Flow result.
+ * @returns A force-completion decision.
+ */
 export const forceComplete = (output?: unknown): StepDecision => ({ kind: "forceComplete", output });
 
+/**
+ * Completes only when selected Channels are empty, otherwise schedules a fallback.
+ * @param output - Codec-supported completion result.
+ * @param fallback - Movement used when any selected Channel is non-empty.
+ * @param channels - Registered Channel definitions to inspect.
+ * @returns A conditional force-completion decision.
+ */
 export const forceCompleteWhenChannelsEmpty = (
   output: unknown,
   fallback: StepMovement<unknown>,
   ...channels: readonly (Channel<unknown> | ChannelMap<unknown>)[]
 ): StepDecision => ({ kind: "forceCompleteIfChannelsEmpty", output, fallback, channels });
 
+/**
+ * Requests immediate Flow failure.
+ * @param reason - Non-empty application-readable failure detail.
+ * @returns A force-failure decision.
+ */
 export const forceFail = (reason: string): StepDecision => ({ kind: "forceFail", reason });
 
+/**
+ * Creates a dead-end decision.
+ * @returns A decision ending this path without closing the Flow.
+ */
 export const deadEnd = (): StepDecision => ({ kind: "deadEnd" });

--- a/sdk-typescript/src/step.ts
+++ b/sdk-typescript/src/step.ts
@@ -20,7 +20,7 @@ export type WaitForFailurePolicy = "failFlow" | "proceed";
 export interface RetryPolicy {
   /** Delay before the first retry in milliseconds. */
   readonly initialIntervalMs?: number;
-  /** Retry-delay multiplier; omission uses the server default. */
+  /** Retry-delay multiplier; uses the server default when omitted. */
   readonly backoffCoefficient?: number;
   /** Upper bound for one retry delay in milliseconds. */
   readonly maximumIntervalMs?: number;
@@ -38,14 +38,14 @@ export interface ExecuteFailure {
   readonly options?: StepOptions;
 }
 
-/** Creates execute-failure routing descriptors. */
+/** Creates execute-failure routing settings. */
 export const ExecuteFailure = Object.freeze({
   /**
    * Routes exhausted execution retries to another Step.
    * @typeParam Input - Fallback Step input type.
    * @param step - Registered fallback Step.
    * @param options - Optional options for the fallback movement.
-   * @returns An immutable failure-routing descriptor.
+   * @returns The failure-routing settings.
    */
   proceedTo<Input>(step: Step<Input>, options?: StepOptions): ExecuteFailure {
     return {
@@ -91,7 +91,7 @@ export interface StepOptions {
  *   execute: (_context, input) => forceComplete(input),
  * };
  * ```
- * @typeParam Input - Value supplied by an incoming Step movement.
+ * @typeParam Input - Value passed by an incoming Step movement.
  */
 export interface Step<Input> {
   /** Codec used for every incoming input value. */
@@ -137,7 +137,7 @@ type StepDefinition = StartStepDefinition<unknown> | NonStartStepDefinition;
 declare const startInputType: unique symbol;
 
 /**
- * Builds immutable Step definitions for a Flow.
+ * Builds the ordered Step definitions for a Flow.
  * @typeParam StartInput - Input type of the optional starting Step.
  */
 export class StepList<StartInput> {
@@ -153,7 +153,7 @@ export class StepList<StartInput> {
   /**
    * Creates a StepList with no Steps.
    * @typeParam StartInput - Declared Flow start input type.
-   * @returns An empty immutable StepList.
+   * @returns An empty StepList.
    */
   public static empty<StartInput = void>(): StepList<StartInput> {
     return new StepList([]);
@@ -184,7 +184,7 @@ export class StepList<StartInput> {
   /**
    * Returns a copy with non-starting Steps appended.
    * @param steps - Registered Steps appended in argument order.
-   * @returns A new immutable StepList.
+   * @returns A new StepList.
    */
   public otherSteps(...steps: readonly Step<any>[]): StepList<StartInput> {
     return new StepList([
@@ -195,7 +195,7 @@ export class StepList<StartInput> {
 
   /**
    * Iterates Step definitions in registration order.
-   * @returns An iterator over immutable internal definitions.
+   * @returns An iterator over the registered Step definitions.
    */
   public [Symbol.iterator](): Iterator<StepDefinition> {
     return this.definitions[Symbol.iterator]();
@@ -223,7 +223,7 @@ export const StepMovement = Object.freeze({
    * @param step - Registered destination Step.
    * @param input - Typed destination input.
    * @param options - Optional per-movement options.
-   * @returns An immutable movement descriptor.
+   * @returns The new Step movement.
    */
   of<Input>(step: Step<Input>, input: Input, options?: StepOptions): StepMovement<Input> {
     return {

--- a/sdk-typescript/src/wait.ts
+++ b/sdk-typescript/src/wait.ts
@@ -14,27 +14,50 @@ import {
   validateChannelBounds,
 } from "./validation.js";
 
+/** Describes one durable Timer or Channel readiness condition. */
 export interface Condition {
+  /** Condition family interpreted by Dex. */
   readonly kind: "timer" | "channel";
+  /** Optional stable ID unique within the Wait tree. */
   readonly conditionId?: string;
+  /** Timer delay in non-negative milliseconds. */
   readonly durationMs?: number;
+  /** Physical Channel name for a Channel condition. */
   readonly channelName?: string;
+  /** ChannelMap instance for a map condition. */
   readonly instance?: string;
+  /** Inclusive lower queued-value bound. */
   readonly atLeast?: number;
+  /** Inclusive upper queued-value bound. */
   readonly atMost?: number;
 }
 
+/** Groups Conditions that must become ready together. */
 export interface ConditionCombination {
+  /** Ordered Conditions in this all-of group. */
   readonly conditions: readonly Condition[];
 }
 
+/** Creates all-of Condition groups for `Wait.anyCombinationOf`. */
 export const ConditionCombination = Object.freeze({
+  /**
+   * Groups conditions that must all become ready together.
+   * @param conditions - Conditions in stable evaluation order.
+   * @returns An immutable combination.
+   */
   of(...conditions: readonly Condition[]): ConditionCombination {
     return { conditions };
   },
 });
 
+/** Creates durable Timer conditions without blocking a worker thread. */
 export const Timer = Object.freeze({
+  /**
+   * Creates a Timer ready after a non-negative delay.
+   * @param durationMs - Durable delay in milliseconds.
+   * @param conditionId - Optional stable ID used by skip-Timer APIs.
+   * @returns A Timer condition accepted by Wait factories.
+   */
   byDuration(durationMs: number, conditionId?: string): Condition {
     if (durationMs < 0 || !Number.isFinite(durationMs)) {
       throw new RangeError("timer duration must be non-negative");
@@ -48,7 +71,16 @@ export const Timer = Object.freeze({
   },
 });
 
+/**
+ * Defines a typed, durable singleton message stream owned by a Flow.
+ * @typeParam T - Type of every published value.
+ */
 export class Channel<T> {
+  /**
+   * Creates a Channel definition.
+   * @param name - Non-empty name unique within the Flow.
+   * @param codec - Element codec.
+   */
   public constructor(
     public readonly name: string,
     public readonly codec: Codec<T>,
@@ -56,34 +88,79 @@ export class Channel<T> {
     requireName(name);
   }
 
+  /**
+   * Stages one value to append with the current decision.
+   * @param context - Current Step or RPC Context.
+   * @param value - Typed value to append.
+   */
   public publish(context: Context, value: T): void {
     context.publish(this, value);
   }
 
+  /**
+   * Returns the current queued value count.
+   * @param context - Current Step or RPC Context.
+   * @returns Non-negative queued value count.
+   */
   public size(context: Context): number {
     return context.channelSize(this as Channel<unknown>);
   }
 
+  /**
+   * Returns values selected by this Step's satisfied condition.
+   * @param context - Current Step Context.
+   * @returns Ordered values, or an empty array when this Channel was not selected.
+   */
   public results(context: Context): readonly T[] {
     return context.channelResults(this);
   }
 
+  /**
+   * Creates a condition consuming exactly one value.
+   * @param conditionId - Optional stable condition identifier.
+   * @returns An exact-one Channel condition.
+   */
   public forOne(conditionId?: string): Condition {
     return this.range(1, 1, conditionId);
   }
 
+  /**
+   * Creates a condition consuming exactly `count` values.
+   * @param count - Required non-negative count.
+   * @param conditionId - Optional stable condition identifier.
+   * @returns A condition with equal lower and upper bounds.
+   */
   public forN(count: number, conditionId?: string): Condition {
     return this.range(count, count, conditionId);
   }
 
+  /**
+   * Creates a condition requiring at least `count` values.
+   * @param count - Inclusive non-negative lower bound.
+   * @param conditionId - Optional stable condition identifier.
+   * @returns A condition without an upper bound.
+   */
   public atLeast(count: number, conditionId?: string): Condition {
     return this.range(count, undefined, conditionId);
   }
 
+  /**
+   * Creates a condition consuming at most `count` available values.
+   * @param count - Inclusive non-negative upper bound.
+   * @param conditionId - Optional stable condition identifier.
+   * @returns A condition without a positive lower bound.
+   */
   public atMost(count: number, conditionId?: string): Condition {
     return this.range(undefined, count, conditionId);
   }
 
+  /**
+   * Creates a bounded condition for queued Channel values.
+   * @param atLeast - Optional inclusive lower bound.
+   * @param atMost - Optional inclusive upper bound.
+   * @param conditionId - Optional stable condition identifier.
+   * @returns A validated Channel condition.
+   */
   public range(atLeast?: number, atMost?: number, conditionId?: string): Condition {
     validateChannelBounds(atLeast, atMost);
     requireConditionId(conditionId);
@@ -97,7 +174,16 @@ export class Channel<T> {
   }
 }
 
+/**
+ * Defines keyed Channel instances that share one typed schema.
+ * @typeParam T - Type of every published value.
+ */
 export class ChannelMap<T> {
+  /**
+   * Creates a ChannelMap definition.
+   * @param name - Non-empty name unique within the Flow.
+   * @param codec - Element codec shared by every instance.
+   */
   public constructor(
     public readonly name: string,
     public readonly codec: Codec<T>,
@@ -105,34 +191,87 @@ export class ChannelMap<T> {
     requireName(name);
   }
 
+  /**
+   * Stages one value for a ChannelMap instance.
+   * @param context - Current Step or RPC Context.
+   * @param instance - Non-empty logical map key.
+   * @param value - Typed value to append.
+   */
   public publish(context: Context, instance: string, value: T): void {
     context.publish(this, value, instance);
   }
 
+  /**
+   * Returns one instance's queued value count.
+   * @param context - Current Step or RPC Context.
+   * @param instance - Non-empty logical map key.
+   * @returns Non-negative queued value count.
+   */
   public size(context: Context, instance: string): number {
     return context.channelSize(this, instance);
   }
 
+  /**
+   * Returns values selected for one instance by the satisfied condition.
+   * @param context - Current Step Context.
+   * @param instance - Non-empty logical map key.
+   * @returns Ordered values for this Step execution.
+   */
   public results(context: Context, instance: string): readonly T[] {
     return context.channelResults(this, instance);
   }
 
+  /**
+   * Creates an instance condition consuming exactly one value.
+   * @param instance - Non-empty logical map key.
+   * @param conditionId - Optional stable condition identifier.
+   * @returns An exact-one instance condition.
+   */
   public forOne(instance: string, conditionId?: string): Condition {
     return this.range(instance, 1, 1, conditionId);
   }
 
+  /**
+   * Creates an instance condition consuming exactly `count` values.
+   * @param instance - Non-empty logical map key.
+   * @param count - Required non-negative count.
+   * @param conditionId - Optional stable condition identifier.
+   * @returns A condition with equal bounds.
+   */
   public forN(instance: string, count: number, conditionId?: string): Condition {
     return this.range(instance, count, count, conditionId);
   }
 
+  /**
+   * Creates an instance condition requiring at least `count` values.
+   * @param instance - Non-empty logical map key.
+   * @param count - Inclusive non-negative lower bound.
+   * @param conditionId - Optional stable condition identifier.
+   * @returns A condition without an upper bound.
+   */
   public atLeast(instance: string, count: number, conditionId?: string): Condition {
     return this.range(instance, count, undefined, conditionId);
   }
 
+  /**
+   * Creates an instance condition consuming at most `count` values.
+   * @param instance - Non-empty logical map key.
+   * @param count - Inclusive non-negative upper bound.
+   * @param conditionId - Optional stable condition identifier.
+   * @returns A condition without a positive lower bound.
+   */
   public atMost(instance: string, count: number, conditionId?: string): Condition {
     return this.range(instance, undefined, count, conditionId);
   }
 
+  /**
+   * Creates a bounded condition for one ChannelMap instance.
+   * @param instance - Non-empty logical map key.
+   * @param atLeast - Optional inclusive lower bound.
+   * @param atMost - Optional inclusive upper bound.
+   * @param conditionId - Optional stable condition identifier.
+   * @returns A validated instance condition.
+   */
   public range(
     instance: string,
     atLeast?: number,
@@ -152,25 +291,65 @@ export class ChannelMap<T> {
   }
 }
 
+/**
+ * Describes the durable readiness rule evaluated before a Step executes.
+ *
+ * @example
+ * ```ts
+ * const approvals = new Channel("approvals", stringCodec);
+ * const wait = Wait.anyOf(
+ *   approvals.forOne("approved"),
+ *   Timer.byDuration(5 * 60_000, "timeout"),
+ * );
+ * ```
+ */
 export type Wait = Readonly<{
+  /** Combination rule interpreted by Dex. */
   kind: "skipImmediately" | "allOf" | "anyOf" | "anyCombinationOf";
+  /** Direct conditions for all-of or any-of waits. */
   conditions: readonly Condition[];
+  /** Alternative all-of groups for any-combination waits. */
   combinations: readonly ConditionCombination[];
 }>;
 
+/** Creates durable Step Wait values. */
 export const Wait = Object.freeze({
+  /**
+   * Creates an immediate Wait.
+   * @returns A Wait that proceeds to `execute` immediately.
+   */
   skipImmediately(): Wait {
     return { kind: "skipImmediately", conditions: [], combinations: [] };
   },
+  /**
+   * Creates a Wait for one condition.
+   * @param condition - Sole readiness condition.
+   * @returns An all-of Wait containing the condition.
+   */
   until(condition: Condition): Wait {
     return Wait.allOf(condition);
   },
+  /**
+   * Creates a Wait requiring every supplied condition.
+   * @param conditions - Conditions evaluated as one all-of group.
+   * @returns An immutable all-of Wait.
+   */
   allOf(...conditions: readonly Condition[]): Wait {
     return { kind: "allOf", conditions, combinations: [] };
   },
+  /**
+   * Creates a Wait proceeding when any supplied condition is ready.
+   * @param conditions - Alternative readiness conditions.
+   * @returns An immutable any-of Wait.
+   */
   anyOf(...conditions: readonly Condition[]): Wait {
     return { kind: "anyOf", conditions, combinations: [] };
   },
+  /**
+   * Creates a Wait accepting any complete condition combination.
+   * @param combinations - Alternative all-of condition groups.
+   * @returns An immutable any-combination Wait.
+   */
   anyCombinationOf(...combinations: readonly ConditionCombination[]): Wait {
     return { kind: "anyCombinationOf", conditions: [], combinations };
   },

--- a/sdk-typescript/src/wait.ts
+++ b/sdk-typescript/src/wait.ts
@@ -43,7 +43,7 @@ export const ConditionCombination = Object.freeze({
   /**
    * Groups conditions that must all become ready together.
    * @param conditions - Conditions in stable evaluation order.
-   * @returns An immutable combination.
+   * @returns A group with the conditions.
    */
   of(...conditions: readonly Condition[]): ConditionCombination {
     return { conditions };
@@ -323,24 +323,24 @@ export const Wait = Object.freeze({
   },
   /**
    * Creates a Wait for one condition.
-   * @param condition - Sole readiness condition.
-   * @returns An all-of Wait containing the condition.
+   * @param condition - The only readiness condition.
+   * @returns An all-of Wait with the condition.
    */
   until(condition: Condition): Wait {
     return Wait.allOf(condition);
   },
   /**
-   * Creates a Wait requiring every supplied condition.
+   * Creates a Wait requiring every condition.
    * @param conditions - Conditions evaluated as one all-of group.
-   * @returns An immutable all-of Wait.
+   * @returns An all-of Wait.
    */
   allOf(...conditions: readonly Condition[]): Wait {
     return { kind: "allOf", conditions, combinations: [] };
   },
   /**
-   * Creates a Wait proceeding when any supplied condition is ready.
+   * Creates a Wait that continues when any condition is ready.
    * @param conditions - Alternative readiness conditions.
-   * @returns An immutable any-of Wait.
+   * @returns An any-of Wait.
    */
   anyOf(...conditions: readonly Condition[]): Wait {
     return { kind: "anyOf", conditions, combinations: [] };
@@ -348,7 +348,7 @@ export const Wait = Object.freeze({
   /**
    * Creates a Wait accepting any complete condition combination.
    * @param combinations - Alternative all-of condition groups.
-   * @returns An immutable any-combination Wait.
+   * @returns An any-combination Wait.
    */
   anyCombinationOf(...combinations: readonly ConditionCombination[]): Wait {
     return { kind: "anyCombinationOf", conditions: [], combinations };

--- a/sdk-typescript/src/worker.ts
+++ b/sdk-typescript/src/worker.ts
@@ -34,7 +34,21 @@ import { WorkerDispatcher } from "./worker-dispatcher.js";
 
 type WorkerState = "created" | "running" | "stopping" | "stopped" | "closed";
 
+/**
+ * Hosts registered Step and RPC handlers over the private WorkerService protocol.
+ *
+ * A Worker is one-shot. Call `start` for non-blocking startup or `run` to await
+ * shutdown, then call `close`. Concurrent handlers must synchronize shared state.
+ *
+ * @example
+ * ```ts
+ * const worker = new Worker(registry, cache);
+ * await worker.start();
+ * try { console.log(worker.workerTarget.address); } finally { await worker.close(); }
+ * ```
+ */
 export class Worker {
+  /** Effective endpoint advertised to Dex. */
   public readonly workerTarget: WorkerTarget;
 
   private readonly server = new Server();
@@ -43,6 +57,12 @@ export class Worker {
   private resolveStopped!: () => void;
   private state: WorkerState = "created";
 
+  /**
+   * Constructs a Worker without starting its listener.
+   * @param registry - Immutable Flow definitions served by this Worker.
+   * @param blobCache - Open cache used to hydrate large handler values.
+   * @param options - Networking and startup settings; omission uses local defaults.
+   */
   public constructor(
     public readonly registry: Registry,
     public readonly blobCache: BlobCache,
@@ -64,6 +84,10 @@ export class Worker {
     });
   }
 
+  /**
+   * Synchronizes Attribute indexes and starts the WorkerService listener.
+   * The promise resolves after successful binding; call exactly once.
+   */
   public async start(): Promise<void> {
     if (this.state !== "created") {
       throw new Error(`Worker cannot start from state ${this.state}`);
@@ -85,11 +109,16 @@ export class Worker {
     }
   }
 
+  /** Starts the Worker and waits until `close` completes shutdown. */
   public async run(): Promise<void> {
     await this.start();
     await this.stopped;
   }
 
+  /**
+   * Gracefully stops the listener and releases the FlowService connection.
+   * Calls before `start` and repeated calls after shutdown are safe.
+   */
   public async close(): Promise<void> {
     if (this.state === "closed") {
       return;

--- a/sdk-typescript/src/worker.ts
+++ b/sdk-typescript/src/worker.ts
@@ -59,9 +59,9 @@ export class Worker {
 
   /**
    * Constructs a Worker without starting its listener.
-   * @param registry - Immutable Flow definitions served by this Worker.
+   * @param registry - Flow definitions served by this Worker.
    * @param blobCache - Open cache used to hydrate large handler values.
-   * @param options - Networking and startup settings; omission uses local defaults.
+   * @param options - Networking and startup settings; uses local defaults when omitted.
    */
   public constructor(
     public readonly registry: Registry,


### PR DESCRIPTION
## Summary

- document every hand-written public API in the Go, Python, Rust, and TypeScript SDKs using each language's native documentation convention
- add application-focused examples plus input, output, error, default, lifecycle, concurrency, and ownership semantics
- add public API documentation coverage checks to all four SDK CI workflows
- document the local checks in each SDK README

## Rationale

PR #224 established detailed Java SDK Javadoc as the reference. The other SDKs should provide the same quality of API guidance and prevent newly exported undocumented declarations from reaching main.

The final audit compared each SDK against the Java API families: Flow and Registry, Step and decisions, persistence, Wait/Timer/Channel, RPC, Client, Worker, configuration and lifecycle, value mapping, BlobCache, and structured errors.

## User impact

Application developers now receive detailed Go Doc, Google-style Python docstrings, rustdoc, and TypeScript JSDoc in generated documentation and IDE hovers. CI fails when a hand-written public API lacks the language-appropriate documentation, including cross-module Go BlobCache APIs.

## Validation

- `make -C sdk-go docsCheck`
- `make -C sdk-go unitTests`
- `uv run --project sdk-python --frozen python scripts/check_public_docs.py`
- `uv run --project sdk-python --frozen pytest -q tests/test_contracts.py` (19 passed)
- `make -C sdk-rust docs-check`
- `make -C sdk-rust fmt`
- `make -C sdk-rust lint`
- `make -C sdk-rust test`
- `npm --prefix sdk-typescript run docs:check`
- `npm --prefix sdk-typescript run typecheck`
- `npm --prefix sdk-typescript test` (15 passed)
- `make copyright-check`
- `git diff --check`
