### PR TITLE
fix(server): retry partially registered indexes

### DIFF
--- a/server/service/indexsync/synchronizer.go
+++ b/server/service/indexsync/synchronizer.go
@@ -183,6 +183,10 @@ func (s *Synchronizer) waitUntilVisible(
 				tag.Missing(missing),
 				tag.Interval(nextPollInterval(interval)),
 			)
+			addErr := s.addAttributeIndexes(ctx, missing)
+			if addErr != nil && !isRetryable(addErr) && !isConcurrentRegistration(addErr) {
+				return backendError(addErr)
+			}
 		} else if !isRetryable(err) {
 			return backendError(err)
 		} else {

--- a/server/service/indexsync/synchronizer_test.go
+++ b/server/service/indexsync/synchronizer_test.go
@@ -70,6 +70,27 @@ func TestSyncWaitsForNewIndexesToBecomeVisible(t *testing.T) {
 	require.Equal(t, 1, client.addCallCount())
 }
 
+func TestSyncRetriesIndexesMissingAfterSuccessfulRegistration(t *testing.T) {
+	client := &scriptedClient{listResults: []listResult{
+		{indexes: map[string]dexpb.IndexType{}},
+		{indexes: map[string]dexpb.IndexType{"Status": dexpb.IndexType_INDEX_TYPE_KEYWORD}},
+		{indexes: map[string]dexpb.IndexType{
+			"FlowType": dexpb.IndexType_INDEX_TYPE_KEYWORD,
+			"Status":   dexpb.IndexType_INDEX_TYPE_KEYWORD,
+		}},
+	}}
+	synchronizer := New(testConfig(2*time.Second), client, log.NewNoop())
+
+	err := synchronizer.Sync(context.Background(), map[string]dexpb.IndexType{
+		"FlowType": dexpb.IndexType_INDEX_TYPE_KEYWORD,
+		"Status":   dexpb.IndexType_INDEX_TYPE_KEYWORD,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 3, client.listCallCount())
+	require.Equal(t, 2, client.addCallCount())
+}
+
 func TestSyncAcceptsConcurrentRegistration(t *testing.T) {
 	client := &scriptedClient{
 		listResults: []listResult{


### PR DESCRIPTION
## Summary

- retry only attribute indexes that remain missing after a successful backend registration call
- preserve immediate failure for permanent registration errors
- cover partial-success registration with a deterministic regression test

## Rationale

Main Server CI repeatedly timed out while starting Temporal partition 4. Temporal accepted a nine-index registration request but kept reporting three indexes as missing for the full two-minute synchronization deadline. The next service startup re-registered those three indexes successfully, showing that the original call had only partially converged.

## User impact

Dex startup now converges when a workflow backend reports a successful but partial attribute-index registration, instead of failing after the propagation timeout.

## Validation

- `make -C server unitTests`
- `make copyright-check`
- `make -C server ci-temporal-integ-test totalPartitions=5 partitionNum=4` (the formerly failing `TestAnyTimerSignalFlowTemporalContinueAsNew` passed; the full local target later failed in unrelated existing `TestWebAPITemporal` assertions)
