### PR TITLE
Fix released SDK examples CI

### DIFF
--- a/.github/workflows/check-gate-ci.yml
+++ b/.github/workflows/check-gate-ci.yml
@@ -41,10 +41,6 @@ jobs:
             sdk_rust:
               - 'sdk-rust/**'
               - '.github/workflows/sdk-rust-ci.yml'
-            examples_go:
-              - 'examples/go/**'
-              - 'cli/**'
-              - '.github/workflows/examples-go-ci.yml'
             web:
               - 'web/**'
               - 'protos/**'
@@ -93,7 +89,6 @@ jobs:
           FILTER_SERVER: ${{ steps.filter.outputs.server }}
           FILTER_SDK_GO: ${{ steps.filter.outputs.sdk_go }}
           FILTER_SDK_RUST: ${{ steps.filter.outputs.sdk_rust }}
-          FILTER_EXAMPLES_GO: ${{ steps.filter.outputs.examples_go }}
           FILTER_WEB: ${{ steps.filter.outputs.web }}
           FILTER_GENERATED_CODE: ${{ steps.filter.outputs.generated_code }}
           FILTER_COPYRIGHT: ${{ steps.filter.outputs.copyright }}
@@ -110,6 +105,7 @@ jobs:
               "Java examples CI"
               "Python examples CI"
               "Rust examples CI"
+              "TypeScript examples CI"
               "Generated Code CI"
               "Go SDK CI"
               "Java SDK CI"
@@ -124,7 +120,6 @@ jobs:
             [[ "$FILTER_SERVER" == "true" ]] && expected+=("Server CI")
             [[ "$FILTER_SDK_GO" == "true" ]] && expected+=("Go SDK CI")
             [[ "$FILTER_SDK_RUST" == "true" ]] && expected+=("Rust SDK CI")
-            [[ "$FILTER_EXAMPLES_GO" == "true" ]] && expected+=("Go examples CI")
             [[ "$FILTER_WEB" == "true" ]] && expected+=("Web CI")
             [[ "$FILTER_GENERATED_CODE" == "true" ]] && expected+=("Generated Code CI")
             [[ "$FILTER_COPYRIGHT" == "true" ]] && expected+=("Copyright")

--- a/.github/workflows/examples-go-ci.yml
+++ b/.github/workflows/examples-go-ci.yml
@@ -1,19 +1,6 @@
 name: Go examples CI
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "examples/go/**"
-      - "sdk-go/**"
-      - "cli/**"
-      - ".github/workflows/examples-go-ci.yml"
-  pull_request:
-    paths:
-      - "examples/go/**"
-      - "sdk-go/**"
-      - "cli/**"
-      - ".github/workflows/examples-go-ci.yml"
   workflow_dispatch:
 
 jobs:
@@ -28,9 +15,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: examples/go/go.mod
-          cache-dependency-path: |
-            examples/go/go.sum
-            sdk-go/go.sum
+          cache-dependency-path: examples/go/go.sum
       - name: Verify released module dependencies
         env:
           GOWORK: "off"
@@ -53,8 +38,6 @@ jobs:
               exit 1
             fi
           done
-      - name: Use checkout SDK
-        run: go mod edit -replace github.com/superdurable/dex/sdk-go=../../sdk-go
       - name: Build
         env:
           GOWORK: "off"
@@ -75,9 +58,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: examples/go/go.mod
-          cache-dependency-path: |
-            examples/go/go.sum
-            sdk-go/go.sum
+          cache-dependency-path: examples/go/go.sum
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -85,8 +66,6 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - name: Install Temporal CLI runtime for dexcli dev
         uses: temporalio/setup-temporal@v0
-      - name: Use checkout SDK
-        run: go mod edit -replace github.com/superdurable/dex/sdk-go=../../sdk-go
       - name: End-to-end tests
         run: make e2eTests
       - name: Upload service logs

--- a/.github/workflows/examples-rust-ci.yml
+++ b/.github/workflows/examples-rust-ci.yml
@@ -1,15 +1,6 @@
 name: Rust examples CI
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "examples/rust/**"
-      - ".github/workflows/examples-rust-ci.yml"
-  pull_request:
-    paths:
-      - "examples/rust/**"
-      - ".github/workflows/examples-rust-ci.yml"
   workflow_dispatch:
 
 permissions:
@@ -50,3 +41,38 @@ jobs:
         run: make clippy
       - name: Run catalog integration tests
         run: make test
+
+  integ:
+    name: Integration tests with dexcli dev
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: examples/rust
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: |
+            cli/go.sum
+            server/go.sum
+            web/go.sum
+      - name: Install Temporal CLI runtime for dexcli dev
+        uses: temporalio/setup-temporal@v0
+      - name: Install Rust
+        run: rustup toolchain install 1.97.1 --profile minimal
+      - name: Integration tests with dexcli dev
+        run: ./run-integration-tests.sh
+      - name: Upload service logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-examples-integration-services
+          path: /tmp/test-rust-examples-integration-services.log
+          if-no-files-found: ignore

--- a/.github/workflows/examples-typescript-ci.yml
+++ b/.github/workflows/examples-typescript-ci.yml
@@ -1,0 +1,79 @@
+name: TypeScript examples CI
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: examples-typescript-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Published SDK, typecheck, and unit tests
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-light' || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: examples/typescript
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: examples/typescript/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Verify published SDK dependency
+        run: |
+          declared_version="$(node -p "require('./package.json').dependencies['@superdurable/dex']")"
+          resolved_version="$(npm ls --json --depth=0 @superdurable/dex | jq -r '.dependencies["@superdurable/dex"].version')"
+          resolved_source="$(node -p "require('./package-lock.json').packages['node_modules/@superdurable/dex'].resolved")"
+          if [[ "$declared_version" != "0.1.5" || "$resolved_version" != "0.1.5" || "$resolved_source" != "https://registry.npmjs.org/@superdurable/dex/-/dex-0.1.5.tgz" ]]; then
+            echo "examples/typescript must use published @superdurable/dex 0.1.5"
+            exit 1
+          fi
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Unit tests
+        run: npm test
+
+  integ:
+    name: Integration tests with dexcli dev
+    runs-on: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && 'linux-dind-heavy' || 'ubuntu-latest' }}
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: examples/typescript
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            examples/typescript/package-lock.json
+            web/package-lock.json
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: |
+            cli/go.sum
+            server/go.sum
+            web/go.sum
+      - name: Install Temporal CLI runtime for dexcli dev
+        uses: temporalio/setup-temporal@v0
+      - name: Install dependencies
+        run: npm ci
+      - name: Integration tests with dexcli dev
+        run: ./run-integration-tests.sh
+      - name: Upload service logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: typescript-examples-integration-services
+          path: /tmp/test-typescript-examples-integration-services.log
+          if-no-files-found: ignore

--- a/.github/workflows/main-ci-all.yml
+++ b/.github/workflows/main-ci-all.yml
@@ -32,6 +32,7 @@ jobs:
             examples-java-ci.yml
             examples-python-ci.yml
             examples-rust-ci.yml
+            examples-typescript-ci.yml
             generated-code-ci.yml
             sdk-go-ci.yml
             sdk-java-ci.yml

--- a/examples/go/run-e2e-tests.sh
+++ b/examples/go/run-e2e-tests.sh
@@ -22,6 +22,8 @@
 
 set -euo pipefail
 
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/../.." && pwd)
 dex_port="${DEX_EXAMPLES_DEX_PORT:-19801}"
 web_port="${DEX_EXAMPLES_WEB_PORT:-19901}"
 temporal_port="${DEX_EXAMPLES_TEMPORAL_PORT:-19233}"
@@ -32,29 +34,48 @@ postgres_url="postgres://dataset_deal:dataset_deal@127.0.0.1:${postgres_port}/da
 compose_project="dataset-deal-e2e-$$"
 log_file="/tmp/test-go-examples-e2e-services.log"
 test_dir=$(mktemp -d)
+binary_dir=$(mktemp -d)
 dexcli_pid=""
+: >"$log_file"
 
 cleanup() {
+  status=$?
   if [[ -n "$dexcli_pid" ]] && kill -0 "$dexcli_pid" 2>/dev/null; then
     kill -TERM "$dexcli_pid"
     wait "$dexcli_pid" || true
   fi
-  DATASET_DEAL_POSTGRES_PORT="$postgres_port" docker compose \
+  if ! DATASET_DEAL_POSTGRES_PORT="$postgres_port" docker compose \
     -p "$compose_project" \
-    -f dataset-deal/docker-compose.yml \
-    down --volumes >/dev/null 2>&1 || true
-  rm -r "$test_dir"
+    -f "$script_dir/dataset-deal/docker-compose.yml" \
+    down --volumes >>"$log_file" 2>&1; then
+    echo "failed to stop the Go examples database" >&2
+  fi
+  if [[ "$status" -ne 0 ]]; then
+    cat "$log_file" >&2
+  fi
+  rm -r "$test_dir" "$binary_dir"
 }
 trap cleanup EXIT
 
 DATASET_DEAL_POSTGRES_PORT="$postgres_port" docker compose \
   -p "$compose_project" \
-  -f dataset-deal/docker-compose.yml \
+  -f "$script_dir/dataset-deal/docker-compose.yml" \
   up -d --wait
 
-make -C ../../cli build
-: >"$log_file"
-../../cli/dexcli dev \
+if [[ ! -f "$repo_root/web/assets/dist/index.html" ]]; then
+  (
+    cd "$repo_root/web"
+    npm ci
+    npm run build
+  )
+fi
+
+(
+  cd "$repo_root/cli"
+  GOWORK=off go build -trimpath -o "$binary_dir/dexcli" ./cmd/dexcli
+)
+
+"$binary_dir/dexcli" dev \
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
@@ -64,9 +85,28 @@ make -C ../../cli build
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 
+dex_ready=false
+for _ in {1..240}; do
+  if grep -q "Dex development environment is ready" "$log_file"; then
+    dex_ready=true
+    break
+  fi
+  if ! kill -0 "$dexcli_pid" 2>/dev/null; then
+    echo "dexcli exited before Dex became ready" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+if ! $dex_ready; then
+  echo "Dex did not become ready" >&2
+  exit 1
+fi
+
+cd "$script_dir"
 DEX_FLOW_SERVICE_ADDRESS="$dex_address" \
 DEX_WORKER_HOST=127.0.0.1 \
 DATASET_DEAL_POSTGRES_URL="$postgres_url" \
 GOCACHE="${GOCACHE:-/tmp/dex-examples-gocache}" \
 GOMODCACHE="${GOMODCACHE:-/tmp/dex-examples-gomodcache}" \
+GOWORK=off \
   go test -count=1 -race -v ./integ

--- a/examples/rust/Makefile
+++ b/examples/rust/Makefile
@@ -1,10 +1,13 @@
-.PHONY: check test clippy fmt-check
+.PHONY: check test clippy fmt-check integTests
 
 check:
 	cargo check --all-targets --locked
 
 test:
 	cargo test --all-targets --locked
+
+integTests:
+	cargo test --locked --test dex_integration -- --ignored --test-threads=1
 
 clippy:
 	cargo clippy --all-targets --locked -- -D warnings

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -77,5 +77,6 @@ The catalog integration test constructs every Flow, checks the exact 9 + 19
 mapping, rejects duplicate names, validates all definitions in one Registry, and
 ensures the manifest uses the published crate rather than a local path.
 
-The integration script starts the current checkout's `dexcli dev`, then runs a
-Money Transfer Flow through the published Rust SDK.
+The integration script starts the current checkout's `dexcli dev`, then starts
+and verifies Money Transfer, Engagement, Microservice, Polling, Subscription,
+and Failure Recovery Flows through the published Rust SDK.

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -70,8 +70,12 @@ cross-language catalog.
 make fmt-check
 make clippy
 make test
+./run-integration-tests.sh
 ```
 
 The catalog integration test constructs every Flow, checks the exact 9 + 19
 mapping, rejects duplicate names, validates all definitions in one Registry, and
 ensures the manifest uses the published crate rather than a local path.
+
+The integration script starts the current checkout's `dexcli dev`, then runs a
+Money Transfer Flow through the published Rust SDK.

--- a/examples/rust/run-integration-tests.sh
+++ b/examples/rust/run-integration-tests.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/../.." && pwd)
+dex_port="${DEX_RUST_EXAMPLES_DEX_PORT:-19804}"
+web_port="${DEX_RUST_EXAMPLES_WEB_PORT:-19904}"
+temporal_port="${DEX_RUST_EXAMPLES_TEMPORAL_PORT:-19236}"
+temporal_ui_port="${DEX_RUST_EXAMPLES_TEMPORAL_UI_PORT:-19336}"
+dex_address="127.0.0.1:${dex_port}"
+log_file="/tmp/test-rust-examples-integration-services.log"
+test_dir=$(mktemp -d)
+binary_dir=$(mktemp -d)
+dexcli_pid=""
+: >"$log_file"
+
+cleanup() {
+  status=$?
+  if [[ -n "$dexcli_pid" ]] && kill -0 "$dexcli_pid" 2>/dev/null; then
+    kill -TERM "$dexcli_pid"
+    wait "$dexcli_pid" || true
+  fi
+  if [[ "$status" -ne 0 ]]; then
+    cat "$log_file" >&2
+  fi
+  rm -r "$test_dir" "$binary_dir"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$repo_root/web/assets/dist/index.html" ]]; then
+  (
+    cd "$repo_root/web"
+    npm ci
+    npm run build
+  )
+fi
+
+(
+  cd "$repo_root/cli"
+  GOWORK=off go build -trimpath -o "$binary_dir/dexcli" ./cmd/dexcli
+)
+
+"$binary_dir/dexcli" dev \
+  -bind-address 127.0.0.1 \
+  -dex-port "$dex_port" \
+  -web-port "$web_port" \
+  -temporal-port "$temporal_port" \
+  -temporal-ui-port "$temporal_ui_port" \
+  -temporal-db-filename "$test_dir/temporal.db" \
+  >>"$log_file" 2>&1 &
+dexcli_pid=$!
+
+dex_ready=false
+for _ in {1..240}; do
+  if grep -q "Dex development environment is ready" "$log_file"; then
+    dex_ready=true
+    break
+  fi
+  if ! kill -0 "$dexcli_pid" 2>/dev/null; then
+    echo "dexcli exited before Dex became ready" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+if ! $dex_ready; then
+  echo "Dex did not become ready" >&2
+  exit 1
+fi
+
+cd "$script_dir"
+DEX_SERVER_ADDRESS="$dex_address" make integTests

--- a/examples/rust/tests/dex_integration.rs
+++ b/examples/rust/tests/dex_integration.rs
@@ -18,9 +18,22 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use dex_examples_rust::create_example_registry;
+use dex_examples_rust::patterns::recovery::FailureRecoveryFlow;
+use dex_examples_rust::workflow::engagement::{
+    ENGAGEMENT_ACCEPT, ENGAGEMENT_DESCRIBE, EngagementFlow, EngagementRequest, EngagementStatus,
+};
+use dex_examples_rust::workflow::microservices::{
+    ORCHESTRATION_READY, ORCHESTRATION_SWAP, OrchestrationFlow,
+};
 use dex_examples_rust::workflow::money_transfer::{MoneyTransferFlow, TransferRequest};
+use dex_examples_rust::workflow::polling::{POLLING_COMPLETE_TASK, PollingFlow};
+use dex_examples_rust::workflow::subscription::{
+    SUBSCRIPTION_CANCEL, SUBSCRIPTION_DESCRIBE, SUBSCRIPTION_UPDATE_CHARGE, SubscriptionFlow,
+    SubscriptionRequest, SubscriptionState,
+};
 use dex_sdk::{
-    BlobCache, BlobCacheConfig, Client, ClientOptions, SdkResult, Worker, WorkerOptions,
+    Attribute, BlobCache, BlobCacheConfig, Client, ClientOptions, FlowStatus, SdkResult, Worker,
+    WorkerOptions,
 };
 use tempfile::TempDir;
 
@@ -80,6 +93,36 @@ impl DexEnvironment {
             _cache_directory: cache_directory,
         }
     }
+
+    fn await_engagement_status(&self, flow_id: &str, expected: &str) -> EngagementStatus {
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while Instant::now() < deadline {
+            let status = self
+                .client
+                .invoke_rpc_without_input(flow_id, ENGAGEMENT_DESCRIBE)
+                .expect("describe Rust Engagement Flow");
+            if status.status == expected {
+                return status;
+            }
+            thread::yield_now();
+        }
+        panic!("Rust Engagement Flow did not reach {expected}");
+    }
+
+    fn await_subscription_charge(&self, flow_id: &str, expected: i64) -> SubscriptionState {
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while Instant::now() < deadline {
+            let state = self
+                .client
+                .invoke_rpc_without_input(flow_id, SUBSCRIPTION_DESCRIBE)
+                .expect("describe Rust Subscription Flow");
+            if state.charge_cents == expected {
+                return state;
+            }
+            thread::yield_now();
+        }
+        panic!("Rust Subscription Flow charge did not reach {expected}");
+    }
 }
 
 impl Drop for DexEnvironment {
@@ -100,7 +143,7 @@ impl Drop for DexEnvironment {
 fn money_transfer_completes_with_released_sdk() {
     let environment = DexEnvironment::start();
     let flow = MoneyTransferFlow::default();
-    let flow_id = unique_flow_id();
+    let flow_id = unique_flow_id("money-transfer");
     let input = TransferRequest {
         from_account: "released-sdk-source".to_string(),
         to_account: "released-sdk-destination".to_string(),
@@ -118,17 +161,216 @@ fn money_transfer_completes_with_released_sdk() {
     assert_eq!(output.from_account, "released-sdk-source");
     assert_eq!(output.to_account, "released-sdk-destination");
     assert_eq!(output.amount_cents, 4_200);
+    assert_eq!(
+        environment
+            .client
+            .describe_flow(&flow_id)
+            .expect("describe completed Rust Money Transfer Flow")
+            .status,
+        FlowStatus::Completed
+    );
 }
 
-fn unique_flow_id() -> String {
+#[test]
+#[ignore = "requires dexcli dev"]
+fn engagement_invokes_rpcs_and_completes() {
+    let environment = DexEnvironment::start();
+    let flow = EngagementFlow::default();
+    let flow_id = unique_flow_id("engagement");
+    let run_id = environment
+        .client
+        .start_flow(
+            &flow,
+            &flow_id,
+            EngagementRequest {
+                employer_id: "released-sdk-employer".to_string(),
+                candidate_id: "released-sdk-candidate".to_string(),
+            },
+        )
+        .expect("start Rust Engagement Flow");
+    assert!(!run_id.is_empty());
+
+    let pending = environment.await_engagement_status(&flow_id, "pending");
+    assert!(pending.notes.is_empty());
+    environment
+        .client
+        .invoke_rpc(
+            &flow_id,
+            ENGAGEMENT_ACCEPT,
+            "accepted in integration test".to_string(),
+        )
+        .expect("accept Rust Engagement Flow");
+    environment
+        .client
+        .wait_for_flow_with_timeout::<()>(&flow_id, Duration::from_secs(30))
+        .expect("complete Rust Engagement Flow");
+    assert_eq!(
+        environment
+            .client
+            .describe_flow(&flow_id)
+            .expect("describe completed Rust Engagement Flow")
+            .status,
+        FlowStatus::Completed
+    );
+}
+
+#[test]
+#[ignore = "requires dexcli dev"]
+fn microservice_swaps_data_and_completes_when_ready() {
+    let environment = DexEnvironment::start();
+    let flow = OrchestrationFlow::default();
+    let flow_id = unique_flow_id("microservice");
+    let run_id = environment
+        .client
+        .start_flow(&flow, &flow_id, "initial-data".to_string())
+        .expect("start Rust Microservice Flow");
+    assert!(!run_id.is_empty());
+
+    let data = Attribute::<String>::new("orchestration-data");
+    environment
+        .client
+        .wait_for_attribute_equal(
+            &flow_id,
+            &data,
+            "initial-data".to_string(),
+            Duration::from_secs(20),
+        )
+        .expect("wait for initial Rust Microservice data");
+    let previous = environment
+        .client
+        .invoke_rpc(&flow_id, ORCHESTRATION_SWAP, "updated-data".to_string())
+        .expect("swap Rust Microservice data");
+    assert_eq!(previous, "initial-data");
+    environment
+        .client
+        .wait_for_attribute_equal(
+            &flow_id,
+            &data,
+            "updated-data".to_string(),
+            Duration::from_secs(20),
+        )
+        .expect("wait for updated Rust Microservice data");
+    environment
+        .client
+        .invoke_rpc_without_input::<()>(&flow_id, ORCHESTRATION_READY)
+        .expect("release Rust Microservice Flow");
+    environment
+        .client
+        .wait_for_flow_with_timeout::<()>(&flow_id, Duration::from_secs(30))
+        .expect("complete Rust Microservice Flow");
+}
+
+#[test]
+#[ignore = "requires dexcli dev"]
+fn polling_completes_all_tasks() {
+    let environment = DexEnvironment::start();
+    let flow = PollingFlow::default();
+    let flow_id = unique_flow_id("polling");
+    let run_id = environment
+        .client
+        .start_flow(&flow, &flow_id, 1)
+        .expect("start Rust Polling Flow");
+    assert!(!run_id.is_empty());
+    environment
+        .client
+        .invoke_rpc(&flow_id, POLLING_COMPLETE_TASK, "a".to_string())
+        .expect("complete Rust Polling task a");
+    environment
+        .client
+        .invoke_rpc(&flow_id, POLLING_COMPLETE_TASK, "b".to_string())
+        .expect("complete Rust Polling task b");
+
+    let output: String = environment
+        .client
+        .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
+        .expect("complete Rust Polling Flow");
+    assert_eq!(output, "task-c");
+    assert_eq!(
+        environment
+            .client
+            .describe_flow(&flow_id)
+            .expect("describe completed Rust Polling Flow")
+            .status,
+        FlowStatus::Completed
+    );
+}
+
+#[test]
+#[ignore = "requires dexcli dev"]
+fn subscription_updates_charge_and_cancels() {
+    let environment = DexEnvironment::start();
+    let flow = SubscriptionFlow::default();
+    let flow_id = unique_flow_id("subscription");
+    let run_id = environment
+        .client
+        .start_flow(
+            &flow,
+            &flow_id,
+            SubscriptionRequest {
+                customer_id: "released-sdk-customer".to_string(),
+                charge_cents: 100,
+                billing_periods: 2,
+            },
+        )
+        .expect("start Rust Subscription Flow");
+    assert!(!run_id.is_empty());
+
+    let initial = environment.await_subscription_charge(&flow_id, 100);
+    assert_eq!(initial.periods_charged, 0);
+    assert!(!initial.cancelled);
+    environment
+        .client
+        .invoke_rpc(&flow_id, SUBSCRIPTION_UPDATE_CHARGE, 250)
+        .expect("update Rust Subscription charge");
+    let updated = environment.await_subscription_charge(&flow_id, 250);
+    assert!(!updated.cancelled);
+    environment
+        .client
+        .invoke_rpc_without_input::<()>(&flow_id, SUBSCRIPTION_CANCEL)
+        .expect("cancel Rust Subscription Flow");
+
+    let output: SubscriptionState = environment
+        .client
+        .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
+        .expect("complete Rust Subscription Flow");
+    assert_eq!(output.charge_cents, 250);
+    assert_eq!(output.periods_charged, 0);
+    assert!(output.cancelled);
+}
+
+#[test]
+#[ignore = "requires dexcli dev"]
+fn failure_recovery_retries_and_compensates() {
+    let environment = DexEnvironment::start();
+    let flow = FailureRecoveryFlow::default();
+    let flow_id = unique_flow_id("failure-recovery");
+    let run_id = environment
+        .client
+        .start_flow(&flow, &flow_id, "released-sdk-reservation".to_string())
+        .expect("start Rust Failure Recovery Flow");
+    assert!(!run_id.is_empty());
+
+    let output: String = environment
+        .client
+        .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
+        .expect("complete Rust Failure Recovery Flow");
+    assert_eq!(output, "compensated");
+    assert_eq!(
+        environment
+            .client
+            .describe_flow(&flow_id)
+            .expect("describe completed Rust Failure Recovery Flow")
+            .status,
+        FlowStatus::Completed
+    );
+}
+
+fn unique_flow_id(prefix: &str) -> String {
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("current time after Unix epoch")
         .as_nanos();
-    format!(
-        "rust-examples-money-transfer-{}-{timestamp}",
-        std::process::id()
-    )
+    format!("rust-examples-{prefix}-{}-{timestamp}", std::process::id())
 }
 
 fn available_worker_port() -> u16 {

--- a/examples/rust/tests/dex_integration.rs
+++ b/examples/rust/tests/dex_integration.rs
@@ -1,0 +1,155 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use dex_examples_rust::create_example_registry;
+use dex_examples_rust::workflow::money_transfer::{MoneyTransferFlow, TransferRequest};
+use dex_sdk::{
+    BlobCache, BlobCacheConfig, Client, ClientOptions, SdkResult, Worker, WorkerOptions,
+};
+use tempfile::TempDir;
+
+struct DexEnvironment {
+    client: Client,
+    worker: Arc<Worker>,
+    worker_thread: Option<JoinHandle<SdkResult<()>>>,
+    cache: Arc<BlobCache>,
+    _cache_directory: TempDir,
+}
+
+impl DexEnvironment {
+    fn start() -> Self {
+        let registry = create_example_registry().expect("register Rust examples");
+        let server_address =
+            std::env::var("DEX_SERVER_ADDRESS").unwrap_or_else(|_| "127.0.0.1:8801".to_string());
+        let worker_port = available_worker_port();
+        let worker_address = format!("127.0.0.1:{worker_port}");
+        let cache_directory = tempfile::tempdir().expect("create Rust examples cache directory");
+        let cache = Arc::new(
+            BlobCache::open(
+                BlobCacheConfig::new(cache_directory.path(), 64 * 1024 * 1024, 10_000)
+                    .expect("valid Rust examples cache config"),
+            )
+            .expect("open Rust examples cache"),
+        );
+        let worker = Arc::new(
+            Worker::try_new(
+                registry.clone(),
+                Arc::clone(&cache),
+                WorkerOptions::new()
+                    .server_address(&server_address)
+                    .bind_address(&worker_address),
+            )
+            .expect("create Rust examples Worker"),
+        );
+        let thread_worker = Arc::clone(&worker);
+        let worker_thread = thread::Builder::new()
+            .name("dex-rust-examples-worker".to_string())
+            .spawn(move || thread_worker.start())
+            .expect("start Rust examples Worker thread");
+        await_worker(worker_port, &worker_thread);
+        let client = Client::try_new(
+            registry,
+            Arc::clone(&cache),
+            ClientOptions::new()
+                .server_address(server_address)
+                .worker_target(worker.worker_target().clone()),
+        )
+        .expect("create Rust examples Client");
+        client.health_check().expect("Dex health check");
+        Self {
+            client,
+            worker,
+            worker_thread: Some(worker_thread),
+            cache,
+            _cache_directory: cache_directory,
+        }
+    }
+}
+
+impl Drop for DexEnvironment {
+    fn drop(&mut self) {
+        self.worker.stop();
+        if let Some(worker_thread) = self.worker_thread.take() {
+            worker_thread
+                .join()
+                .expect("join Rust examples Worker")
+                .expect("stop Rust examples Worker");
+        }
+        self.cache.close().expect("close Rust examples cache");
+    }
+}
+
+#[test]
+#[ignore = "requires dexcli dev"]
+fn money_transfer_completes_with_released_sdk() {
+    let environment = DexEnvironment::start();
+    let flow = MoneyTransferFlow::default();
+    let flow_id = unique_flow_id();
+    let input = TransferRequest {
+        from_account: "released-sdk-source".to_string(),
+        to_account: "released-sdk-destination".to_string(),
+        amount_cents: 4_200,
+        notes: "examples/rust integration".to_string(),
+    };
+    environment
+        .client
+        .start_flow(&flow, &flow_id, input)
+        .expect("start Rust Money Transfer Flow");
+    let output: TransferRequest = environment
+        .client
+        .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
+        .expect("complete Rust Money Transfer Flow");
+    assert_eq!(output.from_account, "released-sdk-source");
+    assert_eq!(output.to_account, "released-sdk-destination");
+    assert_eq!(output.amount_cents, 4_200);
+}
+
+fn unique_flow_id() -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("current time after Unix epoch")
+        .as_nanos();
+    format!(
+        "rust-examples-money-transfer-{}-{timestamp}",
+        std::process::id()
+    )
+}
+
+fn available_worker_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind an available Worker port")
+        .local_addr()
+        .expect("read available Worker port")
+        .port()
+}
+
+fn await_worker(worker_port: u16, worker_thread: &JoinHandle<SdkResult<()>>) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        assert!(
+            !worker_thread.is_finished(),
+            "Rust examples Worker exited before becoming ready"
+        );
+        if TcpStream::connect(("127.0.0.1", worker_port)).is_ok() {
+            return;
+        }
+        thread::yield_now();
+    }
+    panic!("Rust examples Worker did not become ready");
+}

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -35,6 +35,9 @@ npm run smoke            # every product + design-pattern HTTP route
 ./run-integration-tests.sh # start dexcli dev and run both integration suites
 ```
 
+The integration suite starts and verifies Money Transfer, Engagement,
+Microservice, Polling, Subscription, and Failure Recovery Flows.
+
 ## Product examples
 
 - [Money transfer](./src/workflow/money/transfer)

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -7,9 +7,8 @@ controller on port `8080`. Step `execute` / `waitFor` / RPC handlers may
 `await` the shared `Client` directly (async await on the Worker). Disk
 BlobCaches are under `DEX_BLOB_CACHE_DIR`.
 
-Controllers catch concrete SDK errors such as `FlowAlreadyStartedError`,
-`FlowNotFoundError`, and `FlowNotActiveError`; no example compares Dex
-sub-status metadata.
+Controllers handle expected duplicate and missing-Flow failures through
+`DexServiceError` gRPC codes; no example compares Dex sub-status metadata.
 
 ## Run locally
 
@@ -33,6 +32,7 @@ Use Node.js 22 or 24. Defaults connect to Dex at `localhost:8801`. Override with
 npm test                 # SubscriptionBilling unit tests
 npm run test:integ       # product integ tests (requires Dex)
 npm run smoke            # every product + design-pattern HTTP route
+./run-integration-tests.sh # start dexcli dev and run both integration suites
 ```
 
 ## Product examples

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@superdurable/dex-examples-typescript",
       "version": "0.0.0",
       "dependencies": {
-        "@superdurable/dex": "^0.1.5",
+        "@superdurable/dex": "0.1.5",
         "express": "^5.1.0"
       },
       "devDependencies": {

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -16,7 +16,7 @@
     "smoke": "npm run build && node --test --test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/e2e/all-routes.test.js'"
   },
   "dependencies": {
-    "@superdurable/dex": "^0.1.5",
+    "@superdurable/dex": "0.1.5",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/examples/typescript/run-integration-tests.sh
+++ b/examples/typescript/run-integration-tests.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Copyright (c) 2022-2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/../.." && pwd)
+entity_store_dir="$repo_root/examples/entity-store"
+compose_project="dex-typescript-examples-$$"
+dex_port="${DEX_TYPESCRIPT_EXAMPLES_DEX_PORT:-19805}"
+web_port="${DEX_TYPESCRIPT_EXAMPLES_WEB_PORT:-19905}"
+temporal_port="${DEX_TYPESCRIPT_EXAMPLES_TEMPORAL_PORT:-19237}"
+temporal_ui_port="${DEX_TYPESCRIPT_EXAMPLES_TEMPORAL_UI_PORT:-19337}"
+dex_address="127.0.0.1:${dex_port}"
+log_file="/tmp/test-typescript-examples-integration-services.log"
+test_dir=$(mktemp -d)
+binary_dir=$(mktemp -d)
+dexcli_pid=""
+entity_store_started=false
+: >"$log_file"
+
+cleanup() {
+  status=$?
+  if [[ -n "$dexcli_pid" ]] && kill -0 "$dexcli_pid" 2>/dev/null; then
+    kill -TERM "$dexcli_pid"
+    wait "$dexcli_pid" || true
+  fi
+  if $entity_store_started; then
+    if ! docker compose -p "$compose_project" \
+      -f "$entity_store_dir/docker-compose.yml" down --volumes >>"$log_file" 2>&1; then
+      echo "failed to stop the TypeScript examples entity store" >&2
+    fi
+  fi
+  if [[ "$status" -ne 0 ]]; then
+    cat "$log_file" >&2
+  fi
+  rm -r "$test_dir" "$binary_dir"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$repo_root/web/assets/dist/index.html" ]]; then
+  (
+    cd "$repo_root/web"
+    npm ci
+    npm run build
+  )
+fi
+
+(
+  cd "$repo_root/cli"
+  GOWORK=off go build -trimpath -o "$binary_dir/dexcli" ./cmd/dexcli
+)
+
+docker compose -p "$compose_project" \
+  -f "$entity_store_dir/docker-compose.yml" up --detach --wait
+entity_store_started=true
+
+"$binary_dir/dexcli" dev \
+  -attribute-store-config "$entity_store_dir/attribute-store.yaml" \
+  -bind-address 127.0.0.1 \
+  -dex-port "$dex_port" \
+  -web-port "$web_port" \
+  -temporal-port "$temporal_port" \
+  -temporal-ui-port "$temporal_ui_port" \
+  -temporal-db-filename "$test_dir/temporal.db" \
+  >>"$log_file" 2>&1 &
+dexcli_pid=$!
+
+dex_ready=false
+for _ in {1..240}; do
+  if grep -q "Dex development environment is ready" "$log_file"; then
+    dex_ready=true
+    break
+  fi
+  if ! kill -0 "$dexcli_pid" 2>/dev/null; then
+    echo "dexcli exited before Dex became ready" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+if ! $dex_ready; then
+  echo "Dex did not become ready" >&2
+  exit 1
+fi
+
+cd "$script_dir"
+DEX_BLOB_CACHE_DIR="$test_dir/blobs" \
+DEX_FLOW_SERVICE_ADDRESS="$dex_address" \
+  npm run test:integ
+DEX_BLOB_CACHE_DIR="$test_dir/blobs" \
+DEX_FLOW_SERVICE_ADDRESS="$dex_address" \
+  npm run smoke

--- a/examples/typescript/src/config/cron-schedule-starter.ts
+++ b/examples/typescript/src/config/cron-schedule-starter.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { FlowAlreadyStartedError, type Client } from "@superdurable/dex";
+import type { Client } from "@superdurable/dex";
 
 import { HOUR_MS } from "./env.js";
 import { cronScheduleFlow } from "../patterns/workflow/cron/cron-schedule-flow.js";
+import { isFlowAlreadyStarted } from "../service-errors.js";
 
 export const CRON_SCHEDULE_FLOW_ID = "cron-schedule-sample";
 export const CRON_EXPRESSION = "*/1 * * * *";
@@ -29,7 +30,7 @@ export async function startCronSchedule(client: Client): Promise<void> {
       cronSchedule: CRON_EXPRESSION,
     });
   } catch (error) {
-    if (error instanceof FlowAlreadyStartedError) {
+    if (isFlowAlreadyStarted(error)) {
       return;
     }
     throw error;

--- a/examples/typescript/src/controller/shortlist-candidates-controller.ts
+++ b/examples/typescript/src/controller/shortlist-candidates-controller.ts
@@ -16,13 +16,13 @@
 
 import { Router } from "express";
 
-import {
-  FlowAlreadyStartedError,
-  FlowNotActiveError,
-  type Client,
-} from "@superdurable/dex";
+import type { Client } from "@superdurable/dex";
 
 import { startOptions } from "../config/env.js";
+import {
+  isFlowAlreadyStarted,
+  isFlowMissingOrInactive,
+} from "../service-errors.js";
 import { employerOptInFlow } from "../workflow/shortlistcandidates/employer-opt-in-flow.js";
 import type { EmployerOptInInput } from "../workflow/shortlistcandidates/employer-opt-in-input.js";
 import { shortlistFlow } from "../workflow/shortlistcandidates/shortlist-flow.js";
@@ -39,7 +39,7 @@ export function createShortlistCandidatesRouter(client: Client): Router {
     try {
       await client.startFlow(employerOptInFlow, workflowId, input, startOptions());
     } catch (failure) {
-      if (failure instanceof FlowAlreadyStartedError) {
+      if (isFlowAlreadyStarted(failure)) {
         response.send(`Employer ${employerId} has already opted in`);
         return;
       }
@@ -54,7 +54,7 @@ export function createShortlistCandidatesRouter(client: Client): Router {
     try {
       await client.invokeRPC(employerOptInFlow.optOut, workflowId);
     } catch (failure) {
-      if (failure instanceof FlowNotActiveError) {
+      if (isFlowMissingOrInactive(failure)) {
         response.send(`Employer ${employerId} is not in the opt-in status`);
         return;
       }
@@ -82,7 +82,7 @@ export function createShortlistCandidatesRouter(client: Client): Router {
     try {
       await client.startFlow(shortlistFlow, workflowId, input, startOptions());
     } catch (failure) {
-      if (failure instanceof FlowAlreadyStartedError) {
+      if (isFlowAlreadyStarted(failure)) {
         response.send(`Already running workflowId: ${workflowId}`);
         return;
       }
@@ -98,7 +98,7 @@ export function createShortlistCandidatesRouter(client: Client): Router {
     try {
       await client.publish(workflowId, shortlistFlow.revokeShortlist, undefined);
     } catch (failure) {
-      if (failure instanceof FlowNotActiveError) {
+      if (isFlowMissingOrInactive(failure)) {
         response.send(`No running workflow to revoke for ${employerId}-${candidateId}`);
         return;
       }
@@ -118,7 +118,7 @@ export function createShortlistCandidatesRouter(client: Client): Router {
       );
       response.json(Number(timestamp));
     } catch (failure) {
-      if (failure instanceof FlowNotActiveError) {
+      if (isFlowMissingOrInactive(failure)) {
         response.sendStatus(404);
         return;
       }

--- a/examples/typescript/src/controller/signup-workflow-controller.ts
+++ b/examples/typescript/src/controller/signup-workflow-controller.ts
@@ -16,9 +16,10 @@
 
 import { Router } from "express";
 
-import { FlowAlreadyStartedError, type Client } from "@superdurable/dex";
+import type { Client } from "@superdurable/dex";
 
 import { startOptions } from "../config/env.js";
+import { isFlowAlreadyStarted } from "../service-errors.js";
 import type { SignupForm } from "../workflow/signup/signup-form.js";
 import { userSignupFlow } from "../workflow/signup/user-signup-flow.js";
 
@@ -37,7 +38,7 @@ export function createSignupRouter(client: Client): Router {
     try {
       await client.startFlow(userSignupFlow, username, form, startOptions());
     } catch (failure) {
-      if (failure instanceof FlowAlreadyStartedError) {
+      if (isFlowAlreadyStarted(failure)) {
         response.send("username already started registry");
         return;
       }

--- a/examples/typescript/src/patterns/controller/design-pattern-controller.ts
+++ b/examples/typescript/src/patterns/controller/design-pattern-controller.ts
@@ -18,7 +18,6 @@ import type { Express, Router } from "express";
 import { Router as createRouter } from "express";
 
 import {
-  FlowNotActiveError,
   IdReusePolicy,
   InitialAttribute,
   StepExecutionId,
@@ -26,6 +25,7 @@ import {
 } from "@superdurable/dex";
 
 import { startOptions } from "../../config/env.js";
+import { isFlowMissingOrInactive } from "../../service-errors.js";
 import type { BackoffPollingFlow } from "../workflow/polling/backoff-polling-flow.js";
 import type { SimplePollingFlow } from "../workflow/polling/simple-polling-flow.js";
 import type { InterruptibleExecutionFlow } from "../workflow/interruptible/interruptible-execution-flow.js";
@@ -302,7 +302,7 @@ export function registerDesignPatternRoutes(
       );
       message = "Signaled the workflow";
     } catch (error) {
-      if (error instanceof FlowNotActiveError) {
+      if (isFlowMissingOrInactive(error)) {
         const runId = await client.startFlow(
           flows.drainSignalChannelsFlow,
           workflowId,

--- a/examples/typescript/src/patterns/workflow/parentchild/parent-flow-v2.ts
+++ b/examples/typescript/src/patterns/workflow/parentchild/parent-flow-v2.ts
@@ -16,7 +16,6 @@
 
 import {
   Channel,
-  FlowAlreadyStartedError,
   LongPollTimeoutError,
   StepList,
   StepMovement,
@@ -36,6 +35,7 @@ import {
 
 import { getClient } from "../../../client-holder.js";
 import { startOptions } from "../../../config/env.js";
+import { isFlowAlreadyStarted } from "../../../service-errors.js";
 import { childFlow, type ChildFlow } from "../scalableparallel/child-flow.js";
 import {
   waitForChildInputCodec,
@@ -109,7 +109,7 @@ class StartChildWorkflow implements Step<number> {
     try {
       await getClient().startFlow(this.child, childWorkflowId, String(uuid), startOptions());
     } catch (error) {
-      if (error instanceof FlowAlreadyStartedError) {
+      if (isFlowAlreadyStarted(error)) {
         console.log("ignore this error because it is already started");
       } else {
         throw error;
@@ -142,6 +142,7 @@ class AwaitChildWorkflowCompletion implements Step<WaitForChildInput> {
     try {
       await getClient().waitForFlow(
         input.childWFId,
+        voidCodec,
         Math.max(input.timerSeconds, 1) * 1000,
       );
     } catch (error) {

--- a/examples/typescript/src/patterns/workflow/scalableparallel/child-flow.ts
+++ b/examples/typescript/src/patterns/workflow/scalableparallel/child-flow.ts
@@ -16,7 +16,6 @@
 
 import {
   Attribute,
-  FlowNotActiveError,
   StepList,
   Timer,
   Wait,
@@ -30,6 +29,7 @@ import {
 } from "@superdurable/dex";
 
 import { getClient } from "../../../client-holder.js";
+import { isFlowMissingOrInactive } from "../../../service-errors.js";
 
 export const PARENT_WORKFLOW_ID = "ParentWorkflowId";
 
@@ -59,7 +59,7 @@ class Processing implements Step<string> {
           context.flowId,
         );
       } catch (error) {
-        if (error instanceof FlowNotActiveError) {
+        if (isFlowMissingOrInactive(error)) {
           console.log(
             "Parent workflow may have completed, might be duplicate completion request, ignore it.",
           );

--- a/examples/typescript/src/patterns/workflow/scalableparallel/parent-flow.ts
+++ b/examples/typescript/src/patterns/workflow/scalableparallel/parent-flow.ts
@@ -18,7 +18,6 @@ import {
   Attribute,
   Channel,
   ChannelMap,
-  FlowAlreadyStartedError,
   IdReusePolicy,
   InitialAttribute,
   StepList,
@@ -42,6 +41,7 @@ import {
 
 import { getClient } from "../../../client-holder.js";
 import { HOUR_MS } from "../../../config/env.js";
+import { isFlowAlreadyStarted } from "../../../service-errors.js";
 import {
   batchEnqueueRequestCodec,
   type BatchEnqueueRequest,
@@ -130,7 +130,7 @@ class LoopForNextMessage implements Step<void> {
         });
         newWaitList.push(childWorkflowId);
       } catch (error) {
-        if (error instanceof FlowAlreadyStartedError) {
+        if (isFlowAlreadyStarted(error)) {
           console.log(
             "already started by other state/workflow, ignore it -- not waiting for it",
           );

--- a/examples/typescript/src/patterns/workflow/scalableparallel/request-receiver-flow.ts
+++ b/examples/typescript/src/patterns/workflow/scalableparallel/request-receiver-flow.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  FlowNotActiveError,
   StepList,
   doubleCodec,
   gracefulComplete,
@@ -28,6 +27,7 @@ import {
 
 import { getClient } from "../../../client-holder.js";
 import { startOptions } from "../../../config/env.js";
+import { isFlowMissingOrInactive } from "../../../service-errors.js";
 import { EnqueueFailedException } from "./exceptions/enqueue-failed-exception.js";
 import { NUM_PARENT_WORKFLOWS, parentFlow, type ParentFlow } from "./parent-flow.js";
 import type { BatchEnqueueRequest } from "./models/batch-enqueue-request.js";
@@ -60,7 +60,7 @@ class Request implements Step<number> {
         throw new EnqueueFailedException("Enqueue failed, retry in next attempt");
       }
     } catch (error) {
-      if (error instanceof FlowNotActiveError) {
+      if (isFlowMissingOrInactive(error)) {
         await client.startFlow(this.parent, parentWorkflowId, batch, startOptions());
       } else {
         throw error;

--- a/examples/typescript/src/service-errors.ts
+++ b/examples/typescript/src/service-errors.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022-2026 Super Durable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DexServiceError } from "@superdurable/dex";
+
+const grpcNotFound = 5;
+const grpcAlreadyExists = 6;
+
+export function isFlowAlreadyStarted(error: unknown): boolean {
+  return error instanceof DexServiceError && error.code === grpcAlreadyExists;
+}
+
+export function isFlowMissingOrInactive(error: unknown): boolean {
+  return error instanceof DexServiceError && error.code === grpcNotFound;
+}

--- a/examples/typescript/src/workflow/shortlistcandidates/workflow-ids.ts
+++ b/examples/typescript/src/workflow/shortlistcandidates/workflow-ids.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { FlowNotActiveError, type Client } from "@superdurable/dex";
+import type { Client } from "@superdurable/dex";
 
+import { isFlowMissingOrInactive } from "../../service-errors.js";
 import type { EmployerOptInFlow } from "./employer-opt-in-flow.js";
 
 export function employerOptIn(employerId: string): string {
@@ -36,7 +37,7 @@ export async function isOptedIn(
       await client.invokeRPC(employerOptInFlow.isOptedIn, employerOptIn(employerId)),
     );
   } catch (failure) {
-    if (failure instanceof FlowNotActiveError) {
+    if (isFlowMissingOrInactive(failure)) {
       return false;
     }
     throw failure;

--- a/examples/typescript/test/integ/engagement.test.ts
+++ b/examples/typescript/test/integ/engagement.test.ts
@@ -81,6 +81,6 @@ test("engagementStartChannelRpcAndStatus", async () => {
     "engagement status not Accepted",
   );
 
-  const output = await environment.client.waitForFlow(flowId, 45_000).then((result) => result.singleOutput(stringCodec));
+  const output = await environment.client.waitForFlow(flowId, stringCodec, 45_000);
   assert.equal(output, "done");
 });

--- a/examples/typescript/test/integ/environment.ts
+++ b/examples/typescript/test/integ/environment.ts
@@ -23,6 +23,7 @@ import { join } from "node:path";
 import { Client, Registry, Worker, openBlobCache, type Flow } from "@superdurable/dex";
 
 import { HOUR_MS } from "../../src/config/env.js";
+import { failureRecoveryFlow } from "../../src/patterns/workflow/recovery/failure-recovery-flow.js";
 import { engagementFlow } from "../../src/workflow/engagement/engagement-flow.js";
 import { orchestrationFlow } from "../../src/workflow/microservices/orchestration-flow.js";
 import { moneyTransferFlow } from "../../src/workflow/money/transfer/money-transfer-flow.js";
@@ -31,6 +32,7 @@ import { subscriptionFlow } from "../../src/workflow/subscription/subscription-f
 
 export interface IntegEnvironment {
   readonly client: Client;
+  readonly failureRecoveryFlow: typeof failureRecoveryFlow;
   readonly moneyTransferFlow: typeof moneyTransferFlow;
   readonly engagementFlow: typeof engagementFlow;
   readonly orchestrationFlow: typeof orchestrationFlow;
@@ -63,6 +65,7 @@ export async function releaseIntegEnvironment(): Promise<void> {
 async function startIntegEnvironment(): Promise<IntegEnvironment> {
   const serverAddress = process.env.DEX_FLOW_SERVICE_ADDRESS ?? "127.0.0.1:8801";
   const flows: readonly Flow<any>[] = [
+    failureRecoveryFlow,
     moneyTransferFlow,
     engagementFlow,
     orchestrationFlow,
@@ -86,6 +89,7 @@ async function startIntegEnvironment(): Promise<IntegEnvironment> {
   });
   return {
     client,
+    failureRecoveryFlow,
     moneyTransferFlow,
     engagementFlow,
     orchestrationFlow,

--- a/examples/typescript/test/integ/failure-recovery.test.ts
+++ b/examples/typescript/test/integ/failure-recovery.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022-2026 Super Durable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { FlowUncompletedError, voidCodec } from "@superdurable/dex";
+
+import {
+  acquireIntegEnvironment,
+  releaseIntegEnvironment,
+} from "./environment.js";
+
+test.before(async () => {
+  await acquireIntegEnvironment();
+});
+
+test.after(async () => {
+  await releaseIntegEnvironment();
+});
+
+test("failureRecoveryRetriesCompensatesAndFails", async () => {
+  const environment = await acquireIntegEnvironment();
+  const flowId = environment.newFlowId("failure-recovery");
+  const runId = await environment.client.startFlow(
+    environment.failureRecoveryFlow,
+    flowId,
+    {
+      itemName: "released-sdk-item",
+      requestedQuantity: 100,
+    },
+    environment.startOptions(),
+  );
+  assert.ok(runId.length > 0);
+
+  await assert.rejects(
+    environment.client.waitForFlow(flowId, voidCodec, 45_000),
+    (error: unknown) => {
+      assert.ok(error instanceof FlowUncompletedError);
+      assert.equal(error.status, "failed");
+      assert.match(error.message, /Failed to process transaction/);
+      return true;
+    },
+  );
+
+  const summary = await environment.client.describeFlow(flowId);
+  assert.equal(summary.status, "failed");
+});

--- a/examples/typescript/test/integ/microservice.test.ts
+++ b/examples/typescript/test/integ/microservice.test.ts
@@ -56,6 +56,6 @@ test("microserviceStartRpcAndChannel", async () => {
   assert.equal(previous, "initial-data");
 
   await environment.client.publish(flowId, flow.ready, undefined);
-  const output = await environment.client.waitForFlow(flowId, 45_000).then((result) => result.singleOutput(stringCodec));
+  const output = await environment.client.waitForFlow(flowId, stringCodec, 45_000);
   assert.equal(output, "updated-data");
 });

--- a/examples/typescript/test/integ/money-transfer.test.ts
+++ b/examples/typescript/test/integ/money-transfer.test.ts
@@ -47,7 +47,7 @@ test("moneyTransferStart", async () => {
     environment.startOptions(),
   );
   assert.ok(runId.length > 0);
-  const output = await environment.client.waitForFlow(flowId, 45_000).then((result) => result.singleOutput(stringCodec));
+  const output = await environment.client.waitForFlow(flowId, stringCodec, 45_000);
   assert.match(output, /transfer is done/);
   assert.match(output, /from-ci/);
   assert.match(output, /to-ci/);

--- a/examples/typescript/test/integ/polling.test.ts
+++ b/examples/typescript/test/integ/polling.test.ts
@@ -47,7 +47,7 @@ test("pollingStartAndChannels", async () => {
   await environment.client.publish(flowId, flow.taskACompleted, undefined);
   await environment.client.publish(flowId, flow.taskBCompleted, undefined);
 
-  const output = await environment.client.waitForFlow(flowId, 45_000).then((result) => result.singleOutput(stringCodec));
+  const output = await environment.client.waitForFlow(flowId, stringCodec, 45_000);
   assert.equal(output, "all tasks completed");
 
   const polls = await environment.client.getAttribute(flowId, flow.currentPolls);

--- a/examples/typescript/test/integ/subscription.test.ts
+++ b/examples/typescript/test/integ/subscription.test.ts
@@ -81,6 +81,6 @@ test("subscriptionStartRpcAndChannels", async () => {
   );
 
   await environment.client.publish(flowId, flow.cancelSubscription, undefined);
-  const output = await environment.client.waitForFlow(flowId, 45_000).then((result) => result.singleOutput(stringCodec));
+  const output = await environment.client.waitForFlow(flowId, stringCodec, 45_000);
   assert.equal(output, "subscription canceled");
 });


### PR DESCRIPTION
## Summary

- make Go examples use the published Go SDK instead of replacing it with the checkout SDK
- add Rust and TypeScript integration workflows that start the current checkout's `dexcli dev`
- lock TypeScript to the latest released SDK and adapt examples to its released API/error surface
- dispatch all three example workflows from Main CI (all)

## Rationale

The example suites should verify that the latest released SDKs remain compatible with the latest server and dexcli on `main`, matching the Java and Python example model.

## User impact

Go, Rust, and TypeScript examples now exercise published SDK artifacts against the current checkout's development environment. CI will catch release-to-main compatibility regressions without silently substituting local SDK code.

## Validation

- `GOWORK=off make -C examples/go bins`
- `GOWORK=off make -C examples/go unitTests`
- `examples/go/run-e2e-tests.sh`
- `make -C examples/rust fmt-check clippy test`
- `examples/rust/run-integration-tests.sh`
- `npm --prefix examples/typescript run typecheck`
- `npm --prefix examples/typescript test`
- `examples/typescript/run-integration-tests.sh`
- `make -C server unitTests`
- `make copyright-check`
- `make ci-runner-check`
- `actionlint` on changed workflows
- `shellcheck` on changed scripts
