### PR TITLE
fix(examples): wait for worker readiness

### DIFF
--- a/examples/go/cmd/server/dex/dex.go
+++ b/examples/go/cmd/server/dex/dex.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -50,6 +51,7 @@ type sampleServer struct {
 	dealFlow       *datasetdeal.DealFlow
 	dealRepository datasetdeal.Repository
 	httpServer     *http.Server
+	workerAddress  string
 	workerResult   chan error
 	httpResult     chan error
 }
@@ -114,6 +116,7 @@ func newSampleServer(ctx context.Context) (*sampleServer, error) {
 		database:       database,
 		dealFlow:       dealFlow,
 		dealRepository: dealRepository,
+		workerAddress:  workerOptions.BindAddress,
 		workerResult:   make(chan error, 1),
 		httpResult:     make(chan error, 1),
 	}
@@ -178,10 +181,13 @@ func NewRouter(
 }
 
 func (server *sampleServer) Run(ctx context.Context) error {
-	startCronSchedule(server.client)
 	go func() {
 		server.workerResult <- server.worker.Start()
 	}()
+	if err := server.waitForWorker(ctx); err != nil {
+		return errors.Join(err, server.close())
+	}
+	startCronSchedule(server.client)
 	go func() {
 		err := server.httpServer.ListenAndServe()
 		if errors.Is(err, http.ErrServerClosed) {
@@ -199,6 +205,48 @@ func (server *sampleServer) Run(ctx context.Context) error {
 		runErr = err
 	}
 	return errors.Join(runErr, server.close())
+}
+
+func (server *sampleServer) waitForWorker(ctx context.Context) error {
+	address, err := localWorkerAddress(server.workerAddress)
+	if err != nil {
+		return err
+	}
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		connection, dialErr := net.DialTimeout("tcp", address, 100*time.Millisecond)
+		if dialErr == nil {
+			if closeErr := connection.Close(); closeErr != nil {
+				return fmt.Errorf("close Worker readiness connection: %w", closeErr)
+			}
+			return nil
+		}
+		select {
+		case workerErr := <-server.workerResult:
+			if workerErr == nil {
+				return errors.New("Worker stopped before becoming ready")
+			}
+			return workerErr
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func localWorkerAddress(bindAddress string) (string, error) {
+	host, port, err := net.SplitHostPort(bindAddress)
+	if err != nil {
+		return "", fmt.Errorf("parse Worker bind address: %w", err)
+	}
+	switch host {
+	case "", "0.0.0.0":
+		host = "127.0.0.1"
+	case "::":
+		host = "::1"
+	}
+	return net.JoinHostPort(host, port), nil
 }
 
 func (server *sampleServer) close() error {

--- a/examples/go/integ/main_test.go
+++ b/examples/go/integ/main_test.go
@@ -50,13 +50,14 @@ var (
 )
 
 type integrationEnvironment struct {
-	cache        *blobcache.Cache
-	cacheDir     string
-	client       *dex.Client
-	database     *pgxpool.Pool
-	apiServer    *httptest.Server
-	worker       *dex.Worker
-	workerResult chan error
+	cache         *blobcache.Cache
+	cacheDir      string
+	client        *dex.Client
+	database      *pgxpool.Pool
+	apiServer     *httptest.Server
+	worker        *dex.Worker
+	workerAddress string
+	workerResult  chan error
 }
 
 func newIntegrationEnvironment() (*integrationEnvironment, error) {
@@ -117,13 +118,14 @@ func newIntegrationEnvironment() (*integrationEnvironment, error) {
 	}
 	apiServer := httptest.NewServer(exampleserver.NewRouter(client, dealFlow, dealRepository))
 	environment := &integrationEnvironment{
-		cache:        cache,
-		cacheDir:     cacheDir,
-		client:       client,
-		database:     database,
-		apiServer:    apiServer,
-		worker:       worker,
-		workerResult: workerResult,
+		cache:         cache,
+		cacheDir:      cacheDir,
+		client:        client,
+		database:      database,
+		apiServer:     apiServer,
+		worker:        worker,
+		workerAddress: net.JoinHostPort("127.0.0.1", workerPort),
+		workerResult:  workerResult,
 	}
 	integClient = client
 	if err := environment.waitUntilReady(); err != nil {
@@ -161,13 +163,17 @@ func (environment *integrationEnvironment) waitUntilReady() error {
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		if _, err := environment.client.HealthCheck(ctx); err == nil {
+		connection, err := net.DialTimeout("tcp", environment.workerAddress, 100*time.Millisecond)
+		if err == nil {
+			if closeErr := connection.Close(); closeErr != nil {
+				return fmt.Errorf("close Worker readiness connection: %w", closeErr)
+			}
 			return nil
 		}
 		select {
 		case <-ticker.C:
 		case <-ctx.Done():
-			return fmt.Errorf("wait for Dex health: %w", ctx.Err())
+			return fmt.Errorf("wait for Worker readiness: %w", ctx.Err())
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- wait for the Go example Worker listener before exposing the sample HTTP server
- make the integration environment wait for Worker readiness instead of only Dex health
- prevent fresh environments from starting flows before attribute indexes finish syncing

## Rationale

Fresh isolated Docker runners exposed a startup race: Dex health became ready before `Worker.Start()` finished synchronizing Temporal search attributes. The dataset-deal E2E could therefore submit a flow using `BuyerID` before that index existed.

## User impact

Go examples start reliably in fresh environments and no longer return a transient 500 for the first flow execution.

## Validation

- `GOMODCACHE=/tmp/dex-examples-gomodcache-readiness GOCACHE=/tmp/dex-examples-gocache-readiness make -C examples/go e2eTests`
- `make copyright-check`
