### PR TITLE
Address step recovery review feedback

### DIFF
--- a/docs/content/design-patterns/recovery.mdx
+++ b/docs/content/design-patterns/recovery.mdx
@@ -65,17 +65,16 @@ accepts replay of the earlier method after recovery has begun.
 ## Dynamic retry delay
 
 Java Steps can request the next retry interval while preserving the original
-failure:
+attempt failure:
 
 ```java
-throw RetryAfterException.after(Duration.ofSeconds(30), failure);
+throw RetryAfterException.after(Duration.ofSeconds(30), currentFailure);
 ```
 
 Temporal applies this value to the next Activity retry without changing retry
-limits or method timeouts. Cadence cannot apply a dynamic interval; Dex stops
-retrying that method and evaluates its failure policy. In both cases the
-original cause, rather than `RetryAfterException`, is exposed as the Worker
-error.
+limits or method timeouts. Cadence rejects a dynamic interval with an
+`INVALID_USER_FLOW_CODE` validation error. On Temporal, the current attempt
+failure, rather than `RetryAfterException`, is exposed as the Worker error.
 
 ## Backend failures
 

--- a/protos/README.md
+++ b/protos/README.md
@@ -96,8 +96,8 @@ the interpreter synthesizes one from the backend application or timeout type.
 `WorkerErrorResponse.retry_after_seconds` requests the next retry interval.
 The value is copied through
 `ErrorResponse.original_worker_retry_after_seconds`. Temporal applies it to
-the next Activity retry. Cadence cannot apply a dynamic interval, so it stops
-retrying that Step method and evaluates the configured failure policy.
+the next Activity retry. Cadence rejects a nonzero value with an
+`INVALID_USER_FLOW_CODE` validation error from the Step method Activity.
 
 `ErrorResponse.detail` and `original_worker_error_detail` are mutually exclusive.
 Worker responses use the original field; transport failures without a

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -118,16 +118,15 @@ if (error != null) {
 ```
 
 To override the next Temporal retry interval, throw a retry request with the
-original failure as its cause:
+current attempt failure as its cause:
 
 ```java
-throw RetryAfterException.after(Duration.ofSeconds(30), failure);
+throw RetryAfterException.after(Duration.ofSeconds(30), currentFailure);
 ```
 
 The delay must be a positive whole number of seconds in the signed 32-bit
-range. Retry limits and method timeouts remain unchanged. Cadence cannot honor
-dynamic retry intervals; it stops retrying that method and applies its Step
-failure policy while preserving the original cause in `getRecoveryError()`.
+range. Retry limits and method timeouts remain unchanged. Cadence rejects a
+dynamic retry interval with an `INVALID_USER_FLOW_CODE` validation error.
 
 `Flow<StartInput>.getSteps()` returns `StepList<StartInput>`. Start with
 `StepList.startStep(step)` and append heterogeneous Steps with `otherSteps(...)`.

--- a/sdk-java/src/main/java/io/superdurable/dex/exceptions/RetryAfterException.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/exceptions/RetryAfterException.java
@@ -17,33 +17,33 @@ import java.time.Duration;
  *
  * <p>Throw the value returned by {@link #after(Duration, Throwable)} from wait-for or execute. On
  * Temporal, the delay overrides only the next retry interval; retry limits and timeouts remain
- * unchanged. Cadence cannot honor a dynamic interval, so Dex stops retrying that method and applies
- * its configured failure policy. The original cause remains the reported Worker error.
+ * unchanged, and the current attempt failure remains the reported Worker error. Cadence rejects
+ * dynamic retry intervals with a Flow validation error.
  *
  * <pre>{@code
- * throw RetryAfterException.after(Duration.ofSeconds(30), failure);
+ * throw RetryAfterException.after(Duration.ofSeconds(30), currentFailure);
  * }</pre>
  */
 public final class RetryAfterException extends RuntimeException {
     private final Duration retryAfter;
 
-    private RetryAfterException(final Duration retryAfter, final Throwable cause) {
-        super(cause.getMessage(), cause);
+    private RetryAfterException(final Duration retryAfter, final Throwable currentCause) {
+        super(currentCause.getMessage(), currentCause);
         this.retryAfter = retryAfter;
     }
 
     /**
-     * Creates a retry request while preserving the original failure.
+     * Creates a retry request while preserving the current attempt failure.
      *
      * @param retryAfter the positive whole-second delay before the next attempt
-     * @param cause the original Step method failure reported to Dex
+     * @param currentCause the current Step method attempt failure reported to Dex
      * @return an exception to throw from the Step method
      * @throws IllegalArgumentException if the delay is null, nonpositive, fractional, or exceeds
-     *         the signed 32-bit seconds range, or if the cause is null
+     *         the signed 32-bit seconds range, or if the current cause is null
      */
     public static RetryAfterException after(
             final Duration retryAfter,
-            final Throwable cause) {
+            final Throwable currentCause) {
         if (retryAfter == null
                 || retryAfter.isZero()
                 || retryAfter.isNegative()
@@ -52,10 +52,10 @@ public final class RetryAfterException extends RuntimeException {
             throw new IllegalArgumentException(
                     "retryAfter must be positive whole seconds within int32");
         }
-        if (cause == null) {
-            throw new IllegalArgumentException("cause is required");
+        if (currentCause == null) {
+            throw new IllegalArgumentException("currentCause is required");
         }
-        return new RetryAfterException(retryAfter, cause);
+        return new RetryAfterException(retryAfter, currentCause);
     }
 
     /**

--- a/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
@@ -243,23 +243,23 @@ final class WorkerServiceIntegrationTest {
 
     @Test
     void validatesRetryAfter() {
-        final RuntimeException cause = new RuntimeException("failure");
+        final RuntimeException currentCause = new RuntimeException("failure");
         assertThrows(
                 IllegalArgumentException.class,
-                () -> RetryAfterException.after(null, cause));
+                () -> RetryAfterException.after(null, currentCause));
         assertThrows(
                 IllegalArgumentException.class,
-                () -> RetryAfterException.after(Duration.ZERO, cause));
+                () -> RetryAfterException.after(Duration.ZERO, currentCause));
         assertThrows(
                 IllegalArgumentException.class,
-                () -> RetryAfterException.after(Duration.ofSeconds(-1), cause));
+                () -> RetryAfterException.after(Duration.ofSeconds(-1), currentCause));
         assertThrows(
                 IllegalArgumentException.class,
-                () -> RetryAfterException.after(Duration.ofMillis(1500), cause));
+                () -> RetryAfterException.after(Duration.ofMillis(1500), currentCause));
         assertThrows(
                 IllegalArgumentException.class,
                 () -> RetryAfterException.after(
-                        Duration.ofSeconds((long) Integer.MAX_VALUE + 1), cause));
+                        Duration.ofSeconds((long) Integer.MAX_VALUE + 1), currentCause));
         assertThrows(
                 IllegalArgumentException.class,
                 () -> RetryAfterException.after(Duration.ofSeconds(1), null));

--- a/server/integ/wf_state_wait_until_api_fail_and_proceed_test.go
+++ b/server/integ/wf_state_wait_until_api_fail_and_proceed_test.go
@@ -145,7 +145,7 @@ func TestStateApiRetryAfterTemporal(t *testing.T) {
 	require.Less(t, workerHandler.GetRetryAttemptGap(), 5*time.Second)
 }
 
-func TestStateApiRetryAfterCadenceStopsRetry(t *testing.T) {
+func TestStateApiRetryAfterCadenceFailsValidation(t *testing.T) {
 	if !*cadenceIntegTest {
 		t.Skip()
 	}
@@ -168,16 +168,25 @@ func TestStateApiRetryAfterCadenceStopsRetry(t *testing.T) {
 		},
 		StepOptions: &dexpb.StepOptions{
 			WaitForRetryPolicy: &dexpb.RetryPolicy{
-				InitialIntervalSeconds: 10,
-				MaximumAttempts:        3,
+				MaximumAttempts: 1,
 			},
-			WaitForFailurePolicy: dexpb.WaitForMethodFailurePolicy_WAIT_FOR_METHOD_FAILURE_POLICY_PROCEED_ON_FAILURE,
 		},
 		FlowStartOptions: withWorkerTarget(nil, workerTarget),
 	})
 	require.NoError(t, err)
-	_, err = flowClient.WaitForFlow(ctx, &dexpb.WaitForFlowRequest{FlowId: flowId})
+	response, err := flowClient.WaitForFlow(ctx, &dexpb.WaitForFlowRequest{FlowId: flowId})
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]int64{"S1_waitFor": 1, "S1_execute": 1}, workerHandler.GetTestResult().InvokeHistory)
+	require.Equal(t, map[string]int64{"S1_waitFor": 1}, workerHandler.GetTestResult().InvokeHistory)
+	require.Equal(t, dexpb.FlowStatus_FLOW_STATUS_FAILED, response.GetFlowStatus())
+	require.Equal(
+		t,
+		dexpb.FlowErrorType_FLOW_ERROR_TYPE_INVALID_USER_FLOW_CODE,
+		response.GetErrorType(),
+	)
+	require.Contains(
+		t,
+		response.GetErrorMessage(),
+		"WorkerErrorResponse.retry_after_seconds requires the Temporal backend",
+	)
 }

--- a/server/service/common/retry/policy.go
+++ b/server/service/common/retry/policy.go
@@ -18,9 +18,6 @@ import (
 	"go.uber.org/cadence/workflow"
 )
 
-// CadenceRetryAfterErrorReason marks retry-after as unsupported by Cadence.
-const CadenceRetryAfterErrorReason = "__dex_retry_after__"
-
 func ConvertCadenceWorkflowRetryPolicy(policy *dexpb.FlowRetryPolicy) *workflow.RetryPolicy {
 	if policy == nil {
 		return nil
@@ -51,12 +48,11 @@ func ConvertCadenceActivityRetryPolicy(policy *dexpb.RetryPolicy) *workflow.Retr
 	}
 
 	return &workflow.RetryPolicy{
-		InitialInterval:          time.Second * time.Duration(initial),
-		MaximumInterval:          time.Second * time.Duration(maxInterval),
-		MaximumAttempts:          maxAttempts,
-		BackoffCoefficient:       float64(backoff),
-		ExpirationInterval:       expirationInterval,
-		NonRetriableErrorReasons: []string{CadenceRetryAfterErrorReason},
+		InitialInterval:    time.Second * time.Duration(initial),
+		MaximumInterval:    time.Second * time.Duration(maxInterval),
+		MaximumAttempts:    maxAttempts,
+		BackoffCoefficient: float64(backoff),
+		ExpirationInterval: expirationInterval,
 	}
 }
 

--- a/server/service/common/retry/policy_test.go
+++ b/server/service/common/retry/policy_test.go
@@ -26,7 +26,6 @@ func TestConvertCadenceActivityRetryPolicyNilMatchesTemporalDefaults(t *testing.
 	require.Equal(t, int32(0), policy.MaximumAttempts)
 	require.Equal(t, 2.0, policy.BackoffCoefficient)
 	require.Equal(t, time.Hour*24*365, policy.ExpirationInterval)
-	require.Contains(t, policy.NonRetriableErrorReasons, CadenceRetryAfterErrorReason)
 }
 
 func TestConvertCadenceActivityRetryPolicyHonorsExplicitMaximumAttempts(t *testing.T) {

--- a/server/service/common/rpc/invoke.go
+++ b/server/service/common/rpc/invoke.go
@@ -87,7 +87,7 @@ func InvokeWorkerRpc(
 	if err := validateWorkerRpcResponse(resp); err != nil {
 		return nil, err
 	}
-	service.SetFromStepExecutionID(
+	service.SetFromStepExecutionIDForStepDecision(
 		resp.GetStepDecision(),
 		service.GetFromStepExecutionIdForRPC(req.GetRpcName()),
 	)

--- a/server/service/from_step_execution_id.go
+++ b/server/service/from_step_execution_id.go
@@ -21,8 +21,8 @@ func GetFromStepExecutionIdForRPC(rpcName string) string {
 	return rpcStepSourcePrefix + rpcName
 }
 
-// SetFromStepExecutionID overwrites worker-provided movement sources.
-func SetFromStepExecutionID(decision *dexpb.StepDecision, source string) {
+// SetFromStepExecutionIDForStepDecision overwrites worker-provided movement sources.
+func SetFromStepExecutionIDForStepDecision(decision *dexpb.StepDecision, source string) {
 	for _, movement := range decision.GetNextSteps() {
 		if movement != nil {
 			movement.FromStepExecutionIdInternalOnly = source

--- a/server/service/interpreter/activityImpl.go
+++ b/server/service/interpreter/activityImpl.go
@@ -127,18 +127,18 @@ func (a *Activities) InvokeWaitForMethod(
 	if err != nil {
 		a.emitStepWaitForMethodEvent(req, activityInfo, event.EventTypeWaitForAttemptFail)
 		a.logLocalActivityWarn(logger, activityInfo, "InvokeWaitForMethod", req.GetContext().GetStepExecutionId(), req, err)
-		return nil, composeActivityError(provider, err)
+		return nil, composeActivityError(provider, a.unifiedClient.GetBackendType(), err)
 	}
 	if err := validateWaitingCondition(resp.GetWaitingCondition()); err != nil {
 		a.emitStepWaitForMethodEvent(req, activityInfo, event.EventTypeWaitForAttemptFail)
-		return nil, composeActivityError(provider, err)
+		return nil, composeActivityError(provider, a.unifiedClient.GetBackendType(), err)
 	}
 	if err := validateTransientStepMovement(resp.GetTransientStepMovement()); err != nil {
 		a.emitStepWaitForMethodEvent(req, activityInfo, event.EventTypeWaitForAttemptFail)
-		return nil, composeActivityError(provider, err)
+		return nil, composeActivityError(provider, a.unifiedClient.GetBackendType(), err)
 	}
 	if err := validateWorkerWaitForResponse(resp); err != nil {
-		return nil, composeActivityError(provider, err)
+		return nil, composeActivityError(provider, a.unifiedClient.GetBackendType(), err)
 	}
 	if err := a.persistStepEventInput(
 		ctx,
@@ -246,10 +246,10 @@ func (a *Activities) InvokeExecuteMethod(
 	if err != nil {
 		a.emitStepExecuteMethodEvent(req, activityInfo, event.EventTypeExecuteAttemptFail)
 		a.logLocalActivityWarn(logger, activityInfo, "InvokeExecuteMethod", req.GetContext().GetStepExecutionId(), req, err)
-		return nil, composeActivityError(provider, err)
+		return nil, composeActivityError(provider, a.unifiedClient.GetBackendType(), err)
 	}
 	if err := validateExecuteResponse(resp, input.GetIsTransientStep()); err != nil {
-		return nil, composeActivityError(provider, err)
+		return nil, composeActivityError(provider, a.unifiedClient.GetBackendType(), err)
 	}
 	if err := a.persistStepEventInput(
 		ctx,
@@ -267,7 +267,7 @@ func (a *Activities) InvokeExecuteMethod(
 		return nil, composeInternalActivityError(provider, err)
 	}
 
-	service.SetFromStepExecutionID(
+	service.SetFromStepExecutionIDForStepDecision(
 		resp.GetStepDecision(),
 		req.GetContext().GetStepExecutionId(),
 	)
@@ -391,7 +391,7 @@ func (a *Activities) InvokeWorkerRPC(
 		&a.cfg.BlobStore,
 	)
 	if err != nil {
-		return nil, composeActivityError(provider, err)
+		return nil, composeActivityError(provider, a.unifiedClient.GetBackendType(), err)
 	}
 	out := &dexpb.InvokeWorkerRPCActivityOutput{Response: resp}
 	if activityInfo.IsLocalActivity {
@@ -963,7 +963,11 @@ func printDebugMsg(logger interfaces.UnifiedLogger, err error, target string) {
 	}
 }
 
-func composeActivityError(provider interfaces.ActivityProvider, err error) error {
+func composeActivityError(
+	provider interfaces.ActivityProvider,
+	backendType service.BackendType,
+	err error,
+) error {
 	grpcStatus, ok := status.FromError(err)
 	if !ok {
 		return composeInternalActivityError(provider, err)
@@ -983,6 +987,15 @@ func composeActivityError(provider interfaces.ActivityProvider, err error) error
 		workerError, ok := statusDetail.(*dexpb.WorkerErrorResponse)
 		if !ok {
 			continue
+		}
+		if backendType == service.BackendTypeCadence && workerError.GetRetryAfterSeconds() != 0 {
+			return provider.NewFlowError(
+				dexpb.FlowErrorType_FLOW_ERROR_TYPE_INVALID_USER_FLOW_CODE,
+				&dexpb.ErrorResponse{
+					Detail:    "WorkerErrorResponse.retry_after_seconds requires the Temporal backend",
+					SubStatus: dexpb.ErrorSubStatus_ERROR_SUB_STATUS_WORKER_API_ERROR,
+				},
+			)
 		}
 		workerErrorFound = true
 		errorResponse.OriginalWorkerErrorDetail = workerError.GetDetail()

--- a/server/service/interpreter/activityImpl_test.go
+++ b/server/service/interpreter/activityImpl_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/superdurable/dex/gen/dexpb"
+	"github.com/superdurable/dex/service"
 	"github.com/superdurable/dex/service/common/ptr"
 	"github.com/superdurable/dex/service/interpreter/interfaces"
 	"google.golang.org/grpc/codes"
@@ -536,7 +537,11 @@ func TestComposeActivityErrorUsesInternalForNonGRPCError(t *testing.T) {
 			return activityError
 		})
 
-	require.ErrorIs(t, composeActivityError(provider, inputError), activityError)
+	require.ErrorIs(
+		t,
+		composeActivityError(provider, service.BackendTypeTemporal, inputError),
+		activityError,
+	)
 	require.Equal(t, "dial failed", errorResponse.GetDetail())
 	require.Equal(
 		t,
@@ -572,7 +577,11 @@ func TestComposeActivityErrorPreservesWorkerDetails(t *testing.T) {
 			return activityError
 		})
 
-	require.ErrorIs(t, composeActivityError(provider, grpcStatus.Err()), activityError)
+	require.ErrorIs(
+		t,
+		composeActivityError(provider, service.BackendTypeTemporal, grpcStatus.Err()),
+		activityError,
+	)
 	require.Empty(t, errorResponse.GetDetail())
 	require.Equal(
 		t,
@@ -584,6 +593,45 @@ func TestComposeActivityErrorPreservesWorkerDetails(t *testing.T) {
 	require.Equal(t, "worker type", errorResponse.GetOriginalWorkerErrorType())
 	require.Equal(t, "worker stack", errorResponse.GetOriginalWorkerErrorStackTrace())
 	require.Equal(t, int32(17), errorResponse.GetOriginalWorkerRetryAfterSeconds())
+}
+
+func TestComposeActivityErrorRejectsRetryAfterOnCadence(t *testing.T) {
+	provider := interfaces.NewMockActivityProvider(gomock.NewController(t))
+	grpcStatus, err := status.New(codes.Internal, "worker failure").WithDetails(
+		&dexpb.WorkerErrorResponse{RetryAfterSeconds: 17},
+	)
+	require.NoError(t, err)
+
+	activityError := errors.New("activity error")
+	var errorResponse *dexpb.ErrorResponse
+	provider.EXPECT().
+		NewFlowError(
+			dexpb.FlowErrorType_FLOW_ERROR_TYPE_INVALID_USER_FLOW_CODE,
+			gomock.Any(),
+		).
+		DoAndReturn(func(
+			_ dexpb.FlowErrorType,
+			response *dexpb.ErrorResponse,
+		) error {
+			errorResponse = response
+			return activityError
+		})
+
+	require.ErrorIs(
+		t,
+		composeActivityError(provider, service.BackendTypeCadence, grpcStatus.Err()),
+		activityError,
+	)
+	require.Equal(
+		t,
+		"WorkerErrorResponse.retry_after_seconds requires the Temporal backend",
+		errorResponse.GetDetail(),
+	)
+	require.Equal(
+		t,
+		dexpb.ErrorSubStatus_ERROR_SUB_STATUS_WORKER_API_ERROR,
+		errorResponse.GetSubStatus(),
+	)
 }
 
 func TestComposeActivityErrorFallsBackWhenMessageEmpty(t *testing.T) {
@@ -604,7 +652,11 @@ func TestComposeActivityErrorFallsBackWhenMessageEmpty(t *testing.T) {
 			return activityError
 		})
 
-	require.ErrorIs(t, composeActivityError(provider, inputError), activityError)
+	require.ErrorIs(
+		t,
+		composeActivityError(provider, service.BackendTypeTemporal, inputError),
+		activityError,
+	)
 	require.Equal(t, inputError.Error(), errorResponse.GetDetail())
 	require.Equal(
 		t,

--- a/server/service/interpreter/cadence/activityProvider.go
+++ b/server/service/interpreter/cadence/activityProvider.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/superdurable/dex/gen/dexpb"
-	"github.com/superdurable/dex/service/common/retry"
 	"github.com/superdurable/dex/service/interpreter/interfaces"
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/activity"
@@ -34,9 +33,6 @@ func (a *activityProvider) NewFlowError(
 	errType dexpb.FlowErrorType,
 	errorResponse *dexpb.ErrorResponse,
 ) error {
-	if errorResponse.GetOriginalWorkerRetryAfterSeconds() > 0 {
-		return cadence.NewCustomError(retry.CadenceRetryAfterErrorReason, errorResponse)
-	}
 	return cadence.NewCustomError(errType.String(), errorResponse)
 }
 

--- a/server/service/interpreter/cadence/error_test.go
+++ b/server/service/interpreter/cadence/error_test.go
@@ -13,26 +13,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/superdurable/dex/gen/dexpb"
-	"github.com/superdurable/dex/service/common/retry"
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/workflow"
 )
-
-func TestActivityProviderRejectsRetryAfter(t *testing.T) {
-	errorResponse := &dexpb.ErrorResponse{OriginalWorkerRetryAfterSeconds: 7}
-	err := (&activityProvider{}).NewFlowError(
-		dexpb.FlowErrorType_FLOW_ERROR_TYPE_WORKER_API_FAIL,
-		errorResponse,
-	)
-
-	var customError *cadence.CustomError
-	require.ErrorAs(t, err, &customError)
-	require.Equal(t, retry.CadenceRetryAfterErrorReason, customError.Reason())
-	var decoded *dexpb.ErrorResponse
-	require.NoError(t, customError.Details(&decoded))
-	require.Equal(t, errorResponse, decoded)
-}
 
 func TestWorkflowProviderMapsWorkerAndTimeoutErrors(t *testing.T) {
 	provider := &workflowProvider{}
@@ -47,7 +31,7 @@ func TestWorkflowProviderMapsWorkerAndTimeoutErrors(t *testing.T) {
 		original,
 	)
 
-	workerError, err := provider.WorkerError(workerFailure)
+	workerError, err := provider.MapToWorkerError(workerFailure)
 	require.NoError(t, err)
 	require.Equal(t, "worker detail", workerError.GetDetail())
 	require.Equal(t, "worker type", workerError.GetErrorType())
@@ -55,7 +39,7 @@ func TestWorkflowProviderMapsWorkerAndTimeoutErrors(t *testing.T) {
 	require.Equal(t, int32(11), workerError.GetRetryAfterSeconds())
 
 	timeoutFailure := workflow.NewTimeoutError(shared.TimeoutTypeStartToClose)
-	timeoutError, err := provider.WorkerError(timeoutFailure)
+	timeoutError, err := provider.MapToWorkerError(timeoutFailure)
 	require.NoError(t, err)
 	require.Equal(t, shared.TimeoutTypeStartToClose.String(), timeoutError.GetErrorType())
 	require.NotEmpty(t, timeoutError.GetDetail())

--- a/server/service/interpreter/cadence/workflowProvider.go
+++ b/server/service/interpreter/cadence/workflowProvider.go
@@ -66,7 +66,7 @@ func (w *workflowProvider) IsApplicationError(err error) bool {
 	return errors.As(err, &applicationError)
 }
 
-func (w *workflowProvider) WorkerError(err error) (*dexpb.WorkerErrorResponse, error) {
+func (w *workflowProvider) MapToWorkerError(err error) (*dexpb.WorkerErrorResponse, error) {
 	var timeoutError *workflow.TimeoutError
 	if errors.As(err, &timeoutError) {
 		return &dexpb.WorkerErrorResponse{
@@ -350,47 +350,16 @@ func (w *workflowProvider) ExecuteActivity(
 	}
 	switch durability {
 	case dexpb.StepDurability_STEP_DURABILITY_SYNC:
-		err = workflow.ExecuteActivity(wfCtx, activity, regularArgs...).Get(wfCtx, valuePtr)
-		return normalizeCadenceRetryAfterError(err)
+		return workflow.ExecuteActivity(wfCtx, activity, regularArgs...).Get(wfCtx, valuePtr)
 	case dexpb.StepDurability_STEP_DURABILITY_ASYNC:
 		err = workflow.ExecuteLocalActivity(wfCtx, activity, localArgs...).Get(wfCtx, valuePtr)
 		if err == nil {
 			return nil
 		}
-		if isCadenceRetryAfterError(err) {
-			return normalizeCadenceRetryAfterError(err)
-		}
-		err = workflow.ExecuteActivity(wfCtx, activity, regularArgs...).Get(wfCtx, valuePtr)
-		return normalizeCadenceRetryAfterError(err)
+		return workflow.ExecuteActivity(wfCtx, activity, regularArgs...).Get(wfCtx, valuePtr)
 	default:
 		return fmt.Errorf("unsupported step durability %s", durability)
 	}
-}
-
-func normalizeCadenceRetryAfterError(err error) error {
-	if err == nil || !isCadenceRetryAfterError(err) {
-		return err
-	}
-	var customError *cadence.CustomError
-	if !errors.As(err, &customError) {
-		panic("retry-after error lost its Cadence custom error")
-	}
-	var errorResponse *dexpb.ErrorResponse
-	if !customError.HasDetails() {
-		return fmt.Errorf("Cadence retry-after error has no details")
-	}
-	if detailsErr := customError.Details(&errorResponse); detailsErr != nil {
-		return fmt.Errorf("decode Cadence retry-after details: %w", detailsErr)
-	}
-	return cadence.NewCustomError(
-		dexpb.FlowErrorType_FLOW_ERROR_TYPE_WORKER_API_FAIL.String(),
-		errorResponse,
-	)
-}
-
-func isCadenceRetryAfterError(err error) bool {
-	var customError *cadence.CustomError
-	return errors.As(err, &customError) && customError.Reason() == retry.CadenceRetryAfterErrorReason
 }
 
 func (w *workflowProvider) ExecuteLocalActivity(

--- a/server/service/interpreter/interfaces/interfaces_mock.go
+++ b/server/service/interpreter/interfaces/interfaces_mock.go
@@ -615,19 +615,19 @@ func (mr *MockWorkflowProviderMockRecorder) IsApplicationError(err interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationError", reflect.TypeOf((*MockWorkflowProvider)(nil).IsApplicationError), err)
 }
 
-// WorkerError mocks base method.
-func (m *MockWorkflowProvider) WorkerError(err error) (*dexpb.WorkerErrorResponse, error) {
+// MapToWorkerError mocks base method.
+func (m *MockWorkflowProvider) MapToWorkerError(err error) (*dexpb.WorkerErrorResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkerError", err)
+	ret := m.ctrl.Call(m, "MapToWorkerError", err)
 	ret0, _ := ret[0].(*dexpb.WorkerErrorResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WorkerError indicates an expected call of WorkerError.
-func (mr *MockWorkflowProviderMockRecorder) WorkerError(err interface{}) *gomock.Call {
+// MapToWorkerError indicates an expected call of MapToWorkerError.
+func (mr *MockWorkflowProviderMockRecorder) MapToWorkerError(err interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkerError", reflect.TypeOf((*MockWorkflowProvider)(nil).WorkerError), err)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MapToWorkerError", reflect.TypeOf((*MockWorkflowProvider)(nil).MapToWorkerError), err)
 }
 
 // IsContinueAsNewError mocks base method.

--- a/server/service/interpreter/interfaces/workflow_interfaces.go
+++ b/server/service/interpreter/interfaces/workflow_interfaces.go
@@ -98,7 +98,7 @@ type WorkflowProvider interface {
 	NewCanceledError(reason string) error
 	NewUpdateError(errType dexpb.UpdateErrorType, detail string) error
 	IsApplicationError(err error) bool
-	WorkerError(err error) (*dexpb.WorkerErrorResponse, error)
+	MapToWorkerError(err error) (*dexpb.WorkerErrorResponse, error)
 	IsContinueAsNewError(err error) bool
 	GetWorkflowInfo(ctx UnifiedContext) WorkflowInfo
 	GetSearchAttributeKeywordArray(ctx UnifiedContext, key string) ([]string, error)

--- a/server/service/interpreter/temporal/error_test.go
+++ b/server/service/interpreter/temporal/error_test.go
@@ -47,7 +47,7 @@ func TestWorkflowProviderMapsWorkerAndTimeoutErrors(t *testing.T) {
 		*original,
 	)
 
-	workerError, err := provider.WorkerError(workerFailure)
+	workerError, err := provider.MapToWorkerError(workerFailure)
 	require.NoError(t, err)
 	require.Equal(t, "worker detail", workerError.GetDetail())
 	require.Equal(t, "worker type", workerError.GetErrorType())
@@ -55,7 +55,7 @@ func TestWorkflowProviderMapsWorkerAndTimeoutErrors(t *testing.T) {
 	require.Equal(t, int32(11), workerError.GetRetryAfterSeconds())
 
 	timeoutFailure := temporalsdk.NewTimeoutError(enums.TIMEOUT_TYPE_START_TO_CLOSE, nil)
-	timeoutError, err := provider.WorkerError(timeoutFailure)
+	timeoutError, err := provider.MapToWorkerError(timeoutFailure)
 	require.NoError(t, err)
 	require.Equal(t, enums.TIMEOUT_TYPE_START_TO_CLOSE.String(), timeoutError.GetErrorType())
 	require.NotEmpty(t, timeoutError.GetDetail())

--- a/server/service/interpreter/temporal/workflowProvider.go
+++ b/server/service/interpreter/temporal/workflowProvider.go
@@ -67,7 +67,7 @@ func (w *workflowProvider) IsApplicationError(err error) bool {
 	return errors.As(err, &applicationError)
 }
 
-func (w *workflowProvider) WorkerError(err error) (*dexpb.WorkerErrorResponse, error) {
+func (w *workflowProvider) MapToWorkerError(err error) (*dexpb.WorkerErrorResponse, error) {
 	var timeoutError *temporal.TimeoutError
 	if errors.As(err, &timeoutError) {
 		return &dexpb.WorkerErrorResponse{

--- a/server/service/interpreter/timers/greedyTimerScheduler_test.go
+++ b/server/service/interpreter/timers/greedyTimerScheduler_test.go
@@ -40,7 +40,7 @@ func (p *fakeWorkflowProvider) IsApplicationError(error) bool {
 	return false
 }
 
-func (p *fakeWorkflowProvider) WorkerError(error) (*dexpb.WorkerErrorResponse, error) {
+func (p *fakeWorkflowProvider) MapToWorkerError(error) (*dexpb.WorkerErrorResponse, error) {
 	return nil, nil
 }
 

--- a/server/service/interpreter/workflowImpl.go
+++ b/server/service/interpreter/workflowImpl.go
@@ -423,7 +423,7 @@ func (i *Interpreter) StartEngineFlow(
 							errToFailWf = err
 						}
 					} else if stepExecutionStatus == service.StepExecutionStatusFailedAndProceed {
-						recoveryError, mappingErr := provider.WorkerError(stepExeErr)
+						recoveryError, mappingErr := provider.MapToWorkerError(stepExeErr)
 						if mappingErr != nil {
 							errToFailWf = provider.NewFlowError(
 								dexpb.FlowErrorType_FLOW_ERROR_TYPE_INTERNAL,
@@ -909,7 +909,7 @@ func (i *Interpreter) processStepExecution(
 	)
 	if waitForMethErr != nil {
 		conditionResults.WaitForFailed = true
-		recoveryError, mappingErr := provider.WorkerError(waitForMethErr)
+		recoveryError, mappingErr := provider.MapToWorkerError(waitForMethErr)
 		if mappingErr != nil {
 			return nil, service.StepExecutionStatusInternalError, mappingErr
 		}


### PR DESCRIPTION
## Summary

- rename RetryAfterException cause to currentCause and WorkflowProvider mapping to MapToWorkerError
- reject Cadence retry_after_seconds directly in activityImpl with INVALID_USER_FLOW_CODE
- rename SetFromStepExecutionIDForStepDecision and retain server-only recovery metadata sanitization
- update Java and protocol documentation plus Cadence integration coverage

## Testing

- make -C server unitTests
- sdk-java: ./gradlew test localIntegrationTest checkstyleMain javadoc --no-daemon
- make -C server ci-cadence-integ-test totalPartitions=5 partitionNum=0
- make copyright-check