### PR TITLE
Fix cancellation across continue-as-new

### DIFF
--- a/server/integ/step_cancellation_test.go
+++ b/server/integ/step_cancellation_test.go
@@ -186,6 +186,7 @@ func testQueuedStepCancellationAcrossContinueAsNew(
 	require.NoError(t, err)
 	require.Equal(t, dexpb.FlowStatus_FLOW_STATUS_COMPLETED, completed.GetFlowStatus())
 	require.False(t, handler.WasQueuedLoserExecuted())
+	require.False(t, handler.WasWaitingLoserExecuted())
 
 	firstRunEvents, _ := getAllWebHistoryEvents(
 		t,

--- a/server/integ/workflow/step_cancellation/routers.go
+++ b/server/integ/workflow/step_cancellation/routers.go
@@ -35,6 +35,7 @@ const (
 	QueuedProducer      = "QueuedProducer"
 	QueuedWinner        = "QueuedWinner"
 	QueuedLoser         = "QueuedLoser"
+	QueuedWaitingLoser  = "QueuedWaitingLoser"
 	QueuedFinal         = "QueuedFinal"
 	LocalRoot           = "LocalRoot"
 	LocalWinner         = "LocalWinner"
@@ -55,6 +56,7 @@ type Handler struct {
 	canceledHandlers         map[string]bool
 	hasNoHeartbeatLateReturn bool
 	wasQueuedLoserExecuted   bool
+	wasWaitingLoserExecuted  bool
 }
 
 func NewHandler() *Handler {
@@ -109,6 +111,8 @@ func (h *Handler) InvokeWaitForMethod(
 	case GlobalWait:
 		return channelWait(), nil
 	case RpcGlobal:
+		return channelWait(), nil
+	case QueuedWaitingLoser:
 		return channelWait(), nil
 	case RpcFinal:
 		return timerWait(3 * time.Second), nil
@@ -176,6 +180,7 @@ func (h *Handler) InvokeExecuteMethod(
 		return next(
 			movement(QueuedProducer, syncExecuteOptions(false)),
 			movement(QueuedWinner, syncExecuteOptions(false)),
+			movement(QueuedWaitingLoser, nil),
 		), nil
 	case QueuedProducer:
 		time.Sleep(time.Second)
@@ -184,11 +189,16 @@ func (h *Handler) InvokeExecuteMethod(
 		time.Sleep(2 * time.Second)
 		return &dexpb.InvokeExecuteMethodResponse{StepDecision: &dexpb.StepDecision{
 			NextSteps:       []*dexpb.StepMovement{movement(QueuedFinal, nil)},
-			CancelStepTypes: []string{QueuedLoser},
+			CancelStepTypes: []string{QueuedLoser, QueuedWaitingLoser},
 		}}, nil
 	case QueuedLoser:
 		h.mu.Lock()
 		h.wasQueuedLoserExecuted = true
+		h.mu.Unlock()
+		return graceful(), nil
+	case QueuedWaitingLoser:
+		h.mu.Lock()
+		h.wasWaitingLoserExecuted = true
 		h.mu.Unlock()
 		return graceful(), nil
 	case QueuedFinal:
@@ -235,6 +245,12 @@ func (h *Handler) WasQueuedLoserExecuted() bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return h.wasQueuedLoserExecuted
+}
+
+func (h *Handler) WasWaitingLoserExecuted() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.wasWaitingLoserExecuted
 }
 
 func (h *Handler) markCanceled(stepType string) {

--- a/server/service/interfaces.go
+++ b/server/service/interfaces.go
@@ -29,7 +29,6 @@ const StepExecutionStatusFailedNoProceed StepExecutionStatus = "Failure"
 const StepExecutionStatusInternalError StepExecutionStatus = "InternalError"
 const StepExecutionStatusWaitingAborted StepExecutionStatus = "WaitingConditions"
 const StepExecutionStatusFailedAndProceed StepExecutionStatus = "ExecuteMethodFailedAndProceed"
-const StepExecutionStatusCanceled StepExecutionStatus = "Canceled"
 
 // ValidateTimerSkipRequest validates a pending timer by condition ID or index.
 func ValidateTimerSkipRequest(

--- a/server/service/interpreter/workflowImpl.go
+++ b/server/service/interpreter/workflowImpl.go
@@ -413,8 +413,15 @@ func (i *Interpreter) StartEngineFlow(
 						signalReceiver,
 						subFlowTracker,
 					)
-					if stepExecutionRegistry.IsCanceled(stepExeId) {
+					isCanceled := stepExecutionRegistry.IsCanceled(stepExeId)
+					if stepExecutionStatus != service.StepExecutionStatusWaitingAborted {
+						// WaitingAborted ends only the current run's goroutine; the logical Step execution remains resumable.
+						// Keep it registered through continue-as-new finalization because drained RPC signals or parallel
+						// Step decisions can still cancel it. Unregistering it here would consume such cancellation as a
+						// no-op, after which the next run would register and incorrectly resume the execution.
 						stepExecutionRegistry.Unregister(stepExeId)
+					}
+					if isCanceled {
 						return
 					}
 					if stepExecutionStatus == service.StepExecutionStatusInternalError {
@@ -429,7 +436,6 @@ func (i *Interpreter) StartEngineFlow(
 					}
 					if stepExecutionStatus == service.StepExecutionStatusCompleted {
 						// NOTE: decision is only available on this CompletedStepExecutionStatus
-						stepExecutionRegistry.Unregister(stepExeId)
 						if cancelErr := stepExecutionRegistry.CancelByStepTypesAndSiblingStepTypes(
 							ctx,
 							decision,
@@ -501,7 +507,6 @@ func (i *Interpreter) StartEngineFlow(
 							)
 							return
 						}
-						stepExecutionRegistry.Unregister(stepExeId)
 						options := step.GetStepOptions()
 						stepRequestQueue.AddSingleStepStartRequest(
 							options.GetExecuteFailureProceedStepType(),


### PR DESCRIPTION
## Summary

- keep waiting Step executions cancellable through continue-as-new finalization
- remove the obsolete internal canceled Step status
- cover queued and durable-waiting cancellation across continue-as-new on Temporal and Cadence

## Tests

- make -C server unitTests
- focused Temporal Step cancellation integration suite
- focused Cadence Step cancellation integration suite
- make copyright-check