### PR TITLE
ci: report Rust SDK integration coverage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@ examples/go/dex-samples
 examples/go/deepverify
 sdk-typescript/node_modules/
 sdk-rust/target/
+sdk-rust/coverage/
 sdk-typescript/dist/
 sdk-java/publication-smoke-test/target/
 sdk-typescript/coverage/

--- a/.github/workflows/sdk-rust-ci.yml
+++ b/.github/workflows/sdk-rust-ci.yml
@@ -9,6 +9,7 @@ on:
       - "server/**"
       - "protos/**"
       - "web/**"
+      - "codecov.yml"
       - ".github/workflows/sdk-rust-ci.yml"
   pull_request:
     paths:
@@ -17,6 +18,7 @@ on:
       - "server/**"
       - "protos/**"
       - "web/**"
+      - "codecov.yml"
       - ".github/workflows/sdk-rust-ci.yml"
   workflow_dispatch:
 
@@ -70,9 +72,12 @@ jobs:
         run: cargo test --workspace --locked
 
   integration:
-    name: Integration tests
+    name: Integration coverage
     runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 25
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: sdk-rust
@@ -94,8 +99,26 @@ jobs:
         uses: temporalio/setup-temporal@v0
       - name: Install Rust
         run: rustup toolchain install 1.97.1 --profile minimal
-      - name: Run integration tests
-        run: ./run-integration-tests.sh
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run integration coverage
+        run: ./run-integration-tests.sh --coverage
+      - name: Upload Rust integration coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          disable_search: true
+          fail_ci_if_error: true
+          files: ./sdk-rust/coverage/lcov.info
+          flags: sdk-rust-integration
+          name: sdk-rust-integration
+          use_oidc: true
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdk-rust-integration-coverage
+          path: sdk-rust/coverage/
+          if-no-files-found: ignore
       - name: Upload service logs
         if: always()
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ dist/
 
 # Rust
 sdk-rust/target/
+sdk-rust/coverage/
 
 # TypeScript
 sdk-typescript/node_modules/

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -189,6 +189,25 @@ then removes the temporary state. Each Worker synchronizes its registered
 Indexed Attributes before listening; failure or the default two-minute
 deadline aborts startup.
 
+### Measure integration coverage
+
+Install `cargo-llvm-cov`, then run the same integration suite with Rust source
+coverage:
+
+```bash
+cargo install cargo-llvm-cov --locked
+./run-integration-tests.sh --coverage
+```
+
+Only the `integ` and `cross_sdk` integration test targets contribute execution
+data. Test sources and dependencies are excluded from the report by
+`cargo-llvm-cov`; coverage is reported for the production `dex-sdk` crate.
+
+The LCOV report is written to `coverage/lcov.info`, and the browser report
+starts at `coverage/html/index.html`. CI uploads the LCOV report with the
+`sdk-rust-integration` flag and retains the full report as the
+`sdk-rust-integration-coverage` Actions artifact.
+
 ## Releases
 
 Publish `dex-sdk`, `dex-blob-cache`, and `dex-protocol` by creating a GitHub

--- a/sdk-rust/crates/dex-sdk/tests/integ/README.md
+++ b/sdk-rust/crates/dex-sdk/tests/integ/README.md
@@ -31,6 +31,9 @@ Run all scenarios against an isolated `dexcli dev` stack from `sdk-rust`:
 ./run-integration-tests.sh
 ```
 
+To collect production `dex-sdk` coverage from only these integration targets,
+install `cargo-llvm-cov` and run `./run-integration-tests.sh --coverage`.
+
 Go's erased `ChannelDef` variant has no Rust counterpart: Rust keeps typed
 `Channel<T>` values through registration, so the runtime channel scenario does
 not need a second type-erased test. Go's pointer/value Flow cases likewise map

--- a/sdk-rust/run-integration-tests.sh
+++ b/sdk-rust/run-integration-tests.sh
@@ -10,6 +10,16 @@
 
 set -euo pipefail
 
+coverage=false
+if [[ "${1:-}" == "--coverage" ]]; then
+  coverage=true
+  shift
+fi
+if [[ "$#" -ne 0 ]]; then
+  echo "usage: $0 [--coverage]" >&2
+  exit 2
+fi
+
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$script_dir/.." && pwd)
 dex_port="${DEX_INTEG_DEX_PORT:-18821}"
@@ -77,9 +87,22 @@ if ! $dex_ready; then
 fi
 
 cd "$script_dir"
-DEX_SERVER_ADDRESS="$dex_address" cargo test -p dex-sdk \
-  --test integ \
-  --test cross_sdk \
-  -- \
-  --ignored \
-  --test-threads=1
+if $coverage; then
+  cargo llvm-cov clean --workspace
+  DEX_SERVER_ADDRESS="$dex_address" cargo llvm-cov --no-report -p dex-sdk \
+    --test integ \
+    --test cross_sdk \
+    -- \
+    --ignored \
+    --test-threads=1
+  mkdir -p coverage
+  cargo llvm-cov report -p dex-sdk --lcov --output-path coverage/lcov.info
+  cargo llvm-cov report -p dex-sdk --html --output-dir coverage
+else
+  DEX_SERVER_ADDRESS="$dex_address" cargo test -p dex-sdk \
+    --test integ \
+    --test cross_sdk \
+    -- \
+    --ignored \
+    --test-threads=1
+fi


### PR DESCRIPTION
## Summary

- collect Rust SDK coverage from only the `integ` and `cross_sdk` integration test targets
- upload LCOV results to Codecov with the `sdk-rust-integration` flag
- retain the HTML coverage report as a GitHub Actions artifact
- document the local integration coverage workflow and ignore generated reports

## Rationale

The published Rust SDK should report coverage consistently with the Java and Python SDKs while keeping unit-test execution data out of the metric.

## User impact

Contributors can run `./run-integration-tests.sh --coverage` to generate `coverage/lcov.info` and `coverage/html/index.html`. Rust SDK pull requests now publish integration-only coverage to Codecov.

## Validation

- `RUSTUP_TOOLCHAIN=1.88.0 ./run-integration-tests.sh --coverage` (70 passed)
- verified all LCOV source paths are under `sdk-rust/crates/dex-sdk/src/`
- `make copyright-check`
- workflow YAML parse, `bash -n`, and `git diff --check`
