### PR TITLE
test(server): await Temporal step completion

### DIFF
--- a/server/integ/from_step_execution_id_test.go
+++ b/server/integ/from_step_execution_id_test.go
@@ -153,9 +153,20 @@ func testRPCStepLineageAcrossContinueAsNew(
 		RpcName:   deadend.RPCTriggerState,
 	})
 	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		return workerHandler.GetTestResult().InvokeHistory[deadend.State1+"_execute"] > 0
-	}, 30*time.Second, 50*time.Millisecond)
+	if backendType == service.BackendTypeTemporal {
+		_, err = runtime.FlowClient.WaitForStepCompletion(ctx, &dexpb.WaitForStepCompletionRequest{
+			FlowId:              flowID,
+			StepType:            deadend.State1,
+			StepExecutionNumber: "1",
+			WaitTimeSeconds:     30,
+			RequestId:           newRequestID(),
+		})
+		require.NoError(t, err)
+	} else {
+		require.Eventually(t, func() bool {
+			return workerHandler.GetTestResult().InvokeHistory[deadend.State1+"_execute"] > 0
+		}, 30*time.Second, 50*time.Millisecond)
+	}
 
 	_, err = runtime.FlowClient.StopFlow(ctx, &dexpb.StopFlowRequest{FlowId: flowID})
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- wait for the Temporal S1 step completion before stopping the lineage test workflow
- retain the existing worker-observation fallback for Cadence, where step-completion waits are unsupported
- keep the exact RPC lineage assertion unchanged

## Rationale

Main's Temporal integration partition 3 failed because the test stopped the workflow as soon as the worker handler observed the Execute request. The handler increments its counter before returning the response, so StopFlow could race Temporal persisting the async local-activity completion marker. The resulting history occasionally lacked the RPC source lineage.

## User impact

No production behavior changes. The integration test now synchronizes on the durable Temporal step-completion event it later inspects.

## Validation

- `make -C server temporalIntegTests GOFLAGS="-run=TestStepLineageTemporal -count=10"`
- `make -C server unitTests`
- `make copyright-check`
