### PR TITLE
Add agent-friendly Dex CLI operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Dex step inputs and large values persist by default in `$HOME/.dex/blobs`.
 
 See [cli/README.md](cli/README.md) for Dex endpoints and persistence options.
 
+Operate Dex without a browser using the same installed binary:
+
+```bash
+dexcli flow search
+dexcli flow inspect <flow-id>
+dexcli api list
+```
+
 Product documentation: [https://docs.superdurable.io](https://docs.superdurable.io)
 (source in [`docs/`](docs/)).
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -8,4 +8,4 @@ test:
 	GOWORK=off go test ./...
 
 integration-test:
-	GOWORK=off go test -tags=integration ./internal/dev -count=1 -v
+	GOWORK=off go test -tags=integration ./internal/... -count=1 -v

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,8 @@
 # Dex CLI
 
 `dexcli` starts a complete local Dex development environment with one command.
+It also gives humans and AI agents a JSON-first interface to every public Dex
+FlowService API without requiring a browser.
 
 ## Install
 
@@ -81,6 +83,72 @@ must exist and be reachable before startup.
 Operators hosting Dex can use the retained backend compatibility flags for
 external mode, namespaces, and internal ports. Dex does not print those
 endpoints, and application developers do not need them.
+
+## Operate flows
+
+Commands connect to `127.0.0.1:8801` by default. Override the target with
+`--server host:port` or `DEX_FLOW_SERVICE_ADDRESS`; the flag takes precedence.
+
+```bash
+dexcli health
+dexcli flow search --query 'FlowStatus = "Running"'
+dexcli flow inspect order-123 --all-history
+dexcli flow watch order-123 --follow-runs
+```
+
+JSON is the default and stable machine-readable output. Use `--output table`
+for terminal-oriented output. Large strings and objects are loaded from Dex's
+blob store by default. To inspect only their references and avoid the additional
+request, pass `--no-hydrate`:
+
+```bash
+dexcli flow history order-123 --no-hydrate
+```
+
+The friendly Flow commands are:
+
+```text
+dexcli flow search [--query QUERY] [--page-size N] [--page-token TOKEN] [--all]
+dexcli flow summary FLOW_ID [--run-id RUN_ID]
+dexcli flow state FLOW_ID [--run-id RUN_ID]
+dexcli flow history FLOW_ID [--run-id RUN_ID] [--start-event-id N]
+                    [--page-size N] [--page-token BASE64] [--all]
+dexcli flow inspect FLOW_ID [--run-id RUN_ID] [--all-history]
+dexcli flow watch FLOW_ID [--run-id RUN_ID] [--from-event-id N] [--follow-runs]
+dexcli flow stop FLOW_ID --run-id RUN_ID
+                 --type cancel|terminate|fail [--reason TEXT] --yes
+dexcli flow reset FLOW_ID --run-id RUN_ID
+                  --type beginning|history-event-id|history-event-time|step-type|step-execution-id
+                  [--target VALUE] --reason TEXT --yes
+```
+
+With the default JSON output, `watch` writes one object per line and exits when
+the run becomes terminal.
+`--follow-runs` continues into the current run after Continue-As-New. Stop and
+reset require both an exact run ID and `--yes`, including in non-interactive use.
+
+## Call any FlowService API
+
+The installed binary contains the protobuf descriptor for its FlowService
+version. Agents can discover and invoke every public RPC without server-side
+gRPC reflection:
+
+```bash
+dexcli api list
+dexcli api describe GetAttributes
+dexcli api call GetAttributes --data '{"flowId":"order-123","allKeys":true}'
+dexcli api call SetAttributes --data @request.json --yes
+printf '%s' '{"flowId":"order-123"}' | dexcli api call GetFlowSummary --data -
+```
+
+`api call` accepts canonical protobuf JSON: lower-camel-case field names, enum
+names, and base64-encoded bytes. Unlike friendly Flow commands, it deliberately
+does not hydrate or reshape values. Mutating RPCs require `--yes`.
+
+Successful commands write only their result to stdout. Failures write a JSON
+object to stderr with the operation, error kind, gRPC code/name, and status
+details when supplied. Usage and missing-confirmation failures exit with status
+2; connection and RPC failures exit with status 1.
 
 ## Build and test
 

--- a/cli/cmd/dexcli/main.go
+++ b/cli/cmd/dexcli/main.go
@@ -17,6 +17,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/superdurable/dex/cli/internal/command"
 	"github.com/superdurable/dex/cli/internal/dev"
 )
 
@@ -30,8 +31,8 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	defer cancel()
 	if err := run(ctx, os.Args[1:]); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		command.WriteError(os.Stderr, err)
+		os.Exit(command.ExitCode(err))
 	}
 }
 
@@ -50,7 +51,7 @@ func run(ctx context.Context, args []string) error {
 		printUsage(os.Stdout)
 		return nil
 	default:
-		return fmt.Errorf("unknown command %q; run dexcli help", args[0])
+		return command.NewApp(os.Stdin, os.Stdout, os.Stderr).Execute(ctx, args)
 	}
 }
 
@@ -59,5 +60,8 @@ func printUsage(output *os.File) {
 	fmt.Fprintln(output)
 	fmt.Fprintln(output, "Commands:")
 	fmt.Fprintln(output, "  dev       Start a local Dex development environment")
+	fmt.Fprintln(output, "  health    Check Dex FlowService health")
+	fmt.Fprintln(output, "  flow      Search, inspect, watch, stop, or reset Flows")
+	fmt.Fprintln(output, "  api       List, describe, or call FlowService RPCs")
 	fmt.Fprintln(output, "  version   Print version information")
 }

--- a/cli/homebrew/dexcli.rb.tmpl
+++ b/cli/homebrew/dexcli.rb.tmpl
@@ -1,5 +1,5 @@
 class Dexcli < Formula
-  desc "Run Dex, Dex Web, and a local Temporal development server"
+  desc "Develop and operate Dex from the command line"
   homepage "https://github.com/superdurable/dex"
   version "@FORMULA_VERSION@"
   license "MIT"

--- a/cli/internal/command/api.go
+++ b/cli/internal/command/api.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/superdurable/dex/gen/dexpb"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+type apiCommand struct {
+	stdin   io.Reader
+	stdout  io.Writer
+	stderr  io.Writer
+	service protoreflect.ServiceDescriptor
+}
+
+func newAPICommand(stdin io.Reader, stdout io.Writer, stderr io.Writer) *apiCommand {
+	service := dexpb.File_dex_proto.Services().ByName("FlowService")
+	if service == nil {
+		panic("FlowService descriptor is unavailable")
+	}
+	return &apiCommand{stdin: stdin, stdout: stdout, stderr: stderr, service: service}
+}
+
+func (c *apiCommand) Execute(ctx context.Context, args []string, options options) error {
+	if len(args) == 0 {
+		c.printUsage()
+		return nil
+	}
+	switch args[0] {
+	case "list":
+		return c.list(args[1:], options)
+	case "describe":
+		return c.describe(args[1:], options)
+	case "call":
+		return c.call(ctx, args[1:], options)
+	case "help", "--help", "-h":
+		c.printUsage()
+		return nil
+	default:
+		return newUsageError("api", fmt.Errorf("unknown command %q", args[0]))
+	}
+}
+
+func (c *apiCommand) list(args []string, options options) error {
+	flags := newFlagSet("dexcli api list", c.stderr)
+	addCommonFlags(flags, &options)
+	if done, err := parseAPIFlags(flags, args, c.stdout, "dexcli api list [flags]"); done || err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return newUsageError("api list", fmt.Errorf("unexpected arguments: %v", flags.Args()))
+	}
+	methods := make([]any, 0, c.service.Methods().Len())
+	for index := 0; index < c.service.Methods().Len(); index++ {
+		method := c.service.Methods().Get(index)
+		methods = append(methods, map[string]any{
+			"name": string(method.Name()), "fullMethod": fullMethodName(c.service, method),
+			"requestType":  string(method.Input().FullName()),
+			"responseType": string(method.Output().FullName()),
+			"mutating":     isMutatingMethod(method.Name()),
+		})
+	}
+	return writeOutput(c.stdout, options.output, map[string]any{
+		"service": string(c.service.FullName()), "methods": methods,
+	})
+}
+
+func (c *apiCommand) describe(args []string, options options) error {
+	flags := newFlagSet("dexcli api describe", c.stderr)
+	addCommonFlags(flags, &options)
+	if done, err := parseAPIFlags(flags, args, c.stdout, "dexcli api describe METHOD [flags]"); done || err != nil {
+		return err
+	}
+	method, err := c.oneMethod(flags, "api describe")
+	if err != nil {
+		return err
+	}
+	messages := make(map[protoreflect.FullName]map[string]any)
+	describeMessage(method.Input(), messages)
+	describeMessage(method.Output(), messages)
+	names := make([]string, 0, len(messages))
+	for name := range messages {
+		names = append(names, string(name))
+	}
+	sort.Strings(names)
+	described := make([]any, 0, len(names))
+	for _, name := range names {
+		described = append(described, messages[protoreflect.FullName(name)])
+	}
+	return writeOutput(c.stdout, options.output, map[string]any{
+		"name": string(method.Name()), "fullMethod": fullMethodName(c.service, method),
+		"requestType":  string(method.Input().FullName()),
+		"responseType": string(method.Output().FullName()),
+		"mutating":     isMutatingMethod(method.Name()), "messages": described,
+	})
+}
+
+func (c *apiCommand) call(ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli api call", c.stderr)
+	dataSource := flags.String("data", "{}", "protobuf JSON, @file, or - for stdin")
+	yes := flags.Bool("yes", false, "confirm a mutating RPC")
+	addCommonFlags(flags, &options)
+	if done, err := parseAPIFlags(flags, args, c.stdout, "dexcli api call METHOD [--data JSON|@FILE|-] [--yes]"); done || err != nil {
+		return err
+	}
+	method, err := c.oneMethod(flags, "api call")
+	if err != nil {
+		return err
+	}
+	if isMutatingMethod(method.Name()) && !*yes {
+		return newConfirmationError("api call " + string(method.Name()))
+	}
+	data, err := c.readData(*dataSource)
+	if err != nil {
+		return newUsageError("api call "+string(method.Name()), err)
+	}
+	request := dynamicpb.NewMessage(method.Input())
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(data, request); err != nil {
+		return newUsageError("api call "+string(method.Name()), fmt.Errorf("invalid protobuf JSON: %w", err))
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		response := dynamicpb.NewMessage(method.Output())
+		if invokeErr := client.connection.Invoke(callCtx, fullMethodName(c.service, method), request, response); invokeErr != nil {
+			return newOperationError("api call "+string(method.Name()), invokeErr)
+		}
+		mapped, mapErr := strictMessageMap(response)
+		if mapErr != nil {
+			return newOperationError("api call "+string(method.Name()), mapErr)
+		}
+		return writeOutput(c.stdout, options.output, mapped)
+	})
+}
+
+func parseAPIFlags(flags *flag.FlagSet, args []string, output io.Writer, usage string) (bool, error) {
+	if err := flags.Parse(interspersedArgs(flags, args)); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fmt.Fprintln(output, "Usage:", usage)
+			return true, nil
+		}
+		return false, newUsageError(strings.TrimPrefix(flags.Name(), "dexcli "), err)
+	}
+	parsedOptions, err := optionsFromFlags(flags)
+	if err != nil {
+		return false, newUsageError(strings.TrimPrefix(flags.Name(), "dexcli "), err)
+	}
+	if err := parsedOptions.validate(); err != nil {
+		return false, newUsageError(strings.TrimPrefix(flags.Name(), "dexcli "), err)
+	}
+	return false, nil
+}
+
+func optionsFromFlags(flags *flag.FlagSet) (options, error) {
+	server := flags.Lookup("server").Value.String()
+	output := flags.Lookup("output").Value.String()
+	timeout, err := time.ParseDuration(flags.Lookup("timeout").Value.String())
+	if err != nil {
+		return options{}, fmt.Errorf("parse timeout: %w", err)
+	}
+	getter, ok := flags.Lookup("no-hydrate").Value.(flag.Getter)
+	if !ok {
+		return options{}, fmt.Errorf("read no-hydrate flag")
+	}
+	noHydrate, ok := getter.Get().(bool)
+	if !ok {
+		return options{}, fmt.Errorf("no-hydrate flag is not boolean")
+	}
+	return options{server: server, output: output, timeout: timeout, noHydrate: noHydrate}, nil
+}
+
+func (c *apiCommand) oneMethod(flags *flag.FlagSet, operation string) (protoreflect.MethodDescriptor, error) {
+	if flags.NArg() != 1 {
+		return nil, newUsageError(operation, fmt.Errorf("exactly one METHOD is required"))
+	}
+	method := c.findMethod(flags.Arg(0))
+	if method == nil {
+		return nil, newUsageError(operation, fmt.Errorf("unknown FlowService method %q", flags.Arg(0)))
+	}
+	return method, nil
+}
+
+func (c *apiCommand) findMethod(name string) protoreflect.MethodDescriptor {
+	trimmed := strings.TrimPrefix(name, "/dex.FlowService/")
+	for index := 0; index < c.service.Methods().Len(); index++ {
+		method := c.service.Methods().Get(index)
+		if strings.EqualFold(trimmed, string(method.Name())) {
+			return method
+		}
+	}
+	return nil
+}
+
+func (c *apiCommand) readData(source string) ([]byte, error) {
+	switch {
+	case source == "-":
+		data, err := io.ReadAll(c.stdin)
+		if err != nil {
+			return nil, fmt.Errorf("read stdin: %w", err)
+		}
+		return data, nil
+	case strings.HasPrefix(source, "@"):
+		path := strings.TrimPrefix(source, "@")
+		if path == "" {
+			return nil, fmt.Errorf("data file path must not be empty")
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read data file: %w", err)
+		}
+		return data, nil
+	default:
+		return []byte(source), nil
+	}
+}
+
+func fullMethodName(service protoreflect.ServiceDescriptor, method protoreflect.MethodDescriptor) string {
+	return "/" + string(service.FullName()) + "/" + string(method.Name())
+}
+
+func isMutatingMethod(name protoreflect.Name) bool {
+	switch name {
+	case "StartFlow", "PublishToChannel", "StopFlow", "SetAttributes", "SyncAttributeIndexes",
+		"ResetFlow", "InvokeRPC", "SkipTimer", "UpdateFlowConfig", "TriggerContinueAsNew":
+		return true
+	default:
+		return false
+	}
+}
+
+func strictMessageMap(message *dynamicpb.Message) (map[string]any, error) {
+	data, err := (protojson.MarshalOptions{UseProtoNames: false}).Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]any)
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func describeMessage(descriptor protoreflect.MessageDescriptor, messages map[protoreflect.FullName]map[string]any) {
+	if descriptor == nil {
+		return
+	}
+	if _, found := messages[descriptor.FullName()]; found {
+		return
+	}
+	result := map[string]any{"name": string(descriptor.FullName())}
+	messages[descriptor.FullName()] = result
+	fields := make([]any, 0, descriptor.Fields().Len())
+	for index := 0; index < descriptor.Fields().Len(); index++ {
+		field := descriptor.Fields().Get(index)
+		item := map[string]any{
+			"name": field.JSONName(), "protoName": string(field.Name()),
+			"number": field.Number(), "kind": field.Kind().String(),
+			"repeated": field.Cardinality() == protoreflect.Repeated,
+			"required": field.Cardinality() == protoreflect.Required,
+		}
+		if field.ContainingOneof() != nil {
+			item["oneof"] = string(field.ContainingOneof().Name())
+		}
+		if field.IsMap() {
+			item["map"] = true
+		}
+		if field.Message() != nil {
+			item["messageType"] = string(field.Message().FullName())
+			describeMessage(field.Message(), messages)
+		}
+		if field.Enum() != nil {
+			item["enumType"] = string(field.Enum().FullName())
+			item["enumValues"] = enumValues(field.Enum())
+		}
+		fields = append(fields, item)
+	}
+	result["fields"] = fields
+}
+
+func enumValues(descriptor protoreflect.EnumDescriptor) []any {
+	values := make([]any, 0, descriptor.Values().Len())
+	for index := 0; index < descriptor.Values().Len(); index++ {
+		value := descriptor.Values().Get(index)
+		values = append(values, map[string]any{"name": string(value.Name()), "number": value.Number()})
+	}
+	return values
+}
+
+func (c *apiCommand) printUsage() {
+	fmt.Fprintln(c.stdout, "Usage: dexcli api <command>")
+	fmt.Fprintln(c.stdout)
+	fmt.Fprintln(c.stdout, "Commands: list, describe, call")
+}

--- a/cli/internal/command/app.go
+++ b/cli/internal/command/app.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package command
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+type App struct {
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+	getenv func(string) string
+}
+
+func NewApp(stdin io.Reader, stdout io.Writer, stderr io.Writer) *App {
+	if stdin == nil {
+		panic("command stdin must not be nil")
+	}
+	if stdout == nil {
+		panic("command stdout must not be nil")
+	}
+	if stderr == nil {
+		panic("command stderr must not be nil")
+	}
+	return &App{
+		stdin:  stdin,
+		stdout: stdout,
+		stderr: stderr,
+		getenv: os.Getenv,
+	}
+}
+
+func (a *App) Execute(ctx context.Context, args []string) error {
+	options := defaultOptions(a.getenv)
+	remaining, err := parseRootOptions(args, &options)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			a.printUsage()
+			return nil
+		}
+		return newUsageError("dexcli", err)
+	}
+	if len(remaining) == 0 {
+		a.printUsage()
+		return nil
+	}
+	if err := options.validate(); err != nil {
+		return newUsageError("dexcli", err)
+	}
+	switch remaining[0] {
+	case "health":
+		return a.executeHealth(ctx, remaining[1:], options)
+	case "flow":
+		return newFlowCommand(a.stdin, a.stdout, a.stderr).Execute(ctx, remaining[1:], options)
+	case "api":
+		return newAPICommand(a.stdin, a.stdout, a.stderr).Execute(ctx, remaining[1:], options)
+	case "help", "--help", "-h":
+		a.printUsage()
+		return nil
+	default:
+		return newUsageError("dexcli", fmt.Errorf("unknown command %q", remaining[0]))
+	}
+}
+
+func (a *App) executeHealth(ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli health", a.stderr)
+	addCommonFlags(flags, &options)
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fmt.Fprintln(a.stdout, "Usage: dexcli health [global flags]")
+			return nil
+		}
+		return newUsageError("health", err)
+	}
+	if flags.NArg() != 0 {
+		return newUsageError("health", fmt.Errorf("unexpected arguments: %v", flags.Args()))
+	}
+	if err := options.validate(); err != nil {
+		return newUsageError("health", err)
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		response, err := client.service.HealthCheck(callCtx, emptyRequest())
+		if err != nil {
+			return newOperationError("health", err)
+		}
+		result := map[string]any{
+			"condition": response.GetCondition(),
+			"hostname":  response.GetHostname(),
+			"duration":  response.GetDuration(),
+		}
+		return writeOutput(a.stdout, options.output, result)
+	})
+}
+
+func (a *App) printUsage() {
+	fmt.Fprintln(a.stdout, "Usage: dexcli [global flags] <command>")
+	fmt.Fprintln(a.stdout)
+	fmt.Fprintln(a.stdout, "Commands:")
+	fmt.Fprintln(a.stdout, "  health    Check Dex FlowService health")
+	fmt.Fprintln(a.stdout, "  flow      Search, inspect, watch, stop, or reset Flows")
+	fmt.Fprintln(a.stdout, "  api       List, describe, or call FlowService RPCs")
+	fmt.Fprintln(a.stdout)
+	fmt.Fprintln(a.stdout, "Global flags:")
+	fmt.Fprintln(a.stdout, "  --server host:port                 Dex FlowService target")
+	fmt.Fprintln(a.stdout, "  --output json|table                output format (default json)")
+	fmt.Fprintln(a.stdout, "  --timeout duration                 request timeout (default 30s; 0 disables)")
+	fmt.Fprintln(a.stdout, "  --no-hydrate                       return blob references without loading values")
+}

--- a/cli/internal/command/client.go
+++ b/cli/internal/command/client.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/superdurable/dex/gen/dexpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+const defaultMaxMessageBytes = 16 << 20
+
+type flowService struct {
+	connection *grpc.ClientConn
+	service    dexpb.FlowServiceClient
+}
+
+func withFlowService(
+	ctx context.Context,
+	options options,
+	call func(context.Context, *flowService) error,
+) error {
+	client, err := newFlowService(options.server)
+	if err != nil {
+		return newOperationError("connect", err)
+	}
+	callCtx, cancel := requestContext(ctx, options)
+	callErr := call(callCtx, client)
+	cancel()
+	closeErr := client.connection.Close()
+	if callErr != nil {
+		return callErr
+	}
+	if closeErr != nil {
+		return newOperationError("close", closeErr)
+	}
+	return nil
+}
+
+func withStreamingFlowService(
+	ctx context.Context,
+	options options,
+	call func(*flowService) error,
+) error {
+	client, err := newFlowService(options.server)
+	if err != nil {
+		return newOperationError("connect", err)
+	}
+	callErr := call(client)
+	closeErr := client.connection.Close()
+	if callErr != nil {
+		return callErr
+	}
+	if closeErr != nil {
+		return newOperationError("close", closeErr)
+	}
+	return nil
+}
+
+func newFlowService(server string) (*flowService, error) {
+	connection, err := grpc.NewClient(
+		server,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(defaultMaxMessageBytes),
+			grpc.MaxCallSendMsgSize(defaultMaxMessageBytes),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create FlowService client: %w", err)
+	}
+	return &flowService{
+		connection: connection,
+		service:    dexpb.NewFlowServiceClient(connection),
+	}, nil
+}
+
+func requestContext(ctx context.Context, options options) (context.Context, context.CancelFunc) {
+	if options.timeout == 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, options.timeout)
+}
+
+func closeWithError(primary error, closer func() error) error {
+	return errors.Join(primary, closer())
+}
+
+func emptyRequest() *emptypb.Empty {
+	return &emptypb.Empty{}
+}

--- a/cli/internal/command/command_integ_test.go
+++ b/cli/internal/command/command_integ_test.go
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+//go:build integration
+
+package command
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/superdurable/dex/gen/dexpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type testFlowService struct {
+	dexpb.UnimplementedFlowServiceServer
+
+	mu          sync.Mutex
+	loadCalls   int
+	stopCalls   int
+	waitStarted chan struct{}
+	waitOnce    sync.Once
+}
+
+func (s *testFlowService) HealthCheck(context.Context, *emptypb.Empty) (*dexpb.HealthInfo, error) {
+	return &dexpb.HealthInfo{Condition: "SERVING", Hostname: "test", Duration: 7}, nil
+}
+
+func (s *testFlowService) SearchFlows(
+	context.Context,
+	*dexpb.SearchFlowsRequest,
+) (*dexpb.SearchFlowsResponse, error) {
+	return &dexpb.SearchFlowsResponse{FlowRuns: []*dexpb.SearchFlowsResponseEntry{{
+		FlowId: "flow-1", RunId: "run-1", FlowType: "OrderFlow",
+		FlowStatus: dexpb.FlowStatus_FLOW_STATUS_RUNNING,
+		IndexedAttributes: []*dexpb.KV{{
+			Key: "LargeValue",
+			Value: &dexpb.Value{Kind: &dexpb.Value_InternalBlobIdForStringValue{
+				InternalBlobIdForStringValue: "blob-1",
+			}},
+		}},
+	}}}, nil
+}
+
+func (s *testFlowService) LoadBlobs(
+	context.Context,
+	*dexpb.LoadBlobsRequest,
+) (*dexpb.LoadBlobsResponse, error) {
+	s.mu.Lock()
+	s.loadCalls++
+	s.mu.Unlock()
+	return &dexpb.LoadBlobsResponse{Values: map[string]*dexpb.Value{
+		"blob-1": {Kind: &dexpb.Value_StringValue{StringValue: "hydrated"}},
+	}}, nil
+}
+
+func (s *testFlowService) StopFlow(
+	context.Context,
+	*dexpb.StopFlowRequest,
+) (*emptypb.Empty, error) {
+	s.mu.Lock()
+	s.stopCalls++
+	s.mu.Unlock()
+	return &emptypb.Empty{}, nil
+}
+
+func (s *testFlowService) GetFlowSummary(
+	_ context.Context,
+	request *dexpb.GetFlowSummaryRequest,
+) (*dexpb.GetFlowSummaryResponse, error) {
+	flowStatus := dexpb.FlowStatus_FLOW_STATUS_RUNNING
+	if request.GetFlowId() == "terminal-flow" {
+		flowStatus = dexpb.FlowStatus_FLOW_STATUS_COMPLETED
+	}
+	return &dexpb.GetFlowSummaryResponse{
+		FlowExecutionId: &dexpb.FlowExecutionID{FlowId: request.GetFlowId(), RunId: "run-1"},
+		FirstRunId:      "run-1", FlowType: "OrderFlow", FlowStatus: flowStatus,
+	}, nil
+}
+
+func (s *testFlowService) GetHistoryEvents(
+	context.Context,
+	*dexpb.GetHistoryEventsRequest,
+) (*dexpb.GetHistoryEventsResponse, error) {
+	return &dexpb.GetHistoryEventsResponse{
+		Events: []*dexpb.FlowHistoryEvent{{
+			EventId: 1,
+			Payload: &dexpb.FlowHistoryEvent_ChannelExternalPublish{
+				ChannelExternalPublish: &dexpb.ChannelExternalPublishEvent{Messages: []*dexpb.ChannelMessage{{
+					ChannelName: "commands",
+					Value:       &dexpb.Value{Kind: &dexpb.Value_StringValue{StringValue: "go"}},
+				}}},
+			},
+		}},
+		NextInternalEventId: 2,
+	}, nil
+}
+
+func (s *testFlowService) GetFlowState(
+	context.Context,
+	*dexpb.GetFlowStateRequest,
+) (*dexpb.GetFlowStateResponse, error) {
+	return &dexpb.GetFlowStateResponse{
+		FlowConfig: &dexpb.FlowConfig{},
+		Attributes: []*dexpb.KV{{
+			Key: "status", Value: &dexpb.Value{Kind: &dexpb.Value_StringValue{StringValue: "ready"}},
+		}},
+	}, nil
+}
+
+func (s *testFlowService) WaitForHistoryEvent(
+	ctx context.Context,
+	_ *dexpb.WaitForHistoryEventRequest,
+) (*dexpb.WaitForHistoryEventResponse, error) {
+	s.waitOnce.Do(func() { close(s.waitStarted) })
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestHealthAndGenericAPICallUseFlowService(t *testing.T) {
+	service, address := startTestFlowService(t)
+	if service == nil {
+		t.Fatal("test FlowService is nil")
+	}
+
+	health := executeTestCommand(t, nil, "health", "--server", address)
+	if health["condition"] != "SERVING" || health["hostname"] != "test" {
+		t.Fatalf("unexpected health response: %#v", health)
+	}
+
+	raw := executeTestCommand(t, []byte("{}"), "api", "call", "HealthCheck", "--data", "-", "--server", address)
+	if raw["condition"] != "SERVING" {
+		t.Fatalf("unexpected api response: %#v", raw)
+	}
+}
+
+func TestSearchHydratesByDefaultAndCanReturnReferences(t *testing.T) {
+	service, address := startTestFlowService(t)
+
+	hydrated := executeTestCommand(t, nil, "flow", "search", "--server", address)
+	flows := hydrated["flows"].([]any)
+	first := flows[0].(map[string]any)
+	attributes := first["indexedAttributes"].([]any)
+	if attributes[0].(map[string]any)["value"] != "hydrated" {
+		t.Fatalf("expected hydrated attribute: %#v", hydrated)
+	}
+
+	references := executeTestCommand(t, nil, "flow", "search", "--server", address, "--no-hydrate")
+	flows = references["flows"].([]any)
+	first = flows[0].(map[string]any)
+	attributes = first["indexedAttributes"].([]any)
+	reference := attributes[0].(map[string]any)["value"].(map[string]any)["__dexBlobReference"].(map[string]any)
+	if reference["id"] != "blob-1" || reference["kind"] != "string" {
+		t.Fatalf("unexpected blob reference: %#v", reference)
+	}
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	if service.loadCalls != 1 {
+		t.Fatalf("expected one hydration call, got %d", service.loadCalls)
+	}
+}
+
+func TestMutationRequiresYesBeforeSendingRequest(t *testing.T) {
+	service, address := startTestFlowService(t)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := NewApp(bytes.NewReader(nil), stdout, stderr)
+	err := app.Execute(context.Background(), []string{
+		"flow", "stop", "flow-1", "--run-id", "run-1", "--type", "cancel", "--server", address,
+	})
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("expected confirmation error, got %v", err)
+	}
+	service.mu.Lock()
+	if service.stopCalls != 0 {
+		service.mu.Unlock()
+		t.Fatalf("stop was called without confirmation")
+	}
+	service.mu.Unlock()
+
+	result := executeTestCommand(t, nil,
+		"flow", "stop", "flow-1", "--run-id", "run-1", "--type", "cancel", "--yes", "--server", address,
+	)
+	if result["stopped"] != true {
+		t.Fatalf("unexpected stop result: %#v", result)
+	}
+}
+
+func TestHistoryUsesCurrentRunAndReturnsSemanticEvents(t *testing.T) {
+	_, address := startTestFlowService(t)
+	result := executeTestCommand(t, nil, "flow", "history", "flow-1", "--server", address)
+	if result["runId"] != "run-1" || result["nextInternalEventId"] != float64(2) {
+		t.Fatalf("unexpected history cursor: %#v", result)
+	}
+	events := result["events"].([]any)
+	event := events[0].(map[string]any)
+	if event["type"] != "ChannelExternalPublish" {
+		t.Fatalf("unexpected event: %#v", event)
+	}
+	payload := event["payload"].(map[string]any)
+	messages := payload["messages"].([]any)
+	if messages[0].(map[string]any)["value"] != "go" {
+		t.Fatalf("unexpected natural value: %#v", payload)
+	}
+}
+
+func TestInspectOmitsStateForTerminalFlow(t *testing.T) {
+	_, address := startTestFlowService(t)
+	result := executeTestCommand(t, nil, "flow", "inspect", "terminal-flow", "--server", address)
+	if result["state"] != nil {
+		t.Fatalf("terminal inspect returned state: %#v", result)
+	}
+	summary := result["summary"].(map[string]any)
+	if summary["flowStatusCode"] != float64(dexpb.FlowStatus_FLOW_STATUS_COMPLETED) {
+		t.Fatalf("unexpected terminal summary: %#v", summary)
+	}
+}
+
+func TestWatchEmitsHistoryAndCurrentStateBeforeLongPoll(t *testing.T) {
+	service, address := startTestFlowService(t)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := NewApp(bytes.NewReader(nil), stdout, stderr)
+	ctx, cancel := context.WithCancel(context.Background())
+	finished := make(chan error, 1)
+	go func() {
+		finished <- app.Execute(ctx, []string{
+			"flow", "watch", "flow-1", "--run-id", "run-1", "--server", address,
+		})
+	}()
+	<-service.waitStarted
+	cancel()
+	err := <-finished
+	if err == nil || status.Code(err) != codes.Canceled {
+		t.Fatalf("expected canceled watch, got %v stderr=%s", err, stderr.String())
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected history and state lines, got %q", stdout.String())
+	}
+	var event map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &event); err != nil {
+		t.Fatal(err)
+	}
+	if event["type"] != "ChannelExternalPublish" {
+		t.Fatalf("unexpected watch event: %#v", event)
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot["type"] != "FlowStateSnapshot" {
+		t.Fatalf("unexpected watch snapshot: %#v", snapshot)
+	}
+}
+
+func TestAPIDescriptorIncludesEveryFlowServiceMethod(t *testing.T) {
+	result := executeTestCommand(t, nil, "api", "list")
+	methods := result["methods"].([]any)
+	if len(methods) != dexpb.File_dex_proto.Services().ByName("FlowService").Methods().Len() {
+		t.Fatalf("unexpected method count: %d", len(methods))
+	}
+	described := executeTestCommand(t, nil, "api", "describe", "ResetFlow")
+	if described["requestType"] != "dex.ResetFlowRequest" || described["mutating"] != true {
+		t.Fatalf("unexpected descriptor: %#v", described)
+	}
+}
+
+func startTestFlowService(t *testing.T) (*testFlowService, string) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := &testFlowService{waitStarted: make(chan struct{})}
+	server := grpc.NewServer()
+	dexpb.RegisterFlowServiceServer(server, service)
+	serveFinished := make(chan error, 1)
+	go func() {
+		serveFinished <- server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		server.GracefulStop()
+		if err := <-serveFinished; err != nil {
+			t.Errorf("serve FlowService: %v", err)
+		}
+	})
+	return service, listener.Addr().String()
+}
+
+func executeTestCommand(t *testing.T, input []byte, args ...string) map[string]any {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := NewApp(bytes.NewReader(input), stdout, stderr)
+	if err := app.Execute(context.Background(), args); err != nil {
+		t.Fatalf("execute %v: %v stderr=%s", args, err, stderr.String())
+	}
+	result := make(map[string]any)
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode %v output %q: %v", args, stdout.String(), err)
+	}
+	return result
+}

--- a/cli/internal/command/errors.go
+++ b/cli/internal/command/errors.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package command
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+type Error struct {
+	operation string
+	kind      string
+	cause     error
+}
+
+func newUsageError(operation string, cause error) *Error {
+	return &Error{operation: operation, kind: "usage", cause: cause}
+}
+
+func newConfirmationError(operation string) *Error {
+	return &Error{
+		operation: operation,
+		kind:      "confirmation_required",
+		cause:     fmt.Errorf("operation requires --yes"),
+	}
+}
+
+func newOperationError(operation string, cause error) *Error {
+	var commandError *Error
+	if errors.As(cause, &commandError) {
+		return commandError
+	}
+	return &Error{operation: operation, kind: "operation", cause: cause}
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %v", e.operation, e.cause)
+}
+
+func (e *Error) Unwrap() error {
+	return e.cause
+}
+
+func ExitCode(err error) int {
+	var commandError *Error
+	if errors.As(err, &commandError) {
+		if commandError.kind == "usage" || commandError.kind == "confirmation_required" {
+			return 2
+		}
+	}
+	return 1
+}
+
+func WriteError(output io.Writer, err error) {
+	if output == nil {
+		panic("error output must not be nil")
+	}
+	commandError := newOperationError("dexcli", err)
+	var typed *Error
+	if errors.As(err, &typed) {
+		commandError = typed
+	}
+	payload := map[string]any{
+		"error": map[string]any{
+			"kind":      commandError.kind,
+			"operation": commandError.operation,
+			"message":   commandError.cause.Error(),
+		},
+	}
+	if rpcStatus, ok := status.FromError(commandError.cause); ok {
+		errorPayload := payload["error"].(map[string]any)
+		errorPayload["grpcCode"] = int32(rpcStatus.Code())
+		errorPayload["grpcCodeName"] = rpcStatus.Code().String()
+		details := make([]any, 0, len(rpcStatus.Details()))
+		for _, detail := range rpcStatus.Details() {
+			message, messageOK := detail.(proto.Message)
+			if !messageOK {
+				details = append(details, fmt.Sprint(detail))
+				continue
+			}
+			data, marshalErr := protojson.Marshal(message)
+			if marshalErr != nil {
+				details = append(details, fmt.Sprint(detail))
+				continue
+			}
+			var mapped any
+			if unmarshalErr := json.Unmarshal(data, &mapped); unmarshalErr != nil {
+				details = append(details, string(data))
+				continue
+			}
+			details = append(details, mapped)
+		}
+		if len(details) > 0 {
+			errorPayload["details"] = details
+		}
+	}
+	encoder := json.NewEncoder(output)
+	encoder.SetEscapeHTML(false)
+	if encodeErr := encoder.Encode(payload); encodeErr != nil {
+		fmt.Fprintf(output, "{\"error\":{\"kind\":\"output\",\"message\":%q}}\n", encodeErr.Error())
+	}
+}

--- a/cli/internal/command/flow.go
+++ b/cli/internal/command/flow.go
@@ -1,0 +1,306 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package command
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/superdurable/dex/gen/dexpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type flowCommand struct {
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func newFlowCommand(stdin io.Reader, stdout io.Writer, stderr io.Writer) *flowCommand {
+	return &flowCommand{stdin: stdin, stdout: stdout, stderr: stderr}
+}
+
+func (c *flowCommand) Execute(ctx context.Context, args []string, options options) error {
+	if len(args) == 0 {
+		c.printUsage()
+		return nil
+	}
+	switch args[0] {
+	case "search":
+		return c.search(ctx, args[1:], options)
+	case "summary":
+		return c.summary(ctx, args[1:], options)
+	case "state":
+		return c.state(ctx, args[1:], options)
+	case "history":
+		return c.history(ctx, args[1:], options)
+	case "inspect":
+		return executeInspect(c, ctx, args[1:], options)
+	case "watch":
+		return executeWatch(c, ctx, args[1:], options)
+	case "stop":
+		return executeStop(c, ctx, args[1:], options)
+	case "reset":
+		return executeReset(c, ctx, args[1:], options)
+	case "help", "--help", "-h":
+		c.printUsage()
+		return nil
+	default:
+		return newUsageError("flow", fmt.Errorf("unknown command %q", args[0]))
+	}
+}
+
+func (c *flowCommand) search(ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow search", c.stderr)
+	query := flags.String("query", "", "visibility query")
+	pageSize := flags.Int("page-size", 50, "page size")
+	pageToken := flags.String("page-token", "", "next page token")
+	all := flags.Bool("all", false, "load every page")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow search [flags]"); done || err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return newUsageError("flow search", fmt.Errorf("unexpected arguments: %v", flags.Args()))
+	}
+	if *pageSize <= 0 {
+		return newUsageError("flow search", fmt.Errorf("page-size must be positive"))
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		flows := make([]any, 0)
+		nextToken := *pageToken
+		for {
+			response, err := client.service.SearchFlows(callCtx, &dexpb.SearchFlowsRequest{
+				Query: *query, PageSize: int32(*pageSize), NextPageToken: nextToken,
+			})
+			if err != nil {
+				return newOperationError("flow search", err)
+			}
+			for _, entry := range response.GetFlowRuns() {
+				mapped, warnings, mapErr := naturalMessage(callCtx, client.service, entry, options.noHydrate)
+				if mapErr != nil {
+					return newOperationError("flow search", mapErr)
+				}
+				if len(warnings) > 0 {
+					mapped["warnings"] = warnings
+				}
+				mapped["flowStatusCode"] = int32(entry.GetFlowStatus())
+				flows = append(flows, mapped)
+			}
+			nextToken = response.GetNextPageToken()
+			if !*all || nextToken == "" {
+				break
+			}
+		}
+		return writeOutput(c.stdout, options.output, map[string]any{
+			"flows": flows, "nextPageToken": nextToken,
+		})
+	})
+}
+
+func (c *flowCommand) summary(ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow summary", c.stderr)
+	runID := flags.String("run-id", "", "Flow run ID")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow summary FLOW_ID [flags]"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow summary")
+	if err != nil {
+		return err
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		response, callErr := client.service.GetFlowSummary(callCtx, &dexpb.GetFlowSummaryRequest{
+			FlowId: flowID, RunId: *runID,
+		})
+		if callErr != nil {
+			return newOperationError("flow summary", callErr)
+		}
+		return writeOutput(c.stdout, options.output, flowSummary(response))
+	})
+}
+
+func (c *flowCommand) state(ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow state", c.stderr)
+	runID := flags.String("run-id", "", "Flow run ID")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow state FLOW_ID [flags]"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow state")
+	if err != nil {
+		return err
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		resolvedRunID, resolveErr := resolveRunID(callCtx, client.service, flowID, *runID)
+		if resolveErr != nil {
+			return newOperationError("flow state", resolveErr)
+		}
+		response, callErr := client.service.GetFlowState(callCtx, &dexpb.GetFlowStateRequest{
+			FlowId: flowID, RunId: resolvedRunID,
+		})
+		if callErr != nil {
+			return newOperationError("flow state", callErr)
+		}
+		mapped, warnings, mapErr := naturalMessage(callCtx, client.service, response, options.noHydrate)
+		if mapErr != nil {
+			return newOperationError("flow state", mapErr)
+		}
+		mapped["flowId"] = flowID
+		mapped["runId"] = resolvedRunID
+		if len(warnings) > 0 {
+			mapped["warnings"] = warnings
+		}
+		return writeOutput(c.stdout, options.output, mapped)
+	})
+}
+
+func (c *flowCommand) history(ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow history", c.stderr)
+	runID := flags.String("run-id", "", "Flow run ID")
+	startEventID := flags.Int64("start-event-id", 0, "inclusive internal event cursor")
+	pageSize := flags.Int("page-size", 200, "estimated backend page size")
+	pageToken := flags.String("page-token", "", "base64 next page token")
+	all := flags.Bool("all", false, "load every page")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow history FLOW_ID [flags]"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow history")
+	if err != nil {
+		return err
+	}
+	if *startEventID < 0 || *pageSize <= 0 {
+		return newUsageError("flow history", fmt.Errorf("start-event-id must be non-negative and page-size positive"))
+	}
+	decodedToken, err := base64.StdEncoding.DecodeString(*pageToken)
+	if err != nil {
+		return newUsageError("flow history", fmt.Errorf("page-token must be base64: %w", err))
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		resolvedRunID, resolveErr := resolveRunID(callCtx, client.service, flowID, *runID)
+		if resolveErr != nil {
+			return newOperationError("flow history", resolveErr)
+		}
+		page, pageErr := loadHistory(callCtx, client.service, flowID, resolvedRunID, *startEventID, int32(*pageSize), decodedToken, *all, options.noHydrate)
+		if pageErr != nil {
+			return newOperationError("flow history", pageErr)
+		}
+		return writeOutput(c.stdout, options.output, page)
+	})
+}
+
+func parseFlowFlags(flags *flag.FlagSet, args []string, output io.Writer, usage string) (bool, error) {
+	if err := flags.Parse(interspersedArgs(flags, args)); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fmt.Fprintln(output, "Usage:", usage)
+			return true, nil
+		}
+		return false, newUsageError(strings.TrimPrefix(flags.Name(), "dexcli "), err)
+	}
+	parsedOptions, err := optionsFromFlags(flags)
+	if err != nil {
+		return false, newUsageError(strings.TrimPrefix(flags.Name(), "dexcli "), err)
+	}
+	if err := parsedOptions.validate(); err != nil {
+		return false, newUsageError(strings.TrimPrefix(flags.Name(), "dexcli "), err)
+	}
+	return false, nil
+}
+
+func interspersedArgs(flags *flag.FlagSet, args []string) []string {
+	options := make([]string, 0, len(args))
+	positionals := make([]string, 0, len(args))
+	for index := 0; index < len(args); index++ {
+		argument := args[index]
+		if !strings.HasPrefix(argument, "-") || argument == "-" {
+			positionals = append(positionals, argument)
+			continue
+		}
+		options = append(options, argument)
+		name := strings.TrimLeft(strings.SplitN(argument, "=", 2)[0], "-")
+		item := flags.Lookup(name)
+		if strings.Contains(argument, "=") || item == nil {
+			continue
+		}
+		if boolFlag, ok := item.Value.(interface{ IsBoolFlag() bool }); ok && boolFlag.IsBoolFlag() {
+			continue
+		}
+		if index+1 < len(args) {
+			index++
+			options = append(options, args[index])
+		}
+	}
+	return append(options, positionals...)
+}
+
+func oneFlowID(flags *flag.FlagSet, operation string) (string, error) {
+	if flags.NArg() != 1 || strings.TrimSpace(flags.Arg(0)) == "" {
+		return "", newUsageError(operation, fmt.Errorf("exactly one FLOW_ID is required"))
+	}
+	return flags.Arg(0), nil
+}
+
+func resolveRunID(
+	ctx context.Context,
+	client dexpb.FlowServiceClient,
+	flowID string,
+	runID string,
+) (string, error) {
+	if runID != "" {
+		return runID, nil
+	}
+	response, err := client.GetFlowSummary(ctx, &dexpb.GetFlowSummaryRequest{FlowId: flowID})
+	if err != nil {
+		return "", err
+	}
+	resolved := response.GetFlowExecutionId().GetRunId()
+	if resolved == "" {
+		return "", fmt.Errorf("GetFlowSummary response has no run ID")
+	}
+	return resolved, nil
+}
+
+func flowSummary(response *dexpb.GetFlowSummaryResponse) map[string]any {
+	execution := response.GetFlowExecutionId()
+	return map[string]any{
+		"flowId": execution.GetFlowId(), "runId": execution.GetRunId(),
+		"firstRunId": response.GetFirstRunId(), "requestId": response.GetRequestId(),
+		"flowType": response.GetFlowType(), "flowStatus": response.GetFlowStatus().String(),
+		"flowStatusCode": int32(response.GetFlowStatus()),
+		"startTime":      protoTimestamp(response.GetStartTime()), "closeTime": protoTimestamp(response.GetCloseTime()),
+	}
+}
+
+func protoTimestamp(timestamp *timestamppb.Timestamp) any {
+	if timestamp == nil {
+		return nil
+	}
+	return timestamp.AsTime().Format("2006-01-02T15:04:05.999999999Z07:00")
+}
+
+func (c *flowCommand) printUsage() {
+	fmt.Fprintln(c.stdout, "Usage: dexcli flow <command>")
+	fmt.Fprintln(c.stdout)
+	fmt.Fprintln(c.stdout, "Commands: search, summary, state, history, inspect, watch, stop, reset")
+}
+
+func parseInt32(value string, name string) (int32, error) {
+	parsed, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be an integer: %w", name, err)
+	}
+	return int32(parsed), nil
+}

--- a/cli/internal/command/flow_operations.go
+++ b/cli/internal/command/flow_operations.go
@@ -1,0 +1,439 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package command
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/superdurable/dex/gen/dexpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func loadHistory(
+	ctx context.Context,
+	client dexpb.FlowServiceClient,
+	flowID string,
+	runID string,
+	startEventID int64,
+	pageSize int32,
+	pageToken []byte,
+	all bool,
+	noHydrate bool,
+) (map[string]any, error) {
+	events := make([]any, 0)
+	warnings := make([]string, 0)
+	nextEventID := startEventID
+	nextToken := pageToken
+	for {
+		response, err := client.GetHistoryEvents(ctx, &dexpb.GetHistoryEventsRequest{
+			FlowId: flowID, RunId: runID, StartInternalEventId: nextEventID,
+			EstimatePageSize: pageSize, NextPageToken: nextToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, event := range response.GetEvents() {
+			mapped, valueWarnings, mapErr := naturalMessage(ctx, client, event, noHydrate)
+			if mapErr != nil {
+				return nil, mapErr
+			}
+			normalizeHistoryEvent(mapped, event)
+			events = append(events, mapped)
+			warnings = append(warnings, valueWarnings...)
+		}
+		nextEventID = response.GetNextInternalEventId()
+		nextToken = response.GetNextPageToken()
+		if !all || len(nextToken) == 0 {
+			break
+		}
+	}
+	result := map[string]any{
+		"flowId": flowID, "runId": runID, "events": events,
+		"nextPageToken":       base64.StdEncoding.EncodeToString(nextToken),
+		"nextInternalEventId": nextEventID,
+	}
+	if len(warnings) > 0 {
+		result["warnings"] = uniqueStrings(warnings)
+	}
+	return result, nil
+}
+
+func normalizeHistoryEvent(mapped map[string]any, event *dexpb.FlowHistoryEvent) {
+	eventType := historyEventType(event)
+	mapped["type"] = eventType
+	payloadKey := historyPayloadKey(event)
+	if payloadKey == "" {
+		mapped["payload"] = nil
+		return
+	}
+	mapped["payload"] = mapped[payloadKey]
+	delete(mapped, payloadKey)
+}
+
+func historyPayloadKey(event *dexpb.FlowHistoryEvent) string {
+	switch event.GetPayload().(type) {
+	case *dexpb.FlowHistoryEvent_FlowStartedOrContinued:
+		return "flowStartedOrContinued"
+	case *dexpb.FlowHistoryEvent_FlowClosed:
+		return "flowClosed"
+	case *dexpb.FlowHistoryEvent_StepWaitForCompleted:
+		return "stepWaitForCompleted"
+	case *dexpb.FlowHistoryEvent_StepWaitForFailed:
+		return "stepWaitForFailed"
+	case *dexpb.FlowHistoryEvent_StepExecuteCompleted:
+		return "stepExecuteCompleted"
+	case *dexpb.FlowHistoryEvent_StepExecuteFailed:
+		return "stepExecuteFailed"
+	case *dexpb.FlowHistoryEvent_RpcExecutionCompleted:
+		return "rpcExecutionCompleted"
+	case *dexpb.FlowHistoryEvent_ChannelExternalPublish:
+		return "channelExternalPublish"
+	default:
+		return ""
+	}
+}
+
+func historyEventType(event *dexpb.FlowHistoryEvent) string {
+	switch event.GetPayload().(type) {
+	case *dexpb.FlowHistoryEvent_FlowStartedOrContinued:
+		return "FlowStartedOrContinued"
+	case *dexpb.FlowHistoryEvent_FlowClosed:
+		return "FlowClosed"
+	case *dexpb.FlowHistoryEvent_StepWaitForCompleted:
+		return "StepWaitForCompleted"
+	case *dexpb.FlowHistoryEvent_StepWaitForFailed:
+		return "StepWaitForFailed"
+	case *dexpb.FlowHistoryEvent_StepExecuteCompleted:
+		return "StepExecuteCompleted"
+	case *dexpb.FlowHistoryEvent_StepExecuteFailed:
+		return "StepExecuteFailed"
+	case *dexpb.FlowHistoryEvent_RpcExecutionCompleted:
+		return "RpcExecutionCompleted"
+	case *dexpb.FlowHistoryEvent_ChannelExternalPublish:
+		return "ChannelExternalPublish"
+	default:
+		return "Unspecified"
+	}
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, found := seen[value]; found {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func executeInspect(c *flowCommand, ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow inspect", c.stderr)
+	runID := flags.String("run-id", "", "Flow run ID")
+	allHistory := flags.Bool("all-history", false, "load all history pages")
+	pageSize := flags.Int("page-size", 200, "estimated backend page size")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow inspect FLOW_ID [flags]"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow inspect")
+	if err != nil {
+		return err
+	}
+	if *pageSize <= 0 {
+		return newUsageError("flow inspect", fmt.Errorf("page-size must be positive"))
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		summaryResponse, summaryErr := client.service.GetFlowSummary(callCtx, &dexpb.GetFlowSummaryRequest{
+			FlowId: flowID, RunId: *runID,
+		})
+		if summaryErr != nil {
+			return newOperationError("flow inspect", summaryErr)
+		}
+		resolvedRunID := summaryResponse.GetFlowExecutionId().GetRunId()
+		history, historyErr := loadHistory(
+			callCtx, client.service, flowID, resolvedRunID, 0, int32(*pageSize), nil,
+			*allHistory, options.noHydrate,
+		)
+		if historyErr != nil {
+			return newOperationError("flow inspect", historyErr)
+		}
+		result := map[string]any{"summary": flowSummary(summaryResponse), "history": history, "state": nil}
+		if summaryResponse.GetFlowStatus() == dexpb.FlowStatus_FLOW_STATUS_RUNNING {
+			stateResponse, stateErr := client.service.GetFlowState(callCtx, &dexpb.GetFlowStateRequest{
+				FlowId: flowID, RunId: resolvedRunID,
+			})
+			if stateErr != nil {
+				return newOperationError("flow inspect", stateErr)
+			}
+			state, warnings, mapErr := naturalMessage(callCtx, client.service, stateResponse, options.noHydrate)
+			if mapErr != nil {
+				return newOperationError("flow inspect", mapErr)
+			}
+			if len(warnings) > 0 {
+				state["warnings"] = warnings
+			}
+			result["state"] = state
+		}
+		return writeOutput(c.stdout, options.output, result)
+	})
+}
+
+func executeWatch(c *flowCommand, ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow watch", c.stderr)
+	runID := flags.String("run-id", "", "Flow run ID")
+	fromEventID := flags.Int64("from-event-id", 0, "inclusive internal event cursor")
+	followRuns := flags.Bool("follow-runs", false, "follow Continue-As-New runs")
+	pageSize := flags.Int("page-size", 200, "estimated backend page size")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow watch FLOW_ID [flags]"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow watch")
+	if err != nil {
+		return err
+	}
+	if *fromEventID < 0 || *pageSize <= 0 {
+		return newUsageError("flow watch", fmt.Errorf("from-event-id must be non-negative and page-size positive"))
+	}
+	options.timeout = 0
+	return withStreamingFlowService(ctx, options, func(client *flowService) error {
+		return watchRun(c, ctx, client.service, flowID, *runID, *fromEventID, int32(*pageSize), *followRuns, options)
+	})
+}
+
+func watchRun(
+	c *flowCommand,
+	ctx context.Context,
+	client dexpb.FlowServiceClient,
+	flowID string,
+	runID string,
+	fromEventID int64,
+	pageSize int32,
+	followRuns bool,
+	options options,
+) error {
+	currentRunID, err := resolveRunID(ctx, client, flowID, runID)
+	if err != nil {
+		return newOperationError("flow watch", err)
+	}
+	nextEventID := fromEventID
+	var nextPageToken []byte
+	lastStateEventID := int64(-1)
+	for {
+		page, pageErr := client.GetHistoryEvents(ctx, &dexpb.GetHistoryEventsRequest{
+			FlowId: flowID, RunId: currentRunID, StartInternalEventId: nextEventID,
+			EstimatePageSize: pageSize, NextPageToken: nextPageToken,
+		})
+		if pageErr != nil {
+			return newOperationError("flow watch", pageErr)
+		}
+		for _, event := range page.GetEvents() {
+			mapped, warnings, mapErr := naturalMessage(ctx, client, event, options.noHydrate)
+			if mapErr != nil {
+				return newOperationError("flow watch", mapErr)
+			}
+			normalizeHistoryEvent(mapped, event)
+			mapped["flowId"] = flowID
+			mapped["runId"] = currentRunID
+			if len(warnings) > 0 {
+				mapped["warnings"] = warnings
+			}
+			if err := writeOutput(c.stdout, options.output, mapped); err != nil {
+				return err
+			}
+		}
+		nextEventID = page.GetNextInternalEventId()
+		nextPageToken = page.GetNextPageToken()
+		if len(nextPageToken) > 0 {
+			continue
+		}
+		summary, summaryErr := client.GetFlowSummary(ctx, &dexpb.GetFlowSummaryRequest{
+			FlowId: flowID, RunId: currentRunID,
+		})
+		if summaryErr != nil {
+			return newOperationError("flow watch", summaryErr)
+		}
+		if summary.GetFlowStatus() != dexpb.FlowStatus_FLOW_STATUS_RUNNING {
+			if followRuns && summary.GetFlowStatus() == dexpb.FlowStatus_FLOW_STATUS_CONTINUED_AS_NEW {
+				currentRunID, err = resolveRunID(ctx, client, flowID, "")
+				if err != nil {
+					return newOperationError("flow watch", err)
+				}
+				nextEventID = 0
+				nextPageToken = nil
+				lastStateEventID = -1
+				continue
+			}
+			return nil
+		}
+		if nextEventID != lastStateEventID {
+			stateResponse, stateErr := client.GetFlowState(ctx, &dexpb.GetFlowStateRequest{
+				FlowId: flowID, RunId: currentRunID,
+			})
+			if stateErr != nil {
+				return newOperationError("flow watch", stateErr)
+			}
+			state, warnings, mapErr := naturalMessage(ctx, client, stateResponse, options.noHydrate)
+			if mapErr != nil {
+				return newOperationError("flow watch", mapErr)
+			}
+			snapshot := map[string]any{
+				"type": "FlowStateSnapshot", "flowId": flowID, "runId": currentRunID,
+				"nextInternalEventId": nextEventID, "state": state,
+			}
+			if len(warnings) > 0 {
+				snapshot["warnings"] = warnings
+			}
+			if err := writeOutput(c.stdout, options.output, snapshot); err != nil {
+				return err
+			}
+			lastStateEventID = nextEventID
+		}
+		_, waitErr := client.WaitForHistoryEvent(ctx, &dexpb.WaitForHistoryEventRequest{
+			FlowId: flowID, RunId: currentRunID, NextInternalEventId: nextEventID,
+		})
+		if waitErr != nil && status.Code(waitErr) != codes.DeadlineExceeded {
+			return newOperationError("flow watch", waitErr)
+		}
+	}
+}
+
+func executeStop(c *flowCommand, ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow stop", c.stderr)
+	runID := flags.String("run-id", "", "Flow run ID")
+	stopTypeName := flags.String("type", "", "cancel, terminate, or fail")
+	reason := flags.String("reason", "", "stop reason")
+	yes := flags.Bool("yes", false, "confirm the operation")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow stop FLOW_ID --run-id ID --type TYPE --yes"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow stop")
+	if err != nil {
+		return err
+	}
+	if *runID == "" {
+		return newUsageError("flow stop", fmt.Errorf("run-id is required"))
+	}
+	stopType, err := parseStopType(*stopTypeName)
+	if err != nil {
+		return newUsageError("flow stop", err)
+	}
+	if stopType != dexpb.StopType_STOP_TYPE_CANCEL && strings.TrimSpace(*reason) == "" {
+		return newUsageError("flow stop", fmt.Errorf("reason is required for terminate and fail"))
+	}
+	if !*yes {
+		return newConfirmationError("flow stop")
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		_, callErr := client.service.StopFlow(callCtx, &dexpb.StopFlowRequest{
+			FlowId: flowID, RunId: *runID, StopType: stopType, Reason: *reason,
+		})
+		if callErr != nil {
+			return newOperationError("flow stop", callErr)
+		}
+		return writeOutput(c.stdout, options.output, map[string]any{
+			"flowId": flowID, "runId": *runID, "stopped": true,
+		})
+	})
+}
+
+func parseStopType(value string) (dexpb.StopType, error) {
+	switch value {
+	case "cancel":
+		return dexpb.StopType_STOP_TYPE_CANCEL, nil
+	case "terminate":
+		return dexpb.StopType_STOP_TYPE_TERMINATE, nil
+	case "fail":
+		return dexpb.StopType_STOP_TYPE_FAIL, nil
+	default:
+		return dexpb.StopType_STOP_TYPE_UNSPECIFIED, fmt.Errorf("type must be cancel, terminate, or fail")
+	}
+}
+
+func executeReset(c *flowCommand, ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow reset", c.stderr)
+	runID := flags.String("run-id", "", "Flow run ID")
+	resetTypeName := flags.String("type", "", "reset point type")
+	target := flags.String("target", "", "reset point value")
+	reason := flags.String("reason", "", "reset reason")
+	skipChannels := flags.Bool("skip-channel-reapply", false, "skip channel message reapply")
+	skipLocks := flags.Bool("skip-locking-rpc-reapply", false, "skip locking RPC reapply")
+	yes := flags.Bool("yes", false, "confirm the operation")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow reset FLOW_ID --run-id ID --type TYPE --reason TEXT --yes"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow reset")
+	if err != nil {
+		return err
+	}
+	request, err := resetRequest(flowID, *runID, *resetTypeName, *target, *reason)
+	if err != nil {
+		return newUsageError("flow reset", err)
+	}
+	request.SkipChannelMessagesReapply = *skipChannels
+	request.SkipLockingRpcReapply = *skipLocks
+	if !*yes {
+		return newConfirmationError("flow reset")
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		response, callErr := client.service.ResetFlow(callCtx, request)
+		if callErr != nil {
+			return newOperationError("flow reset", callErr)
+		}
+		return writeOutput(c.stdout, options.output, map[string]any{
+			"flowId": flowID, "previousRunId": *runID, "runId": response.GetRunId(),
+		})
+	})
+}
+
+func resetRequest(flowID string, runID string, typeName string, target string, reason string) (*dexpb.ResetFlowRequest, error) {
+	if runID == "" || strings.TrimSpace(reason) == "" {
+		return nil, fmt.Errorf("run-id and reason are required")
+	}
+	request := &dexpb.ResetFlowRequest{FlowId: flowID, RunId: runID, Reason: reason}
+	switch typeName {
+	case "beginning":
+		request.ResetType = dexpb.FlowResetType_FLOW_RESET_TYPE_BEGINNING
+	case "history-event-id":
+		value, err := parseInt32(target, "target")
+		if err != nil || value <= 0 {
+			return nil, fmt.Errorf("target must be a positive history event ID")
+		}
+		request.ResetType = dexpb.FlowResetType_FLOW_RESET_TYPE_HISTORY_EVENT_ID
+		request.HistoryEventId = value
+	case "history-event-time":
+		if _, err := time.Parse(time.RFC3339, target); err != nil {
+			return nil, fmt.Errorf("target must be an RFC3339 timestamp: %w", err)
+		}
+		request.ResetType = dexpb.FlowResetType_FLOW_RESET_TYPE_HISTORY_EVENT_TIME
+		request.HistoryEventTime = target
+	case "step-type":
+		request.ResetType = dexpb.FlowResetType_FLOW_RESET_TYPE_STEP_TYPE
+		request.StepType = target
+	case "step-execution-id":
+		request.ResetType = dexpb.FlowResetType_FLOW_RESET_TYPE_STEP_EXECUTION_ID
+		request.StepExecutionId = target
+	default:
+		return nil, fmt.Errorf("type must be beginning, history-event-id, history-event-time, step-type, or step-execution-id")
+	}
+	if typeName != "beginning" && strings.TrimSpace(target) == "" {
+		return nil, fmt.Errorf("target is required for reset type %s", typeName)
+	}
+	return request, nil
+}

--- a/cli/internal/command/options.go
+++ b/cli/internal/command/options.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package command
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+)
+
+const defaultServerAddress = "127.0.0.1:8801"
+
+type options struct {
+	server    string
+	output    string
+	timeout   time.Duration
+	noHydrate bool
+}
+
+func defaultOptions(getenv func(string) string) options {
+	server := strings.TrimSpace(getenv("DEX_FLOW_SERVICE_ADDRESS"))
+	if server == "" {
+		server = defaultServerAddress
+	}
+	return options{
+		server:  server,
+		output:  "json",
+		timeout: 30 * time.Second,
+	}
+}
+
+func parseRootOptions(args []string, options *options) ([]string, error) {
+	flags := newFlagSet("dexcli", io.Discard)
+	addCommonFlags(flags, options)
+	if err := flags.Parse(args); err != nil {
+		return nil, err
+	}
+	return flags.Args(), nil
+}
+
+func addCommonFlags(flags *flag.FlagSet, options *options) {
+	flags.StringVar(&options.server, "server", options.server, "Dex FlowService host:port")
+	flags.StringVar(&options.output, "output", options.output, "json or table")
+	flags.DurationVar(&options.timeout, "timeout", options.timeout, "request timeout; 0 disables")
+	flags.BoolVar(&options.noHydrate, "no-hydrate", options.noHydrate, "return blob references")
+}
+
+func newFlagSet(name string, output io.Writer) *flag.FlagSet {
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	flags.SetOutput(output)
+	return flags
+}
+
+func (o options) validate() error {
+	if strings.Contains(o.server, "://") {
+		return fmt.Errorf("server must be host:port, not a URL")
+	}
+	if _, _, err := net.SplitHostPort(o.server); err != nil {
+		return fmt.Errorf("server must be host:port: %w", err)
+	}
+	switch o.output {
+	case "json", "table":
+	default:
+		return fmt.Errorf("output must be json or table")
+	}
+	if o.timeout < 0 {
+		return fmt.Errorf("timeout must not be negative")
+	}
+	return nil
+}

--- a/cli/internal/command/output.go
+++ b/cli/internal/command/output.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+
+func writeOutput(output io.Writer, format string, value any) error {
+	if format == "table" {
+		return writeTable(output, value)
+	}
+	encoder := json.NewEncoder(output)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return newOperationError("output", err)
+	}
+	return nil
+}
+
+func writeTable(output io.Writer, value any) error {
+	rows, headers := tableRows(value)
+	written := tabwriter.NewWriter(output, 0, 4, 2, ' ', 0)
+	if len(headers) == 0 {
+		_, err := fmt.Fprintln(written, tableCell(value))
+		return closeWithError(err, written.Flush)
+	}
+	if _, err := fmt.Fprintln(written, strings.Join(headers, "\t")); err != nil {
+		return closeWithError(err, written.Flush)
+	}
+	for _, row := range rows {
+		cells := make([]string, len(headers))
+		for index, header := range headers {
+			cells[index] = tableCell(row[header])
+		}
+		if _, err := fmt.Fprintln(written, strings.Join(cells, "\t")); err != nil {
+			return closeWithError(err, written.Flush)
+		}
+	}
+	if err := written.Flush(); err != nil {
+		return newOperationError("output", err)
+	}
+	return nil
+}
+
+func tableRows(value any) ([]map[string]any, []string) {
+	switch current := value.(type) {
+	case []any:
+		rows := make([]map[string]any, 0, len(current))
+		for _, entry := range current {
+			if row, ok := entry.(map[string]any); ok {
+				rows = append(rows, row)
+			} else {
+				rows = append(rows, map[string]any{"value": entry})
+			}
+		}
+		return rows, tableHeaders(rows)
+	case map[string]any:
+		for _, key := range []string{"flows", "events", "methods"} {
+			if entries, ok := current[key].([]any); ok {
+				return tableRows(entries)
+			}
+		}
+		rows := make([]map[string]any, 0, len(current))
+		keys := make([]string, 0, len(current))
+		for key := range current {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			rows = append(rows, map[string]any{"field": key, "value": current[key]})
+		}
+		return rows, []string{"field", "value"}
+	default:
+		return []map[string]any{{"value": value}}, []string{"value"}
+	}
+}
+
+func tableHeaders(rows []map[string]any) []string {
+	set := make(map[string]struct{})
+	for _, row := range rows {
+		for key := range row {
+			set[key] = struct{}{}
+		}
+	}
+	headers := make([]string, 0, len(set))
+	for key := range set {
+		headers = append(headers, key)
+	}
+	sort.Strings(headers)
+	return headers
+}
+
+func tableCell(value any) string {
+	switch current := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.ReplaceAll(current, "\t", " ")
+	case float64, float32, int, int32, int64, uint, uint32, uint64, bool:
+		return fmt.Sprint(current)
+	default:
+		data, err := json.Marshal(current)
+		if err != nil {
+			return fmt.Sprint(current)
+		}
+		return string(data)
+	}
+}

--- a/cli/internal/command/values.go
+++ b/cli/internal/command/values.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package command
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/superdurable/dex/gen/dexpb"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+type blobReference struct {
+	id   string
+	kind string
+}
+
+func naturalMessage(
+	ctx context.Context,
+	client dexpb.FlowServiceClient,
+	message proto.Message,
+	noHydrate bool,
+) (map[string]any, []string, error) {
+	raw, err := messageMap(message)
+	if err != nil {
+		return nil, nil, err
+	}
+	references := make(map[string]blobReference)
+	collectBlobReferences(raw, references)
+	if noHydrate || len(references) == 0 {
+		return naturalValue(raw, nil, false).(map[string]any), nil, nil
+	}
+	replacements, warnings := hydrateBlobReferences(ctx, client, references)
+	return naturalValue(raw, replacements, true).(map[string]any), warnings, nil
+}
+
+func messageMap(message proto.Message) (map[string]any, error) {
+	data, err := (protojson.MarshalOptions{}).Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]any)
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func collectBlobReferences(value any, references map[string]blobReference) {
+	switch current := value.(type) {
+	case map[string]any:
+		if reference, ok := rawBlobReference(current); ok {
+			references[blobReferenceKey(reference)] = reference
+			return
+		}
+		for _, entry := range current {
+			collectBlobReferences(entry, references)
+		}
+	case []any:
+		for _, entry := range current {
+			collectBlobReferences(entry, references)
+		}
+	}
+}
+
+func hydrateBlobReferences(
+	ctx context.Context,
+	client dexpb.FlowServiceClient,
+	references map[string]blobReference,
+) (map[string]any, []string) {
+	values := make([]*dexpb.Value, 0, len(references))
+	for _, reference := range references {
+		value := &dexpb.Value{}
+		if reference.kind == "string" {
+			value.Kind = &dexpb.Value_InternalBlobIdForStringValue{
+				InternalBlobIdForStringValue: reference.id,
+			}
+		} else {
+			value.Kind = &dexpb.Value_InternalBlobIdForObjValue{
+				InternalBlobIdForObjValue: reference.id,
+			}
+		}
+		values = append(values, value)
+	}
+	response, err := client.LoadBlobs(ctx, &dexpb.LoadBlobsRequest{Values: values})
+	if err != nil {
+		return nil, []string{fmt.Sprintf("stored values unavailable: %v", err)}
+	}
+	replacements := make(map[string]any, len(references))
+	missing := 0
+	for key, reference := range references {
+		value, found := response.GetValues()[reference.id]
+		if !found {
+			missing++
+			continue
+		}
+		raw, mapErr := messageMap(value)
+		if mapErr != nil {
+			missing++
+			continue
+		}
+		replacements[key] = naturalValue(raw, nil, false)
+	}
+	if missing > 0 {
+		return replacements, []string{fmt.Sprintf("%d stored value(s) unavailable", missing)}
+	}
+	return replacements, nil
+}
+
+func naturalValue(value any, replacements map[string]any, unavailableWhenMissing bool) any {
+	switch current := value.(type) {
+	case map[string]any:
+		if reference, ok := rawBlobReference(current); ok {
+			if replacement, found := replacements[blobReferenceKey(reference)]; found {
+				return replacement
+			}
+			if unavailableWhenMissing {
+				return map[string]any{
+					"__dexStoredValueUnavailable": true,
+					"__dexBlobReference":          mappedBlobReference(reference),
+				}
+			}
+			return map[string]any{"__dexBlobReference": mappedBlobReference(reference)}
+		}
+		if mapped, ok := concreteDexValue(current); ok {
+			return mapped
+		}
+		mapped := make(map[string]any, len(current))
+		for key, entry := range current {
+			mapped[key] = naturalValue(entry, replacements, unavailableWhenMissing)
+		}
+		return mapped
+	case []any:
+		mapped := make([]any, len(current))
+		for index, entry := range current {
+			mapped[index] = naturalValue(entry, replacements, unavailableWhenMissing)
+		}
+		return mapped
+	default:
+		return value
+	}
+}
+
+func rawBlobReference(value map[string]any) (blobReference, bool) {
+	if len(value) != 1 {
+		return blobReference{}, false
+	}
+	if id, ok := value["internalBlobIdForStringValue"].(string); ok && id != "" {
+		return blobReference{id: id, kind: "string"}, true
+	}
+	if id, ok := value["internalBlobIdForObjValue"].(string); ok && id != "" {
+		return blobReference{id: id, kind: "object"}, true
+	}
+	return blobReference{}, false
+}
+
+func concreteDexValue(value map[string]any) (any, bool) {
+	if len(value) != 1 {
+		return nil, false
+	}
+	if current, ok := value["stringValue"]; ok {
+		return current, true
+	}
+	if current, ok := value["intValue"]; ok {
+		stringValue, stringOK := current.(string)
+		if !stringOK {
+			return current, true
+		}
+		parsed, err := strconv.ParseInt(stringValue, 10, 64)
+		if err != nil {
+			return stringValue, true
+		}
+		return parsed, true
+	}
+	if current, ok := value["doubleValue"]; ok {
+		return current, true
+	}
+	if current, ok := value["boolValue"]; ok {
+		return current, true
+	}
+	if _, ok := value["nullValue"]; ok {
+		return nil, true
+	}
+	if current, ok := value["objValue"].(map[string]any); ok {
+		return decodedObject(current), true
+	}
+	return nil, false
+}
+
+func decodedObject(value map[string]any) any {
+	encoding := ""
+	if current, ok := value["encoding"].(string); ok {
+		encoding = current
+	}
+	payload := ""
+	if current, ok := value["payload"].(string); ok {
+		payload = current
+	}
+	if encoding == "json" {
+		decoded, err := base64.StdEncoding.DecodeString(payload)
+		if err == nil {
+			var mapped any
+			if err := json.Unmarshal(decoded, &mapped); err == nil {
+				return mapped
+			}
+		}
+	}
+	return map[string]any{"encoding": encoding, "payload": payload}
+}
+
+func mappedBlobReference(reference blobReference) map[string]any {
+	return map[string]any{"id": reference.id, "kind": reference.kind}
+}
+
+func blobReferenceKey(reference blobReference) string {
+	return reference.kind + ":" + reference.id
+}

--- a/cli/internal/dev/supervisor_integ_test.go
+++ b/cli/internal/dev/supervisor_integ_test.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/superdurable/dex/cli/internal/command"
 )
 
 func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
@@ -66,6 +68,45 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 	if searchResponse.StatusCode != http.StatusOK || !bytes.Contains(body, []byte(`"flows":[]`)) {
 		cancel()
 		t.Fatalf("search response: status=%d body=%s", searchResponse.StatusCode, body)
+	}
+	cliOutput := &bytes.Buffer{}
+	cliErrors := &bytes.Buffer{}
+	cliApp := command.NewApp(bytes.NewReader(nil), cliOutput, cliErrors)
+	dexAddress := net.JoinHostPort(cfg.BindAddress, strconv.Itoa(cfg.DexPort))
+	if err := cliApp.Execute(
+		context.Background(),
+		[]string{"health", "--server", dexAddress},
+	); err != nil {
+		cancel()
+		t.Fatalf("CLI health failed: %v stderr=%s", err, cliErrors.String())
+	}
+	if !bytes.Contains(cliOutput.Bytes(), []byte(`"condition":"OK"`)) {
+		cancel()
+		t.Fatalf("unexpected CLI health response: %s", cliOutput.String())
+	}
+	cliOutput.Reset()
+	if err := cliApp.Execute(
+		context.Background(),
+		[]string{"flow", "search", "--server", dexAddress},
+	); err != nil {
+		cancel()
+		t.Fatalf("CLI search failed: %v stderr=%s", err, cliErrors.String())
+	}
+	if !bytes.Contains(cliOutput.Bytes(), []byte(`"flows":[]`)) {
+		cancel()
+		t.Fatalf("unexpected CLI search response: %s", cliOutput.String())
+	}
+	cliOutput.Reset()
+	if err := cliApp.Execute(
+		context.Background(),
+		[]string{"api", "call", "HealthCheck", "--server", dexAddress},
+	); err != nil {
+		cancel()
+		t.Fatalf("CLI API call failed: %v stderr=%s", err, cliErrors.String())
+	}
+	if !bytes.Contains(cliOutput.Bytes(), []byte(`"condition":"OK"`)) {
+		cancel()
+		t.Fatalf("unexpected CLI API response: %s", cliOutput.String())
 	}
 
 	cancel()

--- a/docs/content/references/cli.mdx
+++ b/docs/content/references/cli.mdx
@@ -1,0 +1,74 @@
+---
+id: cli
+title: Dex CLI
+sidebar_label: CLI
+---
+
+# Dex CLI
+
+`dexcli` provides a JSON-first interface for operating and inspecting Flows. It
+is designed for shell automation and AI agents as well as human operators.
+
+## Connect to Dex
+
+Commands connect to `127.0.0.1:8801` by default. Set
+`DEX_FLOW_SERVICE_ADDRESS` for a process-wide target or pass `--server` for one
+command. The server address is a plaintext gRPC `host:port`, not an HTTP URL.
+
+```bash
+DEX_FLOW_SERVICE_ADDRESS=dex.example.internal:8801 dexcli health
+dexcli --server 127.0.0.1:9901 flow search
+```
+
+## Friendly Flow operations
+
+Use `flow search`, `summary`, `state`, `history`, and `inspect` for bounded JSON
+responses. `inspect` combines summary, current state, and history, making it the
+best starting point for an agent investigating a Flow.
+
+```bash
+dexcli flow inspect order-123 --all-history
+```
+
+Stored strings and objects are hydrated automatically. Use `--no-hydrate` when
+only structure and blob identities are needed. The output then contains stable
+`__dexBlobReference` objects rather than the stored payload.
+
+`flow watch` first emits available semantic history events and then long-polls
+for new events. Each line is one JSON object. It stops at a terminal status;
+`--follow-runs` follows Continue-As-New into the current run.
+
+Stop and reset always require an exact `--run-id` and explicit `--yes`. This
+prevents an agent from mutating a newer run after resolving an older one.
+
+## Complete public API access
+
+The `api` commands expose every public `FlowService` RPC known to the installed
+CLI version:
+
+```bash
+dexcli api list
+dexcli api describe InvokeRPC
+dexcli api call InvokeRPC --data @invoke.json --yes
+```
+
+`api describe` reports request and response fields, oneofs, enums, maps, and
+reachable message definitions. `api call` accepts canonical protobuf JSON from
+an inline string, `@file`, or stdin via `--data -`. It returns canonical
+protobuf JSON and does not perform friendly value hydration.
+
+`WorkerService` and `InternalService` are intentionally excluded because they
+are worker callbacks and server-internal protocols rather than public operator
+APIs.
+
+## Output and errors
+
+JSON is the default stable output. `--output table` is intended for human
+display and is not a machine compatibility contract. Use `--timeout 0` to
+disable the default 30-second client deadline for a bounded command; watch
+manages its long-poll lifecycle until interrupted.
+
+Errors are JSON on stderr. They include `kind`, `operation`, `message`, and,
+when applicable, `grpcCode`, `grpcCodeName`, and structured status details.
+Exit status 2 means invalid usage or missing confirmation; status 1 means the
+request failed.

--- a/docs/content/references/index.mdx
+++ b/docs/content/references/index.mdx
@@ -10,6 +10,7 @@ slug: /references
 Deeper API and concept notes (Dex vocabulary). Legacy iWF wiki sources live under `docs/archive/` for contributors.
 
 - [Client APIs](/references/client-apis)
+- [Dex CLI](/references/cli)
 - [Persistence (Attributes)](/references/persistence)
 - [RPC](/references/rpc)
 - [RPC locking](/references/rpc-locking)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -98,6 +98,7 @@ const sidebars: SidebarsConfig = {
       label: 'References',
       link: {type: 'doc', id: 'references/index'},
       items: [
+        'references/cli',
         'references/client-apis',
         'references/persistence',
         'references/rpc',


### PR DESCRIPTION
## Summary
- add JSON-first `health` and `flow` commands for search, summary, state, history, inspect, watch, stop, and reset
- add descriptor-driven `api list`, `api describe`, and `api call` coverage for every public FlowService RPC
- hydrate stored values by default, with `--no-hydrate` for reference-only output
- require exact run IDs and `--yes` for destructive operations
- document the CLI contract for humans and AI agents

## Why
Dex Web gives humans semantic Flow inspection and operations, but browser interaction is inefficient for AI agents and shell automation. This adds a stable machine-readable interface while preserving an escape hatch to every public server API without requiring gRPC reflection.

## User impact
Users can inspect and operate Dex from the installed `dexcli` binary. Existing `dev`, `version`, and help behavior remains available. Successful commands emit JSON by default; errors are structured JSON on stderr.

## Validation
- `make -C cli test`
- `make -C cli integration-test`
- `make -C cli build`
- `npm run typecheck && npm run build` in `docs/`
- `make copyright-check`
