### PR TITLE
Stabilize concurrent RPC invocation counting

### DIFF
--- a/server/integ/workflow/rpc/routers.go
+++ b/server/integ/workflow/rpc/routers.go
@@ -13,10 +13,10 @@ package rpc
 import (
 	"context"
 	"fmt"
-	"github.com/superdurable/dex/integ/workflow/common"
 	"sync"
 
 	"github.com/superdurable/dex/gen/dexpb"
+	"github.com/superdurable/dex/integ/workflow/common"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -57,13 +57,14 @@ const (
 
 type handler struct {
 	dexpb.UnimplementedWorkerServiceServer
-	invokeHistory sync.Map
-	invokeData    sync.Map
+	invokeHistoryMutex sync.Mutex
+	invokeHistory      map[string]int64
+	invokeData         sync.Map
 }
 
 func NewHandler() *handler {
 	return &handler{
-		invokeHistory: sync.Map{},
+		invokeHistory: make(map[string]int64),
 		invokeData:    sync.Map{},
 	}
 }
@@ -232,11 +233,13 @@ func (h *handler) InvokeExecuteMethod(
 }
 
 func (h *handler) GetTestResult() common.TestResult {
-	invokeHistory := make(map[string]int64)
-	h.invokeHistory.Range(func(key, value interface{}) bool {
-		invokeHistory[key.(string)] = value.(int64)
-		return true
-	})
+	h.invokeHistoryMutex.Lock()
+	invokeHistory := make(map[string]int64, len(h.invokeHistory))
+	for key, value := range h.invokeHistory {
+		invokeHistory[key] = value
+	}
+	h.invokeHistoryMutex.Unlock()
+
 	invokeData := make(map[string]interface{})
 	h.invokeData.Range(func(key, value interface{}) bool {
 		invokeData[key.(string)] = value
@@ -246,11 +249,9 @@ func (h *handler) GetTestResult() common.TestResult {
 }
 
 func (h *handler) incrementInvokeHistory(key string) {
-	if value, ok := h.invokeHistory.Load(key); ok {
-		h.invokeHistory.Store(key, value.(int64)+1)
-		return
-	}
-	h.invokeHistory.Store(key, int64(1))
+	h.invokeHistoryMutex.Lock()
+	defer h.invokeHistoryMutex.Unlock()
+	h.invokeHistory[key]++
 }
 
 func validateStepContext(stepContext *dexpb.Context) error {


### PR DESCRIPTION
## Summary

- protect the RPC integration worker's invocation counter with a mutex
- take counter snapshots under the same lock
- preserve the strict expected invocation counts in the Cadence Continue-As-New test

## Why

`TestRpcWorkflowCadenceContinueAsNew` runs two `S2_waitFor` callbacks concurrently. The test helper previously implemented increment as `sync.Map.Load` followed by `Store`, so both callbacks could observe the same value and lose one increment. This produced the flaky `S2_waitFor: expected 2, actual 1` failure even though both callbacks were present in the job log.

## User impact

No production behavior changes. CI now records concurrent worker callbacks deterministically instead of intermittently failing the Cadence integration partition.

## Validation

- `make -C server unitTests`
- `make -C server cadenceIntegTests integrationCoverageArgs='-run ^TestRpcWorkflowCadenceContinueAsNew -repeat 20'`
- `make copyright-check`
