### PR TITLE
Aggregate server integration test coverage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,5 @@ sdk-java/publication-smoke-test/target/
 sdk-typescript/coverage/
 sdk-python/coverage/
 sdk-go/coverage/
+server/coverage/
+server/coverage-raw/

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - "server/**"
       - "protos/**"
+      - "codecov.yml"
       - ".github/scripts/dump-docker-logs.sh"
       - ".github/workflows/server-ci.yml"
   pull_request:
     paths:
       - "server/**"
       - "protos/**"
+      - "codecov.yml"
       - ".github/scripts/dump-docker-logs.sh"
       - ".github/workflows/server-ci.yml"
   workflow_dispatch:
@@ -54,7 +56,15 @@ jobs:
       - name: Attribute Store integration tests
         env:
           GOWORK: "off"
-        run: make attributeStoreIntegTests
+        run: make attributeStoreIntegTests integrationCoverageDir=coverage-raw
+      - name: Upload integration coverage data
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: server-integration-coverage-attribute-store
+          path: server/coverage-raw/
+          if-no-files-found: ignore
+          retention-days: 1
       - name: Dump docker logs
         if: always()
         run: bash "$GITHUB_WORKSPACE/.github/scripts/dump-docker-logs.sh"
@@ -77,7 +87,15 @@ jobs:
       - name: Blob Store integration tests
         env:
           GOWORK: "off"
-        run: make blobStoreIntegTests
+        run: make blobStoreIntegTests integrationCoverageDir=coverage-raw
+      - name: Upload integration coverage data
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: server-integration-coverage-blob-store
+          path: server/coverage-raw/
+          if-no-files-found: ignore
+          retention-days: 1
       - name: Dump docker logs
         if: always()
         run: bash "$GITHUB_WORKSPACE/.github/scripts/dump-docker-logs.sh"
@@ -110,7 +128,15 @@ jobs:
       - name: Web API integration tests
         env:
           GOWORK: "off"
-        run: make ${{ matrix.make_target }}
+        run: make ${{ matrix.make_target }} integrationCoverageDir=coverage-raw
+      - name: Upload integration coverage data
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: server-integration-coverage-web-api-${{ matrix.backend }}
+          path: server/coverage-raw/
+          if-no-files-found: ignore
+          retention-days: 1
       - name: Dump docker logs
         if: always()
         run: bash "$GITHUB_WORKSPACE/.github/scripts/dump-docker-logs.sh"
@@ -137,7 +163,15 @@ jobs:
       - name: Temporal integ tests
         env:
           GOWORK: "off"
-        run: make ci-temporal-integ-test totalPartitions=5 partitionNum=${{ matrix.partition }}
+        run: make ci-temporal-integ-test totalPartitions=5 partitionNum=${{ matrix.partition }} integrationCoverageDir=coverage-raw
+      - name: Upload integration coverage data
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: server-integration-coverage-temporal-${{ matrix.partition }}
+          path: server/coverage-raw/
+          if-no-files-found: ignore
+          retention-days: 1
       - name: Dump docker logs
         if: always()
         run: bash "$GITHUB_WORKSPACE/.github/scripts/dump-docker-logs.sh"
@@ -164,7 +198,60 @@ jobs:
       - name: Cadence integ tests
         env:
           GOWORK: "off"
-        run: make ci-cadence-integ-test totalPartitions=5 partitionNum=${{ matrix.partition }}
+        run: make ci-cadence-integ-test totalPartitions=5 partitionNum=${{ matrix.partition }} integrationCoverageDir=coverage-raw
+      - name: Upload integration coverage data
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: server-integration-coverage-cadence-${{ matrix.partition }}
+          path: server/coverage-raw/
+          if-no-files-found: ignore
+          retention-days: 1
       - name: Dump docker logs
         if: always()
         run: bash "$GITHUB_WORKSPACE/.github/scripts/dump-docker-logs.sh"
+
+  integration-coverage:
+    name: Integration coverage
+    needs:
+      - attribute-store-integ
+      - blob-store-integ
+      - web-api-integ
+      - temporal-integ
+      - cadence-integ
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+      - name: Download integration coverage data
+        uses: actions/download-artifact@v7
+        with:
+          pattern: server-integration-coverage-*
+          path: server/coverage-raw
+      - name: Merge integration coverage
+        run: ./script/merge-integ-coverage.sh coverage coverage-raw/*
+      - name: Upload server integration coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          disable_search: true
+          fail_ci_if_error: true
+          files: ./server/coverage/coverage.out
+          flags: server-integration
+          name: server-integration
+          use_oidc: true
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: server-integration-coverage
+          path: server/coverage/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 *.test
 *.out
 coverage.out
+server/coverage/
+server/coverage-raw/
 sdk-go/coverage/
 dex-server
 examples/go/dex-samples

--- a/server/CONTRIBUTING.md
+++ b/server/CONTRIBUTING.md
@@ -193,6 +193,26 @@ make ci-cadence-integ-test totalPartitions=5 partitionNum=0
 the complete suite. Each CI partition uses an independent runner and backend
 stack.
 
+### Measure integration coverage
+
+Run the main Temporal and Cadence integration suite with Go coverage:
+
+```shell
+make integrationCoverage
+```
+
+The report measures production packages under `./service/...` from integration
+tests only. It does not run `unitTests`. Open `coverage/index.html` for annotated
+source, or inspect `coverage/coverage.txt` for per-function totals.
+`coverage/coverage.out` is the profile format uploaded by CI.
+
+Server CI also instruments the Attribute Store, Blob Store, Web API, Temporal,
+and Cadence integration jobs. Each matrix partition publishes binary Go coverage
+data, and the `Integration coverage` job merges every successful partition before
+uploading one report to Codecov. The upload uses the `server-integration` flag
+and GitHub OIDC. The merged HTML, text, and profile reports are available in the
+`server-integration-coverage` Actions artifact.
+
 To debug the failed test, search for `--- FAIL` in the output logs (in GitHub Action, click "view raw logs"") 
 
 ### Pending Step failures

--- a/server/Makefile
+++ b/server/Makefile
@@ -140,7 +140,7 @@ dex-server:
 	@echo "compiling dex-server with OS: $(GOOS), ARCH: $(GOARCH)"
 	@go build -o $@ cmd/server/main.go
 
-.PHONY: bins release clean replayTests
+.PHONY: bins release clean replayTests integrationCoverage prepareIntegrationCoverage
 
 idl-code-gen: # regenerate protobuf stubs from protos/dex.proto into server + SDKs
 	$(MAKE) -C ../protos proto
@@ -168,75 +168,86 @@ deps-all: ## Check for all dependency updates
 cleanTestCache:
 	$Q go clean -testcache
 
-integTestsTemporalWithCover: # for local debugging
-	$Q go test -v -cover ./integ -coverprofile coverage.out -coverpkg ./service/... -cadence=false
-	$Q go tool cover -func coverage.out -o coverage.out
+integrationCoverageDir ?=
+integrationCoverageFlags = $(if $(integrationCoverageDir),-covermode=atomic -coverpkg=./service/...)
+integrationCoverageArgs = $(if $(integrationCoverageDir),-args -test.gocoverdir="$(abspath $(integrationCoverageDir))")
 
-integTests:
-	$Q go test -v ./integ -timeout 20m
+prepareIntegrationCoverage:
+	$(if $(integrationCoverageDir),$Q mkdir -p "$(abspath $(integrationCoverageDir))")
 
-temporalIntegTests:
-	$Q go test -v ./integ -timeout 20m -cadence=false
+integrationCoverage:
+	$Q set -e; \
+		coverage_raw_dir="$$(mktemp -d)"; \
+		trap 'rm -rf "$$coverage_raw_dir"' EXIT; \
+		$(MAKE) --no-print-directory integTests integrationCoverageDir="$$coverage_raw_dir"; \
+		./script/merge-integ-coverage.sh coverage "$$coverage_raw_dir"
+
+integTests: prepareIntegrationCoverage
+	$Q go test $(integrationCoverageFlags) -v ./integ -timeout 20m $(integrationCoverageArgs)
+
+temporalIntegTests: prepareIntegrationCoverage
+	$Q go test $(integrationCoverageFlags) -v ./integ -timeout 20m -cadence=false $(integrationCoverageArgs)
 
 dexServerAddress ?= 127.0.0.1:8801
 temporalHostPort ?= 127.0.0.1:7233
 skipContinueAsNewTests ?= true
 
-temporalIntegTestsAgainstLocalDexDev:
+temporalIntegTestsAgainstLocalDexDev: prepareIntegrationCoverage
 	$Q set -e; \
 		test_run_pattern='.'; \
 		if [ "$(skipContinueAsNewTests)" = "true" ]; then \
 			test_run_pattern="$$(go test -v ./integ -list '^Test' -temporal=false -cadence=false -dependencyWaitSeconds=0 | awk '/^Test/ && $$0 !~ /ContinueAsNew/ { tests = tests separator $$0; separator = "|" } END { print "^(" tests ")$$" }')"; \
 		fi; \
-		go test -v ./integ -timeout 20m -run "$$test_run_pattern" -search=false -cadence=false -dexServerAddress=$(dexServerAddress) -temporalHostPort=$(temporalHostPort)
+		go test $(integrationCoverageFlags) -v ./integ -timeout 20m -run "$$test_run_pattern" -search=false -cadence=false -dexServerAddress=$(dexServerAddress) -temporalHostPort=$(temporalHostPort) $(integrationCoverageArgs)
 
-cadenceIntegTests:
-	$Q go test -v ./integ -timeout 20m -temporal=false
+cadenceIntegTests: prepareIntegrationCoverage
+	$Q go test $(integrationCoverageFlags) -v ./integ -timeout 20m -temporal=false $(integrationCoverageArgs)
 
-ci-web-api-temporal-test:
-	$Q go test -v ./integ -timeout 5m -run '^TestWebAPITemporal$$' -search=false -cadence=false -dependencyWaitSeconds=60 -temporalHostPort=$(temporalHostPort)
+ci-web-api-temporal-test: prepareIntegrationCoverage
+	$Q go test $(integrationCoverageFlags) -v ./integ -timeout 5m -run '^TestWebAPITemporal$$' -search=false -cadence=false -dependencyWaitSeconds=60 -temporalHostPort=$(temporalHostPort) $(integrationCoverageArgs)
 
-ci-web-api-cadence-test:
-	$Q go test -v ./integ -timeout 5m -run '^TestWebAPICadence$$' -search=false -temporal=false -dependencyWaitSeconds=180
+ci-web-api-cadence-test: prepareIntegrationCoverage
+	$Q go test $(integrationCoverageFlags) -v ./integ -timeout 5m -run '^TestWebAPICadence$$' -search=false -temporal=false -dependencyWaitSeconds=180 $(integrationCoverageArgs)
 
 totalPartitions ?= 1
 partitionNum ?= 0
 
-ci-cadence-integ-test:
+ci-cadence-integ-test: prepareIntegrationCoverage
 	$Q set -e; \
 		test_run_pattern="$$(./script/select-integ-test-partition.sh "$(totalPartitions)" "$(partitionNum)")"; \
-		go test -v ./integ -timeout 20m -run "$$test_run_pattern" -search=false -temporal=false -dependencyWaitSeconds=180
+		go test $(integrationCoverageFlags) -v ./integ -timeout 20m -run "$$test_run_pattern" -search=false -temporal=false -dependencyWaitSeconds=180 $(integrationCoverageArgs)
 
-ci-cadence-integ-test-disable-sticky:
-	$Q go test -v ./integ -run "(?i)^Test[${startsWith}]" -search=false -temporal=false -dependencyWaitSeconds=180 -disableStickyCache
+ci-cadence-integ-test-disable-sticky: prepareIntegrationCoverage
+	$Q go test $(integrationCoverageFlags) -v ./integ -run "(?i)^Test[${startsWith}]" -search=false -temporal=false -dependencyWaitSeconds=180 -disableStickyCache $(integrationCoverageArgs)
 
-ci-temporal-integ-test:
+ci-temporal-integ-test: prepareIntegrationCoverage
 	$Q set -e; \
 		test_run_pattern="$$(./script/select-integ-test-partition.sh "$(totalPartitions)" "$(partitionNum)")"; \
-		go test -v ./integ -timeout 20m -run "$$test_run_pattern" -search=false -cadence=false -dependencyWaitSeconds=60
+		go test $(integrationCoverageFlags) -v ./integ -timeout 20m -run "$$test_run_pattern" -search=false -cadence=false -dependencyWaitSeconds=60 $(integrationCoverageArgs)
 
-ci-temporal-integ-test-disable-sticky:
-	$Q go test -v ./integ -timeout 20m -run "(?i)^Test[${startsWith}]" -search=false -cadence=false -dependencyWaitSeconds=60 -disableStickyCache
+ci-temporal-integ-test-disable-sticky: prepareIntegrationCoverage
+	$Q go test $(integrationCoverageFlags) -v ./integ -timeout 20m -run "(?i)^Test[${startsWith}]" -search=false -cadence=false -dependencyWaitSeconds=60 -disableStickyCache $(integrationCoverageArgs)
 
 ci-all-tests:
 	$Q go test -v ./... -timeout 20m -cover -coverprofile coverage.out -coverpkg ./service/...
 
-integTestsNoSearch:
-	$Q go test -v ./integ -search=false -timeout 20m
+integTestsNoSearch: prepareIntegrationCoverage
+	$Q go test $(integrationCoverageFlags) -v ./integ -search=false -timeout 20m $(integrationCoverageArgs)
 
 unitTests:
 	@GOWORK=off go test -v $$(GOWORK=off go list ./service/... | grep -v ./service/common/blobstore)
+	@GOWORK=off go test -v ./service/common/blobstore -run '^TestDeterministicBlobUUID'
 
 # Requires SQL dependencies and covers both workflow backends in dedicated CI.
-attributeStoreIntegTests:
-	@GOWORK=off go test -v -tags=attributestore_integration ./service/common/attributestore -timeout 5m
-	@GOWORK=off go test -v -tags=attributestore_integration ./integ -run '^TestAttributeSync' -timeout 10m
+attributeStoreIntegTests: prepareIntegrationCoverage
+	@GOWORK=off go test $(integrationCoverageFlags) -v -tags=attributestore_integration ./service/common/attributestore -run '^TestMySQLAndPostgresAttributeStoreIntegration$$' -timeout 5m $(integrationCoverageArgs)
+	@GOWORK=off go test $(integrationCoverageFlags) -v -tags=attributestore_integration ./integ -run '^TestAttributeSync' -timeout 10m $(integrationCoverageArgs)
 
-blobStoreIntegTests:
-	@GOWORK=off go test -v ./service/common/blobstore -timeout 5m
+blobStoreIntegTests: prepareIntegrationCoverage
+	@GOWORK=off go test $(integrationCoverageFlags) -v ./service/common/blobstore -run '^(TestBlobStoreIntegration|TestLocalBlobStore|TestS3AttributeBlobCache)' -timeout 5m $(integrationCoverageArgs)
 
-localBlobStoreTests:
-	@GOWORK=off go test -v ./service/common/blobstore -run '^TestLocalBlobStore'
+localBlobStoreTests: prepareIntegrationCoverage
+	@GOWORK=off go test $(integrationCoverageFlags) -v ./service/common/blobstore -run '^TestLocalBlobStore' $(integrationCoverageArgs)
 
 replayTests:
 	@GOWORK=off go test -v ./replayTests -timeout 10m

--- a/server/script/merge-integ-coverage.sh
+++ b/server/script/merge-integ-coverage.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <output-dir> <coverage-data-dir> [<coverage-data-dir> ...]" >&2
+  exit 2
+fi
+
+output_dir=$1
+shift
+coverage_dirs=("$@")
+shopt -s nullglob
+for coverage_dir in "${coverage_dirs[@]}"; do
+  if [[ ! -d "$coverage_dir" ]]; then
+    echo "coverage data directory does not exist: $coverage_dir" >&2
+    exit 1
+  fi
+  coverage_metadata=("$coverage_dir"/covmeta.*)
+  coverage_counters=("$coverage_dir"/covcounters.*)
+  if [[ ${#coverage_metadata[@]} -eq 0 || ${#coverage_counters[@]} -eq 0 ]]; then
+    echo "coverage data directory is incomplete: $coverage_dir" >&2
+    exit 1
+  fi
+done
+
+coverage_inputs=$(IFS=,; echo "${coverage_dirs[*]}")
+mkdir -p "$output_dir"
+rm -f "$output_dir/coverage.out" "$output_dir/coverage.txt" "$output_dir/index.html"
+go tool covdata textfmt -i="$coverage_inputs" -o="$output_dir/coverage.out"
+go tool cover -func="$output_dir/coverage.out" | tee "$output_dir/coverage.txt"
+go tool cover -html="$output_dir/coverage.out" -o="$output_dir/index.html"


### PR DESCRIPTION
## Summary

- instrument all server integration jobs with Go binary coverage output
- collect coverage from Attribute Store, Blob Store, Web API, Temporal, and Cadence matrix shards, then merge and upload one `server-integration` report to Codecov
- add a local `make integrationCoverage` workflow and document the generated profile, text, and HTML reports
- keep unit tests out of integration coverage while preserving Blob Store unit cases in `unitTests`

## Rationale

Server integration tests run across 14 separate CI executions, so no single job currently sees the complete integration coverage. Publishing raw covdata from each shard and merging it after every integration job succeeds produces one accurate server integration profile without mixing in unit coverage.

## User impact

No production behavior changes. Server CI gains an integration-only Codecov report and a downloadable `server-integration-coverage` artifact. Local contributors can generate the main Temporal/Cadence integration report with `make -C server integrationCoverage`.

## Validation

- generated coverage from two independent Blob Store integration shards and merged both with `merge-integ-coverage.sh`
- `make -C server unitTests`
- `actionlint .github/workflows/server-ci.yml`
- `shellcheck server/script/merge-integ-coverage.sh`
- `make copyright-check`
