### PR TITLE
ci(server): wait for Temporal Postgres readiness

### DIFF
--- a/server/docker-compose/ci-temporal-dependencies.yml
+++ b/server/docker-compose/ci-temporal-dependencies.yml
@@ -25,6 +25,11 @@ services:
     environment:
       POSTGRES_PASSWORD: temporal
       POSTGRES_USER: temporal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U temporal -d temporal"]
+      interval: 1s
+      timeout: 5s
+      retries: 60
     image: postgres:${POSTGRESQL_VERSION}
     networks:
       - testing-network
@@ -33,8 +38,10 @@ services:
   temporal:
     container_name: temporal
     depends_on:
-      - postgresql
-      - elasticsearch
+      postgresql:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
     environment:
       - DB=postgres12
       - DB_PORT=5432


### PR DESCRIPTION
## Summary

- add a TCP PostgreSQL healthcheck to the Temporal CI dependency stack
- start Temporal only after PostgreSQL accepts connections on its final TCP listener

## Rationale

The PostgreSQL image briefly starts a Unix-socket-only server during initialization, shuts it down, and then starts the final TCP listener. Temporal auto-setup could start during that transition, fail schema setup with `database system is starting up`, and exit permanently. The integration test would then wait 60 seconds for a service that could never recover.

Using `pg_isready -h 127.0.0.1` avoids treating the temporary initialization server as ready.

## User impact

No runtime product behavior changes. Temporal-backed CI starts deterministically instead of intermittently failing before tests run.

## Validation

- `docker compose -f docker-compose/ci-temporal-dependencies.yml config --quiet`
- clean dependency-stack recreation showed `temporal-postgresql Waiting`, `Healthy`, then `temporal Starting`
- `make ci-temporal-integ-test totalPartitions=5 partitionNum=2 integrationCoverageDir=coverage-raw 2>&1 | tee /tmp/test-temporal-postgres-partition-2.log`
- `make copyright-check 2>&1 | tee /tmp/test-temporal-postgres-copyright.log`
- `git diff --check`
