### PR TITLE
ci: activate Rust 1.97 for Python builds

### DIFF
--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -33,6 +33,9 @@ on:
 permissions:
   contents: read
 
+env:
+  RUSTUP_TOOLCHAIN: "1.97.1"
+
 concurrency:
   group: sdk-python-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- activate Rust 1.97.1 for every Python SDK CI job
- ensure `uv` and maturin use the compiler installed by the workflow

## Rationale

Python CI forced a native package rebuild after cache restoration, but `rustup toolchain install` did not select the new toolchain. The self-hosted runner continued using Rust 1.88, while the blob-cache crates require Rust 1.97.

## User impact

Python 3.11 and 3.13 CI can rebuild and import `dex._native` consistently on clean or restored environments.

## Validation

- `make ci-runner-check`
- workflow lint and YAML parse
- Python 3.11: `uv sync --locked --reinstall-package dex-python-sdk`; 22 contract tests passed
- Python 3.13: `uv sync --locked --reinstall-package dex-python-sdk`; 22 contract tests passed
