### PR TITLE
Reserve readable SubFlow workflow IDs

### DIFF
--- a/docs/content/capabilities/advanced/subflows.mdx
+++ b/docs/content/capabilities/advanced/subflows.mdx
@@ -60,7 +60,8 @@ with the stop request, so callers should treat an already-closed Flow as a succe
 Dex reserves `:` in application-created Flow IDs so `StartFlow` cannot occupy the
 `SubFlow:` namespace. Operations targeting an existing SubFlow, including RPCs and stops, accept
 its generated ID. Clients with direct Temporal or Cadence access must also leave this namespace to
-Dex.
+Dex. Step types cannot contain `/`, `$`, or `:` because their Step execution IDs are embedded in
+generated SubFlow IDs and readable blob paths.
 
 Every SubFlow execution also has the keyword Search Attribute `DexParentFlowID`. Query it to list
 all SubFlows for one parent. Together with the generated SubFlow Flow ID, it identifies the source

--- a/docs/content/capabilities/advanced/subflows.mdx
+++ b/docs/content/capabilities/advanced/subflows.mdx
@@ -39,7 +39,7 @@ query.
 Dex generates IDs that application code cannot override:
 
 ```text
-Flow ID    SubFlow-{parentFlowID}-{stepExecutionID}-{index}
+Flow ID    SubFlow:{parentFlowID}-{stepExecutionID}-{index}
 request ID {parentRunID}{stepExecutionID}
 ```
 
@@ -56,6 +56,11 @@ if (!loser.isTerminal()) {
 
 An external worker or service can consume that ID and call `Client.stopFlow`. Completion can race
 with the stop request, so callers should treat an already-closed Flow as a successful cleanup.
+
+Dex reserves `:` in application-created Flow IDs so `StartFlow` cannot occupy the
+`SubFlow:` namespace. Operations targeting an existing SubFlow, including RPCs and stops, accept
+its generated ID. Clients with direct Temporal or Cadence access must also leave this namespace to
+Dex.
 
 Every SubFlow execution also has the keyword Search Attribute `DexParentFlowID`. Query it to list
 all SubFlows for one parent. Together with the generated SubFlow Flow ID, it identifies the source

--- a/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
@@ -190,7 +190,7 @@ final class InvocationContext implements Context {
         if (index < 0 || index >= conditionResults.getSubFlowResultsCount()) {
             throw new IllegalArgumentException("SubFlow condition index is out of range: " + index);
         }
-        return "SubFlow-" + metadata.getFlowId() + "-" + metadata.getStepExecutionId() + "-" + index;
+        return "SubFlow:" + metadata.getFlowId() + "-" + metadata.getStepExecutionId() + "-" + index;
     }
 
     @Override

--- a/sdk-java/src/main/java/io/superdurable/dex/SubFlow.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/SubFlow.java
@@ -101,7 +101,8 @@ public final class SubFlow {
     /**
      * Returns the generated Flow ID for the first SubFlow condition in this Step invocation.
      *
-     * <p>The ID is available for running and terminal results. It can be passed to
+     * <p>The ID starts with {@code SubFlow:} and is available for running and terminal results.
+     * It can be passed to
      * {@link Client#stopFlow(String)} when another condition wins a {@link Wait#anyOf}.
      *
      * @param context the current execute invocation context

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/BasicTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/BasicTest.java
@@ -112,7 +112,7 @@ public final class BasicTest {
                     .getSingleOutput(String.class);
             final String[] parts = output.split("\\|", -1);
             assertEquals(2, parts.length);
-            assertEquals("SubFlow-" + flowId + "-ParentStep-1-0", parts[0]);
+            assertEquals("SubFlow:" + flowId + "-ParentStep-1-0", parts[0]);
             assertEquals("6", parts[1]);
         }
     }
@@ -150,7 +150,7 @@ public final class BasicTest {
                     .getSingleOutput(String.class);
             final String[] result = output.split("\\|", -1);
             assertEquals(4, result.length);
-            assertEquals("SubFlow-" + flowId + "-ParentStep-1-0", result[0]);
+            assertEquals("SubFlow:" + flowId + "-ParentStep-1-0", result[0]);
             assertEquals("RUNNING", result[1]);
             assertEquals("false", result[2]);
             assertEquals("true", result[3]);
@@ -181,7 +181,7 @@ public final class BasicTest {
                 SUB_FLOW_ABNORMAL_PARENT_WORKFLOW,
                 ABNORMAL_EXIT_WORKFLOW)) {
             final String flowId = flowId("sub-flow-abnormal");
-            final String childFlowId = "SubFlow-" + flowId + "-ParentStep-1-0";
+            final String childFlowId = "SubFlow:" + flowId + "-ParentStep-1-0";
             environment.client().startFlow(SUB_FLOW_ABNORMAL_PARENT_WORKFLOW, flowId, 1);
             final String[] first = environment.client()
                     .waitForFlow(flowId, Duration.ofSeconds(30))
@@ -213,8 +213,8 @@ public final class BasicTest {
                 WORKFLOW,
                 new TimerWorkflow())) {
             final String flowId = flowId("sub-flow-can");
-            final String completedChildId = "SubFlow-" + flowId + "-ParentStep-1-0";
-            final String delayedChildId = "SubFlow-" + flowId + "-ParentStep-1-1";
+            final String completedChildId = "SubFlow:" + flowId + "-ParentStep-1-0";
+            final String delayedChildId = "SubFlow:" + flowId + "-ParentStep-1-1";
             final String firstParentRunId = environment.client().startFlow(
                     SUB_FLOW_CAN_PARENT_WORKFLOW,
                     flowId,
@@ -504,7 +504,7 @@ public final class BasicTest {
                 parent,
                 new TimerWorkflow())) {
             final String flowId = flowId("sub-flow-reuse");
-            final String childFlowId = "SubFlow-" + flowId + "-ParentStep-1-0";
+            final String childFlowId = "SubFlow:" + flowId + "-ParentStep-1-0";
             environment.client().startFlow(parent, flowId, 300);
             final String firstChildRunId = awaitFlowRun(
                     environment.client(), childFlowId, null);
@@ -565,7 +565,7 @@ public final class BasicTest {
             final String output) {
         final String[] fields = encoded.split("\\|", -1);
         assertEquals(3, fields.length);
-        assertEquals("SubFlow-" + parentFlowId + "-ParentStep-1-" + index, fields[0]);
+        assertEquals("SubFlow:" + parentFlowId + "-ParentStep-1-" + index, fields[0]);
         assertEquals(status, fields[1]);
         assertEquals(output, fields[2]);
     }

--- a/server/integ/subflow_test.go
+++ b/server/integ/subflow_test.go
@@ -101,6 +101,23 @@ func doTestSubFlowCondition(
 	parentFlowID := subFlowParentType + "-" + uuid.NewString()
 	childFlowID := "SubFlow:" + parentFlowID + "-" + subFlowParentStep + "-1-0"
 	input := stringValue(subFlowInput)
+	for _, reservedCharacter := range []string{"/", "$", ":"} {
+		_, err := flowClient.StartFlow(ctx, &dexpb.StartFlowRequest{
+			RequestId:          newRequestID(),
+			FlowId:             parentFlowID,
+			FlowType:           subFlowParentType,
+			FlowTimeoutSeconds: 30,
+			StartStepType:      subFlowParentStep + reservedCharacter + "Invalid",
+			StepInput:          input,
+			FlowStartOptions:   withWorkerTarget(&dexpb.FlowStartOptions{}, workerTarget),
+		})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+		require.ErrorContains(
+			t,
+			err,
+			fmt.Sprintf("step type contains reserved character %q", reservedCharacter),
+		)
+	}
 	_, err := flowClient.StartFlow(ctx, &dexpb.StartFlowRequest{
 		RequestId:          newRequestID(),
 		FlowId:             childFlowID,

--- a/server/integ/subflow_test.go
+++ b/server/integ/subflow_test.go
@@ -99,8 +99,20 @@ func doTestSubFlowCondition(
 	defer cancel()
 
 	parentFlowID := subFlowParentType + "-" + uuid.NewString()
-	childFlowID := "SubFlow-" + parentFlowID + "-" + subFlowParentStep + "-1-0"
+	childFlowID := "SubFlow:" + parentFlowID + "-" + subFlowParentStep + "-1-0"
 	input := stringValue(subFlowInput)
+	_, err := flowClient.StartFlow(ctx, &dexpb.StartFlowRequest{
+		RequestId:          newRequestID(),
+		FlowId:             childFlowID,
+		FlowType:           subFlowChildType,
+		FlowTimeoutSeconds: 30,
+		StartStepType:      subFlowChildStep,
+		StepInput:          input,
+		FlowStartOptions:   withWorkerTarget(&dexpb.FlowStartOptions{}, workerTarget),
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.ErrorContains(t, err, `flow ID contains reserved character ":"`)
+
 	startResponse, err := flowClient.StartFlow(ctx, &dexpb.StartFlowRequest{
 		RequestId:          newRequestID(),
 		FlowId:             parentFlowID,

--- a/server/service/api/service.go
+++ b/server/service/api/service.go
@@ -125,7 +125,7 @@ func (s *serviceImpl) StartFlow(
 	searchAttributes := index.ConvertAttributeWritesToSearchAttributeUpsertMap(attributes)
 	searchAttributes[service.SearchAttributeDexWorkflowType] = req.GetFlowType()
 
-	if err := blobstore.ValidateUserFlowID(req.GetFlowId()); err != nil {
+	if err := blobstore.ValidateFlowID(req.GetFlowId()); err != nil {
 		return nil, makeInvalidRequestError(err.Error())
 	}
 	if err := blobstore.OffloadLargeValue(
@@ -963,9 +963,6 @@ func (s *serviceImpl) InvokeRPC(
 		return nil, status.Errorf(codes.Unimplemented, "locking RPC requires Temporal synchronous update")
 	}
 	useSynchronousUpdate := s.shouldInvokeRPCWithSynchronousUpdate(req)
-	if err := blobstore.ValidateBlobPathFlowID(req.GetFlowId()); err != nil {
-		return nil, makeInvalidRequestError(err.Error())
-	}
 	if err := blobstore.OffloadLargeValue(
 		ctx,
 		req.GetInput(),

--- a/server/service/api/service.go
+++ b/server/service/api/service.go
@@ -125,7 +125,7 @@ func (s *serviceImpl) StartFlow(
 	searchAttributes := index.ConvertAttributeWritesToSearchAttributeUpsertMap(attributes)
 	searchAttributes[service.SearchAttributeDexWorkflowType] = req.GetFlowType()
 
-	if err := blobstore.ValidateWorkflowId(req.GetFlowId()); err != nil {
+	if err := blobstore.ValidateUserFlowID(req.GetFlowId()); err != nil {
 		return nil, makeInvalidRequestError(err.Error())
 	}
 	if err := blobstore.OffloadLargeValue(
@@ -963,7 +963,7 @@ func (s *serviceImpl) InvokeRPC(
 		return nil, status.Errorf(codes.Unimplemented, "locking RPC requires Temporal synchronous update")
 	}
 	useSynchronousUpdate := s.shouldInvokeRPCWithSynchronousUpdate(req)
-	if err := blobstore.ValidateWorkflowId(req.GetFlowId()); err != nil {
+	if err := blobstore.ValidateBlobPathFlowID(req.GetFlowId()); err != nil {
 		return nil, makeInvalidRequestError(err.Error())
 	}
 	if err := blobstore.OffloadLargeValue(

--- a/server/service/api/service.go
+++ b/server/service/api/service.go
@@ -125,7 +125,13 @@ func (s *serviceImpl) StartFlow(
 	searchAttributes := index.ConvertAttributeWritesToSearchAttributeUpsertMap(attributes)
 	searchAttributes[service.SearchAttributeDexWorkflowType] = req.GetFlowType()
 
-	if err := blobstore.ValidateFlowID(req.GetFlowId()); err != nil {
+	if err := service.ValidateFlowID(req.GetFlowId()); err != nil {
+		return nil, makeInvalidRequestError(err.Error())
+	}
+	if err := service.ValidateStepType(req.GetStartStepType()); err != nil {
+		return nil, makeInvalidRequestError(err.Error())
+	}
+	if err := service.ValidateStepOptions(req.GetStepOptions()); err != nil {
 		return nil, makeInvalidRequestError(err.Error())
 	}
 	if err := blobstore.OffloadLargeValue(

--- a/server/service/common/blobstore/interfaces.go
+++ b/server/service/common/blobstore/interfaces.go
@@ -18,17 +18,32 @@ import (
 	"time"
 )
 
-var reservedCharacters = []string{"/", "$"}
+var blobPathReservedCharacters = []string{"/", "$"}
+
+const userFlowIDReservedCharacter = ":"
 
 const (
 	StepEventInputMethodWaitFor = "wait_for"
 	StepEventInputMethodExecute = "execute"
 )
 
-func ValidateWorkflowId(fowId string) error {
+// ValidateUserFlowID rejects characters reserved for Dex identities and blob paths.
+func ValidateUserFlowID(flowID string) error {
+	if err := ValidateBlobPathFlowID(flowID); err != nil {
+		return err
+	}
+	return validateFlowIDCharacters(flowID, []string{userFlowIDReservedCharacter})
+}
+
+// ValidateBlobPathFlowID rejects characters that alter the blob storage hierarchy.
+func ValidateBlobPathFlowID(flowID string) error {
+	return validateFlowIDCharacters(flowID, blobPathReservedCharacters)
+}
+
+func validateFlowIDCharacters(flowID string, reservedCharacters []string) error {
 	for _, reservedCharacter := range reservedCharacters {
-		if strings.Contains(fowId, reservedCharacter) {
-			return fmt.Errorf("fowId contains reserved character: %s", reservedCharacter)
+		if strings.Contains(flowID, reservedCharacter) {
+			return fmt.Errorf("flow ID contains reserved character %q", reservedCharacter)
 		}
 	}
 	return nil

--- a/server/service/common/blobstore/interfaces.go
+++ b/server/service/common/blobstore/interfaces.go
@@ -18,30 +18,16 @@ import (
 	"time"
 )
 
-var blobPathReservedCharacters = []string{"/", "$"}
-
-const userFlowIDReservedCharacter = ":"
+var flowIDReservedCharacters = []string{"/", "$", ":"}
 
 const (
 	StepEventInputMethodWaitFor = "wait_for"
 	StepEventInputMethodExecute = "execute"
 )
 
-// ValidateUserFlowID rejects characters reserved for Dex identities and blob paths.
-func ValidateUserFlowID(flowID string) error {
-	if err := ValidateBlobPathFlowID(flowID); err != nil {
-		return err
-	}
-	return validateFlowIDCharacters(flowID, []string{userFlowIDReservedCharacter})
-}
-
-// ValidateBlobPathFlowID rejects characters that alter the blob storage hierarchy.
-func ValidateBlobPathFlowID(flowID string) error {
-	return validateFlowIDCharacters(flowID, blobPathReservedCharacters)
-}
-
-func validateFlowIDCharacters(flowID string, reservedCharacters []string) error {
-	for _, reservedCharacter := range reservedCharacters {
+// ValidateFlowID rejects characters reserved for Dex identities and blob paths.
+func ValidateFlowID(flowID string) error {
+	for _, reservedCharacter := range flowIDReservedCharacters {
 		if strings.Contains(flowID, reservedCharacter) {
 			return fmt.Errorf("flow ID contains reserved character %q", reservedCharacter)
 		}

--- a/server/service/common/blobstore/interfaces.go
+++ b/server/service/common/blobstore/interfaces.go
@@ -18,6 +18,17 @@ import (
 	"time"
 )
 
+// flowIDReservedCharacters are rejected only when an application creates a Flow through StartFlow.
+//
+// "/" separates object-key path segments. Reserving it keeps every Flow's blobs in one directory
+// and preserves local and remote blob listing and cleanup boundaries.
+//
+// "$" separates the UTC date prefix from the Flow ID in `<yyyymmdd>$<flowID>/<blobID>`.
+// Reserving it keeps date-scoped listing and cleanup prefixes unambiguous.
+//
+// ":" identifies server-generated Flow namespaces such as `SubFlow:`. Reserving it prevents an
+// application from pre-creating an internal Flow ID and interfering with SubFlow reuse resolution.
+// Server-generated Flows bypass ValidateFlowID.
 var flowIDReservedCharacters = []string{"/", "$", ":"}
 
 const (

--- a/server/service/common/blobstore/interfaces.go
+++ b/server/service/common/blobstore/interfaces.go
@@ -18,33 +18,10 @@ import (
 	"time"
 )
 
-// flowIDReservedCharacters are rejected only when an application creates a Flow through StartFlow.
-//
-// "/" separates object-key path segments. Reserving it keeps every Flow's blobs in one directory
-// and preserves local and remote blob listing and cleanup boundaries.
-//
-// "$" separates the UTC date prefix from the Flow ID in `<yyyymmdd>$<flowID>/<blobID>`.
-// Reserving it keeps date-scoped listing and cleanup prefixes unambiguous.
-//
-// ":" identifies server-generated Flow namespaces such as `SubFlow:`. Reserving it prevents an
-// application from pre-creating an internal Flow ID and interfering with SubFlow reuse resolution.
-// Server-generated Flows bypass ValidateFlowID.
-var flowIDReservedCharacters = []string{"/", "$", ":"}
-
 const (
 	StepEventInputMethodWaitFor = "wait_for"
 	StepEventInputMethodExecute = "execute"
 )
-
-// ValidateFlowID rejects characters reserved for Dex identities and blob paths.
-func ValidateFlowID(flowID string) error {
-	for _, reservedCharacter := range flowIDReservedCharacters {
-		if strings.Contains(flowID, reservedCharacter) {
-			return fmt.Errorf("flow ID contains reserved character %q", reservedCharacter)
-		}
-	}
-	return nil
-}
 
 func MustExtractWorkflowId(workflowPath string) string {
 	workflowId, err := ExtractWorkflowId(workflowPath)

--- a/server/service/common/rpc/invoke.go
+++ b/server/service/common/rpc/invoke.go
@@ -182,9 +182,23 @@ func validateWorkerRpcResponse(resp *dexpb.InvokeWorkerRPCResponse) error {
 	if decision.GetCloseDecision() != nil {
 		return fmt.Errorf("closing flow in RPC is not supported yet")
 	}
+	for index, movement := range decision.GetNextSteps() {
+		if movement == nil || movement.GetStepType() == "" {
+			return fmt.Errorf("next step at index %d is invalid", index)
+		}
+		if err := service.ValidateStepType(movement.GetStepType()); err != nil {
+			return fmt.Errorf("next step at index %d: %w", index, err)
+		}
+		if err := service.ValidateStepOptions(movement.GetStepOptions()); err != nil {
+			return fmt.Errorf("next step at index %d: %w", index, err)
+		}
+	}
 	for index, stepType := range decision.GetCancelStepTypes() {
 		if stepType == "" {
 			return fmt.Errorf("cancel step type at index %d is invalid", index)
+		}
+		if err := service.ValidateStepType(stepType); err != nil {
+			return fmt.Errorf("cancel step type at index %d: %w", index, err)
 		}
 	}
 	if len(decision.GetCancelSiblingStepTypes()) > 0 {

--- a/server/service/const.go
+++ b/server/service/const.go
@@ -56,5 +56,5 @@ const (
 
 // SubFlowID returns the durable child identity for one parent Step condition.
 func SubFlowID(parentFlowID string, stepExecutionID string, index int32) string {
-	return fmt.Sprintf("SubFlow-%s-%s-%d", parentFlowID, stepExecutionID, index)
+	return fmt.Sprintf("SubFlow:%s-%s-%d", parentFlowID, stepExecutionID, index)
 }

--- a/server/service/identifiers.go
+++ b/server/service/identifiers.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/superdurable/dex/gen/dexpb"
+)
+
+// flowIDReservedCharacters are rejected from application-created Flow IDs and Step types.
+//
+// "/" separates object-key path segments. Reserving it keeps every Flow's blobs in one directory
+// and preserves local and remote blob listing and cleanup boundaries.
+//
+// "$" separates the UTC date prefix from the Flow ID in `<yyyymmdd>$<flowID>/<blobID>`.
+// Reserving it keeps date-scoped listing and cleanup prefixes unambiguous.
+//
+// ":" identifies server-generated Flow namespaces such as `SubFlow:`. Reserving it prevents an
+// application from pre-creating an internal Flow ID and interfering with SubFlow reuse resolution.
+// Server-generated Flows bypass ValidateFlowID.
+//
+// Step types follow the same rules because Dex embeds a parent Step execution ID in each generated
+// SubFlow ID. Allowing any reserved character there would reintroduce the same ambiguity indirectly.
+var flowIDReservedCharacters = []string{"/", "$", ":"}
+
+// ValidateFlowID rejects characters reserved for Dex identities and blob paths.
+func ValidateFlowID(flowID string) error {
+	return validateIdentifierCharacters("flow ID", flowID)
+}
+
+// ValidateStepType rejects characters reserved for generated Flow identities and blob paths.
+func ValidateStepType(stepType string) error {
+	return validateIdentifierCharacters("step type", stepType)
+}
+
+// ValidateStepOptions validates every Step type reachable through failure-proceed options.
+func ValidateStepOptions(options *dexpb.StepOptions) error {
+	for current := options; current != nil; current = current.GetExecuteFailureProceedStepOptions() {
+		if err := ValidateStepType(current.GetExecuteFailureProceedStepType()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateIdentifierCharacters(identifierName string, value string) error {
+	for _, reservedCharacter := range flowIDReservedCharacters {
+		if strings.Contains(value, reservedCharacter) {
+			return fmt.Errorf("%s contains reserved character %q", identifierName, reservedCharacter)
+		}
+	}
+	return nil
+}

--- a/server/service/interpreter/activityImpl.go
+++ b/server/service/interpreter/activityImpl.go
@@ -963,15 +963,27 @@ func validateStepDecision(decision *dexpb.StepDecision) error {
 		if movement == nil || movement.GetStepType() == "" {
 			return fmt.Errorf("next step at index %d is invalid", index)
 		}
+		if err := service.ValidateStepType(movement.GetStepType()); err != nil {
+			return fmt.Errorf("next step at index %d: %w", index, err)
+		}
+		if err := service.ValidateStepOptions(movement.GetStepOptions()); err != nil {
+			return fmt.Errorf("next step at index %d: %w", index, err)
+		}
 	}
 	for index, stepType := range decision.GetCancelStepTypes() {
 		if stepType == "" {
 			return fmt.Errorf("cancel step type at index %d is invalid", index)
 		}
+		if err := service.ValidateStepType(stepType); err != nil {
+			return fmt.Errorf("cancel step type at index %d: %w", index, err)
+		}
 	}
 	for index, stepType := range decision.GetCancelSiblingStepTypes() {
 		if stepType == "" {
 			return fmt.Errorf("cancel sibling step type at index %d is invalid", index)
+		}
+		if err := service.ValidateStepType(stepType); err != nil {
+			return fmt.Errorf("cancel sibling step type at index %d: %w", index, err)
 		}
 	}
 	if closeDecision := decision.GetCloseDecision(); closeDecision != nil {
@@ -1119,6 +1131,12 @@ func validateWaitingCondition(waiting *dexpb.WaitingCondition) error {
 		}
 		if subFlowCondition.GetSubFlowType() == "" || subFlowCondition.GetStartStepType() == "" {
 			return fmt.Errorf("SubFlow condition at index %d requires Flow and starting Step types", i)
+		}
+		if err := service.ValidateStepType(subFlowCondition.GetStartStepType()); err != nil {
+			return fmt.Errorf("SubFlow condition at index %d: %w", i, err)
+		}
+		if err := service.ValidateStepOptions(subFlowCondition.GetStepOptions()); err != nil {
+			return fmt.Errorf("SubFlow condition at index %d: %w", i, err)
 		}
 		if subFlowCondition.GetSubFlowIndex() != int32(i) {
 			return fmt.Errorf("SubFlow condition at index %d has unstable index %d", i, subFlowCondition.GetSubFlowIndex())

--- a/server/service/interpreter/activityImpl.go
+++ b/server/service/interpreter/activityImpl.go
@@ -216,7 +216,7 @@ func (a *Activities) offloadSubFlowStartInputs(
 		if err != nil {
 			return err
 		}
-		if err := blobstore.ValidateWorkflowId(subFlowID); err != nil {
+		if err := blobstore.ValidateBlobPathFlowID(subFlowID); err != nil {
 			return err
 		}
 		if err := blobstore.OffloadLargeValue(
@@ -525,7 +525,7 @@ func (a *Activities) StartSubFlow(
 	if err != nil {
 		return nil, err
 	}
-	if err := blobstore.ValidateWorkflowId(subFlowID); err != nil {
+	if err := blobstore.ValidateBlobPathFlowID(subFlowID); err != nil {
 		return nil, err
 	}
 	options := condition.GetOptions()

--- a/server/service/interpreter/activityImpl.go
+++ b/server/service/interpreter/activityImpl.go
@@ -216,9 +216,6 @@ func (a *Activities) offloadSubFlowStartInputs(
 		if err != nil {
 			return err
 		}
-		if err := blobstore.ValidateBlobPathFlowID(subFlowID); err != nil {
-			return err
-		}
 		if err := blobstore.OffloadLargeValue(
 			ctx,
 			condition.GetStepInput(),
@@ -523,9 +520,6 @@ func (a *Activities) StartSubFlow(
 		ctx, input.GetParentStepExecutionId(), condition.GetSubFlowIndex(),
 	)
 	if err != nil {
-		return nil, err
-	}
-	if err := blobstore.ValidateBlobPathFlowID(subFlowID); err != nil {
 		return nil, err
 	}
 	options := condition.GetOptions()

--- a/web/app/components/StructuredValue.tsx
+++ b/web/app/components/StructuredValue.tsx
@@ -19,6 +19,7 @@ import {
   durabilityLabel,
   waitingConditionTypeLabel,
 } from '@/lib/semantic';
+import { generatedSubFlowID } from '@/lib/subflows';
 import { VALUE_BLOB_UNAVAILABLE } from '@/lib/unavailable';
 import { usePreferences } from '@/app/providers';
 
@@ -176,14 +177,6 @@ function WaitingConditionStructured({
       ))}
     </div>
   );
-}
-
-function generatedSubFlowID(
-  parentFlowId: string,
-  stepExecutionId: string,
-  index: number,
-): string {
-  return `SubFlow-${parentFlowId}-${stepExecutionId}-${index}`;
 }
 
 function KeyValueListStructured({ value }: { value: unknown }) {

--- a/web/app/flows/details/EventDetails.test.tsx
+++ b/web/app/flows/details/EventDetails.test.tsx
@@ -384,8 +384,8 @@ describe('selected step event details', () => {
       }],
     }));
 
-    expect(markup).toContain('href="/flows/SubFlow-parent-charge-1-0"');
-    expect(markup).toContain('aria-label="Open SubFlow SubFlow-parent-charge-1-0"');
+    expect(markup).toContain('href="/flows/SubFlow%3Aparent-charge-1-0"');
+    expect(markup).toContain('aria-label="Open SubFlow SubFlow:parent-charge-1-0"');
     expect(markup).toContain('Attach');
   });
 
@@ -425,7 +425,7 @@ describe('selected step event details', () => {
     expect(waitMarkup).toContain('continueAsNewThreshold');
 
     const resultMarkup = renderDetails(event, [wait, event]);
-    expect(resultMarkup).toContain('href="/flows/SubFlow-parent-charge-1-0"');
+    expect(resultMarkup).toContain('href="/flows/SubFlow%3Aparent-charge-1-0"');
     expect(resultMarkup).toContain('Worker method failed');
     expect(resultMarkup).toContain('child failed');
     expect(resultMarkup).toContain('ChildStep-1');
@@ -525,7 +525,7 @@ describe('flow start event details', () => {
 
     const markup = renderDetails(event);
 
-    expect(markup).toContain('href="/flows/SubFlow-parent-charge-1-0"');
-    expect(markup).toContain('SubFlow-parent-charge-1-0');
+    expect(markup).toContain('href="/flows/SubFlow%3Aparent-charge-1-0"');
+    expect(markup).toContain('SubFlow:parent-charge-1-0');
   });
 });

--- a/web/app/flows/details/EventDetails.tsx
+++ b/web/app/flows/details/EventDetails.tsx
@@ -36,6 +36,7 @@ import {
 import { formatDate, type TimezonePreference } from '@/lib/format';
 import { formatElapsedDuration } from '@/lib/timeline';
 import { findSourceStepOptions } from '@/lib/stepOptions';
+import { generatedSubFlowID } from '@/lib/subflows';
 import { usePreferences } from '@/app/providers';
 
 type Data = Record<string, unknown>;
@@ -523,11 +524,6 @@ function SubFlowRecord({
       )}
     </a>
   );
-}
-
-function generatedSubFlowID(parentFlowId: string, stepExecutionId: string, index: number): string {
-  if (!parentFlowId || !stepExecutionId) return '';
-  return `SubFlow-${parentFlowId}-${stepExecutionId}-${index}`;
 }
 
 function SubFlowResultRecord({

--- a/web/lib/graph.test.ts
+++ b/web/lib/graph.test.ts
@@ -158,7 +158,7 @@ describe('step graph', () => {
     const subFlow = graph.nodes.find((node) => node.kind === 'subflow');
     expect(subFlow).toMatchObject({
       parentStepId: 'Parent-1',
-      flowId: 'SubFlow-parent-Parent-1-0',
+      flowId: 'SubFlow:parent-Parent-1-0',
       subFlowStatus: 'COMPLETED',
       reusePolicy: 'Attach',
     });
@@ -188,7 +188,7 @@ describe('step graph', () => {
     expect(graph.nodes.find((node) => node.kind === 'subflow')).toMatchObject({
       status: 'Failed',
       subFlowStatus: 'FAILED',
-      flowId: 'SubFlow-parent-Parent-1-0',
+      flowId: 'SubFlow:parent-Parent-1-0',
     });
   });
 });

--- a/web/lib/graph.ts
+++ b/web/lib/graph.ts
@@ -13,6 +13,7 @@ import type {
   StepGraphNode,
 } from './types';
 import { subFlowReusePolicyLabel, subFlowStatusName } from './semantic';
+import { generatedSubFlowID } from './subflows';
 
 export const START_NODE_ID = '__start__';
 export const END_NODE_ID = '__end__';
@@ -210,15 +211,6 @@ function addSubFlowNodes(
       reusePolicy: subFlowReusePolicyLabel(options.reusePolicy),
     });
   });
-}
-
-function generatedSubFlowID(
-  parentFlowID: string,
-  stepExecutionID: string,
-  index: number,
-): string {
-  if (!parentFlowID || !stepExecutionID) return '';
-  return `SubFlow-${parentFlowID}-${stepExecutionID}-${index}`;
 }
 
 function hasCloseDecision(event: FlowHistoryEvent): boolean {

--- a/web/lib/subflows.ts
+++ b/web/lib/subflows.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+export function generatedSubFlowID(
+  parentFlowID: string,
+  stepExecutionID: string,
+  index: number,
+): string {
+  if (!parentFlowID || !stepExecutionID) return '';
+  return `SubFlow:${parentFlowID}-${stepExecutionID}-${index}`;
+}


### PR DESCRIPTION
## Summary

- reserve `:` in application-created Flow IDs and move generated durable SubFlows into the readable `SubFlow:` namespace
- allow operations and internal starts targeting existing generated SubFlow IDs while preserving human-readable blob paths
- centralize Web SubFlow ID construction and update Java, UI, integration tests, and documentation

## Why

Application-created workflows could previously occupy a generated SubFlow ID before the parent reached its wait, interfering with reuse resolution. A reserved `SubFlow:` namespace prevents that collision through the Dex API without encoding IDs in blob paths.

## Validation

- `make -C server unitTests`
- Temporal SubFlow integration scenarios, including reserved public start, internal colon ID, and readable blob paths
- `make -C server cadenceIntegTests integrationCoverageArgs="-run ^TestSubFlowConditionCadence"`
- `./sdk-java/gradlew -p sdk-java test localIntegrationTest --no-daemon`
- `sdk-java/run-integration-tests.sh`
- `npm --prefix web run check`
- `make copyright-check`

The complete local Temporal suite also exercised and passed the SubFlow scenarios; four pre-existing persistence search-index convergence cases timed out against the local dev server and are left unchanged for clean CI validation.
