### PR TITLE
fix(server): serialize attribute index synchronization

### DIFF
--- a/server/service/indexsync/synchronizer.go
+++ b/server/service/indexsync/synchronizer.go
@@ -42,6 +42,8 @@ type Synchronizer struct {
 	cfg    *config.Interpreter
 	client Client
 	logger log.Logger
+	// Cadence mutates shared search-attribute state unsafely during concurrent registrations.
+	syncSlot chan struct{}
 }
 
 // New creates an attribute index synchronizer.
@@ -55,7 +57,14 @@ func New(interpreterCfg *config.Interpreter, client Client, logger log.Logger) *
 	if logger == nil {
 		panic("attribute index logger must not be nil")
 	}
-	return &Synchronizer{cfg: interpreterCfg, client: client, logger: logger}
+	synchronizer := &Synchronizer{
+		cfg:      interpreterCfg,
+		client:   client,
+		logger:   logger,
+		syncSlot: make(chan struct{}, 1),
+	}
+	synchronizer.syncSlot <- struct{}{}
+	return synchronizer
 }
 
 // Sync creates missing indexes and waits until the backend reports them.
@@ -66,9 +75,14 @@ func (s *Synchronizer) Sync(ctx context.Context, requested map[string]dexpb.Inde
 	if len(requested) == 0 {
 		return nil
 	}
-
 	syncCtx, cancel := context.WithTimeout(ctx, s.cfg.EffectiveAttributeIndexSyncTimeout())
 	defer cancel()
+	select {
+	case <-syncCtx.Done():
+		return backendError(syncCtx.Err())
+	case <-s.syncSlot:
+	}
+	defer func() { s.syncSlot <- struct{}{} }()
 
 	existing, err := s.listUntilAvailable(syncCtx)
 	if err != nil {


### PR DESCRIPTION
## Summary
- serialize attribute index synchronization within each Dex service instance
- keep queue waits bounded by the configured synchronization timeout
- prevent concurrent Cadence AddSearchAttribute calls from crashing Cadence v1.4.1

## Tests
- `make -C server unitTests`
- `make -C server ci-cadence-integ-test totalPartitions=5 partitionNum=2`
- `GOFLAGS='-run=^TestAttributeIndexSyncCadence$' make -C server cadenceIntegTests`\n- `make copyright-check`