### PR TITLE
test(server): accept Temporal timeout stream cancellation

### DIFF
--- a/server/integ/web_api_test.go
+++ b/server/integ/web_api_test.go
@@ -638,11 +638,13 @@ func requireSyncTimeoutFailure(
 	)
 	workerStatus := codes.Code(details.GetOriginalWorkerErrorStatus())
 	workerDetail := details.GetDetail()
-	if workerStatus == codes.DeadlineExceeded && strings.Contains(workerDetail, "context deadline exceeded") {
-		return
+	if workerStatus == codes.DeadlineExceeded {
+		if strings.Contains(workerDetail, "context deadline exceeded") ||
+			strings.Contains(workerDetail, "RST_STREAM") {
+			return
+		}
 	}
-	if backendType == service.BackendTypeCadence &&
-		(workerStatus == codes.DeadlineExceeded || workerStatus == codes.Internal) {
+	if backendType == service.BackendTypeCadence && workerStatus == codes.Internal {
 		require.Contains(t, workerDetail, "RST_STREAM")
 		return
 	}


### PR DESCRIPTION
## Summary

- accept HTTP/2 `RST_STREAM` cancellation when Temporal reports a synchronous timeout as `DeadlineExceeded`
- retain Cadence's `Internal` + `RST_STREAM` timeout handling

## Rationale

Main's Temporal integration partition 4 surfaced the same activity timeout/cancellation semantics as `DeadlineExceeded: stream terminated by RST_STREAM with error code: CANCEL`.

## Validation

- `make -C server ci-temporal-integ-test totalPartitions=5 partitionNum=4 integrationCoverageDir=coverage-raw`
- `make -C server unitTests`
- `make copyright-check`
