### PR TITLE
test(server): stabilize Cadence timeout assertion

### DIFF
--- a/server/integ/web_api_test.go
+++ b/server/integ/web_api_test.go
@@ -636,19 +636,17 @@ func requireSyncTimeoutFailure(
 		dexpb.ErrorSubStatus_ERROR_SUB_STATUS_WORKER_API_ERROR,
 		details.GetSubStatus(),
 	)
-	switch codes.Code(details.GetOriginalWorkerErrorStatus()) {
-	case codes.DeadlineExceeded:
-		require.Contains(t, details.GetDetail(), "context deadline exceeded")
-	case codes.Internal:
-		require.Equal(t, service.BackendTypeCadence, backendType)
-		require.Contains(t, details.GetDetail(), "RST_STREAM")
-	default:
-		t.Fatalf(
-			"unexpected worker status %v: %q",
-			codes.Code(details.GetOriginalWorkerErrorStatus()),
-			details.GetDetail(),
-		)
+	workerStatus := codes.Code(details.GetOriginalWorkerErrorStatus())
+	workerDetail := details.GetDetail()
+	if workerStatus == codes.DeadlineExceeded && strings.Contains(workerDetail, "context deadline exceeded") {
+		return
 	}
+	if backendType == service.BackendTypeCadence &&
+		(workerStatus == codes.DeadlineExceeded || workerStatus == codes.Internal) {
+		require.Contains(t, workerDetail, "RST_STREAM")
+		return
+	}
+	t.Fatalf("unexpected worker status %v: %q", workerStatus, workerDetail)
 }
 
 func requireStepMethodFailureJSON(t *testing.T, failure *dexpb.StepMethodFailure) {


### PR DESCRIPTION
## Summary

- accept Cadence HTTP/2 timeout cancellation details when the original worker status is `DeadlineExceeded`
- keep the assertion strict for non-Cadence backends and unrelated worker failures

## Rationale

Cadence can report the same timed-out worker RPC as `DeadlineExceeded` with `RST_STREAM ... CANCEL`, not only as `Internal`. This race caused recurring failures in `TestWebAPICadence/sync-timeout-wait-for` on main even though the timeout behavior was correct.

## User impact

No runtime behavior changes. The integration test now recognizes both valid Cadence timeout representations.

## Validation

- `make -C server ci-web-api-cadence-test 2>&1 | tee /tmp/test-cadence-timeout-web-api.log`
- `make copyright-check 2>&1 | tee /tmp/test-cadence-timeout-copyright.log`
- `git diff --check`
