### PR TITLE
ci: activate Rust 1.97 for Java contracts

### DIFF
--- a/.github/workflows/sdk-java-ci.yml
+++ b/.github/workflows/sdk-java-ci.yml
@@ -41,6 +41,8 @@ jobs:
   contracts:
     name: User contracts (Java ${{ matrix.java-version }})
     runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    env:
+      RUSTUP_TOOLCHAIN: "1.97.1"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- activate Rust 1.97.1 in the Java contract-test matrix
- ensure Gradle's JNI native build uses the toolchain installed by the workflow

## Rationale

The Java 8 and Java 17 contract jobs installed Rust 1.97.1 but left Rust 1.88 active. `buildBlobCacheNative` therefore failed because `dex-blob-cache` and `dex-blob-cache-jni` require Rust 1.97.

## User impact

Java contract CI can compile the native blob-cache JNI library on clean and self-hosted runners.

## Validation

- `make ci-runner-check`
- workflow lint and YAML parse
- Java 17: `./gradlew compileTestJava --no-daemon`
- Java 17: `./gradlew test --tests io.superdurable.dex.contracts.UserContractsTest --no-daemon`
