### PR TITLE
ci: rebuild Python native extension after cache restore

### DIFF
--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: sdk-python
         enable-cache: true
     - name: Install dependencies
-      run: uv sync --locked
+      run: uv sync --locked --reinstall-package dex-python-sdk
     - name: Test contracts
       run: uv run --frozen pytest tests/test_contracts.py
     - name: Check static types with mypy
@@ -167,7 +167,7 @@ jobs:
         working-directory: sdk-python
         enable-cache: true
     - name: Install dependencies
-      run: uv sync --locked
+      run: uv sync --locked --reinstall-package dex-python-sdk
     - name: Run Python and dexcli dev integration coverage
       run: ./run-integration-tests.sh --coverage
     - name: Upload Python integration coverage to Codecov


### PR DESCRIPTION
## Summary

- rebuild the local Python SDK package after restoring the uv cache in contract jobs
- apply the same safeguard to Python integration jobs

## Rationale

uv caches maturin's editable build metadata, while the generated `dex._native` extension lives in the checkout and is removed by checkout cleanup. A subsequent fresh environment can therefore install the cached editable package without recreating the native module.

`--reinstall-package dex-python-sdk` refreshes and rebuilds only the local SDK package while retaining cached third-party dependencies.

## User impact

Restores reliable Python SDK CI on main. Runtime behavior and public APIs are unchanged.

## Validation

- reproduced the stale-cache `ModuleNotFoundError: No module named 'dex._native'`
- Python 3.11 contracts: 22 passed
- Python 3.11 mypy and pyright: passed
- Python 3.13 contracts: 22 passed
- Python 3.13 mypy and pyright: passed
- Python integration suite with coverage: 51 passed
- `actionlint .github/workflows/sdk-python-ci.yml`
- `make copyright-check`
