### PR TITLE
Harden Java step cancellation

### DIFF
--- a/docs/content/capabilities/advanced/step-execution-cancellation.mdx
+++ b/docs/content/capabilities/advanced/step-execution-cancellation.mdx
@@ -75,6 +75,27 @@ CPU-bound or batch-oriented handlers may additionally check
 `Context.isCancellationRequested()` at natural work boundaries. They do not
 need to poll continuously.
 
+## ASYNC local activities and timers
+
+An ASYNC Step first runs as a local activity. The local activity keeps the
+current backend Workflow Task open until it returns or reaches Dex's seven-second
+local optimization timeout. While that task is occupied, another Step may be
+unable to finish `waitFor` and start its durable timer. In that case, the timer
+starts after the local stage ends.
+
+If the timer was already started, it keeps its original deadline. Dex processes
+an elapsed deadline when the Workflow Task resumes instead of restarting the
+timer. In either case, cancellation can arrive up to the local-stage duration
+later than it would with a SYNC Step. If the local activity successfully returns
+first, its result is processed first and a later selector is a no-op for that
+completed execution.
+
+Use SYNC durability when a timer must cancel an executing handler close to its
+deadline. If the ASYNC local optimization times out, Dex falls back to a regular
+activity and the timer can cancel that fallback. A backend error without local
+attempt metadata conservatively consumes one attempt and the elapsed local-stage
+duration before Dex calculates the regular activity's remaining retry budget.
+
 ## Snapshot and completion semantics
 
 When Dex applies a `StepDecision`, it processes cancellation in this order:

--- a/docs/content/references/step-options.mdx
+++ b/docs/content/references/step-options.mdx
@@ -16,6 +16,12 @@ it. Heartbeats let a running handler observe
 [Step execution cancellation](/capabilities/advanced/step-execution-cancellation)
 promptly.
 
+An ASYNC local activity can delay a sibling Step from starting a durable timer,
+or delay processing a timer that already elapsed, until its Workflow Task
+resumes. The delay is at most the local stage's seven-second optimization
+window. An already-started timer keeps its deadline. Use SYNC durability when
+timer precision is required.
+
 ## Recovery durability
 
 Dex resolves each Step method's durability in this order:

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -170,6 +170,15 @@ requests. Without a heartbeat, the Flow still cancels logically and proceeds,
 but the Java handler may run until its RPC or activity timeout and its response
 is ignored.
 
+An ASYNC local activity keeps the current backend Workflow Task open until it
+returns or reaches Dex's seven-second local optimization timeout. This can delay
+another Step from starting its durable timer, or delay processing a timer that
+already elapsed. An already-started timer keeps its deadline. Use SYNC durability
+when cancellation must reach a running handler close to the intended deadline.
+After an ASYNC local timeout, Dex falls back to a regular activity; a backend
+error without local attempt metadata conservatively consumes one attempt and the
+elapsed local duration before fallback.
+
 `ClientOptions` and `WorkerOptions` contain a default Jackson `ObjectMapper` and
 accept a configured mapper when needed. Java does not expose a public Codec API.
 Workers use a builder so optional transport settings remain readable:

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/README.md
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/README.md
@@ -20,6 +20,7 @@ persistence, reset, signals, timers, recovery, and failure behavior.
 | `RpcWithMemoTest` | typed RPC persistence without the removed memo API |
 | `SignalTest` | typed publish, channel combinations, timer skipping, and closed-flow errors |
 | `SkipWaitUntilTest` | execute-only and mixed wait styles |
+| `StepCancellationTest` | global/sibling snapshots, local cancellation, regular activity heartbeats, and discarded late results |
 | `StateOptionsOverrideTest` | per-movement StepOptions overrides |
 | `StateOptionsTest` | attribute visibility and parallel WaitFor/Execute locks |
 | `StateRecoveryTest` | execute-failure recovery with and without WaitFor |

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/README.md
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/README.md
@@ -20,7 +20,7 @@ persistence, reset, signals, timers, recovery, and failure behavior.
 | `RpcWithMemoTest` | typed RPC persistence without the removed memo API |
 | `SignalTest` | typed publish, channel combinations, timer skipping, and closed-flow errors |
 | `SkipWaitUntilTest` | execute-only and mixed wait styles |
-| `StepCancellationTest` | global/sibling snapshots, local cancellation, regular activity heartbeats, and discarded late results |
+| `StepCancellationTest` | global/sibling selectors, local and fallback cancellation, heartbeats, and discarded late results |
 | `StateOptionsOverrideTest` | per-movement StepOptions overrides |
 | `StateOptionsTest` | attribute visibility and parallel WaitFor/Execute locks |
 | `StateRecoveryTest` | execute-failure recovery with and without WaitFor |

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationTest.java
@@ -75,6 +75,31 @@ public final class StepCancellationTest {
     }
 
     @Test
+    void testTimerCancelsAfterLocalTimeoutFallback() throws Exception {
+        final StepCancellationWorkflow workflow = new StepCancellationWorkflow(
+                StepCancellationWorkflow.Scenario.LOCAL_TIMEOUT_FALLBACK);
+        try (DexDevTestEnvironment environment = DexDevTestEnvironment.start(
+                cacheDirectory,
+                workflow)) {
+            final String flowId = start(environment, workflow, "cancel-local-fallback");
+            assertTrue(workflow.awaitBlockingHandlerStarted(START_TIMEOUT));
+            environment.client().waitForStepCompletion(
+                    flowId,
+                    StepExecutionId.of(workflow.canceledStepType()),
+                    FLOW_TIMEOUT);
+            assertCompleted(
+                    environment,
+                    flowId,
+                    StepCancellationWorkflow.Scenario.LOCAL_TIMEOUT_FALLBACK);
+            assertEquals(1, workflow.blockingExecuteInvocations());
+            assertTrue(workflow.wasHandlerInterrupted());
+            assertTrue(workflow.didContextReportCancellation());
+            assertFalse(workflow.wasRecoveryRun());
+            assertNull(environment.client().getAttribute(flowId, workflow.lateWrite));
+        }
+    }
+
+    @Test
     void testCancellationWithoutHeartbeatContinuesBeforeLateHandlerReturn() throws Exception {
         final StepCancellationWorkflow workflow = new StepCancellationWorkflow(
                 StepCancellationWorkflow.Scenario.NO_HEARTBEAT);

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationTest.java
@@ -1,0 +1,166 @@
+/*
+ * Portions of this file are derived from indeedeng/iwf-java-sdk.
+ * Those portions are licensed under the Apache License, Version 2.0.
+ * See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+ *
+ * Modifications Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Modifications are licensed under the Super Durable Source License 1.0.
+ * Third-Party Materials remain under the Apache License, Version 2.0.
+ * See LICENSE and LEGACY_NOTICES.md.
+ */
+
+package io.superdurable.dex.integ;
+
+import io.superdurable.dex.FlowResult;
+import io.superdurable.dex.StepExecutionId;
+import io.superdurable.dex.testing.DexDevTestEnvironment;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("dex-dev")
+public final class StepCancellationTest {
+    private static final Duration START_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration CANCELLATION_TIMEOUT = Duration.ofSeconds(8);
+    private static final Duration FLOW_TIMEOUT = Duration.ofSeconds(30);
+
+    @TempDir
+    Path cacheDirectory;
+
+    @Test
+    void testHeartbeatCancelsRegularExecuteAndInterruptsHandler() throws Exception {
+        assertCooperativeCancellation(
+                StepCancellationWorkflow.Scenario.HEARTBEAT_EXECUTE,
+                CANCELLATION_TIMEOUT);
+    }
+
+    @Test
+    void testHeartbeatCancelsRegularWaitForAndInterruptsHandler() throws Exception {
+        assertCooperativeCancellation(
+                StepCancellationWorkflow.Scenario.HEARTBEAT_WAIT_FOR,
+                CANCELLATION_TIMEOUT);
+    }
+
+    @Test
+    void testLocalActivityCancellationInterruptsWithoutFallback() throws Exception {
+        final StepCancellationWorkflow workflow = new StepCancellationWorkflow(
+                StepCancellationWorkflow.Scenario.LOCAL_EXECUTE);
+        try (DexDevTestEnvironment environment = DexDevTestEnvironment.start(
+                cacheDirectory,
+                workflow)) {
+            final String flowId = start(environment, workflow, "cancel-local");
+            assertTrue(workflow.awaitBlockingHandlerStarted(START_TIMEOUT));
+            environment.client().waitForStepCompletion(
+                    flowId,
+                    StepExecutionId.of(workflow.canceledStepType()),
+                    CANCELLATION_TIMEOUT);
+            assertTrue(workflow.awaitCancellation(CANCELLATION_TIMEOUT));
+            assertCompleted(environment, flowId, StepCancellationWorkflow.Scenario.LOCAL_EXECUTE);
+            assertTrue(workflow.wasHandlerInterrupted());
+            assertTrue(workflow.didContextReportCancellation());
+            assertEquals(1, workflow.blockingExecuteInvocations());
+            assertFalse(workflow.wasRecoveryRun());
+            assertNull(environment.client().getAttribute(flowId, workflow.lateWrite));
+        }
+    }
+
+    @Test
+    void testCancellationWithoutHeartbeatContinuesBeforeLateHandlerReturn() throws Exception {
+        final StepCancellationWorkflow workflow = new StepCancellationWorkflow(
+                StepCancellationWorkflow.Scenario.NO_HEARTBEAT);
+        try (DexDevTestEnvironment environment = DexDevTestEnvironment.start(
+                cacheDirectory,
+                workflow)) {
+            final String flowId = start(environment, workflow, "cancel-no-heartbeat");
+            assertTrue(workflow.awaitBlockingHandlerStarted(START_TIMEOUT));
+            environment.client().waitForStepCompletion(
+                    flowId,
+                    StepExecutionId.of(workflow.canceledStepType()),
+                    CANCELLATION_TIMEOUT);
+            assertCompleted(environment, flowId, StepCancellationWorkflow.Scenario.NO_HEARTBEAT);
+            assertFalse(workflow.hasLateHandlerReturned());
+            assertFalse(workflow.wasHandlerInterrupted());
+            assertTrue(workflow.awaitLateHandlerReturn(CANCELLATION_TIMEOUT));
+            assertEquals(1, workflow.blockingExecuteInvocations());
+            assertFalse(workflow.wasRecoveryRun());
+            assertNull(environment.client().getAttribute(flowId, workflow.lateWrite));
+        }
+    }
+
+    @Test
+    void testGlobalSelectorCancelsMatchingExecutionsFromBothParents() throws Exception {
+        final StepCancellationWorkflow workflow = new StepCancellationWorkflow(
+                StepCancellationWorkflow.Scenario.GLOBAL_SELECTOR);
+        try (DexDevTestEnvironment environment = DexDevTestEnvironment.start(
+                cacheDirectory,
+                workflow)) {
+            final String flowId = start(environment, workflow, "cancel-global");
+            assertCompleted(environment, flowId, StepCancellationWorkflow.Scenario.GLOBAL_SELECTOR);
+            assertFalse(workflow.wasFirstSelectorExecuted());
+            assertFalse(workflow.wasSecondSelectorExecuted());
+        }
+    }
+
+    @Test
+    void testSiblingSelectorKeepsMatchingExecutionFromOtherParent() throws Exception {
+        final StepCancellationWorkflow workflow = new StepCancellationWorkflow(
+                StepCancellationWorkflow.Scenario.SIBLING_SELECTOR);
+        try (DexDevTestEnvironment environment = DexDevTestEnvironment.start(
+                cacheDirectory,
+                workflow)) {
+            final String flowId = start(environment, workflow, "cancel-sibling");
+            assertCompleted(environment, flowId, StepCancellationWorkflow.Scenario.SIBLING_SELECTOR);
+            assertFalse(workflow.wasFirstSelectorExecuted());
+            assertTrue(workflow.wasSecondSelectorExecuted());
+        }
+    }
+
+    private void assertCooperativeCancellation(
+            final StepCancellationWorkflow.Scenario scenario,
+            final Duration cancellationTimeout) throws Exception {
+        final StepCancellationWorkflow workflow = new StepCancellationWorkflow(scenario);
+        try (DexDevTestEnvironment environment = DexDevTestEnvironment.start(
+                cacheDirectory,
+                workflow)) {
+            final String flowId = start(environment, workflow, "cancel-heartbeat");
+            assertTrue(workflow.awaitBlockingHandlerStarted(START_TIMEOUT));
+            environment.client().waitForStepCompletion(
+                    flowId,
+                    StepExecutionId.of(workflow.canceledStepType()),
+                    cancellationTimeout);
+            assertTrue(workflow.awaitCancellation(cancellationTimeout));
+            assertCompleted(environment, flowId, scenario);
+            assertTrue(workflow.wasHandlerInterrupted());
+            assertTrue(workflow.didContextReportCancellation());
+            assertFalse(workflow.wasRecoveryRun());
+            assertNull(environment.client().getAttribute(flowId, workflow.lateWrite));
+        }
+    }
+
+    private static String start(
+            final DexDevTestEnvironment environment,
+            final StepCancellationWorkflow workflow,
+            final String prefix) {
+        final String flowId = prefix + "-" + UUID.randomUUID();
+        environment.client().startFlow(workflow, flowId, null);
+        return flowId;
+    }
+
+    private static void assertCompleted(
+            final DexDevTestEnvironment environment,
+            final String flowId,
+            final StepCancellationWorkflow.Scenario scenario) {
+        final FlowResult result = environment.client().waitForFlow(flowId, FLOW_TIMEOUT);
+        assertEquals(scenario.name(), result.getSingleOutput(String.class));
+    }
+}

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationWorkflow.java
@@ -37,6 +37,7 @@ final class StepCancellationWorkflow implements Flow<Void> {
         HEARTBEAT_EXECUTE,
         HEARTBEAT_WAIT_FOR,
         LOCAL_EXECUTE,
+        LOCAL_TIMEOUT_FALLBACK,
         NO_HEARTBEAT,
         GLOBAL_SELECTOR,
         SIBLING_SELECTOR
@@ -228,6 +229,12 @@ final class StepCancellationWorkflow implements Flow<Void> {
                     .onExecuteFailureProceedTo(recovery);
             if (scenario == Scenario.LOCAL_EXECUTE) {
                 return options.executeDurability(StepDurability.ASYNC).build();
+            }
+            if (scenario == Scenario.LOCAL_TIMEOUT_FALLBACK) {
+                return options
+                        .heartbeatTimeout(HEARTBEAT_TIMEOUT)
+                        .executeDurability(StepDurability.ASYNC)
+                        .build();
             }
             if (scenario == Scenario.HEARTBEAT_EXECUTE) {
                 options.heartbeatTimeout(HEARTBEAT_TIMEOUT);

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationWorkflow.java
@@ -1,0 +1,406 @@
+/*
+ * Portions of this file are derived from indeedeng/iwf-java-sdk.
+ * Those portions are licensed under the Apache License, Version 2.0.
+ * See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+ *
+ * Modifications Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Modifications are licensed under the Super Durable Source License 1.0.
+ * Third-Party Materials remain under the Apache License, Version 2.0.
+ * See LICENSE and LEGACY_NOTICES.md.
+ */
+
+package io.superdurable.dex.integ;
+
+import io.superdurable.dex.Attribute;
+import io.superdurable.dex.Context;
+import io.superdurable.dex.Flow;
+import io.superdurable.dex.PersistenceSchema;
+import io.superdurable.dex.Step;
+import io.superdurable.dex.StepDecision;
+import io.superdurable.dex.StepDurability;
+import io.superdurable.dex.StepList;
+import io.superdurable.dex.StepMovement;
+import io.superdurable.dex.StepOptions;
+import io.superdurable.dex.Timer;
+import io.superdurable.dex.Wait;
+import io.superdurable.dex.WaitForFailurePolicy;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class StepCancellationWorkflow implements Flow<Void> {
+    enum Scenario {
+        HEARTBEAT_EXECUTE,
+        HEARTBEAT_WAIT_FOR,
+        LOCAL_EXECUTE,
+        NO_HEARTBEAT,
+        GLOBAL_SELECTOR,
+        SIBLING_SELECTOR
+    }
+
+    private static final Duration HANDLER_TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration HEARTBEAT_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration WINNER_DELAY = Duration.ofSeconds(3);
+    private static final long LOCAL_WINNER_DELAY_MILLIS = 1_000L;
+    private static final long BLOCKING_HANDLER_MILLIS = 10_000L;
+    private static final long LATE_HANDLER_MILLIS = 7_000L;
+
+    final Attribute<String> lateWrite = Attribute.define("cancellation-late-write", String.class);
+
+    private final Scenario scenario;
+    private final CountDownLatch blockingHandlerStarted = new CountDownLatch(1);
+    private final CountDownLatch cancellationObserved = new CountDownLatch(1);
+    private final CountDownLatch lateHandlerReturned = new CountDownLatch(1);
+    private final CountDownLatch selectorWaitsRegistered = new CountDownLatch(2);
+    private final AtomicBoolean handlerInterrupted = new AtomicBoolean();
+    private final AtomicBoolean contextReportedCancellation = new AtomicBoolean();
+    private final AtomicBoolean recoveryRan = new AtomicBoolean();
+    private final AtomicBoolean firstSelectorExecuted = new AtomicBoolean();
+    private final AtomicBoolean secondSelectorExecuted = new AtomicBoolean();
+    private final AtomicInteger blockingExecuteInvocations = new AtomicInteger();
+
+    private final StepCancellationStartStep start = new StepCancellationStartStep();
+    private final StepCancellationBlockingExecuteStep blockingExecute =
+            new StepCancellationBlockingExecuteStep();
+    private final StepCancellationBlockingWaitForStep blockingWaitFor =
+            new StepCancellationBlockingWaitForStep();
+    private final StepCancellationWinnerStep winner = new StepCancellationWinnerStep();
+    private final StepCancellationRecoveryStep recovery = new StepCancellationRecoveryStep();
+    private final StepCancellationFinalStep finalStep = new StepCancellationFinalStep();
+    private final StepCancellationFirstParentStep firstParent =
+            new StepCancellationFirstParentStep();
+    private final StepCancellationSecondParentStep secondParent =
+            new StepCancellationSecondParentStep();
+    private final StepCancellationSelectorWinnerStep selectorWinner =
+            new StepCancellationSelectorWinnerStep();
+    private final StepCancellationSelectorWaitingStep selectorWaiting =
+            new StepCancellationSelectorWaitingStep();
+
+    StepCancellationWorkflow(final Scenario scenario) {
+        this.scenario = scenario;
+    }
+
+    @Override
+    public StepList<Void> getSteps() {
+        return StepList.startStep(start).otherSteps(
+                blockingExecute,
+                blockingWaitFor,
+                winner,
+                recovery,
+                finalStep,
+                firstParent,
+                secondParent,
+                selectorWinner,
+                selectorWaiting);
+    }
+
+    @Override
+    public PersistenceSchema getPersistenceSchema() {
+        return PersistenceSchema.of(lateWrite);
+    }
+
+    String canceledStepType() {
+        return scenario == Scenario.HEARTBEAT_WAIT_FOR
+                ? blockingWaitFor.getStepType()
+                : blockingExecute.getStepType();
+    }
+
+    boolean awaitBlockingHandlerStarted(final Duration timeout) throws InterruptedException {
+        return blockingHandlerStarted.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    boolean awaitCancellation(final Duration timeout) throws InterruptedException {
+        return cancellationObserved.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    boolean awaitLateHandlerReturn(final Duration timeout) throws InterruptedException {
+        return lateHandlerReturned.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    boolean hasLateHandlerReturned() {
+        return lateHandlerReturned.getCount() == 0L;
+    }
+
+    boolean wasHandlerInterrupted() {
+        return handlerInterrupted.get();
+    }
+
+    boolean didContextReportCancellation() {
+        return contextReportedCancellation.get();
+    }
+
+    boolean wasRecoveryRun() {
+        return recoveryRan.get();
+    }
+
+    boolean wasFirstSelectorExecuted() {
+        return firstSelectorExecuted.get();
+    }
+
+    boolean wasSecondSelectorExecuted() {
+        return secondSelectorExecuted.get();
+    }
+
+    int blockingExecuteInvocations() {
+        return blockingExecuteInvocations.get();
+    }
+
+    private void awaitSelectorWaits() {
+        try {
+            if (!selectorWaitsRegistered.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("selector Steps did not reach waiting");
+            }
+        } catch (InterruptedException interruption) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("selector winner interrupted", interruption);
+        }
+    }
+
+    private void blockUntilCanceled(final Context context) {
+        blockingHandlerStarted.countDown();
+        try {
+            Thread.sleep(BLOCKING_HANDLER_MILLIS);
+        } catch (InterruptedException interruption) {
+            handlerInterrupted.set(true);
+            contextReportedCancellation.set(context.isCancellationRequested());
+            cancellationObserved.countDown();
+        }
+    }
+
+    final class StepCancellationStartStep implements Step<Void> {
+        @Override
+        public Class<Void> getInputType() {
+            return Void.class;
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final Void input) {
+            switch (scenario) {
+                case HEARTBEAT_WAIT_FOR:
+                    return StepDecision.goToMulti(
+                            StepMovement.of(blockingWaitFor, null),
+                            StepMovement.of(winner, null));
+                case GLOBAL_SELECTOR:
+                case SIBLING_SELECTOR:
+                    return StepDecision.goToMulti(
+                            StepMovement.of(firstParent, null),
+                            StepMovement.of(secondParent, null));
+                default:
+                    return StepDecision.goToMulti(
+                            StepMovement.of(blockingExecute, null),
+                            StepMovement.of(winner, null));
+            }
+        }
+    }
+
+    final class StepCancellationBlockingExecuteStep implements Step<Void> {
+        @Override
+        public Class<Void> getInputType() {
+            return Void.class;
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final Void input) {
+            blockingExecuteInvocations.incrementAndGet();
+            blockingHandlerStarted.countDown();
+            try {
+                Thread.sleep(scenario == Scenario.NO_HEARTBEAT
+                        ? LATE_HANDLER_MILLIS
+                        : BLOCKING_HANDLER_MILLIS);
+            } catch (InterruptedException interruption) {
+                handlerInterrupted.set(true);
+                contextReportedCancellation.set(context.isCancellationRequested());
+                cancellationObserved.countDown();
+            }
+            lateWrite.set(context, "late");
+            lateHandlerReturned.countDown();
+            return StepDecision.goTo(recovery, null);
+        }
+
+        @Override
+        public StepOptions getStepOptions() {
+            final StepOptions.Builder options = StepOptions.newBuilder()
+                    .executeMethodTimeout(HANDLER_TIMEOUT)
+                    .onExecuteFailureProceedTo(recovery);
+            if (scenario == Scenario.LOCAL_EXECUTE) {
+                return options.executeDurability(StepDurability.ASYNC).build();
+            }
+            if (scenario == Scenario.HEARTBEAT_EXECUTE) {
+                options.heartbeatTimeout(HEARTBEAT_TIMEOUT);
+            }
+            return options.executeDurability(StepDurability.SYNC).build();
+        }
+    }
+
+    final class StepCancellationBlockingWaitForStep implements Step<Void> {
+        @Override
+        public Class<Void> getInputType() {
+            return Void.class;
+        }
+
+        @Override
+        public Wait waitFor(final Context context, final Void input) {
+            blockUntilCanceled(context);
+            return Wait.skipImmediately();
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final Void input) {
+            recoveryRan.set(true);
+            return StepDecision.forceFail("canceled waitFor execution continued");
+        }
+
+        @Override
+        public StepOptions getStepOptions() {
+            return StepOptions.newBuilder()
+                    .waitForMethodTimeout(HANDLER_TIMEOUT)
+                    .heartbeatTimeout(HEARTBEAT_TIMEOUT)
+                    .waitForDurability(StepDurability.SYNC)
+                    .waitForFailure(WaitForFailurePolicy.PROCEED)
+                    .build();
+        }
+    }
+
+    final class StepCancellationWinnerStep implements Step<Void> {
+        @Override
+        public Class<Void> getInputType() {
+            return Void.class;
+        }
+
+        @Override
+        public Wait waitFor(final Context context, final Void input) {
+            if (scenario == Scenario.LOCAL_EXECUTE) {
+                return Wait.skipImmediately();
+            }
+            return Wait.until(Timer.byDuration(WINNER_DELAY));
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final Void input) {
+            if (scenario == Scenario.LOCAL_EXECUTE) {
+                awaitLocalWinnerDelay();
+            }
+            final Step<?> canceled = scenario == Scenario.HEARTBEAT_WAIT_FOR
+                    ? blockingWaitFor
+                    : blockingExecute;
+            return StepDecision.goTo(finalStep, scenario.name()).withCancelingSteps(canceled);
+        }
+
+        private void awaitLocalWinnerDelay() {
+            try {
+                if (!blockingHandlerStarted.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("local loser did not start");
+                }
+                Thread.sleep(LOCAL_WINNER_DELAY_MILLIS);
+            } catch (InterruptedException interruption) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("local winner interrupted", interruption);
+            }
+        }
+    }
+
+    final class StepCancellationRecoveryStep implements Step<Void> {
+        @Override
+        public Class<Void> getInputType() {
+            return Void.class;
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final Void input) {
+            recoveryRan.set(true);
+            return StepDecision.forceFail("canceled execution reached recovery");
+        }
+    }
+
+    static final class StepCancellationFinalStep implements Step<String> {
+        @Override
+        public Class<String> getInputType() {
+            return String.class;
+        }
+
+        @Override
+        public Wait waitFor(final Context context, final String input) {
+            return Wait.until(Timer.byDuration(Duration.ofSeconds(1)));
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final String input) {
+            return StepDecision.gracefulComplete(input);
+        }
+    }
+
+    final class StepCancellationFirstParentStep implements Step<Void> {
+        @Override
+        public Class<Void> getInputType() {
+            return Void.class;
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final Void input) {
+            return StepDecision.goToMulti(
+                    StepMovement.of(selectorWinner, null),
+                    StepMovement.of(selectorWaiting, "first"));
+        }
+    }
+
+    final class StepCancellationSecondParentStep implements Step<Void> {
+        @Override
+        public Class<Void> getInputType() {
+            return Void.class;
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final Void input) {
+            return StepDecision.goTo(selectorWaiting, "second");
+        }
+    }
+
+    final class StepCancellationSelectorWinnerStep implements Step<Void> {
+        @Override
+        public Class<Void> getInputType() {
+            return Void.class;
+        }
+
+        @Override
+        public Wait waitFor(final Context context, final Void input) {
+            return Wait.until(Timer.byDuration(Duration.ofSeconds(1)));
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final Void input) {
+            awaitSelectorWaits();
+            final StepDecision decision = StepDecision.goTo(finalStep, scenario.name());
+            return scenario == Scenario.GLOBAL_SELECTOR
+                    ? decision.withCancelingSteps(selectorWaiting)
+                    : decision.withCancelingSiblingSteps(selectorWaiting);
+        }
+    }
+
+    final class StepCancellationSelectorWaitingStep implements Step<String> {
+        @Override
+        public Class<String> getInputType() {
+            return String.class;
+        }
+
+        @Override
+        public Wait waitFor(final Context context, final String input) {
+            selectorWaitsRegistered.countDown();
+            return Wait.until(Timer.byDuration(
+                    "first".equals(input) ? Duration.ofSeconds(30) : Duration.ofSeconds(2)));
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final String input) {
+            if ("first".equals(input)) {
+                firstSelectorExecuted.set(true);
+            } else {
+                secondSelectorExecuted.set(true);
+            }
+            return StepDecision.deadEnd();
+        }
+    }
+}

--- a/server/integ/README.md
+++ b/server/integ/README.md
@@ -20,7 +20,8 @@ offload threshold. S3-specific tests replace it with MinIO.
 
 Step cancellation coverage runs against both Temporal and Cadence. It verifies
 Flow-wide and sibling selectors; queued and active executions; local and
-regular activities; heartbeat-driven handler cancellation;
+regular activities; local-timeout fallback with cumulative attempts;
+heartbeat-driven handler cancellation;
 fire-and-continue behavior; late-result suppression;
 continue-as-new; Step and RPC producers; signal and synchronous-update RPC
 delivery; RPC sibling-selector rejection; snapshot exclusion of RPC next Steps;

--- a/server/integ/step_cancellation_test.go
+++ b/server/integ/step_cancellation_test.go
@@ -64,6 +64,20 @@ func TestLocalStepCancellationCadence(t *testing.T) {
 	testLocalStepCancellation(t, service.BackendTypeCadence)
 }
 
+func TestLocalTimeoutFallbackCancellationTemporal(t *testing.T) {
+	if !*temporalIntegTest {
+		t.Skip()
+	}
+	testLocalTimeoutFallbackCancellation(t, service.BackendTypeTemporal)
+}
+
+func TestLocalTimeoutFallbackCancellationCadence(t *testing.T) {
+	if !*cadenceIntegTest {
+		t.Skip()
+	}
+	testLocalTimeoutFallbackCancellation(t, service.BackendTypeCadence)
+}
+
 func TestRpcStepCancellationTemporal(t *testing.T) {
 	if !*temporalIntegTest {
 		t.Skip()
@@ -224,6 +238,32 @@ func testLocalStepCancellation(t *testing.T, backendType service.BackendType) {
 	require.True(t, handler.IsCancellationObserved(step_cancellation.LocalLoser))
 	events, _ := getAllWebHistoryEvents(t, ctx, runtime.FlowClient, flowID, start.GetRunId())
 	assertNoExecuteHistory(t, events, step_cancellation.LocalLoser+"-1")
+}
+
+func testLocalTimeoutFallbackCancellation(t *testing.T, backendType service.BackendType) {
+	handler := step_cancellation.NewHandler()
+	workerTarget := startWorker(t, handler)
+	runtime := startDexService(t, DexServiceTestConfig{BackendType: backendType})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	flowID := step_cancellation.FlowType + "-local-timeout-" + uuid.NewString()
+	_, err := runtime.FlowClient.StartFlow(ctx, &dexpb.StartFlowRequest{
+		RequestId:          newRequestID(),
+		FlowId:             flowID,
+		FlowType:           step_cancellation.FlowType,
+		FlowTimeoutSeconds: 20,
+		StartStepType:      step_cancellation.LocalTimeoutRoot,
+		FlowStartOptions:   withWorkerTarget(nil, workerTarget),
+	})
+	require.NoError(t, err)
+	completed, err := runtime.FlowClient.WaitForFlow(ctx, &dexpb.WaitForFlowRequest{
+		FlowId:          flowID,
+		WaitTimeSeconds: 15,
+	})
+	require.NoError(t, err)
+	require.Equal(t, dexpb.FlowStatus_FLOW_STATUS_COMPLETED, completed.GetFlowStatus())
+	require.Equal(t, int32(2), handler.LocalTimeoutLoserAttempt())
 }
 
 func testRpcStepCancellation(

--- a/server/integ/workflow/step_cancellation/routers.go
+++ b/server/integ/workflow/step_cancellation/routers.go
@@ -41,6 +41,10 @@ const (
 	LocalWinner         = "LocalWinner"
 	LocalLoser          = "LocalLoser"
 	LocalFinal          = "LocalFinal"
+	LocalTimeoutRoot    = "LocalTimeoutRoot"
+	LocalTimeoutWinner  = "LocalTimeoutWinner"
+	LocalTimeoutLoser   = "LocalTimeoutLoser"
+	LocalTimeoutFinal   = "LocalTimeoutFinal"
 	RpcA                = "cancelRpcA"
 	RpcB                = "cancelRpcB"
 	RpcSpawn            = "spawn"
@@ -57,6 +61,7 @@ type Handler struct {
 	hasNoHeartbeatLateReturn bool
 	wasQueuedLoserExecuted   bool
 	wasWaitingLoserExecuted  bool
+	localTimeoutLoserAttempt int32
 }
 
 func NewHandler() *Handler {
@@ -103,6 +108,8 @@ func (h *Handler) InvokeWaitForMethod(
 	switch request.GetStepType() {
 	case Winner:
 		return timerWait(2 * time.Second), nil
+	case LocalTimeoutWinner:
+		return timerWait(3 * time.Second), nil
 	case SiblingWait:
 		if request.GetContext().GetFromStepExecutionId() == ParentA+"-1" {
 			return channelWait(), nil
@@ -220,6 +227,27 @@ func (h *Handler) InvokeExecuteMethod(
 		return nil, ctx.Err()
 	case LocalFinal:
 		return graceful(), nil
+	case LocalTimeoutRoot:
+		return next(
+			movement(LocalTimeoutWinner, asyncExecuteAfterWaitOptions()),
+			movement(LocalTimeoutLoser, asyncExecuteOptions()),
+		), nil
+	case LocalTimeoutWinner:
+		return &dexpb.InvokeExecuteMethodResponse{StepDecision: &dexpb.StepDecision{
+			NextSteps:       []*dexpb.StepMovement{movement(LocalTimeoutFinal, nil)},
+			CancelStepTypes: []string{LocalTimeoutLoser},
+		}}, nil
+	case LocalTimeoutLoser:
+		h.mu.Lock()
+		h.localTimeoutLoserAttempt = max(
+			h.localTimeoutLoserAttempt,
+			request.GetContext().GetAttempt(),
+		)
+		h.mu.Unlock()
+		<-ctx.Done()
+		return nil, ctx.Err()
+	case LocalTimeoutFinal:
+		return graceful(), nil
 	case RpcFinal:
 		return forceComplete(), nil
 	case CanceledRecovery:
@@ -251,6 +279,12 @@ func (h *Handler) WasWaitingLoserExecuted() bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return h.wasWaitingLoserExecuted
+}
+
+func (h *Handler) LocalTimeoutLoserAttempt() int32 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.localTimeoutLoserAttempt
 }
 
 func (h *Handler) markCanceled(stepType string) {

--- a/server/service/interpreter/cadence/workflowProvider.go
+++ b/server/service/interpreter/cadence/workflowProvider.go
@@ -454,29 +454,31 @@ func (w *workflowProvider) ExecuteActivity(
 		if wfCtx.Err() != nil {
 			return wfCtx.Err()
 		}
-		if cadence.IsCanceledError(err) {
-			return err
-		}
 		if !isStepMethodActivity {
 			return workflow.ExecuteActivity(wfCtx, activity, regularArgs...).Get(wfCtx, valuePtr)
 		}
-		customError, localFailure, isApplicationFailure := cadenceLocalStepActivityError(err)
-		if !isApplicationFailure {
-			return err
+		customError, localFailure, hasLocalFailure := cadenceLocalStepActivityError(err)
+		previousAttempts := int32(1)
+		firstAttemptTimestamp := firstAttemptTime.Unix()
+		if hasLocalFailure {
+			previousAttempts = localFailure.GetAttempt()
+			firstAttemptTimestamp = localFailure.GetFirstAttemptTimestamp()
 		}
-		previousAttempts := localFailure.GetAttempt()
 		remainingPolicy, canFallback := retry.RemainingActivityRetryPolicy(
 			options.RetryPolicy,
 			previousAttempts,
 			workflow.Now(wfCtx).Sub(firstAttemptTime),
 		)
 		if !canFallback {
-			return cadenceFinalFlowError(customError, localFailure.GetActivityError())
+			if hasLocalFailure {
+				return cadenceFinalFlowError(customError, localFailure.GetActivityError())
+			}
+			return err
 		}
 		regularInput = interfaces.StepActivityInputWithAttemptContext(
 			regularInput,
 			previousAttempts,
-			localFailure.GetFirstAttemptTimestamp(),
+			firstAttemptTimestamp,
 		)
 		options.RetryPolicy = remainingPolicy
 		regularCtx := workflow.WithActivityOptions(wfCtx, cadenceActivityOptions(options))
@@ -530,17 +532,14 @@ func cadenceLocalStepActivityError(
 		return nil, nil, false
 	}
 	if !customError.HasDetails() {
-		panic("Cadence local Step failure details required")
+		return nil, nil, false
 	}
 	var failure *dexpb.InternalLocalStepActivityFailure
 	if detailErr := customError.Details(&failure); detailErr != nil {
-		panic(fmt.Sprintf("decode Cadence local Step failure details: %v", detailErr))
+		return nil, nil, false
 	}
-	if failure == nil || failure.GetActivityError() == nil {
-		panic("Cadence local Step activity error required")
-	}
-	if failure.GetAttempt() <= 0 {
-		panic("Cadence local Step failure attempt required")
+	if failure == nil || failure.GetActivityError() == nil || failure.GetAttempt() <= 0 {
+		return nil, nil, false
 	}
 	return customError, failure, true
 }

--- a/server/service/interpreter/temporal/workflowProvider.go
+++ b/server/service/interpreter/temporal/workflowProvider.go
@@ -453,29 +453,31 @@ func (w *workflowProvider) ExecuteActivity(
 		if wfCtx.Err() != nil {
 			return wfCtx.Err()
 		}
-		if temporal.IsCanceledError(err) {
-			return err
-		}
 		if !isStepMethodActivity {
 			return workflow.ExecuteActivity(wfCtx, activity, regularArgs...).Get(wfCtx, valuePtr)
 		}
-		applicationError, localFailure, isApplicationFailure := temporalLocalStepActivityError(err)
-		if !isApplicationFailure {
-			return err
+		applicationError, localFailure, hasLocalFailure := temporalLocalStepActivityError(err)
+		previousAttempts := int32(1)
+		firstAttemptTimestamp := firstAttemptTime.Unix()
+		if hasLocalFailure {
+			previousAttempts = localFailure.GetAttempt()
+			firstAttemptTimestamp = localFailure.GetFirstAttemptTimestamp()
 		}
-		previousAttempts := localFailure.GetAttempt()
 		remainingPolicy, canFallback := retry.RemainingActivityRetryPolicy(
 			options.RetryPolicy,
 			previousAttempts,
 			workflow.Now(wfCtx).Sub(firstAttemptTime),
 		)
 		if !canFallback {
-			return temporalFinalFlowError(applicationError, localFailure.GetActivityError())
+			if hasLocalFailure {
+				return temporalFinalFlowError(applicationError, localFailure.GetActivityError())
+			}
+			return err
 		}
 		regularInput = interfaces.StepActivityInputWithAttemptContext(
 			regularInput,
 			previousAttempts,
-			localFailure.GetFirstAttemptTimestamp(),
+			firstAttemptTimestamp,
 		)
 		options.RetryPolicy = remainingPolicy
 		regularCtx := workflow.WithActivityOptions(wfCtx, temporalActivityOptions(options))
@@ -528,17 +530,14 @@ func temporalLocalStepActivityError(
 		return nil, nil, false
 	}
 	if !applicationError.HasDetails() {
-		panic("Temporal local Step failure details required")
+		return nil, nil, false
 	}
 	failure, detailErr := decodeTemporalLocalStepErrorDetails(applicationError)
 	if detailErr != nil {
-		panic(fmt.Sprintf("decode Temporal local Step failure details: %v", detailErr))
+		return nil, nil, false
 	}
-	if failure.GetActivityError() == nil {
-		panic("Temporal local Step activity error required")
-	}
-	if failure.GetAttempt() <= 0 {
-		panic("Temporal local Step failure attempt required")
+	if failure.GetActivityError() == nil || failure.GetAttempt() <= 0 {
+		return nil, nil, false
 	}
 	return applicationError, failure, true
 }

--- a/web/README.md
+++ b/web/README.md
@@ -76,6 +76,7 @@ Flow continued, RPC, Step decision, or recovery event that scheduled it.
 Selecting the first event reveals that source link; selecting a
 WaitFor event also reveals its outgoing WaitFor-to-Execute link.
 Step graph nodes separate WaitFor and Execute with distinct colors, channel names, condition icons, and individual event details.
+Persisted Step decisions add planned graph branches. A selector-matched branch without a Step event appears Canceled with no execution ID.
 SubFlow conditions appear as linked leaf nodes and compact WaitFor cards. Running
 and terminal nodes display and link by their generated Flow ID. Original WaitFor
 events retain the configured reuse policy; continue-as-new state retains only

--- a/web/app/flows/details/EventDetails.test.tsx
+++ b/web/app/flows/details/EventDetails.test.tsx
@@ -82,6 +82,26 @@ describe('selected step event details', () => {
     expect(markup).not.toContain('previousAttempt');
   });
 
+  it('renders Flow-wide and sibling cancellation selectors with next Steps', () => {
+    const event = executeEvent(2);
+    event.payload.output = {
+      stepDecision: {
+        nextSteps: [{ stepType: 'complete' }],
+        cancelStepTypes: ['global-loser', 'shared-loser'],
+        cancelSiblingStepTypes: ['sibling-loser'],
+      },
+    };
+    const markup = renderDetails(event);
+
+    expect(markup).toContain('complete');
+    expect(markup).toContain('Cancel Step executions');
+    expect(markup).toContain('Entire Flow');
+    expect(markup).toContain('global-loser, shared-loser');
+    expect(markup).toContain('Cancel sibling Step executions');
+    expect(markup).toContain('Same parent execution');
+    expect(markup).toContain('sibling-loser');
+  });
+
   it('renders the latest sync failure in context', () => {
     const event = executeEvent(1);
     event.payload.context = {

--- a/web/app/flows/details/EventDetails.tsx
+++ b/web/app/flows/details/EventDetails.tsx
@@ -581,8 +581,9 @@ function StepDecisionContent({ value }: { value: unknown }) {
   if (!hasData(decision)) return null;
   const close = asData(decision.closeDecision);
   return (
-    <>
+    <div className="step-decision-content">
       <StepMovements values={decision.nextSteps} showFrom={false} />
+      <CancellationSelectors decision={decision} />
       {hasData(close) && (
         <div className="semantic-record decision-record">
           <strong>{closeDecisionTypeLabel(close.closeDecisionType)}</strong>
@@ -593,7 +594,35 @@ function StepDecisionContent({ value }: { value: unknown }) {
           <ValueBlock label="Close input" value={close.closeInput} />
         </div>
       )}
-    </>
+    </div>
+  );
+}
+
+function CancellationSelectors({ decision }: { decision: Data }) {
+  const flowStepTypes = listText(decision.cancelStepTypes);
+  const siblingStepTypes = listText(decision.cancelSiblingStepTypes);
+  if (!flowStepTypes && !siblingStepTypes) return null;
+  return (
+    <div className="semantic-records">
+      {flowStepTypes && (
+        <div className="semantic-record decision-record">
+          <strong>Cancel Step executions</strong>
+          <Fields values={[
+            ['Scope', 'Entire Flow'],
+            ['Step types', flowStepTypes],
+          ]} />
+        </div>
+      )}
+      {siblingStepTypes && (
+        <div className="semantic-record decision-record">
+          <strong>Cancel sibling Step executions</strong>
+          <Fields values={[
+            ['Scope', 'Same parent execution'],
+            ['Step types', siblingStepTypes],
+          ]} />
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -28,7 +28,7 @@ interface StepNodeData extends Record<string, unknown> {
   model: StepGraphNode;
 }
 
-type MethodStatus = 'Started' | 'Waiting' | 'Running' | 'Pending' | 'Completed' | 'Failed' | 'Not started';
+type MethodStatus = 'Started' | 'Waiting' | 'Running' | 'Pending' | 'Completed' | 'Failed' | 'Canceled' | 'Not started';
 
 function waitingCondition(node: StepGraphNode): Record<string, unknown> {
   const output = node.waitFor?.payload.output;
@@ -55,7 +55,7 @@ function channelNames(condition: Record<string, unknown>): string[] {
 }
 
 function skipsWaitFor(node: StepGraphNode): boolean {
-  const options = node.active?.movement?.stepOptions;
+  const options = node.active?.movement?.stepOptions ?? node.movement?.stepOptions;
   return Boolean(options && typeof options === 'object' && (options as Record<string, unknown>).skipWaitFor === true);
 }
 
@@ -91,6 +91,7 @@ function waitForStatus(node: StepGraphNode): MethodStatus {
   if (node.active?.phase === 'Waiting') return 'Waiting';
   if (node.waitFor) return 'Started';
   if (node.active) return 'Running';
+  if (node.status === 'Canceled') return 'Canceled';
   return 'Not started';
 }
 
@@ -99,6 +100,7 @@ function executeStatus(node: StepGraphNode): MethodStatus {
   if (node.pendingExecute) return 'Pending';
   if (node.execute) return 'Completed';
   if (node.active?.phase === 'Active' && node.waitFor) return 'Running';
+  if (node.status === 'Canceled') return 'Canceled';
   return 'Not started';
 }
 
@@ -147,14 +149,21 @@ function StepNodeLabel({
   const channelSummary = channels.length > 0 ? channels.join(', ') : `${channelCount} channel${channelCount === 1 ? '' : 's'}`;
   const showWaitFor = Boolean(
     node.waitFor || node.pendingWaitFor
-      || (!skipsWaitFor(node) && node.active && !node.execute),
+      || (!skipsWaitFor(node) && (node.active || node.isPlanned) && !node.execute),
   );
   return (
     <div className="graph-step-label">
       <div className="graph-step-heading">
         <span>{node.status}</span>
         <b>{node.label}</b>
-        <code>{node.id}</code>
+        <code title={node.isPlanned
+          ? node.status === 'Canceled'
+            ? 'Canceled before a Step event was recorded'
+            : 'No Step event has been recorded'
+          : undefined}
+        >
+          {node.isPlanned ? 'Execution ID unavailable' : node.id}
+        </code>
       </div>
       <div className="graph-methods">
         {showWaitFor && (
@@ -281,7 +290,7 @@ export function StepGraph({
           <h2>Step graph</h2>
         </div>
         <div className="graph-legend">
-          {['Active', 'Waiting', 'Pending', 'Completed', 'Failed'].map((status) => (
+          {['Active', 'Waiting', 'Pending', 'Completed', 'Failed', 'Canceled'].map((status) => (
             <span key={status}><i className={`legend-${status.toLowerCase()}`} />{status}</span>
           ))}
           <span><i className="legend-subflow" />SubFlow</span>

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -8,7 +8,7 @@
 
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Background,
@@ -235,6 +235,7 @@ export function StepGraph({
   selectedEvent: FlowHistoryEvent | null;
   onSelectEvent: (event: FlowHistoryEvent | null) => void;
 }) {
+  const [isMiniMapExpanded, setIsMiniMapExpanded] = useState(false);
   const graph = useMemo(
     () => buildStepGraph(events, state?.activeStepExecutions ?? [], flowId),
     [events, flowId, state],
@@ -312,7 +313,28 @@ export function StepGraph({
         >
           <Background gap={22} size={1} color="#dfe7e5" />
           <Controls position="top-right" />
-          <MiniMap pannable zoomable nodeStrokeWidth={2} />
+          <div className={`graph-minimap-shell${isMiniMapExpanded ? ' expanded' : ''}`}>
+            {isMiniMapExpanded && (
+              <MiniMap
+                ariaLabel="Step graph Mini Map"
+                className="graph-minimap"
+                pannable
+                position="top-left"
+                zoomable
+                nodeStrokeWidth={2}
+              />
+            )}
+            <button
+              aria-expanded={isMiniMapExpanded}
+              aria-label={isMiniMapExpanded ? 'Collapse Mini Map' : 'Expand Mini Map'}
+              className="graph-minimap-toggle"
+              onClick={() => setIsMiniMapExpanded((expanded) => !expanded)}
+              title={isMiniMapExpanded ? 'Collapse Mini Map' : 'Expand Mini Map'}
+              type="button"
+            >
+              {isMiniMapExpanded ? <span aria-hidden="true">×</span> : 'Mini Map'}
+            </button>
+          </div>
         </ReactFlow>
       </div>
       {selectedEvent && (

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1116,6 +1116,12 @@ pre {
   gap: 7px;
 }
 
+.step-decision-content {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
 .semantic-record {
   min-width: 0;
   padding: 8px;
@@ -2042,10 +2048,62 @@ pre {
   background: #f9fbfa;
 }
 
-.graph-canvas .react-flow__minimap {
+.graph-minimap-shell {
+  position: absolute;
+  right: 12px;
+  bottom: 26px;
+  z-index: 5;
+  pointer-events: none;
+}
+
+.graph-minimap-shell.expanded {
+  width: 200px;
+  height: 150px;
+}
+
+.graph-canvas .react-flow__minimap.graph-minimap {
+  top: 0;
+  left: 0;
+  margin: 0;
   border: 1px solid #c8d4d1;
   border-radius: 8px;
   background: rgba(249, 251, 250, 0.94);
+}
+
+.graph-minimap-toggle {
+  min-height: 34px;
+  padding: 7px 11px;
+  border: 1px solid #b8c6c2;
+  border-radius: 7px;
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 3px 10px rgba(28, 51, 45, 0.14);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 750;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.graph-minimap-toggle:hover {
+  border-color: var(--brand);
+  color: var(--brand-dark);
+}
+
+.graph-minimap-toggle:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.graph-minimap-shell.expanded .graph-minimap-toggle {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  min-width: 30px;
+  min-height: 30px;
+  padding: 0;
+  font-size: 18px;
+  line-height: 1;
 }
 
 .react-flow__node.step-flow-node {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2025,6 +2025,10 @@ pre {
   background: #c95252;
 }
 
+.legend-canceled {
+  background: #7b8581;
+}
+
 .legend-subflow {
   border: 1px solid #4f7ba7;
   background: #f2f7fb;
@@ -2075,6 +2079,11 @@ pre {
 
 .react-flow__node.node-failed {
   border-color: #c95252;
+}
+
+.react-flow__node.node-canceled {
+  border-color: #7b8581;
+  background: #f4f6f5;
 }
 
 .react-flow__node.node-source {
@@ -2349,6 +2358,10 @@ pre {
 
 .graph-method-failed strong {
   color: var(--danger);
+}
+
+.graph-method-canceled strong {
+  color: #626c68;
 }
 
 .graph-method-pending strong {

--- a/web/lib/graph.test.ts
+++ b/web/lib/graph.test.ts
@@ -133,6 +133,175 @@ describe('step graph', () => {
     expect(node?.pendingExecute?.type).toBe('StepExecutePending');
   });
 
+  it('shows a planned branch canceled before a Step event was recorded', () => {
+    const graph = buildStepGraph([
+      event(1, 'StepExecuteCompleted', {
+        stepExecutionId: 'Root-1',
+        fromStepExecutionId: '__start__',
+        stepType: 'Root',
+      }, {
+        output: { stepDecision: { nextSteps: [{
+          stepType: 'Winner',
+          fromStepExecutionIdInternalOnly: 'Root-1',
+        }, {
+          stepType: 'Loser',
+          fromStepExecutionIdInternalOnly: 'Root-1',
+          stepOptions: { skipWaitFor: true },
+        }] } },
+      }),
+      event(2, 'StepExecuteCompleted', {
+        stepExecutionId: 'Winner-1',
+        fromStepExecutionId: 'Root-1',
+        stepType: 'Winner',
+      }, {
+        output: { stepDecision: { cancelStepTypes: ['Loser'] } },
+      }),
+      event(3, 'FlowClosed'),
+    ]);
+
+    expect(graph.nodes.filter((node) => node.stepType === 'Winner')).toHaveLength(1);
+    const loser = graph.nodes.find((node) => node.stepType === 'Loser');
+    expect(loser).toMatchObject({
+      status: 'Canceled',
+      fromStepExecutionId: 'Root-1',
+      isPlanned: true,
+    });
+    expect(graph.edges).toContainEqual({
+      id: `Root-1->${loser?.id}`,
+      source: 'Root-1',
+      target: loser?.id,
+    });
+  });
+
+  it('excludes next Steps created by the canceling decision from its snapshot', () => {
+    const graph = buildStepGraph([
+      event(1, 'StepExecuteCompleted', {
+        stepExecutionId: 'Root-1',
+        fromStepExecutionId: '__start__',
+        stepType: 'Root',
+      }, {
+        output: { stepDecision: { nextSteps: [{
+          stepType: 'Worker',
+          fromStepExecutionIdInternalOnly: 'Root-1',
+        }, {
+          stepType: 'Worker',
+          fromStepExecutionIdInternalOnly: 'Root-1',
+        }, {
+          stepType: 'Winner',
+          fromStepExecutionIdInternalOnly: 'Root-1',
+        }] } },
+      }),
+      event(2, 'StepExecuteCompleted', {
+        stepExecutionId: 'Worker-1',
+        fromStepExecutionId: 'Root-1',
+        stepType: 'Worker',
+      }),
+      event(3, 'StepExecuteCompleted', {
+        stepExecutionId: 'Winner-1',
+        fromStepExecutionId: 'Root-1',
+        stepType: 'Winner',
+      }, {
+        output: { stepDecision: {
+          cancelStepTypes: ['Worker'],
+          nextSteps: [{
+            stepType: 'Worker',
+            fromStepExecutionIdInternalOnly: 'Winner-1',
+          }],
+        } },
+      }),
+    ]);
+
+    const workers = graph.nodes.filter((node) => node.stepType === 'Worker');
+    expect(workers).toHaveLength(3);
+    expect(workers.find((node) => node.id === 'Worker-1')?.status).toBe('Completed');
+    expect(workers.find((node) => node.isPlanned
+      && node.fromStepExecutionId === 'Root-1')?.status).toBe('Canceled');
+    expect(workers.find((node) => node.fromStepExecutionId === 'Winner-1')?.status).toBe('Pending');
+  });
+
+  it('limits sibling cancellation to the canceling Step lineage', () => {
+    const graph = buildStepGraph([
+      event(1, 'StepExecuteCompleted', {
+        stepExecutionId: 'Root-1',
+        fromStepExecutionId: '__start__',
+        stepType: 'Root',
+      }, {
+        output: { stepDecision: { nextSteps: [{
+          stepType: 'ParentA',
+          fromStepExecutionIdInternalOnly: 'Root-1',
+        }, {
+          stepType: 'ParentB',
+          fromStepExecutionIdInternalOnly: 'Root-1',
+        }] } },
+      }),
+      event(2, 'StepExecuteCompleted', {
+        stepExecutionId: 'ParentA-1',
+        fromStepExecutionId: 'Root-1',
+        stepType: 'ParentA',
+      }, {
+        output: { stepDecision: { nextSteps: [{
+          stepType: 'Worker',
+          fromStepExecutionIdInternalOnly: 'ParentA-1',
+        }, {
+          stepType: 'Winner',
+          fromStepExecutionIdInternalOnly: 'ParentA-1',
+        }] } },
+      }),
+      event(3, 'StepExecuteCompleted', {
+        stepExecutionId: 'ParentB-1',
+        fromStepExecutionId: 'Root-1',
+        stepType: 'ParentB',
+      }, {
+        output: { stepDecision: { nextSteps: [{
+          stepType: 'Worker',
+          fromStepExecutionIdInternalOnly: 'ParentB-1',
+        }] } },
+      }),
+      event(4, 'StepExecuteCompleted', {
+        stepExecutionId: 'Winner-1',
+        fromStepExecutionId: 'ParentA-1',
+        stepType: 'Winner',
+      }, {
+        output: { stepDecision: { cancelSiblingStepTypes: ['Worker'] } },
+      }),
+    ]);
+
+    const workers = graph.nodes.filter((node) => node.stepType === 'Worker');
+    expect(workers.find((node) => node.fromStepExecutionId === 'ParentA-1')?.status).toBe('Canceled');
+    expect(workers.find((node) => node.fromStepExecutionId === 'ParentB-1')?.status).toBe('Pending');
+  });
+
+  it('keeps cancellation ahead of a stale active-state overlay', () => {
+    const graph = buildStepGraph([
+      event(1, 'StepWaitForCompleted', {
+        stepExecutionId: 'Worker-1',
+        fromStepExecutionId: 'Root-1',
+        stepType: 'Worker',
+      }),
+      event(2, 'StepExecuteCompleted', {
+        stepExecutionId: 'Winner-1',
+        fromStepExecutionId: 'Root-1',
+        stepType: 'Winner',
+      }, {
+        output: { stepDecision: { cancelStepTypes: ['Worker'] } },
+      }),
+    ], [{
+      stepExecutionId: 'Worker-1',
+      fromStepExecutionId: 'Root-1',
+      stepType: 'Worker',
+      phase: 'Active',
+      stepExecutionLocals: [],
+      timers: [],
+    }]);
+
+    const worker = graph.nodes.find((node) => node.id === 'Worker-1');
+    expect(worker).toMatchObject({
+      status: 'Canceled',
+      active: undefined,
+    });
+    expect(worker?.isPlanned).toBeUndefined();
+  });
+
   it('creates linked SubFlow leaf nodes with deterministic identity', () => {
     const graph = buildStepGraph([
       event(1, 'StepWaitForCompleted', {

--- a/web/lib/graph.ts
+++ b/web/lib/graph.ts
@@ -27,6 +27,12 @@ const stepEventTypes = new Set([
   'StepExecutePending',
 ]);
 
+const cancellableStatuses = new Set<StepGraphNode['status']>([
+  'Active',
+  'Waiting',
+  'Pending',
+]);
+
 function stepContext(event: FlowHistoryEvent): Record<string, unknown> {
   const value = event.payload.context;
   return value && typeof value === 'object' ? value as Record<string, unknown> : {};
@@ -49,6 +55,7 @@ export function buildStepGraph(
   parentFlowID = '',
 ): { nodes: StepGraphNode[]; edges: StepGraphEdge[] } {
   const nodes = new Map<string, StepGraphNode>();
+  const plannedNodesByLineage = new Map<string, string[]>();
   const closingStepExecutionIDs = new Set<string>();
   nodes.set(START_NODE_ID, {
     id: START_NODE_ID,
@@ -59,46 +66,42 @@ export function buildStepGraph(
   });
 
   for (const event of events) {
-    if (!stepEventTypes.has(event.type)) continue;
-    const info = stepContext(event);
-    const id = stringField(info.stepExecutionId);
-    if (!id) continue;
-    const existing = nodes.get(id);
-    const failed = event.type.endsWith('Failed');
-    const pending = event.type.endsWith('Pending');
-    const waitFor = event.type.startsWith('StepWaitFor') && !pending ? event : existing?.waitFor;
-    const execute = event.type.startsWith('StepExecute') && !pending ? event : existing?.execute;
-    if (event.type === 'StepExecuteCompleted' && hasCloseDecision(event)) {
-      closingStepExecutionIDs.add(id);
+    if (stepEventTypes.has(event.type)) {
+      addStepEvent(nodes, plannedNodesByLineage, event);
+      const stepExecutionID = stringField(stepContext(event).stepExecutionId);
+      if (stepExecutionID && event.type === 'StepExecuteCompleted' && hasCloseDecision(event)) {
+        closingStepExecutionIDs.add(stepExecutionID);
+      }
     }
-    nodes.set(id, {
-      id,
-      label: stringField(info.stepType) || id,
-      kind: 'step',
-      status: pending ? 'Pending' : failed ? 'Failed' : execute ? 'Completed' : 'Waiting',
-      stepType: stringField(info.stepType),
-      fromStepExecutionId: stringField(info.fromStepExecutionId) || START_NODE_ID,
-      waitFor,
-      execute,
-      pendingWaitFor: event.type === 'StepWaitForPending' ? event : existing?.pendingWaitFor,
-      pendingExecute: event.type === 'StepExecutePending' ? event : existing?.pendingExecute,
-    });
+    const decision = stepDecision(event);
+    if (!decision) continue;
+    cancelMatchingNodes(nodes, decision, stringField(stepContext(event).fromStepExecutionId));
+    addPlannedNodes(nodes, plannedNodesByLineage, event, decision);
   }
 
   for (const active of activeSteps) {
-    const existing = nodes.get(active.stepExecutionId);
+    const existing = nodes.get(active.stepExecutionId)
+      ?? takePlannedNode(
+        nodes,
+        plannedNodesByLineage,
+        active.fromStepExecutionId || START_NODE_ID,
+        active.stepType,
+      );
+    if (existing?.isPlanned) nodes.delete(existing.id);
+    const isCanceled = existing?.status === 'Canceled';
     nodes.set(active.stepExecutionId, {
       id: active.stepExecutionId,
       label: active.stepType || active.stepExecutionId,
       kind: 'step',
-      status: active.phase === 'Waiting' ? 'Waiting' : 'Active',
+      status: isCanceled ? 'Canceled' : active.phase === 'Waiting' ? 'Waiting' : 'Active',
       stepType: active.stepType,
       fromStepExecutionId: active.fromStepExecutionId || START_NODE_ID,
+      movement: existing?.movement ?? active.movement,
       waitFor: existing?.waitFor,
       execute: existing?.execute,
       pendingWaitFor: existing?.pendingWaitFor,
       pendingExecute: existing?.pendingExecute,
-      active,
+      active: isCanceled ? undefined : active,
     });
   }
 
@@ -157,6 +160,131 @@ export function buildStepGraph(
   }
 
   return { nodes: [...nodes.values()], edges };
+}
+
+function addStepEvent(
+  nodes: Map<string, StepGraphNode>,
+  plannedNodesByLineage: Map<string, string[]>,
+  event: FlowHistoryEvent,
+): void {
+  const info = stepContext(event);
+  const id = stringField(info.stepExecutionId);
+  if (!id) return;
+  const stepType = stringField(info.stepType);
+  const fromStepExecutionID = stringField(info.fromStepExecutionId) || START_NODE_ID;
+  const existing = nodes.get(id)
+    ?? takePlannedNode(nodes, plannedNodesByLineage, fromStepExecutionID, stepType);
+  if (existing?.isPlanned) nodes.delete(existing.id);
+  const failed = event.type.endsWith('Failed');
+  const pending = event.type.endsWith('Pending');
+  const waitFor = event.type.startsWith('StepWaitFor') && !pending ? event : existing?.waitFor;
+  const execute = event.type.startsWith('StepExecute') && !pending ? event : existing?.execute;
+  const status = existing?.status === 'Canceled'
+    ? 'Canceled'
+    : pending ? 'Pending' : failed ? 'Failed' : execute ? 'Completed' : 'Waiting';
+  nodes.set(id, {
+    id,
+    label: stepType || id,
+    kind: 'step',
+    status,
+    stepType,
+    fromStepExecutionId: fromStepExecutionID,
+    movement: existing?.movement,
+    waitFor,
+    execute,
+    pendingWaitFor: event.type === 'StepWaitForPending' ? event : existing?.pendingWaitFor,
+    pendingExecute: event.type === 'StepExecutePending' ? event : existing?.pendingExecute,
+  });
+}
+
+function addPlannedNodes(
+  nodes: Map<string, StepGraphNode>,
+  plannedNodesByLineage: Map<string, string[]>,
+  event: FlowHistoryEvent,
+  decision: Record<string, unknown>,
+): void {
+  const producerID = stringField(stepContext(event).stepExecutionId);
+  const movements = Array.isArray(decision.nextSteps) ? decision.nextSteps : [];
+  movements.forEach((rawMovement, index) => {
+    if (!rawMovement || typeof rawMovement !== 'object') return;
+    const movement = rawMovement as Record<string, unknown>;
+    const stepType = stringField(movement.stepType);
+    if (!stepType) return;
+    const fromStepExecutionID = stringField(movement.fromStepExecutionIdInternalOnly)
+      || stringField(movement.fromStepExecutionId)
+      || producerID
+      || START_NODE_ID;
+    const id = `__planned:${event.eventId}:${index}`;
+    nodes.set(id, {
+      id,
+      label: stepType,
+      kind: 'step',
+      status: 'Pending',
+      stepType,
+      fromStepExecutionId: fromStepExecutionID,
+      movement,
+      isPlanned: true,
+    });
+    const key = lineageKey(fromStepExecutionID, stepType);
+    plannedNodesByLineage.set(key, [...(plannedNodesByLineage.get(key) ?? []), id]);
+  });
+}
+
+function cancelMatchingNodes(
+  nodes: Map<string, StepGraphNode>,
+  decision: Record<string, unknown>,
+  producerFromStepExecutionID: string,
+): void {
+  const globalStepTypes = stringSet(decision.cancelStepTypes);
+  const siblingStepTypes = stringSet(decision.cancelSiblingStepTypes);
+  if (globalStepTypes.size === 0 && siblingStepTypes.size === 0) return;
+  for (const [id, node] of nodes) {
+    if (node.kind !== 'step' || !cancellableStatuses.has(node.status)) continue;
+    const isGlobalMatch = globalStepTypes.has(node.stepType ?? '');
+    const isSiblingMatch = siblingStepTypes.has(node.stepType ?? '')
+      && node.fromStepExecutionId === producerFromStepExecutionID;
+    if (isGlobalMatch || isSiblingMatch) {
+      nodes.set(id, { ...node, status: 'Canceled', active: undefined });
+    }
+  }
+}
+
+function takePlannedNode(
+  nodes: Map<string, StepGraphNode>,
+  plannedNodesByLineage: Map<string, string[]>,
+  fromStepExecutionID: string,
+  stepType: string,
+): StepGraphNode | undefined {
+  const key = lineageKey(fromStepExecutionID, stepType);
+  const ids = plannedNodesByLineage.get(key) ?? [];
+  const index = ids.findIndex((id) => {
+    const node = nodes.get(id);
+    return node?.isPlanned === true && node.status !== 'Canceled';
+  });
+  if (index < 0) return undefined;
+  const [id] = ids.splice(index, 1);
+  if (ids.length === 0) plannedNodesByLineage.delete(key);
+  return nodes.get(id);
+}
+
+function lineageKey(fromStepExecutionID: string, stepType: string): string {
+  return `${fromStepExecutionID}\u0000${stepType}`;
+}
+
+function stringSet(value: unknown): Set<string> {
+  if (!Array.isArray(value)) return new Set();
+  return new Set(value.filter((entry): entry is string => typeof entry === 'string'));
+}
+
+function stepDecision(event: FlowHistoryEvent): Record<string, unknown> | undefined {
+  const container = event.type === 'StepExecuteCompleted'
+    ? event.payload.output
+    : event.type === 'RpcExecutionCompleted' ? event.payload : undefined;
+  if (!container || typeof container !== 'object') return undefined;
+  const decision = (container as Record<string, unknown>).stepDecision;
+  return decision && typeof decision === 'object'
+    ? decision as Record<string, unknown>
+    : undefined;
 }
 
 function addSubFlowNodes(

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -103,10 +103,12 @@ export interface StepGraphNode {
   id: string;
   label: string;
   kind: 'source' | 'step' | 'subflow' | 'terminal';
-  status: 'Source' | 'Active' | 'Waiting' | 'Pending' | 'Completed' | 'Failed' | 'Terminal';
+  status: 'Source' | 'Active' | 'Waiting' | 'Pending' | 'Completed' | 'Failed' | 'Canceled' | 'Terminal';
   previousRunId?: string;
   stepType?: string;
   fromStepExecutionId?: string;
+  movement?: Record<string, unknown>;
+  isPlanned?: boolean;
   waitFor?: FlowHistoryEvent;
   execute?: FlowHistoryEvent;
   pendingWaitFor?: FlowHistoryEvent;


### PR DESCRIPTION
## Summary

- add Java SDK integration coverage for global, sibling, heartbeat, no-heartbeat, local, and timeout cancellation paths
- preserve the regular-activity fallback contract when an ASYNC local activity times out
- show canceled planned Step branches in the graph, including executions canceled before a Step event exists
- collapse the Mini Map by default and expose global and sibling cancellation selectors in Step decision details

## Rationale

PR #265 introduced Java Step execution cancellation. These follow-ups cover real worker/backend behavior, fix the local-timeout fallback found by that coverage, and make cancellation outcomes understandable in Dex Web.

## User impact

Java users get integration-tested cooperative cancellation and heartbeat behavior. ASYNC Steps still fall back after local activity timeouts, and Dex Web shows canceled branches and the selectors that caused cancellation.

## Validation

- `make -C server unitTests`
- `npm run check` in `web/`
- `npm run build` in `web/`
- `make copyright-check`
- browser verification against the local Temporal cancellation fixture
