### PR TITLE
Fix stale datetime search integration fixture

### DIFF
--- a/server/integ/persistence_test.go
+++ b/server/integ/persistence_test.go
@@ -125,7 +125,6 @@ func doTestPersistenceWorkflow(
 	nowTime := time.Now().Add(
 		time.Duration(persistenceSearchTimeSequence.Add(1)) * time.Hour,
 	)
-	notTimeNanoStr := fmt.Sprintf("%v", nowTime.UnixNano())
 	nowTimeStr := nowTime.Format(timeparser.DateTimeFormat)
 
 	expectedDataAttribute := dataObjectAttribute("TestKey", `"TestValue"`)
@@ -324,21 +323,21 @@ func doTestPersistenceWorkflow(
 
 		startMore(firstFlowId+"-1", []*dexpb.AttributeWrite{
 			indexedBoolAttribute("CustomBoolField", true),
-			indexedDatetimeAttribute("CustomDatetimeField", notTimeNanoStr),
+			indexedDatetimeAttribute("CustomDatetimeField", nowTimeStr),
 		})
 		startMore(firstFlowId+"-2", []*dexpb.AttributeWrite{
 			indexedBoolAttribute("CustomBoolField", true),
-			indexedDatetimeAttribute("CustomDatetimeField", notTimeNanoStr),
+			indexedDatetimeAttribute("CustomDatetimeField", nowTimeStr),
 			indexedDoubleAttribute("CustomDoubleField", 0.01),
 		})
 		attrs3 := []*dexpb.AttributeWrite{
 			indexedBoolAttribute("CustomBoolField", true),
-			indexedDatetimeAttribute("CustomDatetimeField", notTimeNanoStr),
+			indexedDatetimeAttribute("CustomDatetimeField", nowTimeStr),
 			indexedDoubleAttribute("CustomDoubleField", 0.01),
 		}
 		attrs4 := []*dexpb.AttributeWrite{
 			indexedBoolAttribute("CustomBoolField", true),
-			indexedDatetimeAttribute("CustomDatetimeField", notTimeNanoStr),
+			indexedDatetimeAttribute("CustomDatetimeField", nowTimeStr),
 			indexedDoubleAttribute("CustomDoubleField", 0.01),
 		}
 		expectedExtraSearchAttributes := []*dexpb.AttributeWrite{


### PR DESCRIPTION
## Summary

- use the RFC3339Nano datetime fixture for the four additional persistence-search flows
- remove the obsolete UnixNano string fixture
- preserve the strict DATETIME contract instead of restoring legacy numeric-string parsing

## Rationale

The optional search integration queried `CustomDatetimeField` with an RFC3339Nano value but wrote UnixNano numeric strings to the extra flows it expected to find. Numeric strings are no longer valid DATETIME index values, so those flows never entered Temporal visibility and polling timed out.

## User impact

Search integration coverage now matches the current DATETIME contract and no longer fails after a 30-second visibility poll.

## Validation

- `make -C server unitTests`
- `make -C server temporalIntegTests GOFLAGS="-run=^TestPersistenceWorkflowTemporal"` (all four Temporal persistence variants, search enabled)
- `make copyright-check`
- `git diff --check`
