### PR TITLE
feat(sdks): support attribute store sync

### DIFF
--- a/docs/content/capabilities/advanced/storage-sync.mdx
+++ b/docs/content/capabilities/advanced/storage-sync.mdx
@@ -16,12 +16,17 @@ the external row is a latest-state projection.
 
 Two settings opt in:
 
-1. The Flow's `attribute_sync_config_name` selects a named Server store.
-2. Each `AttributeWrite` sets `sync_config.enabled = true`.
+1. The Flow selects a named Server store with `AttributeStoreName` (Go),
+   `attributeStoreName` (Java and TypeScript), or `attribute_store_name`
+   (Python and Rust).
+2. The Attribute definition opts in with `SyncToAttributeStore` (Go),
+   `syncToAttributeStore` (Java and TypeScript), or `sync_to_attribute_store`
+   (Python and Rust).
 
-The current high-level SDKs do not expose these fields. This release supports
-IDL users and Server-side integrations while generated protobuf bindings remain
-available in every SDK module.
+AttributeMap definitions support the same opt-in. Their SQL column names match
+the physical Attribute names produced for individual map instances. SDKs omit
+`sync_config` for ordinary definitions and send `enabled = true` for opted-in
+definitions across initial, Client, Step, and RPC writes and deletions.
 
 Changing the Flow target affects only new writes. Already queued mutations keep
 the target selected when they were enqueued. Clearing the target disables later

--- a/docs/content/references/flow-config.mdx
+++ b/docs/content/references/flow-config.mdx
@@ -6,7 +6,12 @@ title: Flow config
 
 Runtime Flow configuration can be updated for some knobs (see `UpdateFlowConfig`). Prefer documenting the specific fields your SDK exposes rather than inventing server internals.
 
-`attribute_sync_config_name` selects a Server-configured Custom Attribute Store.
-An explicit empty string disables sync for future enabled writes. Pending
-mutations retain the target selected at enqueue time. A non-empty unknown name
-is rejected by StartFlow and UpdateFlowConfig.
+The SDK field is `AttributeStoreName` in Go, `attributeStoreName` in Java and
+TypeScript, and `attribute_store_name` in Python and Rust. Each maps to the
+optional protocol field `attribute_sync_config_name` and selects a
+Server-configured Custom Attribute Store.
+
+An omitted field preserves the current setting. An explicit empty string keeps
+protocol presence and disables synchronization for future enabled writes.
+Pending mutations retain the target selected at enqueue time. A non-empty
+unknown name is rejected by StartFlow and UpdateFlowConfig.

--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -1906,11 +1906,16 @@ type AttributeIndex struct {
 }
 
 func Indexed(index AttributeIndex) AttributeOption
+func SyncToAttributeStore() AttributeOption
 ```
 
 An empty `IndexKey` uses the concrete attribute key. A non-empty key supports
 dynamic attributes that write to a shared visibility key. Phase 2 validates
 that encoded values are compatible with the selected index type.
+
+`SyncToAttributeStore` marks every write from the definition for asynchronous
+latest-state projection to the Flow's selected Attribute Store. Deletes project
+SQL `NULL`; Store failures do not roll back Flow Attribute writes.
 
 ### Typed channels
 
@@ -2490,6 +2495,7 @@ const (
 
 type FlowConfig struct {
 	ActiveStepSearchMode       *ActiveStepSearchMode
+	AttributeStoreName         *string
 	ContinueAsNewThreshold     *int32
 	ContinueAsNewPageSizeBytes *int32
 	StepDurability             *StepDurability
@@ -2589,6 +2595,8 @@ type ResetOptions struct {
 ```
 
 Pointer fields in `FlowConfig` preserve proto presence for partial overrides.
+`AttributeStoreName == nil` omits the target override, while a pointer to an
+empty string disables synchronization for future enabled writes.
 `WorkerTarget` is configured through `FlowConfig`, not as a separate StartFlow
 argument. Phase 5 adds `ClientOptions.WorkerTarget` as the default inserted into
 that FlowConfig.
@@ -2604,7 +2612,7 @@ because its zero duration means the server-configured maximum long poll.
 `StepExecutionID.ExecutionNumber == nil` selects execution one.
 
 `InitialAttributeDef` is sealed and constructed with typed helpers so initial
-values carry the definition's index configuration:
+values carry the definition's index and Attribute Store sync configuration:
 
 ```go
 type InitialAttributeDef interface {

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -120,6 +120,27 @@ the physical index names with Dex Server before opening its listener. Existing
 indexes return immediately; a synchronization failure or the default two-minute
 deadline fails startup. Indexed AttributeMaps must declare a fixed index key.
 
+## Attribute Store synchronization
+
+Opt an Attribute or AttributeMap into the Flow's external latest-state
+projection, then select a Server-configured Attribute Store on the Flow:
+
+```go
+var CustomerEmail = dex.DefineAttribute[string](
+	"customer-email",
+	dex.SyncToAttributeStore(),
+)
+
+config := &dex.FlowConfig{
+	AttributeStoreName: ptr.Any("profiles"),
+}
+```
+
+The Store update is asynchronous. Deleting an opted-in Attribute writes SQL
+`NULL`, and a Store failure does not roll back the Flow Attribute. A `nil`
+`AttributeStoreName` preserves the current target; a pointer to `""` disables
+future synchronization while preserving protocol presence.
+
 `DefineStep` and `DefineStartStep` retain the step input type behind a private
 `typedStepDef` that implements the sealed `StepDef` interface. Runtime
 movements resolve through the current Flow's registered step definitions, so a

--- a/sdk-go/dex/attribute.go
+++ b/sdk-go/dex/attribute.go
@@ -25,15 +25,20 @@ import "github.com/superdurable/dex/sdk-go/gen/dexpb"
 //		dex.Indexed(dex.AttributeIndex{Type: dex.IndexKeyword}),
 //	)
 type Attribute[T any] struct {
-	name  string
-	index *AttributeIndex
+	name                 string
+	index                *AttributeIndex
+	syncToAttributeStore bool
 }
 
-// DefineAttribute creates a typed Attribute with a stable name and optional search index.
+// DefineAttribute creates a typed Attribute with a stable name and definition options.
 // The definition does not perform I/O; register it through PersistenceSchema before use.
 func DefineAttribute[T any](key string, options ...AttributeOption) Attribute[T] {
 	config := applyAttributeOptions(options)
-	return Attribute[T]{name: key, index: config.index}
+	return Attribute[T]{
+		name:                 key,
+		index:                config.index,
+		syncToAttributeStore: config.syncToAttributeStore,
+	}
 }
 
 // AttributeDef is the interface of Attribute, without Go's generic
@@ -45,6 +50,7 @@ type AttributeDef interface {
 	attributeName() string
 	attributeIndex() *AttributeIndex
 	attributeIsMap() bool
+	attributeSyncToAttributeStore() bool
 }
 
 // Get returns the current value. Missing values return AttributeNotFoundError.
@@ -101,21 +107,30 @@ func (Attribute[T]) attributeIsMap() bool {
 	return false
 }
 
+func (a Attribute[T]) attributeSyncToAttributeStore() bool {
+	return a.syncToAttributeStore
+}
+
 // AttributeMap defines keyed typed persisted values.
 //
 // Register the map once in PersistenceSchema, then supply an instance string for every access and
 // lock.
 // String values require valid UTF-8; use []byte for arbitrary bytes.
 type AttributeMap[T any] struct {
-	name  string
-	index *AttributeIndex
+	name                 string
+	index                *AttributeIndex
+	syncToAttributeStore bool
 }
 
-// DefineAttributeMap creates a typed Attribute map with a stable name and optional search index.
+// DefineAttributeMap creates a typed Attribute map with a stable name and definition options.
 // The definition performs no I/O; register it through PersistenceSchema before use.
 func DefineAttributeMap[T any](name string, options ...AttributeOption) AttributeMap[T] {
 	config := applyAttributeOptions(options)
-	return AttributeMap[T]{name: name, index: config.index}
+	return AttributeMap[T]{
+		name:                 name,
+		index:                config.index,
+		syncToAttributeStore: config.syncToAttributeStore,
+	}
 }
 
 // Get returns the current map value. Missing instances return AttributeNotFoundError.
@@ -178,8 +193,12 @@ func (AttributeMap[T]) attributeIsMap() bool {
 	return true
 }
 
+func (a AttributeMap[T]) attributeSyncToAttributeStore() bool {
+	return a.syncToAttributeStore
+}
+
 // AttributeOption configures an Attribute or AttributeMap definition.
-// Use Indexed to create values; custom implementations are not supported.
+// Use Indexed and SyncToAttributeStore to create values; custom implementations are not supported.
 type AttributeOption interface {
 	applyAttribute(*attributeConfig)
 }
@@ -219,6 +238,12 @@ func Indexed(index AttributeIndex) AttributeOption {
 	return indexedAttributeOption{index: index}
 }
 
+// SyncToAttributeStore projects every write through the Flow's configured Attribute Store.
+// Projection is asynchronous and latest-state only. Deletes write SQL NULL, and failures do not roll back Flow Attributes.
+func SyncToAttributeStore() AttributeOption {
+	return syncToAttributeStoreOption{}
+}
+
 // AttributeLock identifies one Attribute or Attribute-map instance lock.
 // Create locks with LockAttribute or LockAttributeMap, then place them in StepOptions or InvokeOptions.
 type AttributeLock interface {
@@ -249,11 +274,12 @@ func InitialAttribute[T any](
 		return nil, err
 	}
 	return initialAttribute{
-		name:        attribute.name,
-		value:       value,
-		index:       attribute.index,
-		encoded:     encoded,
-		indexConfig: indexConfig,
+		name:                 attribute.name,
+		value:                value,
+		index:                attribute.index,
+		syncToAttributeStore: attribute.syncToAttributeStore,
+		encoded:              encoded,
+		indexConfig:          indexConfig,
 	}, nil
 }
 
@@ -275,13 +301,14 @@ func InitialAttributeMapValue[T any](
 		return nil, err
 	}
 	return initialAttribute{
-		name:        attribute.name,
-		instance:    instance,
-		value:       value,
-		index:       attribute.index,
-		isMap:       true,
-		encoded:     encoded,
-		indexConfig: indexConfig,
+		name:                 attribute.name,
+		instance:             instance,
+		value:                value,
+		index:                attribute.index,
+		isMap:                true,
+		syncToAttributeStore: attribute.syncToAttributeStore,
+		encoded:              encoded,
+		indexConfig:          indexConfig,
 	}, nil
 }
 
@@ -295,7 +322,8 @@ type attributeInvocation interface {
 }
 
 type attributeConfig struct {
-	index *AttributeIndex
+	index                *AttributeIndex
+	syncToAttributeStore bool
 }
 
 func applyAttributeOptions(options []AttributeOption) attributeConfig {
@@ -315,6 +343,12 @@ func (option indexedAttributeOption) applyAttribute(config *attributeConfig) {
 	config.index = &index
 }
 
+type syncToAttributeStoreOption struct{}
+
+func (syncToAttributeStoreOption) applyAttribute(config *attributeConfig) {
+	config.syncToAttributeStore = true
+}
+
 type attributeLock struct {
 	name     string
 	instance string
@@ -324,13 +358,14 @@ type attributeLock struct {
 func (attributeLock) attributeLock() {}
 
 type initialAttribute struct {
-	name        string
-	instance    string
-	value       any
-	index       *AttributeIndex
-	isMap       bool
-	encoded     *dexpb.Value
-	indexConfig *dexpb.IndexConfig
+	name                 string
+	instance             string
+	value                any
+	index                *AttributeIndex
+	isMap                bool
+	syncToAttributeStore bool
+	encoded              *dexpb.Value
+	indexConfig          *dexpb.IndexConfig
 }
 
 func (initialAttribute) initialAttribute() {}

--- a/sdk-go/dex/client.go
+++ b/sdk-go/dex/client.go
@@ -208,6 +208,9 @@ type AttributeWrite struct {
 	Value any
 	// Index optionally supplies search-index metadata for the write.
 	Index *AttributeIndex
+	// SyncToAttributeStore asynchronously projects this raw write through the Flow's Attribute Store.
+	// Deletes project SQL NULL, and projection failures do not roll back the Flow Attribute.
+	SyncToAttributeStore bool
 }
 
 // FlowStatus describes the current or terminal state of a Flow run.
@@ -463,6 +466,12 @@ func validateInitialAttributes(
 				concrete.name,
 			)
 		}
+		if registered.syncToAttributeStore != concrete.syncToAttributeStore {
+			return nil, fmt.Errorf(
+				"dex: attribute %q sync setting does not match its registered definition",
+				concrete.name,
+			)
+		}
 		physical, err := physicalName(concrete.name, concrete.instance, concrete.isMap)
 		if err != nil {
 			return nil, err
@@ -478,6 +487,7 @@ func validateInitialAttributes(
 		concrete.index = registered.index
 		concrete.encoded = encoded
 		concrete.indexConfig = indexConfig
+		concrete.syncToAttributeStore = registered.syncToAttributeStore
 		resolved = append(resolved, concrete)
 	}
 	return resolved, nil
@@ -1075,9 +1085,10 @@ func (client *Client) setAttribute(
 		return err
 	}
 	return client.setAttributes(ctx, flowID, []AttributeWrite{{
-		Name:  name,
-		Value: value,
-		Index: registered.index,
+		Name:                 name,
+		Value:                value,
+		Index:                registered.index,
+		SyncToAttributeStore: registered.syncToAttributeStore,
 	}})
 }
 

--- a/sdk-go/dex/client_integration_test.go
+++ b/sdk-go/dex/client_integration_test.go
@@ -45,7 +45,11 @@ import (
 )
 
 var (
-	clientTestStatus   = DefineAttribute[string]("status", Indexed(AttributeIndex{Type: IndexKeyword}))
+	clientTestStatus = DefineAttribute[string](
+		"status",
+		Indexed(AttributeIndex{Type: IndexKeyword}),
+		SyncToAttributeStore(),
+	)
 	clientTestItems    = DefineAttributeMap[int]("items")
 	clientTestCommands = DefineChannel[string]("commands")
 	clientTestByOrder  = DefineChannelMap[string]("commands-by-order")
@@ -451,6 +455,7 @@ func TestClientFlowAndPersistenceTransport(t *testing.T) {
 	require.Equal(t, "dex.clientTestFlow", service.startRequest.FlowType)
 	require.Equal(t, "dex.clientTestStep", service.startRequest.StartStepType)
 	require.Equal(t, "worker.test:8803", service.startRequest.FlowStartOptions.FlowConfigOverride.WorkerTarget.Address)
+	require.True(t, service.startRequest.FlowStartOptions.Attributes[0].GetSyncConfig().GetEnabled())
 
 	require.NoError(t, client.PublishToChannel(ctx, "order-1", clientTestCommands, "approve", "ship"))
 	require.Len(t, service.publishRequest.Messages, 2)
@@ -471,6 +476,8 @@ func TestClientFlowAndPersistenceTransport(t *testing.T) {
 	require.NoError(t, client.SetAttribute(ctx, "order-1", clientTestStatus, "done"))
 	require.NoError(t, client.SetAttributeMap(ctx, "order-1", clientTestItems, "sku-1", 4))
 	require.Len(t, service.setRequests, 2)
+	require.True(t, service.setRequests[0].Attributes[0].GetSyncConfig().GetEnabled())
+	require.Nil(t, service.setRequests[1].Attributes[0].SyncConfig)
 	require.NotEqual(t, service.setRequests[0].RequestId, service.setRequests[1].RequestId)
 	for _, request := range service.setRequests {
 		_, err := uuid.Parse(request.RequestId)
@@ -480,8 +487,13 @@ func TestClientFlowAndPersistenceTransport(t *testing.T) {
 	values, err := client.GetAttributes(ctx, "order-1", clientTestStatus)
 	require.NoError(t, err)
 	require.Contains(t, values, "status")
-	require.NoError(t, client.SetAttributes(ctx, "order-1", AttributeWrite{Name: "status", Value: "batched"}))
+	require.NoError(t, client.SetAttributes(ctx, "order-1", AttributeWrite{
+		Name:                 "status",
+		Value:                "batched",
+		SyncToAttributeStore: true,
+	}))
 	require.Len(t, service.setRequests, 3)
+	require.True(t, service.setRequests[2].Attributes[0].GetSyncConfig().GetEnabled())
 
 	require.NoError(t, client.WaitForAttributeEqual(
 		ctx,
@@ -595,8 +607,10 @@ func TestClientRPCResultsAndAdministrativeTransport(t *testing.T) {
 
 	require.NoError(t, client.UpdateFlowConfig(ctx, "order-1", FlowConfig{
 		ContinueAsNewThreshold: ptr.Any(int32(100)),
+		AttributeStoreName:     ptr.Any("reporting"),
 	}))
 	require.Nil(t, service.updateConfigRequest.FlowConfig.WorkerTarget)
+	require.Equal(t, "reporting", service.updateConfigRequest.FlowConfig.GetAttributeSyncConfigName())
 	require.NoError(t, client.WaitForStepCompletion(
 		ctx,
 		"order-1",

--- a/sdk-go/dex/invocation.go
+++ b/sdk-go/dex/invocation.go
@@ -421,6 +421,7 @@ func (invocation *invocationContext) setAttributeValue(
 		Key:         physical,
 		Value:       encoded,
 		IndexConfig: indexConfig,
+		SyncConfig:  mapAttributeSyncConfig(attribute.syncToAttributeStore),
 	})
 	return nil
 }
@@ -441,7 +442,11 @@ func (invocation *invocationContext) deleteAttributeValue(
 	if err != nil {
 		return err
 	}
-	write, err := mapAttributeDelete(physical, attribute.index)
+	write, err := mapAttributeDelete(
+		physical,
+		attribute.index,
+		attribute.syncToAttributeStore,
+	)
 	if err != nil {
 		return err
 	}

--- a/sdk-go/dex/options.go
+++ b/sdk-go/dex/options.go
@@ -130,6 +130,9 @@ type FlowConfig struct {
 	StepDurability *StepDurability
 	// WorkerTarget routes future Step and RPC invocations.
 	WorkerTarget *WorkerTarget
+	// AttributeStoreName selects the Server-configured Attribute Store for opted-in writes.
+	// Nil preserves the current target; an empty string disables future asynchronous projections.
+	AttributeStoreName *string
 }
 
 // StartFlowOptions configures a new Flow execution.

--- a/sdk-go/dex/proto_mapper.go
+++ b/sdk-go/dex/proto_mapper.go
@@ -51,6 +51,7 @@ func mapInitialAttributes(
 			Key:         key,
 			Value:       concrete.encoded,
 			IndexConfig: concrete.indexConfig,
+			SyncConfig:  mapAttributeSyncConfig(concrete.syncToAttributeStore),
 		})
 	}
 	return mapped, nil
@@ -68,12 +69,14 @@ func mapAttributeWrite(write AttributeWrite) (*dexpb.AttributeWrite, error) {
 		Key:         write.Name,
 		Value:       value,
 		IndexConfig: indexConfig,
+		SyncConfig:  mapAttributeSyncConfig(write.SyncToAttributeStore),
 	}, nil
 }
 
 func mapAttributeDelete(
 	name string,
 	index *AttributeIndex,
+	syncToAttributeStore bool,
 ) (*dexpb.AttributeWrite, error) {
 	if name == "" {
 		return nil, fmt.Errorf("dex: attribute delete name must not be empty")
@@ -86,7 +89,15 @@ func mapAttributeDelete(
 		Key:         name,
 		Value:       value,
 		IndexConfig: indexConfig,
+		SyncConfig:  mapAttributeSyncConfig(syncToAttributeStore),
 	}, nil
+}
+
+func mapAttributeSyncConfig(enabled bool) *dexpb.AttributeSyncConfig {
+	if !enabled {
+		return nil
+	}
+	return &dexpb.AttributeSyncConfig{Enabled: true}
 }
 
 func mapStartFlowOptions(
@@ -330,6 +341,7 @@ func mapFlowConfig(config *FlowConfig) (*dexpb.FlowConfig, error) {
 		ContinueAsNewPageSizeInBytes: config.ContinueAsNewPageSizeBytes,
 		StepDurability:               durability,
 		WorkerTarget:                 mapWorkerTarget(config.WorkerTarget),
+		AttributeSyncConfigName:      config.AttributeStoreName,
 	}, nil
 }
 

--- a/sdk-go/dex/proto_mapper_test.go
+++ b/sdk-go/dex/proto_mapper_test.go
@@ -179,17 +179,22 @@ func TestStartAndFlowConfigMappingPreservesPresence(t *testing.T) {
 	delay := 2 * time.Second
 	searchMode := SearchAllActiveSteps
 	durability := StepDurabilityAsync
-	attribute := DefineAttribute[string]("status")
+	attribute := DefineAttribute[string]("status", SyncToAttributeStore())
 	initial, err := InitialAttribute(attribute, "ready")
 	require.NoError(t, err)
+	attributeMap := DefineAttributeMap[string]("status-by-tenant", SyncToAttributeStore())
+	initialMap, err := InitialAttributeMapValue(attributeMap, "tenant-1", "ready")
+	require.NoError(t, err)
+	storeName := "reporting"
 
 	flowTimeout, options, err := mapStartFlowOptions(StartFlowOptions{
 		Timeout:    &timeout,
 		StartDelay: &delay,
-		Attributes: []InitialAttributeDef{initial},
+		Attributes: []InitialAttributeDef{initial, initialMap},
 		ConfigOverride: &FlowConfig{
 			ActiveStepSearchMode: &searchMode,
 			StepDurability:       &durability,
+			AttributeStoreName:   &storeName,
 			WorkerTarget: &WorkerTarget{
 				Address:  "worker:7233",
 				Headless: true,
@@ -199,14 +204,40 @@ func TestStartAndFlowConfigMappingPreservesPresence(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int32(2), flowTimeout)
 	require.Equal(t, int32(2), options.FlowStartDelaySeconds)
-	require.Len(t, options.Attributes, 1)
+	require.Len(t, options.Attributes, 2)
+	require.True(t, options.Attributes[0].GetSyncConfig().GetEnabled())
+	require.True(t, options.Attributes[1].GetSyncConfig().GetEnabled())
 	require.NotNil(t, options.FlowConfigOverride.ActiveStepSearchMode)
 	require.NotNil(t, options.FlowConfigOverride.StepDurability)
 	require.True(t, options.FlowConfigOverride.WorkerTarget.IsHeadlessAddress)
+	require.Equal(t, "reporting", options.FlowConfigOverride.GetAttributeSyncConfigName())
+	require.NotNil(t, options.FlowConfigOverride.AttributeSyncConfigName)
+
+	disabled := ""
+	_, disabledOptions, err := mapStartFlowOptions(StartFlowOptions{
+		ConfigOverride: &FlowConfig{AttributeStoreName: &disabled},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, disabledOptions.FlowConfigOverride.AttributeSyncConfigName)
+	require.Empty(t, disabledOptions.FlowConfigOverride.GetAttributeSyncConfigName())
 
 	_, empty, err := mapStartFlowOptions(StartFlowOptions{})
 	require.NoError(t, err)
 	require.Nil(t, empty.FlowConfigOverride)
+}
+
+func TestAttributeWriteSyncMapping(t *testing.T) {
+	synced, err := mapAttributeWrite(AttributeWrite{
+		Name:                 "status",
+		Value:                "ready",
+		SyncToAttributeStore: true,
+	})
+	require.NoError(t, err)
+	require.True(t, synced.GetSyncConfig().GetEnabled())
+
+	plain, err := mapAttributeWrite(AttributeWrite{Name: "status", Value: "ready"})
+	require.NoError(t, err)
+	require.Nil(t, plain.SyncConfig)
 }
 
 func TestClientOptionMapping(t *testing.T) {

--- a/sdk-go/dex/registration.go
+++ b/sdk-go/dex/registration.go
@@ -49,10 +49,11 @@ type registeredStep struct {
 }
 
 type registeredAttribute struct {
-	def   AttributeDef
-	name  string
-	index *AttributeIndex
-	isMap bool
+	def                  AttributeDef
+	name                 string
+	index                *AttributeIndex
+	isMap                bool
+	syncToAttributeStore bool
 }
 
 type registeredChannel struct {
@@ -200,10 +201,11 @@ func (flow *registeredFlow) registerAttribute(
 		indexTypes[indexKey] = index.Type
 	}
 	flow.attributes[name] = registeredAttribute{
-		def:   definition,
-		name:  name,
-		index: index,
-		isMap: isMap,
+		def:                  definition,
+		name:                 name,
+		index:                index,
+		isMap:                isMap,
+		syncToAttributeStore: definition.attributeSyncToAttributeStore(),
 	}
 	return nil
 }
@@ -573,7 +575,8 @@ func (registry *Registry) resolveAttribute(
 	for _, flow := range registry.flows {
 		registered, found := flow.attributes[name]
 		if found && registered.isMap == expectMap &&
-			reflect.DeepEqual(registered.index, reference.attributeIndex()) {
+			reflect.DeepEqual(registered.index, reference.attributeIndex()) &&
+			registered.syncToAttributeStore == reference.attributeSyncToAttributeStore() {
 			return registered, nil
 		}
 	}

--- a/sdk-go/dex/worker_integration_test.go
+++ b/sdk-go/dex/worker_integration_test.go
@@ -32,8 +32,8 @@ import (
 )
 
 var (
-	workerTestStatus   = DefineAttribute[string]("status")
-	workerTestItems    = DefineAttributeMap[int]("items")
+	workerTestStatus   = DefineAttribute[string]("status", SyncToAttributeStore())
+	workerTestItems    = DefineAttributeMap[int]("items", SyncToAttributeStore())
 	workerTestCommands = DefineChannel[string]("commands")
 	workerTestByOrder  = DefineChannelMap[string]("commands-by-order")
 )
@@ -285,6 +285,7 @@ func TestWorkerServiceDispatchesWaitExecuteAndRPC(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, waitResponse.UpsertAttributes, 1)
 	require.Equal(t, "waiting", waitResponse.UpsertAttributes[0].Value.GetStringValue())
+	require.True(t, waitResponse.UpsertAttributes[0].GetSyncConfig().GetEnabled())
 	require.Len(t, waitResponse.UpsertStepExeLocals, 1)
 	require.Len(t, waitResponse.RecordEvents, 1)
 	require.Len(t, waitResponse.PublishToChannel, 1)
@@ -328,6 +329,7 @@ func TestWorkerServiceDispatchesWaitExecuteAndRPC(t *testing.T) {
 	require.Len(t, executeResponse.UpsertAttributes, 1)
 	_, deleted := executeResponse.UpsertAttributes[0].Value.Kind.(*dexpb.Value_NullValue)
 	require.True(t, deleted)
+	require.True(t, executeResponse.UpsertAttributes[0].GetSyncConfig().GetEnabled())
 
 	timerRequest := workerExecuteRequest(t, workerTestInput{
 		OrderID: "order-1",
@@ -366,6 +368,7 @@ func TestWorkerServiceDispatchesWaitExecuteAndRPC(t *testing.T) {
 	require.Len(t, rpcResponse.PublishToChannel, 1)
 	require.Len(t, rpcResponse.UpsertAttributes, 1)
 	require.Equal(t, "items/order-1", rpcResponse.UpsertAttributes[0].Key)
+	require.True(t, rpcResponse.UpsertAttributes[0].GetSyncConfig().GetEnabled())
 	require.Len(t, rpcResponse.RecordEvents, 1)
 	require.Len(t, rpcResponse.StepDecision.NextSteps, 1)
 }

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -174,6 +174,21 @@ StartFlowOptions options = StartFlowOptions.newBuilder()
         .build();
 ```
 
+Attribute Store synchronization is definition-level and immutable:
+
+```java
+Attribute<String> email = Attribute.define("customer-email", String.class)
+        .syncToAttributeStore();
+FlowConfig config = FlowConfig.newBuilder()
+        .attributeStoreName("profiles")
+        .build();
+```
+
+The Store is an asynchronous latest-state projection. Deletion writes SQL
+`NULL`, and projection failures do not roll back Flow Attributes. Omitting
+`attributeStoreName` preserves the current target; `attributeStoreName("")`
+disables future synchronization with protocol presence.
+
 The IWF integration inventory is implemented as real Dex E2E tests under
 [`src/test/java/io/superdurable/dex/integ`](src/test/java/io/superdurable/dex/integ/README.md).
 They run Java Client and Java Worker against `dexcli dev`, with Rust used only

--- a/sdk-java/src/main/java/io/superdurable/dex/Attribute.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Attribute.java
@@ -46,11 +46,17 @@ public final class Attribute<T> extends PersistenceDefinition {
     private final String name;
     private final Class<T> valueType;
     private final AttributeIndex index;
+    private final boolean syncToAttributeStore;
 
-    private Attribute(final String name, final Class<T> valueType, final AttributeIndex index) {
+    private Attribute(
+            final String name,
+            final Class<T> valueType,
+            final AttributeIndex index,
+            final boolean syncToAttributeStore) {
         this.name = requireName(name);
         this.valueType = Objects.requireNonNull(valueType, "valueType");
         this.index = index;
+        this.syncToAttributeStore = syncToAttributeStore;
     }
 
     /**
@@ -64,7 +70,7 @@ public final class Attribute<T> extends PersistenceDefinition {
      * @throws NullPointerException if {@code valueType} is {@code null}
      */
     public static <T> Attribute<T> define(final String name, final Class<T> valueType) {
-        return new Attribute<T>(name, valueType, null);
+        return new Attribute<T>(name, valueType, null, false);
     }
 
     /**
@@ -82,7 +88,20 @@ public final class Attribute<T> extends PersistenceDefinition {
             final String name,
             final Class<T> valueType,
             final AttributeIndex index) {
-        return new Attribute<T>(name, valueType, index);
+        return new Attribute<T>(name, valueType, index, false);
+    }
+
+    /**
+     * Returns a definition whose writes are projected through the Flow's Attribute Store.
+     *
+     * <p>The projection is asynchronous and latest-state only. A projection failure does not roll
+     * back the Flow Attribute. Deleting this Attribute projects SQL {@code NULL} when the target
+     * column permits it.
+     *
+     * @return a new immutable Attribute definition with Attribute Store synchronization enabled
+     */
+    public Attribute<T> syncToAttributeStore() {
+        return new Attribute<T>(name, valueType, index, true);
     }
 
     String getName() {
@@ -95,6 +114,11 @@ public final class Attribute<T> extends PersistenceDefinition {
 
     AttributeIndex getIndex() {
         return index;
+    }
+
+    @Override
+    boolean isSyncToAttributeStore() {
+        return syncToAttributeStore;
     }
 
     /**

--- a/sdk-java/src/main/java/io/superdurable/dex/AttributeMap.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/AttributeMap.java
@@ -35,11 +35,17 @@ public final class AttributeMap<T> extends PersistenceDefinition {
     private final String name;
     private final Class<T> valueType;
     private final AttributeIndex index;
+    private final boolean syncToAttributeStore;
 
-    private AttributeMap(final String name, final Class<T> valueType, final AttributeIndex index) {
+    private AttributeMap(
+            final String name,
+            final Class<T> valueType,
+            final AttributeIndex index,
+            final boolean syncToAttributeStore) {
         this.name = Attribute.requireName(name);
         this.valueType = Objects.requireNonNull(valueType, "valueType");
         this.index = index;
+        this.syncToAttributeStore = syncToAttributeStore;
     }
 
     /**
@@ -53,7 +59,7 @@ public final class AttributeMap<T> extends PersistenceDefinition {
      * @throws NullPointerException if {@code valueType} is {@code null}
      */
     public static <T> AttributeMap<T> define(final String name, final Class<T> valueType) {
-        return new AttributeMap<T>(name, valueType, null);
+        return new AttributeMap<T>(name, valueType, null, false);
     }
 
     /**
@@ -71,7 +77,20 @@ public final class AttributeMap<T> extends PersistenceDefinition {
             final String name,
             final Class<T> valueType,
             final AttributeIndex index) {
-        return new AttributeMap<T>(name, valueType, index);
+        return new AttributeMap<T>(name, valueType, index, false);
+    }
+
+    /**
+     * Returns a definition whose instance writes are projected through the Flow's Attribute Store.
+     *
+     * <p>The physical Attribute-map key must match a target column. Projection is asynchronous and
+     * does not roll back the Flow Attribute when external storage fails. Deletion projects SQL
+     * {@code NULL} when the target column permits it.
+     *
+     * @return a new immutable Attribute-map definition with Attribute Store synchronization enabled
+     */
+    public AttributeMap<T> syncToAttributeStore() {
+        return new AttributeMap<T>(name, valueType, index, true);
     }
 
     String getName() {
@@ -84,6 +103,11 @@ public final class AttributeMap<T> extends PersistenceDefinition {
 
     AttributeIndex getIndex() {
         return index;
+    }
+
+    @Override
+    boolean isSyncToAttributeStore() {
+        return syncToAttributeStore;
     }
 
     /**

--- a/sdk-java/src/main/java/io/superdurable/dex/Client.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Client.java
@@ -29,6 +29,7 @@ import io.superdurable.dex.exceptions.FlowUncompletedException;
 import io.superdurable.dex.exceptions.LongPollTimeoutException;
 import io.superdurable.dex.exceptions.RpcLockConflictException;
 import io.superdurable.dex.exceptions.WorkerInvocationException;
+import io.superdurable.gen.AttributeSyncConfig;
 import io.superdurable.gen.AttributeWrite;
 import io.superdurable.gen.FlowAlreadyStartedOptions;
 import io.superdurable.gen.FlowExecutionID;
@@ -921,6 +922,7 @@ public final class Client implements AutoCloseable {
         if (indexConfig != null) {
             write.setIndexConfig(indexConfig);
         }
+        applyAttributeSync(write, definition);
         call(
                 () -> service.setAttributes(SetAttributesRequest.newBuilder()
                         .setFlowId(flowId)
@@ -977,7 +979,7 @@ public final class Client implements AutoCloseable {
         return response;
     }
 
-    private FlowStartOptions mapStartOptions(final StartFlowOptions options) {
+    FlowStartOptions mapStartOptions(final StartFlowOptions options) {
         final FlowStartOptions.Builder mapped = FlowStartOptions.newBuilder()
                 .setIdReusePolicy(mapIdReuse(options.getIdReusePolicy()))
                 .setCronSchedule(options.getCronSchedule() == null ? "" : options.getCronSchedule())
@@ -994,9 +996,11 @@ public final class Client implements AutoCloseable {
             final String key = initialization.getInstance() == null
                     ? definition.getName()
                     : Registry.physicalName(definition.getName(), initialization.getInstance());
-            mapped.addAttributes(AttributeWrite.newBuilder()
+            final AttributeWrite.Builder write = AttributeWrite.newBuilder()
                     .setKey(key)
-                    .setValue(values.encode(initialization.getValue())));
+                    .setValue(values.encode(initialization.getValue()));
+            applyAttributeSync(write, definition);
+            mapped.addAttributes(write);
         }
         final FlowConfig config = options.getConfigOverride();
         if (config != null || this.options.getWorkerTarget() != null) {
@@ -1005,7 +1009,7 @@ public final class Client implements AutoCloseable {
         return mapped.build();
     }
 
-    private io.superdurable.gen.FlowConfig mapFlowConfig(final FlowConfig config) {
+    io.superdurable.gen.FlowConfig mapFlowConfig(final FlowConfig config) {
         final io.superdurable.gen.FlowConfig.Builder mapped =
                 io.superdurable.gen.FlowConfig.newBuilder();
         if (config != null) {
@@ -1022,6 +1026,9 @@ public final class Client implements AutoCloseable {
             if (config.getStepDurability() != null) {
                 mapped.setStepDurability(mapDurability(config.getStepDurability()));
             }
+            if (config.getAttributeStoreName() != null) {
+                mapped.setAttributeSyncConfigName(config.getAttributeStoreName());
+            }
         }
         final WorkerTarget target = config != null && config.getWorkerTarget() != null
                 ? config.getWorkerTarget()
@@ -1032,6 +1039,14 @@ public final class Client implements AutoCloseable {
                     .setIsHeadlessAddress(target.isHeadless()));
         }
         return mapped.build();
+    }
+
+    private static void applyAttributeSync(
+            final AttributeWrite.Builder write,
+            final PersistenceDefinition definition) {
+        if (definition.isSyncToAttributeStore()) {
+            write.setSyncConfig(AttributeSyncConfig.newBuilder().setEnabled(true));
+        }
     }
 
     private static io.superdurable.gen.FlowRetryPolicy mapFlowRetry(final RetryPolicy retry) {

--- a/sdk-java/src/main/java/io/superdurable/dex/FlowConfig.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/FlowConfig.java
@@ -31,6 +31,7 @@ public final class FlowConfig {
     private final Integer continueAsNewPageSizeBytes;
     private final StepDurability stepDurability;
     private final WorkerTarget workerTarget;
+    private final String attributeStoreName;
 
     private FlowConfig(final Builder builder) {
         this.activeStepSearchMode = builder.activeStepSearchMode;
@@ -38,6 +39,7 @@ public final class FlowConfig {
         this.continueAsNewPageSizeBytes = builder.continueAsNewPageSizeBytes;
         this.stepDurability = builder.stepDurability;
         this.workerTarget = builder.workerTarget;
+        this.attributeStoreName = builder.attributeStoreName;
     }
 
     /**
@@ -69,6 +71,10 @@ public final class FlowConfig {
         return workerTarget;
     }
 
+    String getAttributeStoreName() {
+        return attributeStoreName;
+    }
+
     /** Builds immutable {@link FlowConfig} values. */
     public static final class Builder {
         private ActiveStepSearchMode activeStepSearchMode;
@@ -76,6 +82,7 @@ public final class FlowConfig {
         private Integer continueAsNewPageSizeBytes;
         private StepDurability stepDurability;
         private WorkerTarget workerTarget;
+        private String attributeStoreName;
 
         private Builder() {
         }
@@ -142,6 +149,21 @@ public final class FlowConfig {
          */
         public Builder workerTarget(final WorkerTarget value) {
             workerTarget = value;
+            return this;
+        }
+
+        /**
+         * Selects the Server-configured Attribute Store for enabled Attribute writes.
+         *
+         * <p>A nonempty value selects a named store. An empty string explicitly disables future
+         * projections, while omitting this call leaves the current or server-selected value
+         * unchanged. Already queued projections retain their original target.
+         *
+         * @param value the Attribute Store name, or an empty string to disable future projections
+         * @return this builder
+         */
+        public Builder attributeStoreName(final String value) {
+            attributeStoreName = value;
             return this;
         }
 

--- a/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
@@ -14,6 +14,7 @@
 
 package io.superdurable.dex;
 
+import io.superdurable.gen.AttributeSyncConfig;
 import io.superdurable.gen.AttributeWrite;
 import io.superdurable.gen.ChannelInfo;
 import io.superdurable.gen.ChannelMessage;
@@ -292,6 +293,7 @@ final class InvocationContext implements Context {
         if (indexConfig != null) {
             write.setIndexConfig(indexConfig);
         }
+        applyAttributeSync(write, definition);
         attributeWrites.put(key, write.build());
     }
 
@@ -309,7 +311,16 @@ final class InvocationContext implements Context {
         if (indexConfig != null) {
             write.setIndexConfig(indexConfig);
         }
+        applyAttributeSync(write, definition);
         attributeWrites.put(key, write.build());
+    }
+
+    private static void applyAttributeSync(
+            final AttributeWrite.Builder write,
+            final PersistenceDefinition definition) {
+        if (definition.isSyncToAttributeStore()) {
+            write.setSyncConfig(AttributeSyncConfig.newBuilder().setEnabled(true));
+        }
     }
 
     private void publishValue(

--- a/sdk-java/src/main/java/io/superdurable/dex/PersistenceDefinition.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/PersistenceDefinition.java
@@ -25,4 +25,8 @@ public abstract class PersistenceDefinition {
     abstract String getName();
 
     abstract Class<?> getValueType();
+
+    boolean isSyncToAttributeStore() {
+        return false;
+    }
 }

--- a/sdk-java/src/test/java/io/superdurable/dex/AttributeStoreSyncTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/AttributeStoreSyncTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Licensed under the Super Durable Source License 1.0.
+ * You may not use this file except in compliance with the License.
+ * See the LICENSE file in the repository root.
+ *
+ * SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+ */
+
+package io.superdurable.dex;
+
+import io.superdurable.gen.FlowStartOptions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class AttributeStoreSyncTest {
+    @Test
+    void preservesDefinitionAndFlowConfigPresence() {
+        final Attribute<String> plain = Attribute.define("plain", String.class);
+        final Attribute<String> synced = Attribute.define("synced", String.class)
+                .syncToAttributeStore();
+        final AttributeMap<String> syncedMap = AttributeMap.define("mapped", String.class)
+                .syncToAttributeStore();
+
+        assertFalse(plain.isSyncToAttributeStore());
+        assertTrue(synced.isSyncToAttributeStore());
+        assertTrue(syncedMap.isSyncToAttributeStore());
+
+        final Client client = new Client(
+                new Registry(Collections.<Flow<?>>emptyList()),
+                new NoopBlobCache());
+        try {
+            final io.superdurable.gen.FlowConfig absent =
+                    client.mapFlowConfig(FlowConfig.newBuilder().build());
+            assertFalse(absent.hasAttributeSyncConfigName());
+
+            final io.superdurable.gen.FlowConfig selected = client.mapFlowConfig(
+                    FlowConfig.newBuilder().attributeStoreName("reporting").build());
+            assertTrue(selected.hasAttributeSyncConfigName());
+            assertEquals("reporting", selected.getAttributeSyncConfigName());
+
+            final io.superdurable.gen.FlowConfig disabled = client.mapFlowConfig(
+                    FlowConfig.newBuilder().attributeStoreName("").build());
+            assertTrue(disabled.hasAttributeSyncConfigName());
+            assertEquals("", disabled.getAttributeSyncConfigName());
+
+            final FlowStartOptions start = client.mapStartOptions(
+                    StartFlowOptions.newBuilder()
+                            .addAttribute(plain, "plain")
+                            .addAttribute(synced, "synced")
+                            .addAttribute(syncedMap, "tenant-1", "mapped")
+                            .build());
+            assertFalse(start.getAttributes(0).hasSyncConfig());
+            assertTrue(start.getAttributes(1).getSyncConfig().getEnabled());
+            assertTrue(start.getAttributes(2).getSyncConfig().getEnabled());
+        } finally {
+            client.close();
+        }
+    }
+
+    private static final class NoopBlobCache implements BlobCache {
+        @Override
+        public Optional<byte[]> get(final String blobId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public boolean put(final String blobId, final byte[] payload) {
+            return false;
+        }
+
+        @Override
+        public void delete(final String blobId) {
+        }
+
+        @Override
+        public void deleteAll() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -75,6 +75,19 @@ options = (
 )
 ```
 
+Opt in when declaring an Attribute or AttributeMap, and select the Store in
+Flow configuration:
+
+```python
+email = dex.Attribute("customer-email", str, sync_to_attribute_store=True)
+config = dex.FlowConfig(attribute_store_name="profiles")
+```
+
+The Store is an asynchronous latest-state projection. Deletion writes SQL
+`NULL`, and projection failures do not roll back Flow Attributes. `None`
+preserves the current target; an explicit empty string disables future
+synchronization while retaining protocol presence.
+
 ```
 pip install dex-python-sdk==0.1.0
 ```

--- a/sdk-python/dex/_invocation_context.py
+++ b/sdk-python/dex/_invocation_context.py
@@ -13,7 +13,7 @@ from typing import Any, Sequence, TypeVar, cast
 
 from dex._utils import require_name
 from dex._value_mapper import ValueMapper
-from dex.attribute import Attribute, AttributeMap
+from dex.attribute import Attribute, AttributeMap, _apply_attribute_store_sync
 from dex.channel import Channel, ChannelMap
 from dex.codec import Codec
 from dex.dexpb import dex_pb2 as pb
@@ -161,6 +161,7 @@ class InvocationContext:
         )
         if index is not None:
             write.index_config.CopyFrom(index)
+        _apply_attribute_store_sync(write, definition)
         self.attribute_writes[key] = write
 
     def _delete_attribute(
@@ -177,6 +178,7 @@ class InvocationContext:
         )
         if index is not None:
             write.index_config.CopyFrom(index)
+        _apply_attribute_store_sync(write, definition)
         self.attribute_writes[key] = write
 
     def _publish_channel(

--- a/sdk-python/dex/async_client.py
+++ b/sdk-python/dex/async_client.py
@@ -22,7 +22,7 @@ from dex._grpc_errors import FlowTargetRequirement, translate_rpc_error
 from dex._utils import require_name
 from dex._value_mapper import ValueMapper
 from dex._worker_dispatcher import WorkerDispatcher
-from dex.attribute import Attribute, AttributeMap
+from dex.attribute import Attribute, AttributeMap, _apply_attribute_store_sync
 from dex.blob_cache import BlobCache
 from dex.channel import Channel, ChannelMap
 from dex.client_options import ClientOptions
@@ -409,6 +409,7 @@ class AsyncClient:
         )
         if index is not None:
             write.index_config.CopyFrom(index)
+        _apply_attribute_store_sync(write, attribute)
         await self._call(
             self._service.SetAttributes,
             pb.SetAttributesRequest(
@@ -858,7 +859,7 @@ class AsyncClient:
         if self._closed:
             return
         self._closed = True
-        await self._channel.close()
+        await self._channel.close(None)
 
     async def _wait_for_flow_response(
         self,
@@ -921,15 +922,15 @@ class AsyncClient:
         for initialization in options._attribute_initializations:
             definition = initialization.definition
             key = self._definition_name(definition, initialization.instance)
-            mapped.attributes.append(
-                pb.AttributeWrite(
-                    key=key,
-                    value=self._values.encode(
-                        initialization.value,
-                        self._values.codec(definition.value_type),
-                    ),
-                )
+            write = pb.AttributeWrite(
+                key=key,
+                value=self._values.encode(
+                    initialization.value,
+                    self._values.codec(definition.value_type),
+                ),
             )
+            _apply_attribute_store_sync(write, definition)
+            mapped.attributes.append(write)
         if (
             options.config_override is not None
             or self.options.worker_target is not None
@@ -969,6 +970,8 @@ class AsyncClient:
                     StepDurability.SYNC: pb.STEP_DURABILITY_SYNC,
                     StepDurability.ASYNC: pb.STEP_DURABILITY_ASYNC,
                 }[config.step_durability]
+            if config.attribute_store_name is not None:
+                mapped.attribute_sync_config_name = config.attribute_store_name
         target = (
             config.worker_target
             if config is not None and config.worker_target is not None

--- a/sdk-python/dex/attribute.py
+++ b/sdk-python/dex/attribute.py
@@ -16,6 +16,7 @@ from typing import Any, Generic, TypeVar, cast
 
 from dex._utils import require_name
 from dex.context import Context
+from dex.dexpb import dex_pb2 as pb
 
 ValueT = TypeVar("ValueT")
 
@@ -65,13 +66,19 @@ class Attribute(Generic[ValueT]):
     definition from Steps, RPCs, and Client calls. Values are read and written
     through a handler :class:`Context`; Client methods provide external access.
 
+    Set ``sync_to_attribute_store`` to project every write asynchronously through
+    the Flow's configured Attribute Store. Projection is latest-state only, deletion
+    projects SQL NULL, and failures do not roll back the Flow Attribute.
+
     Attributes:
         name: The non-empty logical Attribute name, unique within its Flow.
         value_type: The Python type used to encode and decode values.
         index: Optional search-index configuration; ``None`` disables indexing.
+        sync_to_attribute_store: Whether writes are projected to the selected
+            Attribute Store. Defaults to ``False``.
 
     Examples:
-        >>> status = Attribute("status", str, AttributeIndex(IndexType.KEYWORD))
+        >>> status = Attribute("status", str, sync_to_attribute_store=True)
         >>> status.set(context, "paid")
         >>> status.get(context)
         'paid'
@@ -80,6 +87,7 @@ class Attribute(Generic[ValueT]):
     name: str
     value_type: type[ValueT]
     index: AttributeIndex | None = None
+    sync_to_attribute_store: bool = False
 
     def __post_init__(self) -> None:
         require_name(self.name)
@@ -137,14 +145,19 @@ class AttributeMap(Generic[ValueT]):
 
     AttributeMap instances share one schema definition while keeping independent
     values and locks. Declare the map in ``PersistenceSchema`` before using it.
+    Synced instances use their physical Attribute names as target columns. Projection
+    is asynchronous and latest-state only, deletion projects SQL NULL, and failures
+    do not roll back Flow Attributes.
 
     Attributes:
         name: The non-empty logical Attribute name, unique within its Flow.
         value_type: The Python type used for every map instance.
         index: Optional shared search-index configuration.
+        sync_to_attribute_store: Whether every instance is projected to the selected
+            Attribute Store. Defaults to ``False``.
 
     Examples:
-        >>> balances = AttributeMap("balance", int)
+        >>> balances = AttributeMap("balance", int, sync_to_attribute_store=True)
         >>> balances.set(context, "merchant-7", 1200)
         >>> balances.get(context, "merchant-7")
         1200
@@ -153,6 +166,7 @@ class AttributeMap(Generic[ValueT]):
     name: str
     value_type: type[ValueT]
     index: AttributeIndex | None = None
+    sync_to_attribute_store: bool = False
 
     def __post_init__(self) -> None:
         require_name(self.name)
@@ -219,3 +233,11 @@ class AttributeLock:
 
     attribute: Attribute[Any] | AttributeMap[Any]
     instance: str | None = None
+
+
+def _apply_attribute_store_sync(
+    write: pb.AttributeWrite,
+    definition: Attribute[Any] | AttributeMap[Any],
+) -> None:
+    if definition.sync_to_attribute_store:
+        write.sync_config.enabled = True

--- a/sdk-python/dex/client.py
+++ b/sdk-python/dex/client.py
@@ -22,7 +22,7 @@ from dex._utils import require_name
 from dex._value_hydrator import ValueHydrator
 from dex._value_mapper import ValueMapper
 from dex._worker_dispatcher import WorkerDispatcher
-from dex.attribute import Attribute, AttributeMap
+from dex.attribute import Attribute, AttributeMap, _apply_attribute_store_sync
 from dex.blob_cache import BlobCache
 from dex.channel import Channel, ChannelMap
 from dex.client_options import ClientOptions
@@ -409,6 +409,7 @@ class Client:
         )
         if index is not None:
             write.index_config.CopyFrom(index)
+        _apply_attribute_store_sync(write, attribute)
         self._call(
             self._service.SetAttributes,
             pb.SetAttributesRequest(
@@ -924,15 +925,15 @@ class Client:
         for initialization in options._attribute_initializations:
             definition = initialization.definition
             key = self._definition_name(definition, initialization.instance)
-            mapped.attributes.append(
-                pb.AttributeWrite(
-                    key=key,
-                    value=self._values.encode(
-                        initialization.value,
-                        self._values.codec(definition.value_type),
-                    ),
-                )
+            write = pb.AttributeWrite(
+                key=key,
+                value=self._values.encode(
+                    initialization.value,
+                    self._values.codec(definition.value_type),
+                ),
             )
+            _apply_attribute_store_sync(write, definition)
+            mapped.attributes.append(write)
         if (
             options.config_override is not None
             or self.options.worker_target is not None
@@ -972,6 +973,8 @@ class Client:
                     StepDurability.SYNC: pb.STEP_DURABILITY_SYNC,
                     StepDurability.ASYNC: pb.STEP_DURABILITY_ASYNC,
                 }[config.step_durability]
+            if config.attribute_store_name is not None:
+                mapped.attribute_sync_config_name = config.attribute_store_name
         target = (
             config.worker_target
             if config is not None and config.worker_target is not None

--- a/sdk-python/dex/flow_config.py
+++ b/sdk-python/dex/flow_config.py
@@ -36,6 +36,9 @@ class FlowConfig:
     Every ``None`` field uses the registered or server default. Config may be set
     at start time or replaced on an active Flow through the Client.
 
+    Attribute Store projection is asynchronous. Failures never roll back Flow
+    Attributes, and already queued projections retain their original target.
+
     Attributes:
         active_step_search_mode: Optional active-Step visibility indexing policy.
         continue_as_new_threshold: Optional positive history-event threshold that
@@ -44,6 +47,8 @@ class FlowConfig:
             in bytes used by continue-as-new decisions.
         step_durability: Optional default durability for Step handlers.
         worker_target: Optional Worker endpoint for later handler calls.
+        attribute_store_name: Optional Server-configured Attribute Store name.
+            ``None`` leaves the field absent; an empty string disables future projections.
     """
 
     active_step_search_mode: ActiveStepSearchMode | None = None
@@ -51,3 +56,4 @@ class FlowConfig:
     continue_as_new_page_size_bytes: int | None = None
     step_durability: StepDurability | None = None
     worker_target: WorkerTarget | None = None
+    attribute_store_name: str | None = None

--- a/sdk-python/tests/test_contracts.py
+++ b/sdk-python/tests/test_contracts.py
@@ -26,30 +26,32 @@ from dex import (
     CodecRegistry,
     Context,
     Flow,
+    FlowConfig,
     FlowDefinitionError,
     InvalidStepResultError,
     JsonCodec,
     PersistenceSchema,
     Registry,
     RPCResult,
+    StartFlowOptions,
     Step,
     StepDecision,
     StepDurability,
     StepList,
     StepOptions,
     Timer,
+    ValueMappingError,
     Wait,
     WaitForFailurePolicy,
-    ValueMappingError,
     WireKind,
     graceful_complete,
     open_blob_cache,
     rpc,
 )
-from dex.client import Client as ClientModuleClient
-from dex.client_options import ClientOptions as ClientModuleOptions
 from dex._value_mapper import ValueMapper
 from dex._worker_dispatcher import WorkerDispatcher
+from dex.client import Client as ClientModuleClient
+from dex.client_options import ClientOptions as ClientModuleOptions
 from dex.dexpb import dex_pb2 as pb
 
 
@@ -360,4 +362,34 @@ def test_client_has_single_public_definition() -> None:
 
 def test_client_transport_is_initialized_lazily() -> None:
     client = Client(Registry((ORDERS,)), cast(BlobCache, object()))
+    client.close()
+
+
+def test_attribute_store_sync_mapping_preserves_presence() -> None:
+    plain = Attribute("plain", str)
+    synced = Attribute("synced", str, sync_to_attribute_store=True)
+    synced_map = AttributeMap("mapped", str, sync_to_attribute_store=True)
+    assert not plain.sync_to_attribute_store
+    assert synced.sync_to_attribute_store
+    assert synced_map.sync_to_attribute_store
+
+    client = ClientModuleClient(Registry((ORDERS,)), cast(BlobCache, object()))
+    start = client._map_start_options(
+        StartFlowOptions()
+        .with_attribute(plain, "plain")
+        .with_attribute(synced, "synced")
+        .with_attribute(synced_map, "tenant-1", "mapped")
+    )
+    assert not start.attributes[0].HasField("sync_config")
+    assert start.attributes[1].sync_config.enabled
+    assert start.attributes[2].sync_config.enabled
+
+    absent = client._map_flow_config(FlowConfig())
+    assert not absent.HasField("attribute_sync_config_name")
+    selected = client._map_flow_config(FlowConfig(attribute_store_name="reporting"))
+    assert selected.attribute_sync_config_name == "reporting"
+    assert selected.HasField("attribute_sync_config_name")
+    disabled = client._map_flow_config(FlowConfig(attribute_store_name=""))
+    assert disabled.attribute_sync_config_name == ""
+    assert disabled.HasField("attribute_sync_config_name")
     client.close()

--- a/sdk-python/tests/typecheck_contracts.py
+++ b/sdk-python/tests/typecheck_contracts.py
@@ -16,6 +16,7 @@ from dex import (
     Client,
     Context,
     Flow,
+    FlowConfig,
     PersistenceSchema,
     Registry,
     RPCResult,
@@ -67,11 +68,11 @@ output: Output = client.invoke_rpc(
     Input("input"),
 )
 
-status = Attribute("status", str)
-items = AttributeMap("items", int)
+status = Attribute("status", str, sync_to_attribute_store=True)
+items = AttributeMap("items", int, sync_to_attribute_store=True)
 persistence: PersistenceSchema = PersistenceSchema.of(status, items)
 start_options: StartFlowOptions = (
-    StartFlowOptions()
+    StartFlowOptions(config_override=FlowConfig(attribute_store_name="reporting"))
     .with_attribute(status, "ready")
     .with_attribute(items, "order-1", 1)
 )

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -91,6 +91,21 @@ blocking executor, so they do not occupy gRPC I/O tasks. Long-running handlers
 can call `Context::wait_for_cancellation` or poll `Context::is_cancelled` to
 observe method deadlines and disconnected callers.
 
+Opt an Attribute or AttributeMap into Attribute Store synchronization and
+select the Server-configured Store for the Flow:
+
+```rust
+use dex_sdk::{Attribute, FlowConfig};
+
+let email = Attribute::<String>::new("customer-email").sync_to_attribute_store();
+let config = FlowConfig::new().attribute_store_name("profiles");
+```
+
+The Store is an asynchronous latest-state projection. Deletion writes SQL
+`NULL`, and projection failures do not roll back Flow Attributes. Omitting the
+builder preserves the current target; passing `""` disables future
+synchronization while retaining protocol presence.
+
 ## Blob cache
 
 The shared cache keeps opaque payload bytes on disk and uses Stretto only for

--- a/sdk-rust/crates/dex-sdk/src/attribute.rs
+++ b/sdk-rust/crates/dex-sdk/src/attribute.rs
@@ -8,7 +8,7 @@
 
 use std::marker::PhantomData;
 
-use dex_protocol::dex::IndexConfig;
+use dex_protocol::dex::{AttributeSyncConfig, IndexConfig};
 
 use crate::{Context, HandlerError, HandlerResult, Value};
 
@@ -29,6 +29,7 @@ use crate::{Context, HandlerError, HandlerResult, Value};
 pub struct Attribute<T> {
     name: String,
     index: Option<AttributeIndex>,
+    sync_to_attribute_store: bool,
     marker: PhantomData<fn() -> T>,
 }
 
@@ -38,6 +39,7 @@ impl<T> Attribute<T> {
         Self {
             name: name.into(),
             index: None,
+            sync_to_attribute_store: false,
             marker: PhantomData,
         }
     }
@@ -45,6 +47,17 @@ impl<T> Attribute<T> {
     /// Enables Flow-search indexing with the selected index type.
     pub fn indexed(mut self, index: AttributeIndex) -> Self {
         self.index = Some(index);
+        self
+    }
+
+    /// Enables asynchronous latest-state projection to the Flow's selected Attribute Store.
+    ///
+    /// The Flow must select a server-configured store with
+    /// [`FlowConfig::attribute_store_name`](crate::FlowConfig::attribute_store_name). Deletions
+    /// project SQL `NULL`, and projection failures never roll back the Flow Attribute write.
+    #[must_use]
+    pub fn sync_to_attribute_store(mut self) -> Self {
+        self.sync_to_attribute_store = true;
         self
     }
 
@@ -109,6 +122,15 @@ impl<T> Attribute<T> {
     pub(crate) fn index(&self) -> Option<&AttributeIndex> {
         self.index.as_ref()
     }
+
+    pub(crate) fn sync_config(&self) -> Option<AttributeSyncConfig> {
+        self.sync_to_attribute_store
+            .then_some(AttributeSyncConfig { enabled: true })
+    }
+
+    pub(crate) fn is_sync_to_attribute_store(&self) -> bool {
+        self.sync_to_attribute_store
+    }
 }
 
 impl<T> Clone for Attribute<T> {
@@ -116,6 +138,7 @@ impl<T> Clone for Attribute<T> {
         Self {
             name: self.name.clone(),
             index: self.index.clone(),
+            sync_to_attribute_store: self.sync_to_attribute_store,
             marker: PhantomData,
         }
     }
@@ -128,6 +151,7 @@ impl<T> Clone for Attribute<T> {
 pub struct AttributeMap<T> {
     name: String,
     index: Option<AttributeIndex>,
+    sync_to_attribute_store: bool,
     marker: PhantomData<fn() -> T>,
 }
 
@@ -137,6 +161,7 @@ impl<T> AttributeMap<T> {
         Self {
             name: name.into(),
             index: None,
+            sync_to_attribute_store: false,
             marker: PhantomData,
         }
     }
@@ -144,6 +169,17 @@ impl<T> AttributeMap<T> {
     /// Enables search indexing for every instance using the selected index type.
     pub fn indexed(mut self, index: AttributeIndex) -> Self {
         self.index = Some(index);
+        self
+    }
+
+    /// Enables asynchronous latest-state projection for every AttributeMap instance.
+    ///
+    /// Each instance maps by its physical Attribute name. The Flow must select a server-configured
+    /// store with [`FlowConfig::attribute_store_name`](crate::FlowConfig::attribute_store_name).
+    /// Deletions project SQL `NULL`, and projection failures never roll back Flow Attribute writes.
+    #[must_use]
+    pub fn sync_to_attribute_store(mut self) -> Self {
+        self.sync_to_attribute_store = true;
         self
     }
 
@@ -205,6 +241,15 @@ impl<T> AttributeMap<T> {
     pub(crate) fn index(&self) -> Option<&AttributeIndex> {
         self.index.as_ref()
     }
+
+    pub(crate) fn sync_config(&self) -> Option<AttributeSyncConfig> {
+        self.sync_to_attribute_store
+            .then_some(AttributeSyncConfig { enabled: true })
+    }
+
+    pub(crate) fn is_sync_to_attribute_store(&self) -> bool {
+        self.sync_to_attribute_store
+    }
 }
 
 impl<T> Clone for AttributeMap<T> {
@@ -212,6 +257,7 @@ impl<T> Clone for AttributeMap<T> {
         Self {
             name: self.name.clone(),
             index: self.index.clone(),
+            sync_to_attribute_store: self.sync_to_attribute_store,
             marker: PhantomData,
         }
     }
@@ -339,5 +385,30 @@ impl AttributeLock {
             Some(instance) => crate::registry::physical_name(&self.attribute, instance),
             None => self.attribute.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Attribute, AttributeMap};
+
+    #[test]
+    fn sync_configuration_is_opt_in_and_survives_clone() {
+        let plain = Attribute::<String>::new("plain");
+        let synced = Attribute::<String>::new("synced").sync_to_attribute_store();
+        let synced_map = AttributeMap::<String>::new("synced_map").sync_to_attribute_store();
+
+        assert!(plain.sync_config().is_none());
+        assert_eq!(
+            synced.sync_config().map(|config| config.enabled),
+            Some(true)
+        );
+        assert_eq!(
+            synced_map
+                .clone()
+                .sync_config()
+                .map(|config| config.enabled),
+            Some(true)
+        );
     }
 }

--- a/sdk-rust/crates/dex-sdk/src/client.rs
+++ b/sdk-rust/crates/dex-sdk/src/client.rs
@@ -265,6 +265,7 @@ impl Client {
             attribute.name(),
             &value,
             attribute.index().map(|index| index.proto_config(false)),
+            attribute.sync_config(),
         )
     }
 
@@ -285,6 +286,7 @@ impl Client {
             &crate::registry::physical_name(attribute.name(), instance),
             &value,
             attribute.index().map(|index| index.proto_config(true)),
+            attribute.sync_config(),
         )
     }
 
@@ -740,12 +742,13 @@ impl Client {
         key: &str,
         value: &T,
         index_config: Option<dex_protocol::dex::IndexConfig>,
+        sync_config: Option<dex_protocol::dex::AttributeSyncConfig>,
     ) -> SdkResult<()> {
         let write = AttributeWrite {
             key: key.to_string(),
             value: Some(value_mapper::encode(value)?),
             index_config,
-            sync_config: None,
+            sync_config,
         };
         self.call_empty(
             "set_attribute",
@@ -869,7 +872,7 @@ impl Client {
                     key: attribute.key.clone(),
                     value: Some(attribute.value.encode()?),
                     index_config: attribute.index_config.clone(),
-                    sync_config: None,
+                    sync_config: attribute.sync_config,
                 })
             })
             .collect::<SdkResult<Vec<_>>>()?;
@@ -906,41 +909,7 @@ impl Client {
     }
 
     fn map_flow_config(&self, config: Option<&FlowConfig>) -> SdkResult<ProtoFlowConfig> {
-        let target = config
-            .and_then(|config| config.worker_target.as_ref())
-            .or_else(|| self.options.worker_target_value());
-        Ok(ProtoFlowConfig {
-            active_step_search_mode: config
-                .and_then(|config| config.active_step_search_mode)
-                .map(|mode| match mode {
-                    ActiveStepSearchMode::All => ProtoSearchMode::EnabledForAll as i32,
-                    ActiveStepSearchMode::WithWaitFor => {
-                        ProtoSearchMode::EnabledForStepsWithWaitFor as i32
-                    }
-                    ActiveStepSearchMode::Disabled => ProtoSearchMode::Disabled as i32,
-                }),
-            continue_as_new_threshold: config
-                .and_then(|config| config.continue_as_new_threshold)
-                .map(i32::try_from)
-                .transpose()
-                .map_err(|_| invalid("continue-as-new threshold exceeds int32"))?,
-            continue_as_new_page_size_in_bytes: config
-                .and_then(|config| config.continue_as_new_page_size_bytes)
-                .map(i32::try_from)
-                .transpose()
-                .map_err(|_| invalid("continue-as-new page size exceeds int32"))?,
-            step_durability: config
-                .and_then(|config| config.step_durability)
-                .map(|durability| {
-                    (match durability {
-                        StepDurability::Default => ProtoStepDurability::Unspecified,
-                        StepDurability::Sync => ProtoStepDurability::Sync,
-                        StepDurability::Async => ProtoStepDurability::Async,
-                    }) as i32
-                }),
-            worker_target: target.map(map_worker_target),
-            attribute_sync_config_name: None,
-        })
+        map_flow_config(config, self.options.worker_target_value())
     }
 
     fn call_empty<Response, Future, Call>(
@@ -960,6 +929,47 @@ impl Client {
             .map(|_| ())
             .map_err(|status| SdkError::from_status(status, operation, flow_id, requirement))
     }
+}
+
+fn map_flow_config(
+    config: Option<&FlowConfig>,
+    default_target: Option<&WorkerTarget>,
+) -> SdkResult<ProtoFlowConfig> {
+    let target = config
+        .and_then(|config| config.worker_target.as_ref())
+        .or(default_target);
+    Ok(ProtoFlowConfig {
+        active_step_search_mode: config
+            .and_then(|config| config.active_step_search_mode)
+            .map(|mode| match mode {
+                ActiveStepSearchMode::All => ProtoSearchMode::EnabledForAll as i32,
+                ActiveStepSearchMode::WithWaitFor => {
+                    ProtoSearchMode::EnabledForStepsWithWaitFor as i32
+                }
+                ActiveStepSearchMode::Disabled => ProtoSearchMode::Disabled as i32,
+            }),
+        continue_as_new_threshold: config
+            .and_then(|config| config.continue_as_new_threshold)
+            .map(i32::try_from)
+            .transpose()
+            .map_err(|_| invalid("continue-as-new threshold exceeds int32"))?,
+        continue_as_new_page_size_in_bytes: config
+            .and_then(|config| config.continue_as_new_page_size_bytes)
+            .map(i32::try_from)
+            .transpose()
+            .map_err(|_| invalid("continue-as-new page size exceeds int32"))?,
+        step_durability: config
+            .and_then(|config| config.step_durability)
+            .map(|durability| {
+                (match durability {
+                    StepDurability::Default => ProtoStepDurability::Unspecified,
+                    StepDurability::Sync => ProtoStepDurability::Sync,
+                    StepDurability::Async => ProtoStepDurability::Async,
+                }) as i32
+            }),
+        worker_target: target.map(map_worker_target),
+        attribute_sync_config_name: config.and_then(|config| config.attribute_store_name.clone()),
+    })
 }
 
 fn map_flow_retry(retry: RetryPolicy) -> SdkResult<FlowRetryPolicy> {
@@ -1090,5 +1100,30 @@ fn invalid(message: impl Into<String>) -> SdkError {
 fn service_error(error: impl std::fmt::Display) -> SdkError {
     SdkError::Service {
         service: ServiceError::local("client", error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_flow_config;
+    use crate::FlowConfig;
+
+    #[test]
+    fn attribute_store_name_preserves_protocol_presence() {
+        let absent = map_flow_config(Some(&FlowConfig::new()), None).expect("map absent config");
+        let named = map_flow_config(
+            Some(&FlowConfig::new().attribute_store_name("profiles")),
+            None,
+        )
+        .expect("map named config");
+        let disabled = map_flow_config(Some(&FlowConfig::new().attribute_store_name("")), None)
+            .expect("map disabled config");
+
+        assert_eq!(absent.attribute_sync_config_name, None);
+        assert_eq!(
+            named.attribute_sync_config_name.as_deref(),
+            Some("profiles")
+        );
+        assert_eq!(disabled.attribute_sync_config_name.as_deref(), Some(""));
     }
 }

--- a/sdk-rust/crates/dex-sdk/src/context.rs
+++ b/sdk-rust/crates/dex-sdk/src/context.rs
@@ -209,6 +209,7 @@ impl Context {
             None,
             value_mapper::encode_handler(&value)?,
             attribute.index().map(|index| index.proto_config(false)),
+            attribute.sync_config(),
         )
     }
 
@@ -225,6 +226,7 @@ impl Context {
             Some(instance),
             value_mapper::encode_handler(&value)?,
             attribute.index().map(|index| index.proto_config(true)),
+            attribute.sync_config(),
         )
     }
 
@@ -236,6 +238,7 @@ impl Context {
             None,
             value_mapper::deletion(),
             attribute.index().map(|index| index.proto_config(false)),
+            attribute.sync_config(),
         )
     }
 
@@ -251,6 +254,7 @@ impl Context {
             Some(instance),
             value_mapper::deletion(),
             attribute.index().map(|index| index.proto_config(true)),
+            attribute.sync_config(),
         )
     }
 
@@ -378,6 +382,7 @@ impl Context {
         instance: Option<&str>,
         value: ProtoValue,
         index_config: Option<dex_protocol::dex::IndexConfig>,
+        sync_config: Option<dex_protocol::dex::AttributeSyncConfig>,
     ) -> HandlerResult<()> {
         let key = self.registered_name(name, kind, instance)?;
         self.attribute_writes.insert(
@@ -386,7 +391,7 @@ impl Context {
                 key,
                 value: Some(value),
                 index_config,
-                sync_config: None,
+                sync_config,
             },
         );
         Ok(())

--- a/sdk-rust/crates/dex-sdk/src/flow_config.rs
+++ b/sdk-rust/crates/dex-sdk/src/flow_config.rs
@@ -15,6 +15,7 @@ use crate::{StepDurability, WorkerTarget};
 /// for one execution or to [`crate::Client::update_flow_config`] for an active Flow.
 pub struct FlowConfig {
     pub(crate) active_step_search_mode: Option<ActiveStepSearchMode>,
+    pub(crate) attribute_store_name: Option<String>,
     pub(crate) continue_as_new_threshold: Option<u32>,
     pub(crate) continue_as_new_page_size_bytes: Option<u32>,
     pub(crate) step_durability: Option<StepDurability>,
@@ -30,6 +31,17 @@ impl FlowConfig {
     /// Controls which active Step types Dex places in the search index.
     pub fn active_step_search_mode(mut self, value: ActiveStepSearchMode) -> Self {
         self.active_step_search_mode = Some(value);
+        self
+    }
+
+    /// Selects the server-configured Attribute Store for opted-in Attribute writes.
+    ///
+    /// Omitting this builder preserves the existing Flow setting. Passing an empty string retains
+    /// protocol presence and disables later synchronization. Projection is asynchronous, and an
+    /// external store failure does not roll back the Flow Attribute write.
+    #[must_use]
+    pub fn attribute_store_name(mut self, value: impl Into<String>) -> Self {
+        self.attribute_store_name = Some(value.into());
         self
     }
 

--- a/sdk-rust/crates/dex-sdk/src/persistence.rs
+++ b/sdk-rust/crates/dex-sdk/src/persistence.rs
@@ -32,6 +32,7 @@ pub(crate) struct PersistenceDefinition {
     pub(crate) name: String,
     pub(crate) kind: PersistenceKind,
     pub(crate) index: Option<AttributeIndex>,
+    pub(crate) sync_to_attribute_store: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -54,6 +55,7 @@ impl PersistenceSchema {
             attribute.name(),
             PersistenceKind::Attribute,
             attribute.index().cloned(),
+            attribute.is_sync_to_attribute_store(),
         );
         self
     }
@@ -64,19 +66,20 @@ impl PersistenceSchema {
             attribute.name(),
             PersistenceKind::AttributeMap,
             attribute.index().cloned(),
+            attribute.is_sync_to_attribute_store(),
         );
         self
     }
 
     /// Adds one Channel definition.
     pub fn channel<T>(mut self, channel: &Channel<T>) -> Self {
-        self.add(channel.name(), PersistenceKind::Channel, None);
+        self.add(channel.name(), PersistenceKind::Channel, None, false);
         self
     }
 
     /// Adds one keyed Channel-map definition.
     pub fn channel_map<T>(mut self, channel: &ChannelMap<T>) -> Self {
-        self.add(channel.name(), PersistenceKind::ChannelMap, None);
+        self.add(channel.name(), PersistenceKind::ChannelMap, None, false);
         self
     }
 
@@ -84,11 +87,36 @@ impl PersistenceSchema {
         &self.definitions
     }
 
-    fn add(&mut self, name: &str, kind: PersistenceKind, index: Option<AttributeIndex>) {
+    fn add(
+        &mut self,
+        name: &str,
+        kind: PersistenceKind,
+        index: Option<AttributeIndex>,
+        sync_to_attribute_store: bool,
+    ) {
         self.definitions.push(PersistenceDefinition {
             name: name.to_string(),
             kind,
             index,
+            sync_to_attribute_store,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PersistenceSchema;
+    use crate::{Attribute, AttributeMap};
+
+    #[test]
+    fn registration_metadata_retains_sync_configuration() {
+        let attribute = Attribute::<String>::new("plain");
+        let attribute_map = AttributeMap::<String>::new("map").sync_to_attribute_store();
+        let schema = PersistenceSchema::new()
+            .attribute(&attribute)
+            .attribute_map(&attribute_map);
+
+        assert!(!schema.definitions[0].sync_to_attribute_store);
+        assert!(schema.definitions[1].sync_to_attribute_store);
     }
 }

--- a/sdk-rust/crates/dex-sdk/src/start_flow_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/start_flow_options.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use std::sync::Arc;
 
-use dex_protocol::dex::IndexConfig;
+use dex_protocol::dex::{AttributeSyncConfig, IndexConfig};
 
 use crate::registry::physical_name;
 use crate::step::{ErasedValue, TypedValue};
@@ -67,6 +67,7 @@ pub(crate) struct InitialAttribute {
     pub(crate) key: String,
     pub(crate) value: Arc<dyn ErasedValue>,
     pub(crate) index_config: Option<IndexConfig>,
+    pub(crate) sync_config: Option<AttributeSyncConfig>,
 }
 
 impl StartFlowOptions {
@@ -121,6 +122,7 @@ impl StartFlowOptions {
             key: attribute.name().to_string(),
             value: Arc::new(TypedValue(value)),
             index_config: attribute.index().map(|index| index.proto_config(false)),
+            sync_config: attribute.sync_config(),
         });
         self
     }
@@ -136,6 +138,7 @@ impl StartFlowOptions {
             key: physical_name(attribute.name(), instance),
             value: Arc::new(TypedValue(value)),
             index_config: attribute.index().map(|index| index.proto_config(true)),
+            sync_config: attribute.sync_config(),
         });
         self
     }
@@ -162,5 +165,38 @@ impl StartFlowOptions {
 impl Default for StartFlowOptions {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StartFlowOptions;
+    use crate::{Attribute, AttributeMap};
+
+    #[test]
+    fn initial_attributes_retain_sync_configuration() {
+        let plain = Attribute::<String>::new("plain");
+        let synced = Attribute::<String>::new("synced").sync_to_attribute_store();
+        let synced_map = AttributeMap::<String>::new("map").sync_to_attribute_store();
+        let options = StartFlowOptions::new()
+            .initial_attribute(&plain, "plain".to_string())
+            .initial_attribute(&synced, "synced".to_string())
+            .initial_attribute_map(&synced_map, "tenant-1", "mapped".to_string());
+
+        assert!(options.attributes[0].sync_config.is_none());
+        assert_eq!(
+            options.attributes[1]
+                .sync_config
+                .as_ref()
+                .map(|config| config.enabled),
+            Some(true)
+        );
+        assert_eq!(
+            options.attributes[2]
+                .sync_config
+                .as_ref()
+                .map(|config| config.enabled),
+            Some(true)
+        );
     }
 }

--- a/sdk-rust/crates/dex-sdk/tests/compile_contracts.rs
+++ b/sdk-rust/crates/dex-sdk/tests/compile_contracts.rs
@@ -10,3 +10,12 @@
 fn flow_start_input_is_checked_at_compile_time() {
     trybuild::TestCases::new().compile_fail("tests/compile_fail/wrong_flow_input.rs");
 }
+
+#[test]
+fn attribute_store_sync_builders_compile() {
+    let _attribute = dex_sdk::Attribute::<String>::new("email").sync_to_attribute_store();
+    let _attribute_map =
+        dex_sdk::AttributeMap::<String>::new("email_by_tenant").sync_to_attribute_store();
+    let _config = dex_sdk::FlowConfig::new().attribute_store_name("profiles");
+    let _disabled = dex_sdk::FlowConfig::new().attribute_store_name("");
+}

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -67,6 +67,20 @@ failure or the default 120-second deadline aborts startup. An indexed
 `StepOptions.waitForMethodTimeoutMs` and `executeMethodTimeoutMs` bound the two
 handler calls. Timer and channel conditions determine how long a Step waits.
 
+Opt an Attribute or AttributeMap into Attribute Store synchronization, then
+select the Server-configured Store for the Flow:
+
+```typescript
+const email = new Attribute("customer-email", stringCodec)
+  .syncToAttributeStore();
+const config: FlowConfig = { attributeStoreName: "profiles" };
+```
+
+The Store is an asynchronous latest-state projection. Deletion writes SQL
+`NULL`, and projection failures do not roll back Flow Attributes. Omitting
+`attributeStoreName` preserves the current target; `attributeStoreName: ""`
+disables future synchronization while retaining protocol presence.
+
 ### Async handlers
 
 `Step.execute`, `Step.waitFor`, and RPC methods may be `async` and return a

--- a/sdk-typescript/src/attribute-store-sync.ts
+++ b/sdk-typescript/src/attribute-store-sync.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+import type { AttributeSyncConfig } from "./gen/dex.js";
+import type { FlowConfig } from "./options.js";
+
+const syncedDefinitions = new WeakSet<object>();
+
+export function markAttributeStoreSynced<Definition extends object>(
+  definition: Definition,
+): Definition {
+  syncedDefinitions.add(definition);
+  return definition;
+}
+
+export function mapAttributeStoreSync(
+  definition: object,
+): AttributeSyncConfig | undefined {
+  return syncedDefinitions.has(definition) ? { enabled: true } : undefined;
+}
+
+export function mapAttributeStoreName(config: FlowConfig | undefined): string | undefined {
+  return config?.attributeStoreName;
+}

--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -9,6 +9,7 @@
 import { credentials, type ServiceError } from "@grpc/grpc-js";
 
 import type { BlobCache } from "./blob-cache.js";
+import { mapAttributeStoreName, mapAttributeStoreSync } from "./attribute-store-sync.js";
 import type { Codec } from "./codec.js";
 import type { Context } from "./context.js";
 import {
@@ -143,7 +144,7 @@ export class Client {
           key: physicalName(initial.attribute.name, initial.instance),
           value: encodeValue(initial.attribute.codec, initial.value),
           indexConfig: mapIndex(initial.attribute.index),
-          syncConfig: undefined,
+          syncConfig: mapAttributeStoreSync(initial.attribute),
         })),
         flowConfigOverride: mapFlowConfig(options.configOverride, this.options),
         flowAlreadyStartedOptions: {
@@ -408,7 +409,7 @@ export class Client {
               key: physicalName(attribute.name, instance),
               value: encodeValue(attribute.codec, value),
               indexConfig: mapIndex(attribute.index),
-              syncConfig: undefined,
+              syncConfig: mapAttributeStoreSync(attribute),
             },
           ],
           requestId: crypto.randomUUID(),
@@ -842,6 +843,7 @@ function mapFlowConfig(
         : config.activeStepSearchMode === ActiveStepSearchMode.ALL
           ? ProtoActiveStepSearchMode.ACTIVE_STEP_SEARCH_MODE_ENABLED_FOR_ALL
           : ProtoActiveStepSearchMode.ACTIVE_STEP_SEARCH_MODE_UNSPECIFIED,
+    attributeSyncConfigName: mapAttributeStoreName(config),
     continueAsNewThreshold: config?.continueAsNewThreshold,
     continueAsNewPageSizeInBytes: config?.continueAsNewPageSizeBytes,
     stepDurability:

--- a/sdk-typescript/src/invocation-context.ts
+++ b/sdk-typescript/src/invocation-context.ts
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import type { Codec } from "./codec.js";
+import { mapAttributeStoreSync } from "./attribute-store-sync.js";
 import type { Context } from "./context.js";
 import {
   ConditionStatus,
@@ -129,7 +130,7 @@ export class InvocationContext implements Context {
       key,
       value: encodeValue(attribute.codec, value),
       indexConfig: mapIndex(attribute.index),
-      syncConfig: undefined,
+      syncConfig: mapAttributeStoreSync(attribute),
     });
   }
 
@@ -143,7 +144,7 @@ export class InvocationContext implements Context {
       key,
       value: deletionValue(),
       indexConfig: mapIndex(attribute.index),
-      syncConfig: undefined,
+      syncConfig: mapAttributeStoreSync(attribute),
     });
   }
 

--- a/sdk-typescript/src/options.ts
+++ b/sdk-typescript/src/options.ts
@@ -51,6 +51,14 @@ export type IdReusePolicy = (typeof IdReusePolicy)[keyof typeof IdReusePolicy];
 export interface FlowConfig {
   /** Optional active-Step visibility indexing policy. */
   readonly activeStepSearchMode?: ActiveStepSearchMode;
+  /**
+   * Selects the server-configured Attribute Store receiving opted-in Attribute writes.
+   *
+   * Omit this property to preserve the existing Flow setting. An explicit empty string is sent with
+   * presence and disables later synchronization. Projection is asynchronous and never rolls back Flow
+   * Attribute writes when the external store update fails.
+   */
+  readonly attributeStoreName?: string;
   /** Positive history-event threshold requesting continue-as-new. */
   readonly continueAsNewThreshold?: number;
   /** Positive history page-size budget in bytes for continue-as-new. */

--- a/sdk-typescript/src/persistence.ts
+++ b/sdk-typescript/src/persistence.ts
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import type { Channel, ChannelMap } from "./wait.js";
+import { markAttributeStoreSynced } from "./attribute-store-sync.js";
 import type { Codec } from "./codec.js";
 import type { Context } from "./context.js";
 import { requireName } from "./validation.js";
@@ -102,6 +103,17 @@ export class Attribute<T> {
   }
 
   /**
+   * Returns an immutable Attribute definition whose writes are projected to the Flow's Attribute Store.
+   *
+   * Projection is asynchronous and latest-state only. Deletion writes SQL `NULL`, projection failures do
+   * not roll back Flow Attribute writes, and the Flow must select a configured Attribute Store name.
+   * @returns A new synced definition; this definition remains unchanged.
+   */
+  public syncToAttributeStore(): Attribute<T> {
+    return markAttributeStoreSynced(new Attribute(this.name, this.codec, this.index));
+  }
+
+  /**
    * Creates a lock request for this Attribute.
    * @returns A lock for this singleton Attribute.
    */
@@ -156,6 +168,18 @@ export class AttributeMap<T> {
    */
   public delete(context: Context, instance: string): void {
     context.deleteAttribute(this as AttributeMap<unknown>, instance);
+  }
+
+  /**
+   * Returns an immutable AttributeMap definition whose writes are projected to the Flow's Attribute Store.
+   *
+   * Projection is asynchronous and latest-state only. Each map instance uses its physical Attribute name.
+   * Deletion writes SQL `NULL`, projection failures do not roll back Flow Attribute writes, and the Flow
+   * must select a configured Attribute Store name.
+   * @returns A new synced definition; this definition remains unchanged.
+   */
+  public syncToAttributeStore(): AttributeMap<T> {
+    return markAttributeStoreSynced(new AttributeMap(this.name, this.codec, this.index));
   }
 
   /**

--- a/sdk-typescript/test/contracts.test.ts
+++ b/sdk-typescript/test/contracts.test.ts
@@ -14,6 +14,7 @@ import test from "node:test";
 
 import {
   Attribute,
+  AttributeMap,
   Channel,
   Client,
   FlowDefinitionError,
@@ -32,10 +33,15 @@ import {
   type BlobCache,
   type Context,
   type Flow,
+  type FlowConfig,
   type RPCResult,
   type Step,
   type StepDecision,
 } from "../src/index.js";
+import {
+  mapAttributeStoreName,
+  mapAttributeStoreSync,
+} from "../src/attribute-store-sync.js";
 import {
   Context as ProtoContext,
   InvokeExecuteMethodRequest,
@@ -147,6 +153,22 @@ test("typed definitions construct without runtime", () => {
   assert.equal(definitions[0]?.isStartStep, true);
   assert.equal(definitions[1]?.step, orders.archive);
   assert.equal(definitions[1]?.isStartStep, false);
+});
+
+test("attribute store synchronization is opt-in and immutable", () => {
+  const plain = new Attribute("plain", stringCodec);
+  const synced = plain.syncToAttributeStore();
+  const syncedMap = new AttributeMap("map", stringCodec).syncToAttributeStore();
+  const absent: FlowConfig = {};
+  const named: FlowConfig = { attributeStoreName: "profiles" };
+  const disabled: FlowConfig = { attributeStoreName: "" };
+
+  assert.equal(mapAttributeStoreSync(plain), undefined);
+  assert.equal(mapAttributeStoreSync(synced)?.enabled, true);
+  assert.equal(mapAttributeStoreSync(syncedMap)?.enabled, true);
+  assert.equal(mapAttributeStoreName(absent), undefined);
+  assert.equal(mapAttributeStoreName(named), "profiles");
+  assert.equal(mapAttributeStoreName(disabled), "");
 });
 
 test("registry rejects missing durable-name methods at runtime", () => {


### PR DESCRIPTION
## Summary

- expose definition-level Attribute Store sync opt-in in Go, Java, Python, TypeScript, and Rust
- map the selected Attribute Store through Flow configuration while preserving absent and explicit-empty presence
- carry sync metadata through registration, initial values, Client writes, and Step/RPC set/delete paths
- document the five SDK APIs and storage-sync semantics

## Rationale and user impact

PR #229 added Server support for asynchronously projecting selected Flow Attributes into a configured SQL Attribute Store. This PR makes that capability available through every high-level SDK without requiring applications to construct generated protobuf messages.

Ordinary Attributes continue to omit `sync_config`. Opted-in Attributes send `enabled = true`; deletions project SQL `NULL`, and external projection failures do not roll back Flow Attribute writes. Omitting the Flow Store name preserves the existing target, while an explicit empty string disables later synchronization.

## Validation

- `make -C sdk-go unitTests`
- `JAVA_HOME=... ./gradlew test checkstyleMain javadoc` in `sdk-java`
- Python contract pytest, mypy, pyright, and Python 3.11 pre-commit hooks
- `npm run typecheck` and `npm test` in `sdk-typescript`
- `cargo test --workspace --locked` and Clippy in `sdk-rust`
- `make copyright-check`

No Server/IDL changes, new integration tests, Postgres dependency, or top-level `examples/` changes are included.
