### PR TITLE
build(examples): use Java SDK 0.0.7

### DIFF
--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "io.superdurable:dex-sdk:0.0.6"
+    implementation "io.superdurable:dex-sdk:0.0.7"
 
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"


### PR DESCRIPTION
## Summary

- update Java examples from released dex-sdk 0.0.6 to released dex-sdk 0.0.7
- keep examples isolated from the in-repository Java SDK project

## Rationale

Java examples now use `SubFlow`, which was released in Java SDK 0.0.7. Maven Central publicly serves the 0.0.7 POM and artifacts.

## Validation

- Java SDK v0.0.7 Maven Central publication workflow passed
- `./gradlew test --tests 'io.superdurable.dex.workflow.*' --refresh-dependencies` under Java 17
- dependency insight resolves `io.superdurable:dex-sdk:0.0.7`
