### PR TITLE
Stabilize any-command completion integration test

### DIFF
--- a/server/integ/command_thread_completion_test.go
+++ b/server/integ/command_thread_completion_test.go
@@ -80,7 +80,6 @@ func doTestAnyCommandCompleted(t *testing.T, backendType service.BackendType) {
 	defer cancel()
 
 	flowId := "any_cmd_can_test_" + uuid.NewString()
-	startTime := time.Now()
 	_, err := flowClient.StartFlow(ctx, &dexpb.StartFlowRequest{
 		RequestId:          newRequestID(),
 		FlowId:             flowId,
@@ -128,7 +127,6 @@ func doTestAnyCommandCompleted(t *testing.T, backendType service.BackendType) {
 	}
 	require.NoError(t, err)
 
-	elapsedTime := time.Since(startTime)
 	result := workerHandler.GetTestResult()
 	history := result.InvokeHistory
 	data := result.InvokeData
@@ -145,8 +143,9 @@ func doTestAnyCommandCompleted(t *testing.T, backendType service.BackendType) {
 	signalReceived, ok := data["any_cmd_signal_received"].(bool)
 	assertions.True(ok, "any_cmd_signal_received data should be present")
 	assertions.True(signalReceived)
-	assertions.Less(elapsedTime, 5*time.Second,
-		"Workflow took %v, which suggests we waited for the long timer.", elapsedTime)
+	timerFired, ok := data["any_cmd_timer_fired"].(bool)
+	assertions.True(ok, "any_cmd_timer_fired data should be present")
+	assertions.False(timerFired, "long timer should not fire after the signal completes the wait")
 }
 
 func doTestCommandThreadCompletion(

--- a/server/integ/workflow/command_thread_completion/routers.go
+++ b/server/integ/workflow/command_thread_completion/routers.go
@@ -295,6 +295,7 @@ func (h *handler) InvokeExecuteMethod(
 				timerFired = true
 			}
 		}
+		h.recordData("any_cmd_timer_fired", timerFired)
 
 		if !signalReceived {
 			log.Println("ERROR: Signal should have been received in StateAnyCmd (ANY_COMPLETED)")


### PR DESCRIPTION
## Summary

- record whether the long timer actually completes in the ANY_COMMAND_COMPLETED fixture
- assert signal completion and the absence of long-timer completion directly
- remove the machine-speed-dependent five-second wall-clock assertion

## Rationale

Cadence partition 0 failed on main after the workflow completed in 5.406 seconds, narrowly exceeding a five-second test threshold. The condition results showed the signal completed the wait; CI load, not a product regression, caused the elapsed-time assertion to fail.

## User impact

No runtime behavior changes. The integration test now verifies the workflow semantics directly and remains sensitive to accidentally waiting for the 20-second timer.

## Validation

- `make -C server unitTests`
- `make copyright-check`
- Cadence integration CI (isolated GitHub-hosted PR runner)
