### PR TITLE
Stabilize main CI runner scheduling

### DIFF
--- a/.github/scripts/check-ci-runners.sh
+++ b/.github/scripts/check-ci-runners.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 workflow_dir="${1:-.github/workflows}"
-runner_policy="runs-on: \${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || "
+runner_policy="runs-on: \${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-"
 failures=0
 
 shopt -s nullglob
@@ -15,9 +15,15 @@ if (( ${#workflows[@]} == 0 )); then
 fi
 
 for workflow in "${workflows[@]}"; do
+  case "$(basename "$workflow")" in
+    check-gate-ci.yml|cla-ci.yml)
+      continue
+      ;;
+  esac
+
   while IFS=: read -r line_number runner_line; do
     if [[ "$runner_line" != *"$runner_policy"* ]]; then
-      echo "$workflow:$line_number must route main pushes to a self-hosted runner."
+      echo "$workflow:$line_number must route main push and manual jobs to a role-specific runner."
       failures=$((failures + 1))
     fi
   done < <(grep -nE '^[[:space:]]*runs-on:' "$workflow" || true)
@@ -27,4 +33,4 @@ if (( failures > 0 )); then
   exit 1
 fi
 
-echo "All CI jobs route main pushes to self-hosted runners."
+echo "All CI jobs route main push and manual jobs to role-specific runners."

--- a/.github/workflows/blob-cache-go-ci.yml
+++ b/.github/workflows/blob-cache-go-ci.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   blob-cache:
     name: Blob cache tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: blob-cache-go

--- a/.github/workflows/check-gate-ci.yml
+++ b/.github/workflows/check-gate-ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   check-gate:
     name: Check Gate CI
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
@@ -102,7 +102,23 @@ jobs:
 
           expected=()
           if [[ "$EVENT_NAME" != "pull_request" ]]; then
-            expected=("Server CI" "Go SDK CI" "Rust SDK CI" "Go examples CI" "Web CI" "Generated Code CI" "Copyright")
+            expected=(
+              "Blob Cache Go CI"
+              "Dex CLI CI"
+              "Copyright"
+              "Go examples CI"
+              "Java examples CI"
+              "Python examples CI"
+              "Rust examples CI"
+              "Generated Code CI"
+              "Go SDK CI"
+              "Java SDK CI"
+              "Python SDK CI"
+              "Rust SDK CI"
+              "TypeScript SDK CI"
+              "Server CI"
+              "Web CI"
+            )
           else
             expected+=("CLA")
             [[ "$FILTER_SERVER" == "true" ]] && expected+=("Server CI")

--- a/.github/workflows/cla-ci.yml
+++ b/.github/workflows/cla-ci.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   cla-check:
     name: Contributor agreement
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - name: Verify signature record

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   check:
     name: Build and local-stack integration
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/copyright-ci.yml
+++ b/.github/workflows/copyright-ci.yml
@@ -53,7 +53,7 @@ on:
 jobs:
   copyright-check:
     name: License headers
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/examples-go-ci.yml
+++ b/.github/workflows/examples-go-ci.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   unit:
     name: SDK build
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: examples/go
@@ -66,7 +66,7 @@ jobs:
 
   e2e:
     name: End-to-end tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: examples/go

--- a/.github/workflows/examples-java-ci.yml
+++ b/.github/workflows/examples-java-ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   unit:
     name: Build + unit tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: examples/java
@@ -34,7 +34,7 @@ jobs:
 
   integ:
     name: Integration tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: examples/java

--- a/.github/workflows/examples-python-ci.yml
+++ b/.github/workflows/examples-python-ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   integ:
     name: Install + integ tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: examples/python

--- a/.github/workflows/examples-rust-ci.yml
+++ b/.github/workflows/examples-rust-ci.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   quality:
     name: Published SDK, format, Clippy, and tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     timeout-minutes: 15
     defaults:
       run:

--- a/.github/workflows/generated-code-ci.yml
+++ b/.github/workflows/generated-code-ci.yml
@@ -44,10 +44,14 @@ concurrency:
 jobs:
   freshness:
     name: Generated code freshness
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     timeout-minutes: 10
+    env:
+      RUSTUP_TOOLCHAIN: "1.97.1"
     steps:
       - uses: actions/checkout@v7
+      - name: Install Rust
+        run: rustup toolchain install 1.97.1 --profile minimal
       - uses: actions/setup-go@v7
         with:
           go-version: "1.25.x"

--- a/.github/workflows/main-ci-all.yml
+++ b/.github/workflows/main-ci-all.yml
@@ -1,0 +1,49 @@
+name: Main CI (all)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: main-ci-all
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch latest main CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Dispatch CI workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          workflows=(
+            blob-cache-go-ci.yml
+            cli-ci.yml
+            copyright-ci.yml
+            examples-go-ci.yml
+            examples-java-ci.yml
+            examples-python-ci.yml
+            examples-rust-ci.yml
+            generated-code-ci.yml
+            sdk-go-ci.yml
+            sdk-java-ci.yml
+            sdk-python-ci.yml
+            sdk-rust-ci.yml
+            sdk-typescript-ci.yml
+            server-ci.yml
+            web-ci.yml
+          )
+
+          for workflow in "${workflows[@]}"; do
+            gh workflow run "$workflow" --repo "$REPO" --ref main
+          done
+
+          gh workflow run check-gate-ci.yml --repo "$REPO" --ref main

--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   unit:
     name: Unit tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: sdk-go
@@ -57,7 +57,7 @@ jobs:
 
   worker-integration:
     name: Worker integration tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: sdk-go
@@ -74,7 +74,7 @@ jobs:
 
   client-integration:
     name: Client integration tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: sdk-go
@@ -91,7 +91,7 @@ jobs:
 
   e2e:
     name: Integration coverage
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
     timeout-minutes: 25
     permissions:
       contents: read

--- a/.github/workflows/sdk-java-ci.yml
+++ b/.github/workflows/sdk-java-ci.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   contracts:
     name: User contracts (Java ${{ matrix.java-version }})
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     env:
       RUSTUP_TOOLCHAIN: "1.97.1"
     strategy:
@@ -67,7 +67,7 @@ jobs:
 
   publication:
     name: Maven publication
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     timeout-minutes: 15
     env:
       RUSTUP_TOOLCHAIN: '1.97.1'
@@ -91,7 +91,7 @@ jobs:
 
   tests:
     name: Integration tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
     timeout-minutes: 25
     permissions:
       contents: read

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   contracts:
     name: User contracts (Python ${{ matrix.python-version }})
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +72,7 @@ jobs:
       run: uv run --frozen pyright tests/typecheck_contracts.py tests/integ
 
   lint:
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: sdk-python
@@ -136,7 +136,7 @@ jobs:
 
   integration:
     name: Integration tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
     timeout-minutes: 25
     permissions:
       contents: read

--- a/.github/workflows/sdk-rust-ci.yml
+++ b/.github/workflows/sdk-rust-ci.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   quality:
     name: Format and Clippy
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     timeout-minutes: 15
     defaults:
       run:
@@ -55,7 +55,7 @@ jobs:
 
   tests:
     name: Tests (${{ matrix.os }})
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || matrix.os }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || matrix.os }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -73,7 +73,7 @@ jobs:
 
   integration:
     name: Integration coverage
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
     timeout-minutes: 25
     permissions:
       contents: read

--- a/.github/workflows/sdk-typescript-ci.yml
+++ b/.github/workflows/sdk-typescript-ci.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   contracts:
     name: User contracts (Node ${{ matrix.node-version }})
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -70,7 +70,7 @@ jobs:
 
   integration:
     name: Integration tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   unit:
     name: Unit tests
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: server
@@ -38,8 +38,8 @@ jobs:
 
   attribute-store-integ:
     name: Attribute Store integration
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
-    timeout-minutes: 10
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: server
@@ -71,8 +71,8 @@ jobs:
 
   blob-store-integ:
     name: Blob Store integration
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
-    timeout-minutes: 10
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: server
@@ -102,8 +102,8 @@ jobs:
 
   web-api-integ:
     name: Web API integration (${{ matrix.backend }})
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -143,7 +143,7 @@ jobs:
 
   temporal-integ:
     name: Temporal integration (partition ${{ matrix.partition }})
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
     timeout-minutes: 35
     strategy:
       fail-fast: false
@@ -178,7 +178,7 @@ jobs:
 
   cadence-integ:
     name: Cadence integration (partition ${{ matrix.partition }})
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
     timeout-minutes: 35
     strategy:
       fail-fast: false
@@ -219,7 +219,7 @@ jobs:
       - web-api-integ
       - temporal-integ
       - cadence-integ
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   check:
     name: Typecheck, tests, and build
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: web

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,9 @@ check until the record is updated.
 
 Root workflows under [`.github/workflows/`](.github/workflows/) run path-filtered jobs for server and each SDK/samples tree, plus the copyright check. Prefer fixing those over re-adding nested `*/.github/workflows` duplicates.
 
-Every job in a `*-ci.yml` workflow must use a self-hosted runner for pushes to `main` while retaining its GitHub-hosted runner for pull requests and manual runs. Use `${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'self-hosted' || 'ubuntu-latest' }}` (with the appropriate hosted fallback), and run `make ci-runner-check` before submitting workflow changes.
+CI jobs use role-specific self-hosted runners for pushes and manual runs on `main`, while pull requests retain GitHub-hosted runners. Jobs that start service stacks use `linux-dind-heavy`; other jobs use `linux-dind-light`. Use `${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}` (with the appropriate role and hosted fallback), and run `make ci-runner-check` before submitting workflow changes. Control-plane jobs such as CLA and Check Gate remain GitHub-hosted.
+
+To run every CI workflow against the latest `main` commit, dispatch **Main CI (all)** in GitHub Actions or run `gh workflow run main-ci-all.yml --ref main`. The dispatcher starts every non-release CI workflow, then starts Check Gate to report their aggregate result.
 
 ## Releases (monorepo tags)
 

--- a/server/integ/web_api_test.go
+++ b/server/integ/web_api_test.go
@@ -602,13 +602,53 @@ func testWebSyncTimeoutFailure(
 	require.Nil(t, eventContext.GetLastFailureInfo())
 	require.NotNil(t, terminalFailure)
 	require.Equal(t, int32(1), terminalFailure.GetAttempt())
-	expectedBackendError := "START_TO_CLOSE"
-	if backendType == service.BackendTypeTemporal {
-		expectedBackendError = "StartToClose"
-	}
-	require.Equal(t, expectedBackendError, terminalFailure.GetBackendError())
-	require.Nil(t, terminalFailure.GetDetails())
+	requireSyncTimeoutFailure(t, backendType, terminalFailure)
 	requireStepMethodFailureJSON(t, terminalFailure)
+}
+
+func requireSyncTimeoutFailure(
+	t *testing.T,
+	backendType service.BackendType,
+	failure *dexpb.StepMethodFailure,
+) {
+	t.Helper()
+	expectedBackendError := "START_TO_CLOSE"
+	switch backendType {
+	case service.BackendTypeTemporal:
+		expectedBackendError = "StartToClose"
+	case service.BackendTypeCadence:
+	default:
+		t.Fatalf("unexpected backend type %v", backendType)
+	}
+	if failure.GetBackendError() == expectedBackendError {
+		require.Nil(t, failure.GetDetails())
+		return
+	}
+	require.Equal(
+		t,
+		dexpb.FlowErrorType_FLOW_ERROR_TYPE_WORKER_API_FAIL.String(),
+		failure.GetBackendError(),
+	)
+	details := failure.GetDetails()
+	require.NotNil(t, details)
+	require.Equal(
+		t,
+		dexpb.ErrorSubStatus_ERROR_SUB_STATUS_WORKER_API_ERROR,
+		details.GetSubStatus(),
+	)
+	switch codes.Code(details.GetOriginalWorkerErrorStatus()) {
+	case codes.DeadlineExceeded:
+		require.Contains(t, details.GetDetail(), "context deadline exceeded")
+	case codes.Internal:
+		require.Equal(t, service.BackendTypeCadence, backendType)
+		require.Contains(t, details.GetDetail(), "RST_STREAM")
+	default:
+		t.Fatalf(
+			"unexpected worker status %v: %q",
+			codes.Code(details.GetOriginalWorkerErrorStatus()),
+			details.GetDetail(),
+		)
+	}
 }
 
 func requireStepMethodFailureJSON(t *testing.T, failure *dexpb.StepMethodFailure) {

--- a/server/integ/workflow/wf_execute_method_fail_and_proceed/routers.go
+++ b/server/integ/workflow/wf_execute_method_fail_and_proceed/routers.go
@@ -108,6 +108,10 @@ func (h *handler) InvokeExecuteMethod(
 }
 
 func validateTimeoutRecoveryError(recoveryError *dexpb.RecoveryErrorInfo) {
+	if recoveryError.GetErrorType() == dexpb.FlowErrorType_FLOW_ERROR_TYPE_WORKER_API_FAIL.String() {
+		return
+	}
+
 	normalizedType := strings.ReplaceAll(strings.ToUpper(recoveryError.GetErrorType()), "_", "")
 	if recoveryError.GetDetail() == "" ||
 		!strings.Contains(normalizedType, "STARTTOCLOSE") {


### PR DESCRIPTION
## Summary

- route main push and manual CI jobs to separate heavy and light runner labels
- add a manual Main CI (all) dispatcher and expand Check Gate aggregation
- pin generated-code Rust to 1.97.1 and extend integration job timeouts
- accept both backend and worker deadline representations in timeout integration assertions

## Why

The 10-runner pool let memory-heavy jobs claim more work than the 32 GiB host could execute. Jobs then waited inside the runner hook, hit workflow timeouts, or lost runner sessions. Generated code also used Rust 1.88 while current dependencies require 1.97.

## Validation

- make -C server unitTests
- RUSTUP_TOOLCHAIN=1.97.1 make generated-code-check
- make ci-runner-check
- make copyright-check
- actionlint on all changed workflows
- git diff --check

The local runner pool will be reset separately to 2 heavy and 4 light registrations after current jobs release.