### PR TITLE
Filter system workflows from Dex Web search

### DIFF
--- a/web/api/handlers.go
+++ b/web/api/handlers.go
@@ -23,7 +23,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const maxRequestBytes = 1 << 20
+const (
+	maxRequestBytes               = 1 << 20
+	engineWorkflowVisibilityQuery = `WorkflowType = "Engine"`
+)
 
 type handler struct {
 	client dexpb.FlowServiceClient
@@ -62,7 +65,7 @@ func (h *handler) searchFlows(response http.ResponseWriter, request *http.Reques
 		body.PageSize = 50
 	}
 	result, err := h.client.SearchFlows(request.Context(), &dexpb.SearchFlowsRequest{
-		Query:         body.Query,
+		Query:         engineWorkflowSearchQuery(body.Query),
 		PageSize:      body.PageSize,
 		NextPageToken: body.NextPageToken,
 	})
@@ -78,6 +81,13 @@ func (h *handler) searchFlows(response http.ResponseWriter, request *http.Reques
 		Flows:         flows,
 		NextPageToken: result.GetNextPageToken(),
 	})
+}
+
+func engineWorkflowSearchQuery(query string) string {
+	if strings.TrimSpace(query) == "" {
+		return engineWorkflowVisibilityQuery
+	}
+	return fmt.Sprintf("(%s) AND (%s)", query, engineWorkflowVisibilityQuery)
 }
 
 func (h *handler) getFlowSummary(response http.ResponseWriter, request *http.Request) {

--- a/web/server_integ_test.go
+++ b/web/server_integ_test.go
@@ -35,6 +35,7 @@ type flowService struct {
 	dexpb.UnimplementedFlowServiceServer
 	waitStarted       chan struct{}
 	waitCanceled      chan struct{}
+	searchRequests    chan *dexpb.SearchFlowsRequest
 	loadBlobsRequests chan *dexpb.LoadBlobsRequest
 	loadBlobsError    error
 	stopRequests      chan *dexpb.StopFlowRequest
@@ -90,6 +91,43 @@ func TestWebServerMapsGRPCErrors(t *testing.T) {
 	decodeResponse(t, response, &result)
 	if result.Error != "invalid flow" || result.GRPCCode != int32(codes.InvalidArgument) {
 		t.Fatalf("unexpected error response: %+v", result)
+	}
+}
+
+func TestWebServerScopesSearchesToEngineWorkflows(t *testing.T) {
+	service := &flowService{
+		searchRequests: make(chan *dexpb.SearchFlowsRequest, 2),
+	}
+	harness := newHarness(t, service)
+
+	testCases := []struct {
+		name      string
+		body      string
+		wantQuery string
+	}{
+		{
+			name:      "empty query",
+			body:      `{"pageSize":10}`,
+			wantQuery: `WorkflowType = "Engine"`,
+		},
+		{
+			name:      "user query",
+			body:      `{"query":"ExecutionStatus = \"Running\"","pageSize":10}`,
+			wantQuery: `(ExecutionStatus = "Running") AND (WorkflowType = "Engine")`,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			response := postJSON(t, harness.http.URL+"/api/flows/search", testCase.body)
+			defer response.Body.Close()
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("search status = %d", response.StatusCode)
+			}
+			request := <-service.searchRequests
+			if request.GetQuery() != testCase.wantQuery {
+				t.Fatalf("query = %q, want %q", request.GetQuery(), testCase.wantQuery)
+			}
+		})
 	}
 }
 
@@ -234,9 +272,12 @@ func TestWebServerStopsFlow(t *testing.T) {
 }
 
 func (s *flowService) SearchFlows(
-	context.Context,
-	*dexpb.SearchFlowsRequest,
+	_ context.Context,
+	request *dexpb.SearchFlowsRequest,
 ) (*dexpb.SearchFlowsResponse, error) {
+	if s.searchRequests != nil {
+		s.searchRequests <- request
+	}
 	return &dexpb.SearchFlowsResponse{
 		FlowRuns: []*dexpb.SearchFlowsResponseEntry{{
 			FlowId:   "checkout-1",


### PR DESCRIPTION
## Summary

- constrain every Dex Web flow search to Temporal/Cadence workflow type `Engine`
- preserve user-provided visibility filters by combining them with the Engine predicate
- cover empty and existing-query behavior with Web server integration tests

## Rationale

Dex Web is a Flow-oriented UI, but its search endpoint previously forwarded visibility queries unchanged. Empty searches therefore included internal workflows such as `BlobStoreCleanup`.

## User impact

The Flow search/list page now shows only real Dex Flow executions. Basic filters, advanced filters, pagination, and empty searches all retain the same behavior within that Engine-only scope.

## Validation

- `make copyright-check`
- `make -C cli build`
- `cd web && GOWORK=off go test ./...`
- `make -C server unitTests`
- runtime POSTs to `/api/flows/search` with empty and existing queries returned HTTP 200 against Temporal
