### PR TITLE
Improve WaitFor condition summaries in selected events

### DIFF
--- a/web/app/flows/details/EventDetails.test.tsx
+++ b/web/app/flows/details/EventDetails.test.tsx
@@ -46,10 +46,10 @@ function executeEvent(durability: number): FlowHistoryEvent {
   };
 }
 
-function waitForEvent(waitForCondition: Record<string, unknown>): FlowHistoryEvent {
+function waitForEvent(waitForCondition?: Record<string, unknown>): FlowHistoryEvent {
   const event = executeEvent(1);
   event.type = 'StepWaitForCompleted';
-  event.payload.output = { waitForCondition };
+  event.payload.output = waitForCondition ? { waitForCondition } : {};
   return event;
 }
 
@@ -355,9 +355,7 @@ describe('selected step event details', () => {
   });
 
   it('explains that an empty WaitFor condition skips waiting immediately', () => {
-    const markup = renderDetails(waitForEvent({
-      waitingConditionType: 'WAITING_CONDITION_TYPE_ALL_COMPLETED',
-    }));
+    const markup = renderDetails(waitForEvent());
 
     expect(markup).toContain('Empty condition — skips WaitFor immediately');
     expect(markup).not.toContain('All completed');

--- a/web/app/flows/details/EventDetails.test.tsx
+++ b/web/app/flows/details/EventDetails.test.tsx
@@ -46,6 +46,13 @@ function executeEvent(durability: number): FlowHistoryEvent {
   };
 }
 
+function waitForEvent(waitForCondition: Record<string, unknown>): FlowHistoryEvent {
+  const event = executeEvent(1);
+  event.type = 'StepWaitForCompleted';
+  event.payload.output = { waitForCondition };
+  return event;
+}
+
 function renderDetails(
   event: FlowHistoryEvent,
   history: FlowHistoryEvent[] = [event],
@@ -334,6 +341,37 @@ describe('selected step event details', () => {
 
     expect(markup).toContain('Fail flow');
     expect(markup).toContain('rpc-account');
+  });
+
+  it('describes one WaitFor condition without an allOf or anyOf rule', () => {
+    const markup = renderDetails(waitForEvent({
+      waitingConditionType: 'WAITING_CONDITION_TYPE_ANY_COMPLETED',
+      channelConditions: [{ conditionId: 1, channelName: 'approval' }],
+    }));
+
+    expect(markup).toContain('Single condition');
+    expect(markup).not.toContain('Any completed');
+    expect(markup).not.toContain('All completed');
+  });
+
+  it('explains that an empty WaitFor condition skips waiting immediately', () => {
+    const markup = renderDetails(waitForEvent({
+      waitingConditionType: 'WAITING_CONDITION_TYPE_ALL_COMPLETED',
+    }));
+
+    expect(markup).toContain('Empty condition — skips WaitFor immediately');
+    expect(markup).not.toContain('All completed');
+  });
+
+  it('preserves the completion rule for multiple WaitFor conditions', () => {
+    const markup = renderDetails(waitForEvent({
+      waitingConditionType: 'WAITING_CONDITION_TYPE_ANY_COMPLETED',
+      channelConditions: [{ conditionId: 1, channelName: 'approval' }],
+      timerConditions: [{ conditionId: 2, durationSeconds: 30 }],
+    }));
+
+    expect(markup).toContain('Any completed');
+    expect(markup).not.toContain('Single condition');
   });
 });
 

--- a/web/app/flows/details/EventDetails.tsx
+++ b/web/app/flows/details/EventDetails.tsx
@@ -326,7 +326,7 @@ function WaitingConditionContent({ value }: { value: unknown }) {
     <>
       <Fields values={[[
         'Completion rule',
-        waitingConditionTypeLabel(condition.waitingConditionType),
+        waitingConditionCompletionRule(condition, channels.length + timers.length),
       ]]} />
       {channels.length > 0 && (
         <div className="semantic-records">
@@ -366,6 +366,12 @@ function WaitingConditionContent({ value }: { value: unknown }) {
       )}
     </>
   );
+}
+
+function waitingConditionCompletionRule(condition: Data, conditionCount: number): string {
+  if (conditionCount === 0) return 'Empty condition — skips WaitFor immediately';
+  if (conditionCount === 1) return 'Single condition';
+  return waitingConditionTypeLabel(condition.waitingConditionType);
 }
 
 function unixTime(value: unknown, timezone: TimezonePreference): string | undefined {

--- a/web/app/flows/details/EventDetails.tsx
+++ b/web/app/flows/details/EventDetails.tsx
@@ -315,10 +315,16 @@ function WaitingConditionView({ value }: { value: unknown }) {
   );
 }
 
-function WaitingConditionContent({ value }: { value: unknown }) {
+function WaitingConditionContent({
+  value,
+  showEmpty = false,
+}: {
+  value: unknown;
+  showEmpty?: boolean;
+}) {
   const { timezone } = usePreferences();
   const condition = asData(value);
-  if (!hasData(condition)) return null;
+  if (!hasData(condition) && !showEmpty) return null;
   const channels = asDataArray(condition.channelConditions);
   const timers = asDataArray(condition.timerConditions);
   const combinations = asDataArray(condition.conditionCombinations);
@@ -604,10 +610,10 @@ function StepMethodDetails({
         ) : <p className="muted">No input</p>}
       </DetailSection>
       <DetailSection title="Output">
-        {isWaitFor && hasData(asData(output.waitForCondition)) ? (
+        {event.type === 'StepWaitForCompleted' ? (
           <div className="semantic-subsection">
             <h5>WaitFor condition</h5>
-            <WaitingConditionContent value={output.waitForCondition} />
+            <WaitingConditionContent value={output.waitForCondition} showEmpty />
           </div>
         ) : !isWaitFor && hasData(asData(output.stepDecision)) ? (
           <div className="semantic-subsection">


### PR DESCRIPTION
## Summary

- describe a single WaitFor condition without an `allOf` or `anyOf` completion rule
- explain that an omitted condition means WaitFor is skipped immediately
- retain the configured completion rule when multiple conditions are present
- cover single, empty, and multiple-condition event details

## Rationale

The selected-event panel previously exposed protocol-level completion rules even when they added no useful information. It also rendered no WaitFor condition summary when `SkipWaitImmediately()` omitted `waitForCondition` from the event output.

## User impact

WaitFor event details now read according to the actual condition count:

- one condition: `Single condition`
- no condition: `Empty condition — skips WaitFor immediately`
- multiple conditions: the existing completion rule

## Validation

- `cd web && npm run check`
- `cd web && npm run build`
- `cd web && GOWORK=off go test ./...`
- `make copyright-check`
