### PR TITLE
Add Rust SDK crates.io release pipeline

### DIFF
--- a/.github/workflows/sdk-java-ci.yml
+++ b/.github/workflows/sdk-java-ci.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - uses: actions/setup-java@v5
         with:
           distribution: zulu
@@ -68,14 +68,14 @@ jobs:
     runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 15
     env:
-      RUSTUP_TOOLCHAIN: '1.88.0'
+      RUSTUP_TOOLCHAIN: '1.97.1'
     defaults:
       run:
         working-directory: sdk-java
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - uses: actions/setup-java@v5
         with:
           distribution: zulu
@@ -95,7 +95,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      RUSTUP_TOOLCHAIN: "1.88.0"
+      RUSTUP_TOOLCHAIN: "1.97.1"
     defaults:
       run:
         working-directory: sdk-java
@@ -131,7 +131,7 @@ jobs:
           echo "${binary_dir}" >> "${GITHUB_PATH}"
           "${binary_dir}/temporal" --version
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - uses: actions/setup-java@v5
         with:
           distribution: zulu

--- a/.github/workflows/sdk-java-publish.yml
+++ b/.github/workflows/sdk-java-publish.yml
@@ -45,11 +45,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     env:
-      RUSTUP_TOOLCHAIN: '1.88.0'
+      RUSTUP_TOOLCHAIN: '1.97.1'
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - name: Build BlobCache JNI
         working-directory: sdk-rust
         run: cargo build --release -p dex-blob-cache-jni --locked

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Install Rust
-      run: rustup toolchain install 1.88.0 --profile minimal
+      run: rustup toolchain install 1.97.1 --profile minimal
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b   # v8.1.0
       with:
@@ -76,7 +76,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Install Rust
-      run: rustup toolchain install 1.88.0 --profile minimal
+      run: rustup toolchain install 1.97.1 --profile minimal
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b   # v8.1.0
       with:
@@ -158,7 +158,7 @@ jobs:
     - name: Install Temporal CLI runtime for dexcli dev
       uses: temporalio/setup-temporal@v0
     - name: Install Rust
-      run: rustup toolchain install 1.88.0 --profile minimal
+      run: rustup toolchain install 1.97.1 --profile minimal
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b   # v8.1.0
       with:

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -124,7 +124,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           maturin-version: v1.14.1
-          rust-toolchain: "1.88.0"
+          rust-toolchain: "1.97.1"
           working-directory: sdk-python
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
@@ -169,7 +169,7 @@ jobs:
         with:
           command: sdist
           maturin-version: v1.14.1
-          rust-toolchain: "1.88.0"
+          rust-toolchain: "1.97.1"
           working-directory: sdk-python
           args: --out dist
       - name: Build wheel from source distribution

--- a/.github/workflows/sdk-rust-ci.yml
+++ b/.github/workflows/sdk-rust-ci.yml
@@ -30,7 +30,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "1"
-  RUSTUP_TOOLCHAIN: "1.88.0"
+  RUSTUP_TOOLCHAIN: "1.97.1"
 
 jobs:
   quality:
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal --component rustfmt,clippy
+        run: rustup toolchain install 1.97.1 --profile minimal --component rustfmt,clippy
       - name: Check formatting
         run: cargo fmt --all --check
       - name: Validate public API documentation
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - name: Run tests
         run: cargo test --workspace --locked
 
@@ -93,7 +93,7 @@ jobs:
       - name: Install Temporal CLI runtime for dexcli dev
         uses: temporalio/setup-temporal@v0
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - name: Run integration tests
         run: ./run-integration-tests.sh
       - name: Upload service logs

--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -1,0 +1,144 @@
+name: Publish Rust SDK to crates.io
+
+on:
+  release:
+    types: [published]
+  pull_request:
+    paths:
+      - "sdk-rust/**"
+      - ".github/workflows/sdk-rust-publish.yml"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Rust SDK release version
+        required: true
+        type: string
+      publish:
+        description: Publish the validated crates to crates.io
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-rust-publish-${{ github.event.release.tag_name || inputs.version || github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTUP_TOOLCHAIN: "1.88.0"
+
+jobs:
+  prepare:
+    name: Validate release
+    if: >
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.release.tag_name, 'sdk-rust/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: sdk-rust
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install Rust
+        run: rustup toolchain install 1.88.0 --profile minimal
+      - name: Resolve release version
+        id: release
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_VERSION: ${{ inputs.version }}
+          DISPATCH_PUBLISH: ${{ inputs.publish }}
+          RELEASE_REF: ${{ github.ref }}
+        run: |
+          if [[ "${EVENT_NAME}" == "release" ]]; then
+            version="${RELEASE_TAG#sdk-rust/v}"
+            if ! git merge-base --is-ancestor HEAD origin/main; then
+              echo "Release tag must point to a commit on main" >&2
+              exit 1
+            fi
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            version="${DISPATCH_VERSION}"
+            if [[ "${DISPATCH_PUBLISH}" == "true" && "${RELEASE_REF}" != "refs/heads/main" ]]; then
+              echo "Manual publishing is allowed only from main" >&2
+              exit 1
+            fi
+          else
+            version="$(python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')"
+          fi
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+            echo "Invalid Rust SDK release version: ${version}" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+      - name: Stamp package versions from release
+        run: >-
+          python scripts/stamp_release_version.py
+          '${{ steps.release.outputs.version }}'
+          --stage-protocol
+      - name: Validate stamped workspace
+        run: cargo metadata --locked --no-deps --format-version 1
+      - name: Build publishable crates
+        run: >-
+          cargo package --locked --allow-dirty
+          -p dex-blob-cache
+          -p dex-protocol
+          -p dex-sdk
+      - name: Upload crate archives
+        uses: actions/upload-artifact@v7
+        with:
+          name: dex-rust-crates-${{ steps.release.outputs.version }}
+          path: sdk-rust/target/package/*.crate
+          if-no-files-found: error
+
+  publish:
+    name: Publish Rust crates
+    if: github.event_name == 'release' || inputs.publish == true
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: sdk-rust
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install Rust
+        run: rustup toolchain install 1.88.0 --profile minimal
+      - name: Stamp package versions from release
+        run: >-
+          python scripts/stamp_release_version.py
+          '${{ needs.prepare.outputs.version }}'
+          --stage-protocol
+      - name: Validate crates.io credentials
+        shell: bash
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          [[ -n "${CRATES_IO_TOKEN}" ]] || { echo 'CRATES_IO_TOKEN is missing' >&2; exit 1; }
+      - name: Publish dex-blob-cache
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish --locked --allow-dirty -p dex-blob-cache
+      - name: Publish dex-protocol
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish --locked --allow-dirty -p dex-protocol
+      - name: Publish dex-sdk
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish --locked --allow-dirty -p dex-sdk

--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -28,7 +28,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTUP_TOOLCHAIN: "1.88.0"
+  RUSTUP_TOOLCHAIN: "1.97.1"
 
 jobs:
   prepare:
@@ -52,7 +52,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - name: Resolve release version
         id: release
         shell: bash
@@ -118,7 +118,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - name: Stamp package versions from release
         run: >-
           python scripts/stamp_release_version.py

--- a/.github/workflows/sdk-typescript-ci.yml
+++ b/.github/workflows/sdk-typescript-ci.yml
@@ -46,14 +46,14 @@ jobs:
       matrix:
         node-version: ["22", "24"]
     env:
-      RUSTUP_TOOLCHAIN: "1.88.0"
+      RUSTUP_TOOLCHAIN: "1.97.1"
     defaults:
       run:
         working-directory: sdk-typescript
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
@@ -76,14 +76,14 @@ jobs:
       contents: read
       id-token: write
     env:
-      RUSTUP_TOOLCHAIN: "1.88.0"
+      RUSTUP_TOOLCHAIN: "1.97.1"
     defaults:
       run:
         working-directory: sdk-typescript
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - uses: actions/setup-node@v6
         with:
           node-version: "22"

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -38,11 +38,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     env:
-      RUSTUP_TOOLCHAIN: "1.88.0"
+      RUSTUP_TOOLCHAIN: "1.97.1"
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - name: Build BlobCache Node binding
         working-directory: sdk-rust
         run: cargo build --release -p dex-blob-cache-node --locked
@@ -67,14 +67,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      RUSTUP_TOOLCHAIN: "1.88.0"
+      RUSTUP_TOOLCHAIN: "1.97.1"
     defaults:
       run:
         working-directory: sdk-typescript
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust
-        run: rustup toolchain install 1.88.0 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
       - uses: actions/setup-node@v6
         with:
           node-version: "24"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,22 +160,23 @@ Each component has its own version and tag prefix. Create a GitHub Release for t
 | Go SDK | `sdk-go/vX.Y.Z` | `sdk-go/v1.2.3` | Go module tag for `github.com/superdurable/dex/sdk-go` |
 | Blob Cache Go | `blob-cache-go/vX.Y.Z` | `blob-cache-go/v0.1.0` | Go module tag for `github.com/superdurable/dex/blob-cache-go` |
 | TypeScript SDK | `sdk-typescript/vX.Y.Z` | `sdk-typescript/v0.1.0` | npm [`@superdurable/dex`](https://www.npmjs.com/package/@superdurable/dex) via [`.github/workflows/sdk-typescript-publish.yml`](.github/workflows/sdk-typescript-publish.yml) (version from the tag) |
+| Rust SDK | `sdk-rust/vX.Y.Z` | `sdk-rust/v0.1.0` | crates.io `dex-sdk`, `dex-blob-cache`, and `dex-protocol` via [`.github/workflows/sdk-rust-publish.yml`](.github/workflows/sdk-rust-publish.yml) (version from the tag) |
 | Dex CLI | `cli-vX.Y.Z` | `cli-v0.1.0` | macOS/Linux archives and Homebrew formula input |
 
 Notes:
 
-- Java, TypeScript, and Python derive publish versions from tags (CI stamps the package metadata for the build). Bump committed version files when you want the repo tip to match.
+- Java, TypeScript, Python, and Rust derive publish versions from tags (CI stamps the package metadata for the build). Bump committed version files when you want the repo tip to match.
 - Go modules use path-style tags (`sdk-go/v…`, `blob-cache-go/v…`) so `go get` resolves each subdirectory module.
 - Python, Java, and Docker release workflows also support **workflow_dispatch** for manual runs. Python manual runs build without publishing unless `publish` is selected.
 - TypeScript publishing requires a GitHub Release after its one-time npm bootstrap publish.
 
-### Committed `version` vs release tags (Python / TypeScript / Java)
+### Committed `version` vs release tags (Python / TypeScript / Java / Rust)
 
-For the Python, TypeScript, and Java SDKs, the **GitHub Release tag** is the source of
+For the Python, TypeScript, Java, and Rust SDKs, the **GitHub Release tag** is the source of
 truth for what gets published (`sdk-python/vX.Y.Z` → PyPI, `sdk-typescript/vX.Y.Z` → npm,
-`sdk-java/vX.Y.Z` → Maven Central). CI applies that version for the release build (Python
-and TypeScript stamp package metadata on the runner; Java passes `-PreleaseVersion`) and
-does **not** commit the change.
+`sdk-java/vX.Y.Z` → Maven Central, `sdk-rust/vX.Y.Z` → crates.io). CI applies that version
+for the release build (Python, TypeScript, and Rust stamp package metadata on the runner;
+Java passes `-PreleaseVersion`) and does **not** commit the change.
 
 The committed fields still matter; they are not unused:
 
@@ -184,10 +185,11 @@ The committed fields still matter; they are not unused:
 | [`sdk-python/pyproject.toml`](sdk-python/pyproject.toml) `project.version` | Required package metadata. Used for local / editable installs (`pip` / `uv`), metadata queries, and aligning `uv.lock`. Also used when [`.github/workflows/sdk-python-publish.yml`](.github/workflows/sdk-python-publish.yml) runs on a **pull_request** (no tag): that dry-run builds wheels/sdists using the committed version. |
 | [`sdk-typescript/package.json`](sdk-typescript/package.json) `version` | Required package metadata. Used for local installs, `npm pack`, and keeping `package-lock.json` in sync. The TypeScript publish workflow only runs on release tags, so the committed value is not what npm receives unless CI has just rewritten it for that job. |
 | [`sdk-java/build.gradle`](sdk-java/build.gradle) default `releaseVersion` | Fallback when `-PreleaseVersion` is omitted (local / SNAPSHOT builds). Maven Central publish always supplies the version from the tag (or workflow_dispatch). |
+| [`sdk-rust/Cargo.toml`](sdk-rust/Cargo.toml) `workspace.package.version` | Required Cargo metadata shared by workspace crates. Local builds use it; the publish workflow temporarily stamps it and internal registry dependency requirements from the release tag. |
 
 What the committed value is **not**:
 
-- Not the source of the next PyPI / npm / Maven Central release (the tag /
+- Not the source of the next PyPI / npm / Maven Central / crates.io release (the tag /
   workflow_dispatch version is).
 - Not automatically updated in git when you publish a tag.
 - Not what examples pin when they depend on a registry version.
@@ -200,10 +202,11 @@ Practical workflow:
    - Python: `pyproject.toml` (+ `uv.lock`) and docs install pins
    - TypeScript: `package.json` (+ `package-lock.json`)
    - Java: default `…-SNAPSHOT` in `build.gradle` / smoke-test coords, plus README pins
+   - Rust: workspace package and internal dependency versions in `Cargo.toml`, plus `Cargo.lock`
 
-`package.json` cannot carry comments; the TypeScript SDK README Releases section
-documents the same tag-driven rule. `pyproject.toml` and `build.gradle` may note that
-publish takes the version from the tag.
+`package.json` cannot carry comments; the TypeScript and Rust SDK README Releases
+sections document the same tag-driven rule. `pyproject.toml` and `build.gradle` may
+note that publish takes the version from the tag.
 
 ## Package-specific guides
 

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -311,7 +311,7 @@ Dex environment. Each Worker automatically synchronizes its registered Indexed
 Attributes before listening. Gradle builds
 the Rust BlobCache JNI library and starts a fresh Java Worker for each E2E case
 with a unique worker port and flow ID. A clean checkout also requires Go 1.24+,
-Node.js 22+, Rust 1.88+, and Temporal CLI.
+Node.js 22+, Rust 1.97+, and Temporal CLI.
 
 ### Measure integration coverage
 
@@ -338,7 +338,7 @@ open the packaged Rust BlobCache library and perform a cache round trip.
 ./validate-publication.sh 0.0.3-local
 ```
 
-The command requires JDK 17, Rust 1.88+, and Maven. Published classes still
+The command requires JDK 17, Rust 1.97+, and Maven. Published classes still
 target Java 8.
 
 ### Validate public API documentation

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 edition = "2024"
 license-file = "LICENSE"
 repository = "https://github.com/superdurable/dex"
-rust-version = "1.88"
+rust-version = "1.97"
 
 [workspace.dependencies]
 crc32c = "0.6"

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -18,6 +18,8 @@ rust-version = "1.88"
 
 [workspace.dependencies]
 crc32c = "0.6"
+dex-blob-cache = { path = "crates/dex-blob-cache", version = "0.1.0" }
+dex-protocol = { path = "crates/dex-protocol", version = "0.1.0" }
 jni = "0.21"
 napi = { version = "3.12.0", default-features = false }
 napi-build = "2.4.0"

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -160,6 +160,8 @@ npm run build:native
 
 ## Development
 
+Rust 1.97 or newer is required.
+
 Format and test the workspace:
 
 ```bash

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -186,6 +186,17 @@ then removes the temporary state. Each Worker synchronizes its registered
 Indexed Attributes before listening; failure or the default two-minute
 deadline aborts startup.
 
+## Releases
+
+Publish `dex-sdk`, `dex-blob-cache`, and `dex-protocol` by creating a GitHub
+Release whose tag is `sdk-rust/vX.Y.Z`. The release workflow stamps all crate
+versions and internal registry requirements from the tag in its temporary
+checkout, then publishes the crates in dependency order. No version-bump commit
+is required before publishing.
+
+The workflow also supports a manual validation run. Manual publishing is
+restricted to `main` and requires the `CRATES_IO_TOKEN` repository secret.
+
 ## License
 
 [Super Durable Source License 1.0](LICENSE), with legacy portions under their

--- a/sdk-rust/crates/dex-blob-cache-jni/Cargo.toml
+++ b/sdk-rust/crates/dex-blob-cache-jni/Cargo.toml
@@ -6,10 +6,11 @@ license-file.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "Java JNI binding for the shared Dex DXBC blob cache"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-dex-blob-cache = { path = "../dex-blob-cache" }
+dex-blob-cache.workspace = true
 jni.workspace = true

--- a/sdk-rust/crates/dex-blob-cache-node/Cargo.toml
+++ b/sdk-rust/crates/dex-blob-cache-node/Cargo.toml
@@ -6,12 +6,13 @@ license-file.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "Node-API binding for the shared Dex DXBC blob cache"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-dex-blob-cache = { path = "../dex-blob-cache" }
+dex-blob-cache.workspace = true
 napi = { workspace = true, features = ["napi6"] }
 napi-derive.workspace = true
 

--- a/sdk-rust/crates/dex-blob-cache-python/Cargo.toml
+++ b/sdk-rust/crates/dex-blob-cache-python/Cargo.toml
@@ -6,11 +6,12 @@ license-file.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "Python binding for the shared Dex DXBC blob cache"
+publish = false
 
 [lib]
 name = "_native"
 crate-type = ["cdylib"]
 
 [dependencies]
-dex-blob-cache = { path = "../dex-blob-cache" }
+dex-blob-cache.workspace = true
 pyo3 = { workspace = true, features = ["abi3-py311", "extension-module"] }

--- a/sdk-rust/crates/dex-blob-cache/Cargo.toml
+++ b/sdk-rust/crates/dex-blob-cache/Cargo.toml
@@ -6,6 +6,7 @@ license-file.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "Go-compatible DXBC blob cache for Dex SDKs"
+publish = ["crates-io"]
 
 [dependencies]
 crc32c.workspace = true

--- a/sdk-rust/crates/dex-protocol/Cargo.toml
+++ b/sdk-rust/crates/dex-protocol/Cargo.toml
@@ -6,6 +6,7 @@ license-file.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "Generated Dex protobuf and gRPC protocol"
+publish = ["crates-io"]
 
 [dependencies]
 prost.workspace = true

--- a/sdk-rust/crates/dex-protocol/build.rs
+++ b/sdk-rust/crates/dex-protocol/build.rs
@@ -9,13 +9,21 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut prost_config = tonic_prost_build::Config::new();
     prost_config.protoc_executable(protoc_bin_vendored::protoc_bin_path()?);
-    let protos = [std::path::PathBuf::from("../../../protos/dex.proto")];
-    let includes = [
-        std::path::PathBuf::from("../../../protos"),
-        protoc_bin_vendored::include_path()?,
-    ];
+    let bundled_proto = std::path::PathBuf::from("proto/dex.proto");
+    let repository_proto = std::path::PathBuf::from("../../../protos/dex.proto");
+    let proto = if bundled_proto.exists() {
+        bundled_proto
+    } else {
+        repository_proto
+    };
+    let proto_include = proto
+        .parent()
+        .ok_or("Dex proto must have a parent directory")?
+        .to_path_buf();
+    let protos = [proto.clone()];
+    let includes = [proto_include, protoc_bin_vendored::include_path()?];
 
     tonic_prost_build::configure().compile_with_config(prost_config, &protos, &includes)?;
-    println!("cargo:rerun-if-changed=../../../protos/dex.proto");
+    println!("cargo:rerun-if-changed={}", proto.display());
     Ok(())
 }

--- a/sdk-rust/crates/dex-sdk/Cargo.toml
+++ b/sdk-rust/crates/dex-sdk/Cargo.toml
@@ -6,10 +6,11 @@ edition.workspace = true
 license-file.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+publish = ["crates-io"]
 
 [dependencies]
-dex-blob-cache = { path = "../dex-blob-cache" }
-dex-protocol = { path = "../dex-protocol" }
+dex-blob-cache.workspace = true
+dex-protocol.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 serde.workspace = true

--- a/sdk-rust/scripts/stamp_release_version.py
+++ b/sdk-rust/scripts/stamp_release_version.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Super Durable Source License 1.0.
+# You may not use this file except in compliance with the License.
+# See the LICENSE file in the repository root.
+#
+# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+"""Stamp Rust workspace package metadata for a release build."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+PUBLISHED_DEPENDENCIES = ("dex-blob-cache", "dex-protocol")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+    )
+    parser.add_argument("--stage-protocol", action="store_true")
+    arguments = parser.parse_args()
+    manifest_path = arguments.workspace / "Cargo.toml"
+    lock_path = arguments.workspace / "Cargo.lock"
+
+    manifest_text = manifest_path.read_text()
+    manifest_text = replace_workspace_version(manifest_text, arguments.version)
+    for dependency in PUBLISHED_DEPENDENCIES:
+        manifest_text = replace_dependency_version(
+            manifest_text, dependency, arguments.version
+        )
+    manifest_path.write_text(manifest_text)
+
+    workspace_packages = read_workspace_packages(arguments.workspace, manifest_text)
+    lock_text = lock_path.read_text()
+    for package in workspace_packages:
+        lock_text = replace_lock_version(lock_text, package, arguments.version)
+    lock_path.write_text(lock_text)
+
+    if arguments.stage_protocol:
+        stage_protocol(arguments.workspace)
+
+    return validate_versions(
+        manifest_path,
+        lock_path,
+        workspace_packages,
+        arguments.version,
+    )
+
+
+def replace_workspace_version(text: str, version: str) -> str:
+    pattern = r'(?ms)(\[workspace\.package\].*?^version = ")[^"]+("$)'
+    return replace_once(text, pattern, rf"\g<1>{version}\g<2>", "workspace version")
+
+
+def replace_dependency_version(text: str, dependency: str, version: str) -> str:
+    pattern = (
+        rf'(?m)^({re.escape(dependency)} = \{{[^\n]*version = ")'
+        r'[^"]+("[^\n]*\})$'
+    )
+    return replace_once(
+        text,
+        pattern,
+        rf"\g<1>{version}\g<2>",
+        f"{dependency} dependency version",
+    )
+
+
+def replace_lock_version(text: str, package: str, version: str) -> str:
+    pattern = rf'(?m)(^name = "{re.escape(package)}"\nversion = ")[^"]+("$)'
+    return replace_once(
+        text,
+        pattern,
+        rf"\g<1>{version}\g<2>",
+        f"{package} lock version",
+    )
+
+
+def replace_once(text: str, pattern: str, replacement: str, field: str) -> str:
+    updated, count = re.subn(pattern, replacement, text, count=1)
+    if count != 1:
+        raise ValueError(f"failed to stamp {field}")
+    return updated
+
+
+def read_workspace_packages(workspace: Path, manifest_text: str) -> tuple[str, ...]:
+    manifest = tomllib.loads(manifest_text)
+    packages = []
+    for member in manifest["workspace"]["members"]:
+        member_manifest = tomllib.loads((workspace / member / "Cargo.toml").read_text())
+        if member_manifest["package"]["version"].get("workspace") is True:
+            packages.append(member_manifest["package"]["name"])
+    return tuple(packages)
+
+
+def stage_protocol(workspace: Path) -> None:
+    source = workspace.parent / "protos" / "dex.proto"
+    destination = workspace / "crates" / "dex-protocol" / "proto" / "dex.proto"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(source.read_bytes())
+
+
+def validate_versions(
+    manifest_path: Path,
+    lock_path: Path,
+    workspace_packages: tuple[str, ...],
+    expected: str,
+) -> int:
+    manifest = tomllib.loads(manifest_path.read_text())
+    actual_versions = {"workspace": manifest["workspace"]["package"]["version"]}
+    for dependency in PUBLISHED_DEPENDENCIES:
+        actual_versions[dependency] = manifest["workspace"]["dependencies"][dependency][
+            "version"
+        ]
+
+    lock = tomllib.loads(lock_path.read_text())
+    lock_versions = {
+        package["name"]: package["version"]
+        for package in lock["package"]
+        if package["name"] in workspace_packages
+    }
+    actual_versions.update(lock_versions)
+
+    mismatches = {
+        name: version for name, version in actual_versions.items() if version != expected
+    }
+    missing = set(workspace_packages) - lock_versions.keys()
+    if mismatches or missing:
+        print(
+            f"release version validation failed: mismatches={mismatches}, missing={missing}",
+            file=sys.stderr,
+        )
+        return 1
+    print(expected)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (KeyError, OSError, TypeError, ValueError, tomllib.TOMLDecodeError) as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1) from error


### PR DESCRIPTION
## Summary

- add a tag-driven crates.io publishing workflow for `sdk-rust/vX.Y.Z` releases
- stamp workspace, lockfile, and internal dependency versions only in the release checkout
- publish `dex-blob-cache`, `dex-protocol`, and `dex-sdk` in dependency order
- prevent the JNI, Python, and Node binding crates from being published accidentally
- bundle `dex.proto` into the packaged protocol crate so registry consumers can compile it
- raise the Rust SDK MSRV and all native SDK build workflows from Rust 1.88 to 1.97

## Rationale and user impact

Rust SDK releases currently require package metadata changes and the protocol crate cannot compile outside the monorepo. This makes the GitHub Release tag the source of truth, matching the Java, Python, and TypeScript SDK release model. Maintainers can publish without a version-bump commit, while crates.io users receive self-contained packages.

Cargo 1.88 cannot package multiple unpublished workspace crates with dependencies between them. Rust 1.97 supports that release validation flow, so the Rust SDK now requires Rust 1.97 or newer. Java, Python, and TypeScript workflows that compile the shared native crates use the same pinned toolchain.

The workflow requires the `CRATES_IO_TOKEN` repository secret. Manual publishing remains restricted to `main`; manual validation can run without publishing.

## Validation

- `RUSTUP_TOOLCHAIN=1.97.1 cargo package --locked --allow-dirty -p dex-blob-cache -p dex-protocol -p dex-sdk`
- `RUSTUP_TOOLCHAIN=1.97.1 make -C sdk-rust test 2>&1 | tee /tmp/test-rust-sdk-toolchain-upgrade.log`
- `RUSTUP_TOOLCHAIN=1.97.1 make lint 2>&1 | tee /tmp/test-rust-sdk-toolchain-upgrade-lint.log` (from `sdk-rust`)
- `RUSTUP_TOOLCHAIN=1.97.1 make docs-check 2>&1 | tee /tmp/test-rust-sdk-toolchain-upgrade-docs.log` (from `sdk-rust`)
- `make copyright-check`
- `make ci-runner-check`
- parsed all updated GitHub Actions workflows as YAML
