### PR TITLE
fix(examples): use released Python SDK 0.1.4

### DIFF
--- a/.github/workflows/examples-python-ci.yml
+++ b/.github/workflows/examples-python-ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: uv sync --locked
       - name: Verify published package
         run: |
-          uv run --frozen python -c "import dex, importlib.metadata as m; print(m.version('dex-python-sdk')); assert m.version('dex-python-sdk') == '0.1.1'"
+          uv run --frozen python -c "import dex, importlib.metadata as m; print(m.version('dex-python-sdk')); assert m.version('dex-python-sdk') == '0.1.4'"
       - name: Integ tests with dexcli dev
         run: ./run-integ-tests.sh
       - name: Upload service logs

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,6 +1,6 @@
 # Dex Python examples
 
-These examples target [`dex-python-sdk==0.1.3`](https://pypi.org/project/dex-python-sdk/0.1.3/)
+These examples target [`dex-python-sdk==0.1.4`](https://pypi.org/project/dex-python-sdk/0.1.4/)
 (`import dex`). Requires Python 3.11+.
 
 The primary sample process hosts one asyncio `AsyncWorker` on `127.0.0.1:8803` and a

--- a/examples/python/pyproject.toml
+++ b/examples/python/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "dex-python-sdk==0.1.3",
+    "dex-python-sdk==0.1.4",
     "flask>=3.0,<4",
     "openai>=1.66.2,<2",
     "openai-agents>=0.0.4,<0.0.5",

--- a/examples/python/run-integ-tests.sh
+++ b/examples/python/run-integ-tests.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$script_dir/../.." && pwd)
+entity_store_dir="$repo_root/examples/entity-store"
+compose_project="dex-python-examples-$$"
 dex_port="${DEX_EXAMPLES_DEX_PORT:-19802}"
 web_port="${DEX_EXAMPLES_WEB_PORT:-19902}"
 temporal_port="${DEX_EXAMPLES_TEMPORAL_PORT:-19234}"
@@ -27,6 +29,7 @@ log_file="/tmp/test-python-examples-integ-services.log"
 test_dir=$(mktemp -d)
 binary_dir=$(mktemp -d)
 dexcli_pid=""
+entity_store_started=false
 : >"$log_file"
 
 cleanup() {
@@ -34,6 +37,12 @@ cleanup() {
   if [[ -n "$dexcli_pid" ]] && kill -0 "$dexcli_pid" 2>/dev/null; then
     kill -TERM "$dexcli_pid"
     wait "$dexcli_pid" || true
+  fi
+  if $entity_store_started; then
+    if ! docker compose -p "$compose_project" \
+      -f "$entity_store_dir/docker-compose.yml" down --volumes >>"$log_file" 2>&1; then
+      echo "failed to stop the Python examples entity store" >&2
+    fi
   fi
   if [[ "$status" -ne 0 ]]; then
     cat "$log_file" >&2
@@ -55,7 +64,12 @@ fi
   GOWORK=off go build -trimpath -o "$binary_dir/dexcli" ./cmd/dexcli
 )
 
+docker compose -p "$compose_project" \
+  -f "$entity_store_dir/docker-compose.yml" up --detach --wait
+entity_store_started=true
+
 "$binary_dir/dexcli" dev \
+  -attribute-store-config "$entity_store_dir/attribute-store.yaml" \
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
@@ -84,4 +98,6 @@ fi
 
 cd "$script_dir"
 DEX_FLOW_SERVICE_ADDRESS="$dex_address" \
-  uv run --frozen pytest -vv tests/ sync-python/tests/integ
+  uv run --frozen pytest -vv tests/
+DEX_FLOW_SERVICE_ADDRESS="$dex_address" \
+  uv run --frozen pytest -vv sync-python/tests/integ

--- a/examples/python/sync-python/README.md
+++ b/examples/python/sync-python/README.md
@@ -3,7 +3,7 @@
 Showcase of the **sync** Dex Python SDK surface (`Client` / `Worker`) next to
 the primary async examples under `examples/python/`.
 
-Targets [`dex-python-sdk==0.1.3`](https://pypi.org/project/dex-python-sdk/0.1.3/).
+Targets [`dex-python-sdk==0.1.4`](https://pypi.org/project/dex-python-sdk/0.1.4/).
 Requires Python 3.11+.
 
 The samples use concrete SDK errors for missing, inactive, and duplicate Flows

--- a/examples/python/sync-python/tests/integ/conftest.py
+++ b/examples/python/sync-python/tests/integ/conftest.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import socket
 import time
 from collections.abc import Callable, Iterator
 from datetime import timedelta
@@ -39,7 +40,7 @@ def sync_app(tmp_path_factory: pytest.TempPathFactory) -> Iterator[SyncExampleAp
         server_address=os.environ.get(
             "DEX_FLOW_SERVICE_ADDRESS", DEFAULT_SERVER_ADDRESS
         ),
-        worker_bind_address="127.0.0.1:0",
+        worker_bind_address=_available_worker_address(),
         worker_target=None,
         http_address="127.0.0.1:0",
         blob_cache_dir=tmp_path_factory.mktemp("dex-sync-examples-blob-cache"),
@@ -85,3 +86,10 @@ def _server_is_ready(client: Client) -> bool:
         except DexServiceError:
             time.sleep(POLL_INTERVAL_SECONDS)
     return False
+
+
+def _available_worker_address() -> str:
+    with socket.socket() as worker_socket:
+        worker_socket.bind(("127.0.0.1", 0))
+        host, port = worker_socket.getsockname()
+    return f"{host}:{port}"

--- a/examples/python/tests/integ/conftest.py
+++ b/examples/python/tests/integ/conftest.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import socket
 from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import timedelta
 from typing import Any
@@ -56,9 +57,8 @@ async def example_app(
     """Boots one ExampleApp with every Flow on an ephemeral Worker port."""
     config = ExamplesConfig(
         server_address=server_address(),
-        # Port 0 lets the Worker's gRPC server pick a free port; the Client then
-        # targets that exact Worker, so parallel sample apps cannot collide.
-        worker_bind_address="127.0.0.1:0",
+        # Reserve first so the readiness probe targets the Worker's actual port.
+        worker_bind_address=_available_worker_address(),
         worker_target=None,
         http_address="127.0.0.1:0",
         blob_cache_dir=tmp_path_factory.mktemp("dex-examples-blob-cache"),
@@ -106,6 +106,13 @@ async def server_is_ready(client: AsyncClient) -> bool:
         except DexServiceError:
             await asyncio.sleep(POLL_INTERVAL_SECONDS)
     return False
+
+
+def _available_worker_address() -> str:
+    with socket.socket() as worker_socket:
+        worker_socket.bind(("127.0.0.1", 0))
+        host, port = worker_socket.getsockname()
+    return f"{host}:{port}"
 
 
 async def wait_until(

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -293,7 +293,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dex-python-sdk", specifier = "==0.1.3" },
+    { name = "dex-python-sdk", specifier = "==0.1.4" },
     { name = "flask", specifier = ">=3.0,<4" },
     { name = "openai", specifier = ">=1.66.2,<2" },
     { name = "openai-agents", specifier = ">=0.0.4,<0.0.5" },
@@ -312,20 +312,20 @@ dev = [
 
 [[package]]
 name = "dex-python-sdk"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "grpcio-status" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/41/748c7b6f22b4b076da10c9ba4e3f81e507a9353fc697c6b2f7de66bcac09/dex_python_sdk-0.1.3.tar.gz", hash = "sha256:c89ece5a46e8f7755e2bf6a03f7bd5d5e0d7053e228687ed486487d24c0f575e", size = 135978, upload-time = "2026-08-11T23:31:17.557Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/cb/02c7873d9a3dfe11e27d3a99afe796cca287fa776d057af57323e0df6be4/dex_python_sdk-0.1.4.tar.gz", hash = "sha256:6ff5b64b204b6f2a2205b46ee2c41cc5158cc8b7a01b81e2407fd62008051bbd", size = 139139, upload-time = "2026-08-14T00:54:41.001Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/72/053c24de9c513778ff6ada40963d2354411c23739e4fe3314dee750f1339/dex_python_sdk-0.1.3-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2aee93c11c5c5f425c3952a12995ee8c9ff09aaf3f8c612729841bdf1db5b5e2", size = 633427, upload-time = "2026-08-11T23:31:11.66Z" },
-    { url = "https://files.pythonhosted.org/packages/85/a8/dce7686656afbf98e837a171eefbd8968a540e15e0c33ca04e2dbc7735c6/dex_python_sdk-0.1.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:01909b34709ddeff9fd94cb4e07b93af008a680a75441f525eef69a63bdda8b3", size = 613969, upload-time = "2026-08-11T23:31:12.91Z" },
-    { url = "https://files.pythonhosted.org/packages/db/60/3bcbe7048b431babf640bc3a887cdb7ba3739275eaf596e94547a62bc96b/dex_python_sdk-0.1.3-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f75c7f4da491844bb9c94d6749bd26a3deca81b696531d3d8c950ccda5fca49", size = 670809, upload-time = "2026-08-11T23:31:14.129Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/7d/d37e4417731cc70fc3433f216489612b756b0bdc2fce50adc95d472aae97/dex_python_sdk-0.1.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:11cafccdcbb0a4213c7fc5a902fcee2dda61e20b931589004530e71510e6994a", size = 672954, upload-time = "2026-08-11T23:31:15.582Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/72/2c3b69c60cca8d069696c2411c8ce946735f6c8f8427beff750d58a5b3a2/dex_python_sdk-0.1.3-cp311-abi3-win_amd64.whl", hash = "sha256:7f98ccd348cae939d3eb6676fd2d9b4be6cf99c01140587c53d0f17872397a1f", size = 515958, upload-time = "2026-08-11T23:31:16.564Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/58/b295af7b243cec8dec78834ade06f94086722aacdca9da7280495c1685a7/dex_python_sdk-0.1.4-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e039fb0544d57146fd6cf0ef68857d3a817c97509c5434aa4bcdc7d7e7444d0d", size = 619247, upload-time = "2026-08-14T00:54:33.868Z" },
+    { url = "https://files.pythonhosted.org/packages/23/75/9d310194b57169e5d24c84b8024f104e6d7caa46afad4639b43062ca9290/dex_python_sdk-0.1.4-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:f9aecab13ac475d8168352fa26d85ca56ac162cdd153575bf024d94d3d32f55e", size = 597763, upload-time = "2026-08-14T00:54:35.504Z" },
+    { url = "https://files.pythonhosted.org/packages/71/5f/608b98776b1a298e86a469cf5772c71908bda6b82fb9b409ad93c6d8b3d9/dex_python_sdk-0.1.4-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd8166227a6be34dda784c78138be985d383f3a5a2b801dc0231606fae2f649e", size = 660700, upload-time = "2026-08-14T00:54:37.019Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/d1948be947d58e11d040e717e46c4d43f01eb8393733bddd03e34ab49624/dex_python_sdk-0.1.4-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6474952a50c34bfef8c95611069c6524d301898fd1f0f72ca636ea28a310192f", size = 663002, upload-time = "2026-08-14T00:54:38.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b2/e0e3ba0587683334bd2fe7e18ba98701e2c7faacde36281c2be8d8af6fda/dex_python_sdk-0.1.4-cp311-abi3-win_amd64.whl", hash = "sha256:ee35f98cc44802318ab1980ca7cc08d9e76a083ad29f630c3ca4b4cbe7034e4c", size = 506813, upload-time = "2026-08-14T00:54:39.59Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- pin Python examples and CI verification to the released `dex-python-sdk==0.1.4`
- split async and sync pytest suites to avoid duplicate `tests` package collection
- give integration workers explicit available ports so readiness probes can connect
- start the shared PostgreSQL entity-store fixture for the entity-store scenario

## Rationale

The full-main Python examples run failed before tests because CI asserted 0.1.1 while the lockfile used 0.1.3. After fixing that stale check, 0.1.3 was still incompatible with the examples' current `wait_for_flow` API and lacked the nested dataclass datetime codec fix. Python SDK 0.1.4 was published from main and is now public on PyPI, so examples continue to consume only a released package.

## User impact

Python async and sync examples now install the public 0.1.4 release and their integration harness covers worker readiness plus the PostgreSQL-backed entity-store configuration.

## Validation

- Python SDK 0.1.4 release: https://github.com/superdurable/dex/releases/tag/sdk-python/v0.1.4
- PyPI 0.1.4 metadata returned HTTP 200
- `uv run --frozen python -c "import importlib.metadata as metadata; assert metadata.version('dex-python-sdk') == '0.1.4'"`
- `./run-integ-tests.sh` (40 async tests and 6 sync tests passed)
- `make copyright-check`
- `bash -n examples/python/run-integ-tests.sh`
- `git diff --check`
