### PR TITLE
fix(server): reject contended RPC locks without waiting

### DIFF
--- a/server/service/interpreter/persistence.go
+++ b/server/service/interpreter/persistence.go
@@ -92,10 +92,18 @@ func (am *PersistenceManager) LoadAttributes(
 	}); err != nil {
 		return nil, err
 	}
-	for _, key := range keysToLock {
-		am.lockedKeys[key] = true
-	}
+	am.lockKeys(keysToLock)
 	return am.GetAllAttributes(), nil
+}
+
+func (am *PersistenceManager) TryLoadAttributes(
+	keysToLock []string,
+) ([]*dexpb.KV, bool) {
+	if !am.CanLockKeys(keysToLock) {
+		return nil, false
+	}
+	am.lockKeys(keysToLock)
+	return am.GetAllAttributes(), true
 }
 
 func (am *PersistenceManager) GetAllAttributes() []*dexpb.KV {
@@ -143,6 +151,12 @@ func (am *PersistenceManager) CanLockKeys(keys []string) bool {
 		}
 	}
 	return true
+}
+
+func (am *PersistenceManager) lockKeys(keys []string) {
+	for _, key := range keys {
+		am.lockedKeys[key] = true
+	}
 }
 
 func (am *PersistenceManager) UnlockKeys(keys []string) {

--- a/server/service/interpreter/workflowUpdater.go
+++ b/server/service/interpreter/workflowUpdater.go
@@ -155,9 +155,9 @@ func (u *WorkflowUpdater) handleWorkerRpc(
 			err.Error(),
 		)
 	}
-	attributes, err := u.persistenceManager.LoadAttributes(ctx, keysToLock)
-	if err != nil {
-		return nil, err
+	attributes, locked := u.persistenceManager.TryLoadAttributes(keysToLock)
+	if !locked {
+		return nil, u.rpcLockError()
 	}
 
 	rpcPrep := &dexpb.PrepareRpcQueryResponse{
@@ -235,12 +235,16 @@ func (u *WorkflowUpdater) validateWorkerRpc(
 		)
 	}
 	if !u.persistenceManager.CanLockKeys(keys) {
-		return u.provider.NewUpdateError(
-			dexpb.UpdateErrorType_UPDATE_ERROR_TYPE_RPC_ACQUIRE_LOCK_FAILURE,
-			"one or more attribute keys are locked",
-		)
+		return u.rpcLockError()
 	}
 	return nil
+}
+
+func (u *WorkflowUpdater) rpcLockError() error {
+	return u.provider.NewUpdateError(
+		dexpb.UpdateErrorType_UPDATE_ERROR_TYPE_RPC_ACQUIRE_LOCK_FAILURE,
+		"one or more attribute keys are locked",
+	)
 }
 
 func (u *WorkflowUpdater) effectiveRPCBudget(requestedSeconds int32) time.Duration {


### PR DESCRIPTION
## Summary reject contended locking RPC updates immediately in the handler

close the Temporal batch-validation race with a second non-blocking lock check\n- reuse the same typed lock-conflict error from validation and execution\n\n## Root cause\n\nTemporal may validate several updates before executing their handlers. Those validators can all observe the key as unlocked. The handlers then previously waited for the lock, creating a long backlog that could exceed the SDK long-poll deadline under 100 concurrent RPCs.\n\n## Tests\n\n- make -C server unitTests\n- make copyright-check\n- git diff --check\n\nThe PR server change also triggers the Python SDK integration workflow containing the failing 100-concurrent-RPC scenario.