### PR TITLE
Add step cancellation to Go, Python, TypeScript, and Rust SDKs

### DIFF
--- a/docs/content/capabilities/advanced/step-execution-cancellation.mdx
+++ b/docs/content/capabilities/advanced/step-execution-cancellation.mdx
@@ -11,10 +11,12 @@ replica, or the first branch that reaches quorum. Once the result is durable,
 the remaining work should stop consuming capacity and must not produce a late
 decision that changes the Flow.
 
-## Java example
+## SDK examples
 
 Return the winner's normal next action and select losing Step types in the same
-immutable decision:
+decision. Each SDK keeps its language's normal builder style.
+
+### Java
 
 ```java
 @Override
@@ -25,14 +27,79 @@ public StepDecision execute(Context context, Quote quote) {
 }
 ```
 
-`withCancelingSteps(...)` selects all queued or active executions of the exact
-registered Step types in the current Flow. `withCancelingSiblingSteps(...)`
-selects only targets with the same `Context.getFromStepExecutionId()` as the
-winner. Sibling selection is useful when several independent fan-outs reuse the
-same Step classes.
+### Go
 
-An RPC can cancel all executions of selected Step types with
-`RPCResult.withCancelingSteps(...)`:
+```go
+func (Winner) Execute(
+    ctx dex.Context,
+    quote Quote,
+) (*dex.StepDecision, error) {
+    return dex.GoTo(RecordQuote, quote).
+        CancelSiblingSteps(CarrierA, CarrierB).
+        CancelSteps(GlobalQuoteTimeout), nil
+}
+```
+
+### Python
+
+```python
+def execute(self, context: dex.Context, quote: Quote) -> dex.StepDecision:
+    return (
+        dex.go_to(self.record_quote, quote)
+        .with_canceling_sibling_steps(self.carrier_a, self.carrier_b)
+        .with_canceling_steps(self.global_quote_timeout)
+    )
+```
+
+### TypeScript
+
+```typescript
+execute(_context: Context, quote: Quote): StepDecision {
+  return withCancelingSteps(
+    withCancelingSiblingSteps(
+      goTo(this.recordQuote, quote),
+      this.carrierA,
+      this.carrierB,
+    ),
+    this.globalQuoteTimeout,
+  );
+}
+```
+
+### Rust
+
+```rust
+fn execute(
+    &self,
+    _context: &mut Context,
+    quote: Quote,
+) -> HandlerResult<StepDecision> {
+    Ok(StepDecision::go_to(&self.record_quote, quote)
+        .cancel_sibling_step(&self.carrier_a)
+        .cancel_sibling_step(&self.carrier_b)
+        .cancel_step(&self.global_quote_timeout))
+}
+```
+
+Use the first method to select all queued or active executions of a registered
+Step type. Use the sibling method when the target must also have the same
+`fromStepExecutionId` as the winner.
+
+| SDK | All current executions | Same-source executions |
+| --- | --- | --- |
+| Java | `withCancelingSteps` | `withCancelingSiblingSteps` |
+| Go | `CancelSteps` | `CancelSiblingSteps` |
+| Python | `with_canceling_steps` | `with_canceling_sibling_steps` |
+| TypeScript | `withCancelingSteps` | `withCancelingSiblingSteps` |
+| Rust | `cancel_step` | `cancel_sibling_step` |
+
+Sibling selection is useful when independent fan-outs reuse the same Step
+types.
+
+An RPC can cancel all executions of selected Step types. Java uses
+`RPCResult.withCancelingSteps(...)`; Go, Python, TypeScript, and Rust expose the
+same Flow-wide capability as `CancelSteps`, `with_canceling_steps`, the
+`cancelingSteps` result field, and `cancel_step` respectively:
 
 ```java
 @RPC(name = "acceptQuote")
@@ -49,9 +116,12 @@ same RPC name do not share an invocation-scoped Step execution lineage, so
 treating their Steps as siblings could cancel unrelated work.
 
 Long-running regular Steps should use a heartbeat timeout so cancellation
-reaches the Java Worker promptly. Dex then cancels the handler task with
-`Future.cancel(true)`, which interrupts the handler thread. Blocking handlers
-should return when interrupted:
+reaches the Worker promptly. The option is `heartbeatTimeout` in Java,
+`HeartbeatTimeout` in Go, `heartbeat_timeout` in Python,
+`heartbeatTimeoutMs` in TypeScript, and `heartbeat_timeout` in Rust.
+
+Java cancels the handler task with `Future.cancel(true)`, which interrupts the
+handler thread. Blocking handlers should return when interrupted:
 
 ```java
 private final StepOptions options = StepOptions.newBuilder()
@@ -74,6 +144,13 @@ public StepDecision execute(Context context, Job job) {
 CPU-bound or batch-oriented handlers may additionally check
 `Context.isCancellationRequested()` at natural work boundaries. They do not
 need to poll continuously.
+
+Go handlers observe the standard `Context.Done()` channel. Python's
+`AsyncWorker` cancels the asyncio task and exposes
+`Context.is_cancellation_requested()` for synchronous or batch work.
+TypeScript aborts `Context.cancellationSignal`, which can be passed directly to
+abort-aware APIs. Rust handlers can block in `Context::wait_for_cancellation()`
+or inspect `Context::is_cancelled()` at natural work boundaries.
 
 ## ASYNC local activities and timers
 

--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -2092,6 +2092,19 @@ func ForceCompleteIfChannelsEmpty(
 	channels []ChannelDef,
 	otherwise ...StepMovement,
 ) *StepDecision
+
+type StepSelector interface {
+	GetStepType() string
+	GetStepOptions() *StepOptions
+}
+
+func (decision *StepDecision) CancelSteps(
+	steps ...StepSelector,
+) *StepDecision
+
+func (decision *StepDecision) CancelSiblingSteps(
+	steps ...StepSelector,
+) *StepDecision
 ```
 
 Rules enforced by construction or Phase 3 validation:
@@ -2108,6 +2121,13 @@ Rules enforced by construction or Phase 3 validation:
 
 An RPC may return optional next-step movements but cannot close the flow.
 Execute must return a valid, non-nil, non-empty `StepDecision`.
+
+Cancellation selectors are resolved after the successful execution commits and
+before its next Steps are queued. `CancelSteps` selects the current Flow;
+`CancelSiblingSteps` additionally requires matching
+`Context.FromStepExecutionID()`. Repeated calls form a stable-order union, and a
+Flow-wide selector supersedes the same sibling selector. Registered identity is
+validated when the Worker maps the result.
 
 ### Step options
 
@@ -2159,6 +2179,7 @@ func ProceedToOnExecuteFailure[IN any](
 type StepOptions struct {
 	WaitForMethodTimeout  time.Duration
 	ExecuteMethodTimeout  time.Duration
+	HeartbeatTimeout      time.Duration
 	WaitForRetry    *RetryPolicy
 	ExecuteRetry    *RetryPolicy
 	WaitForFailure  WaitForFailurePolicy
@@ -2174,6 +2195,9 @@ The typed constructor prevents callers from placing an erased step inside
 `ExecuteFailure`. Phase 3 validates that its target consumes the failed step's
 unchanged input, because the server reuses that input. `StepOptions` does not
 expose physical attribute keys, server-owned fields, or a generic skip flag.
+`HeartbeatTimeout` applies to regular WaitFor and Execute activities. Zero
+disables it; positive values require whole seconds in the signed int32 range.
+Local activities ignore it, and an asynchronous regular fallback uses it.
 
 ### RPC
 
@@ -2186,9 +2210,14 @@ type RPC[IN, OUT any] func(
 ) (*RPCResult[OUT], error)
 
 type RPCResult[OUT any] struct {
-	Output    OUT
-	NextSteps []StepMovement
+	Output         OUT
+	NextSteps      []StepMovement
+	CancelingSteps []StepSelector
 }
+
+func (result *RPCResult[OUT]) CancelSteps(
+	steps ...StepSelector,
+) *RPCResult[OUT]
 ```
 
 Application code defines a Flow method with that signature:
@@ -2213,7 +2242,9 @@ name as the durable RPC name. Package-level functions are not registrable RPCs.
 
 RPC methods use typed attributes/channels and `Context.RecordEvent`. They do not
 receive a legacy `Persistence` or `Communication` argument. RPC cannot use
-step-execution locals or return a close decision.
+step-execution locals or return a close decision. It cannot use the sibling
+selector because an RPC has no Step execution lineage. Its Flow-wide selector
+is resolved before the same result's Next Steps are queued.
 
 ### Public client types and façade
 

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -95,6 +95,49 @@ attempts, total duration, and 1-based attempt numbers. Fallback starts
 immediately; later regular retries continue the backoff sequence at the
 cumulative attempt.
 
+### Canceling Step executions
+
+A successful Step can cancel queued or active executions while continuing with
+its normal decision:
+
+```go
+return dex.GoTo(RecordQuote, quote).
+	CancelSiblingSteps(CarrierA, CarrierB).
+	CancelSteps(GlobalQuoteTimeout), nil
+```
+
+`CancelSteps` selects every current execution of each registered Step type.
+`CancelSiblingSteps` selects only executions whose
+`Context.FromStepExecutionID()` matches the current execution. Repeated calls
+form a union, and a Flow-wide selector wins for the same Step type. The Worker
+rejects nil, mismatched, or unregistered selectors as invalid Step results.
+
+Dex resolves one snapshot after the current execution succeeds. Completed,
+already-canceled, and absent targets are no-ops. Next Steps created by the same
+decision are not in that snapshot. Dex immediately applies the next or close
+action without waiting for target handlers; late decisions, writes, retries,
+and recovery Steps are discarded.
+
+Configure `StepOptions.HeartbeatTimeout` on long-running regular Steps so
+cancellation reaches the Worker promptly. The same setting applies to WaitFor
+and Execute; local activities ignore it, while an ASYNC fallback uses it. Zero
+disables heartbeats, and positive values must be whole seconds within the
+signed int32 range. Go handlers receive cancellation through the standard
+`Context.Done()` channel:
+
+```go
+select {
+case <-ctx.Done():
+	return nil, ctx.Err()
+case result := <-work:
+	return dex.GracefulComplete(result), nil
+}
+```
+
+An RPC may call `RPCResult.CancelSteps` for Flow-wide selection while also
+returning output and scheduling Next Steps. RPCs do not support sibling
+selection because an RPC invocation has no Step execution lineage.
+
 Use `dex.None` when a Step, RPC, or Channel has no application payload, and pass
 `nil` at every call site. It rejects accidental values unlike `any` and makes
 the absence of a payload explicit.

--- a/sdk-go/dex/decision.go
+++ b/sdk-go/dex/decision.go
@@ -113,9 +113,34 @@ func ForceCompleteIfChannelsEmpty(
 
 // StepDecision describes the durable outcome of one successful Step Execute call.
 type StepDecision struct {
-	kind      decisionKind
-	movements []StepMovement
-	close     CloseDecision
+	kind                  decisionKind
+	movements             []StepMovement
+	close                 CloseDecision
+	cancelingSteps        []StepSelector
+	cancelingSiblingSteps []StepSelector
+}
+
+// CancelSteps selects every queued or active execution of each registered Step type.
+//
+// Dex resolves one snapshot after the current Execute succeeds. Finished, already-canceled,
+// and absent executions are no-ops. Steps scheduled by this decision are outside the snapshot.
+// Repeated calls take the union; a Flow-wide selector supersedes a sibling selector.
+//
+// The decision is mutated and returned for fluent use.
+func (decision *StepDecision) CancelSteps(steps ...StepSelector) *StepDecision {
+	decision.cancelingSteps = append(decision.cancelingSteps, steps...)
+	return decision
+}
+
+// CancelSiblingSteps selects executions sharing the current execution's scheduling source.
+//
+// A sibling has the same Context.FromStepExecutionID value. Snapshot and no-op behavior match
+// CancelSteps. Repeated calls take the union; Flow-wide selection wins for the same Step type.
+//
+// The decision is mutated and returned for fluent use.
+func (decision *StepDecision) CancelSiblingSteps(steps ...StepSelector) *StepDecision {
+	decision.cancelingSiblingSteps = append(decision.cancelingSiblingSteps, steps...)
+	return decision
 }
 
 // CloseDecision stores the terminal output, failure reason, and guarded Channels.

--- a/sdk-go/dex/options.go
+++ b/sdk-go/dex/options.go
@@ -79,6 +79,9 @@ type StepOptions struct {
 	WaitForMethodTimeout time.Duration
 	// ExecuteMethodTimeout limits one Execute attempt; zero uses the server default.
 	ExecuteMethodTimeout time.Duration
+	// HeartbeatTimeout enables cooperative cancellation for regular WaitFor and Execute activities.
+	// Zero disables heartbeats. Positive values must be whole seconds within int32 range.
+	HeartbeatTimeout time.Duration
 	// WaitForRetry overrides the WaitFor retry policy; nil uses server defaults.
 	WaitForRetry *RetryPolicy
 	// ExecuteRetry overrides the Execute retry policy; nil uses server defaults.

--- a/sdk-go/dex/proto_mapper.go
+++ b/sdk-go/dex/proto_mapper.go
@@ -174,6 +174,10 @@ func mapStepOptionsRecursive(
 	if err != nil {
 		return nil, fmt.Errorf("dex: Execute method timeout: %w", err)
 	}
+	heartbeatTimeout, err := exactDurationSeconds32(options.HeartbeatTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("dex: heartbeat timeout: %w", err)
+	}
 	waitForRetry, err := mapRetryPolicy(options.WaitForRetry)
 	if err != nil {
 		return nil, fmt.Errorf("dex: WaitFor retry: %w", err)
@@ -210,6 +214,7 @@ func mapStepOptionsRecursive(
 	return &dexpb.StepOptions{
 		WaitForTimeoutSeconds:            waitForMethodTimeout,
 		ExecuteTimeoutSeconds:            executeMethodTimeout,
+		HeartbeatTimeoutSeconds:          heartbeatTimeout,
 		WaitForRetryPolicy:               waitForRetry,
 		ExecuteRetryPolicy:               executeRetry,
 		WaitForFailurePolicy:             waitForFailure,
@@ -1140,6 +1145,9 @@ func mergeStepOptions(defaults *StepOptions, overrides *StepOptions) *StepOption
 	if overrides.ExecuteMethodTimeout != 0 {
 		merged.ExecuteMethodTimeout = overrides.ExecuteMethodTimeout
 	}
+	if overrides.HeartbeatTimeout != 0 {
+		merged.HeartbeatTimeout = overrides.HeartbeatTimeout
+	}
 	if overrides.WaitForRetry != nil {
 		merged.WaitForRetry = overrides.WaitForRetry
 	}
@@ -1360,6 +1368,20 @@ func durationSeconds32(duration time.Duration) (int32, error) {
 	if err != nil {
 		return 0, err
 	}
+	if seconds > math.MaxInt32 {
+		return 0, fmt.Errorf("duration %s exceeds int32 seconds", duration)
+	}
+	return int32(seconds), nil
+}
+
+func exactDurationSeconds32(duration time.Duration) (int32, error) {
+	if duration < 0 {
+		return 0, fmt.Errorf("duration must not be negative")
+	}
+	if duration%time.Second != 0 {
+		return 0, fmt.Errorf("duration must use whole seconds")
+	}
+	seconds := duration / time.Second
 	if seconds > math.MaxInt32 {
 		return 0, fmt.Errorf("duration %s exceeds int32 seconds", duration)
 	}

--- a/sdk-go/dex/registration.go
+++ b/sdk-go/dex/registration.go
@@ -431,6 +431,26 @@ func (flow *registeredFlow) resolveStepReference(
 	return target, nil
 }
 
+func (flow *registeredFlow) resolveStepSelector(
+	selector StepSelector,
+) (*registeredStep, error) {
+	if selector == nil || nilInterface(selector) {
+		return nil, fmt.Errorf("step cancellation selector is nil")
+	}
+	stepType := selector.GetStepType()
+	if stepType == "" {
+		stepType = getSimpleTypeNameFromReflect(selector)
+	}
+	target, found := flow.steps[stepType]
+	if !found {
+		return nil, fmt.Errorf("step %q is not registered", stepType)
+	}
+	if reflect.TypeOf(target.handler.stepValue()) != reflect.TypeOf(selector) {
+		return nil, fmt.Errorf("step %q selector does not match its registered type", stepType)
+	}
+	return target, nil
+}
+
 func (flow *registeredFlow) resolveChannels(
 	definitions []ChannelDef,
 ) ([]registeredChannel, error) {

--- a/sdk-go/dex/rpc.go
+++ b/sdk-go/dex/rpc.go
@@ -30,18 +30,31 @@ type RPC[IN, OUT any] func(
 	input IN,
 ) (*RPCResult[OUT], error)
 
-// RPCResult carries typed RPC output and optional Step movements committed after success.
+// RPCResult carries typed output, Step movements, and Flow-wide Step cancellation.
 type RPCResult[OUT any] struct {
 	// Output is encoded as the RPC response value.
 	Output OUT
 	// NextSteps are scheduled in order after the RPC persistence changes commit.
 	NextSteps []StepMovement
+	// CancelingSteps selects registered Step types canceled before NextSteps are scheduled.
+	CancelingSteps []StepSelector
+}
+
+// CancelSteps selects queued or active executions of registered Step types.
+//
+// Dex resolves the selection after RPC persistence commits and before NextSteps are queued.
+// Finished, already-canceled, and absent executions are no-ops. RPCs cannot select siblings.
+// The result is mutated and returned for fluent use.
+func (result *RPCResult[OUT]) CancelSteps(steps ...StepSelector) *RPCResult[OUT] {
+	result.CancelingSteps = append(result.CancelingSteps, steps...)
+	return result
 }
 
 type rpcResult interface {
 	rpcOutput() any
 	rpcOutputType() reflect.Type
 	rpcMovements() []StepMovement
+	rpcCancelingSteps() []StepSelector
 }
 
 func (result RPCResult[OUT]) rpcOutput() any {
@@ -54,4 +67,8 @@ func (RPCResult[OUT]) rpcOutputType() reflect.Type {
 
 func (result RPCResult[OUT]) rpcMovements() []StepMovement {
 	return result.NextSteps
+}
+
+func (result RPCResult[OUT]) rpcCancelingSteps() []StepSelector {
+	return result.CancelingSteps
 }

--- a/sdk-go/dex/step.go
+++ b/sdk-go/dex/step.go
@@ -20,6 +20,21 @@ type none struct{}
 // None is the nil-only SDK payload, rejecting arbitrary values unlike any and clarifying struct{} intent.
 type None = *none
 
+// StepSelector identifies a registered Step type for cancellation decisions.
+//
+// Every Step implements StepSelector through GetStepType and GetStepOptions. This
+// non-generic view lets one cancellation request select Steps with different input types.
+type StepSelector interface {
+	// GetStepType overrides the default package-qualified Go type name.
+	// Embed DefaultStepType to use the default.
+	GetStepType() string
+
+	// GetStepOptions returns immutable defaults applied whenever this Step is
+	// scheduled. Return nil (e.g. by embedding StepDefaults) to use server
+	// defaults. A movement may override individual fields when transitioning.
+	GetStepOptions() *StepOptions
+}
+
 // Step is one node in a Flow's durable state machine. IN is the typed input
 // passed into WaitFor and Execute for this step.
 //
@@ -70,14 +85,8 @@ type None = *none
 //
 //	var ShipOrder = ShipOrderStep{}
 type Step[IN any] interface {
-	// GetStepType overrides the default package-qualified Go type name.
-	// Embed DefaultStepType to use the default.
-	GetStepType() string
-
-	// GetStepOptions returns immutable defaults applied whenever this step is
-	// scheduled. Return nil (e.g. by embedding StepDefaults) to use server
-	// defaults. A movement may override individual fields when transitioning.
-	GetStepOptions() *StepOptions
+	// StepSelector supplies this Step's durable type and static options.
+	StepSelector
 
 	// WaitFor sets up the conditions this step waits on before Execute runs.
 	//

--- a/sdk-go/dex/worker_mapping.go
+++ b/sdk-go/dex/worker_mapping.go
@@ -97,6 +97,7 @@ func mapRegisteredDecision(
 	if decision == nil {
 		return nil, fmt.Errorf("dex: Execute returned nil")
 	}
+	var mapped *dexpb.StepDecision
 	switch decision.kind {
 	case decisionNext:
 		if len(decision.movements) == 0 {
@@ -106,7 +107,7 @@ func mapRegisteredDecision(
 		if err != nil {
 			return nil, err
 		}
-		return &dexpb.StepDecision{NextSteps: movements}, nil
+		mapped = &dexpb.StepDecision{NextSteps: movements}
 	case decisionClose:
 		if len(decision.movements) != 0 {
 			return nil, fmt.Errorf("dex: close decision cannot have next steps")
@@ -115,7 +116,7 @@ func mapRegisteredDecision(
 		if err != nil {
 			return nil, err
 		}
-		return &dexpb.StepDecision{CloseDecision: closeDecision}, nil
+		mapped = &dexpb.StepDecision{CloseDecision: closeDecision}
 	case decisionConditionalClose:
 		if len(decision.movements) == 0 {
 			return nil, fmt.Errorf("dex: conditional close requires fallback movements")
@@ -131,13 +132,68 @@ func mapRegisteredDecision(
 		if err != nil {
 			return nil, err
 		}
-		return &dexpb.StepDecision{
+		mapped = &dexpb.StepDecision{
 			NextSteps:     movements,
 			CloseDecision: closeDecision,
-		}, nil
+		}
 	default:
 		return nil, fmt.Errorf("dex: Execute returned an empty decision")
 	}
+	cancelingSteps, cancelingSiblings, err := mapCancellationSelectors(
+		flow,
+		decision.cancelingSteps,
+		decision.cancelingSiblingSteps,
+	)
+	if err != nil {
+		return nil, err
+	}
+	mapped.CancelStepTypes = cancelingSteps
+	mapped.CancelSiblingStepTypes = cancelingSiblings
+	return mapped, nil
+}
+
+func mapCancellationSelectors(
+	flow *registeredFlow,
+	global []StepSelector,
+	siblings []StepSelector,
+) ([]string, []string, error) {
+	globalTypes, err := mapStepSelectors(flow, global, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	selected := make(map[string]struct{}, len(globalTypes))
+	for _, stepType := range globalTypes {
+		selected[stepType] = struct{}{}
+	}
+	siblingTypes, err := mapStepSelectors(flow, siblings, selected)
+	if err != nil {
+		return nil, nil, err
+	}
+	return globalTypes, siblingTypes, nil
+}
+
+func mapStepSelectors(
+	flow *registeredFlow,
+	selectors []StepSelector,
+	excluded map[string]struct{},
+) ([]string, error) {
+	stepTypes := make([]string, 0, len(selectors))
+	seen := make(map[string]struct{}, len(selectors))
+	for _, selector := range selectors {
+		target, err := flow.resolveStepSelector(selector)
+		if err != nil {
+			return nil, err
+		}
+		if _, found := excluded[target.stepType]; found {
+			continue
+		}
+		if _, found := seen[target.stepType]; found {
+			continue
+		}
+		seen[target.stepType] = struct{}{}
+		stepTypes = append(stepTypes, target.stepType)
+	}
+	return stepTypes, nil
 }
 
 func validateRegisteredCloseChannels(
@@ -228,13 +284,20 @@ func mapRegisteredRPCResult(
 	}
 	response := &dexpb.InvokeWorkerRPCResponse{Output: output}
 	movements := result.rpcMovements()
-	if len(movements) == 0 {
+	cancelingSteps, err := mapStepSelectors(flow, result.rpcCancelingSteps(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(movements) == 0 && len(cancelingSteps) == 0 {
 		return response, nil
 	}
 	nextSteps, err := mapRegisteredMovements(flow, movements)
 	if err != nil {
 		return nil, err
 	}
-	response.StepDecision = &dexpb.StepDecision{NextSteps: nextSteps}
+	response.StepDecision = &dexpb.StepDecision{
+		NextSteps:       nextSteps,
+		CancelStepTypes: cancelingSteps,
+	}
 	return response, nil
 }

--- a/sdk-go/integ/main_test.go
+++ b/sdk-go/integ/main_test.go
@@ -179,6 +179,7 @@ func integrationFlows() []dex.Flow {
 		subFlowTimerFlow{},
 		subFlowFailingFlow{},
 		subFlowImmediateFlow{},
+		stepCancellationFlow{},
 	}
 }
 

--- a/sdk-go/integ/step_cancellation_test.go
+++ b/sdk-go/integ/step_cancellation_test.go
@@ -1,0 +1,494 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package integ
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+type cancellationScenario string
+
+const (
+	cancelHeartbeatExecute cancellationScenario = "heartbeat-execute"
+	cancelHeartbeatWaitFor cancellationScenario = "heartbeat-wait-for"
+	cancelLocalExecute     cancellationScenario = "local-execute"
+	cancelLocalFallback    cancellationScenario = "local-timeout-fallback"
+	cancelNoHeartbeat      cancellationScenario = "no-heartbeat"
+	cancelGlobalSelector   cancellationScenario = "global-selector"
+	cancelSiblingSelector  cancellationScenario = "sibling-selector"
+)
+
+const (
+	cancellationHandlerTimeout = 15 * time.Second
+	cancellationHeartbeat      = 2 * time.Second
+	cancellationWinnerDelay    = 3 * time.Second
+)
+
+var (
+	cancellationLateWrite = dex.DefineAttribute[string]("go-cancellation-late-write")
+	cancellationStates    sync.Map
+)
+
+type cancellationState struct {
+	scenario                cancellationScenario
+	blockingStarted         chan struct{}
+	cancellationObserved    chan struct{}
+	lateHandlerReturned     chan struct{}
+	selectorWaitsRegistered chan struct{}
+	startedOnce             sync.Once
+	canceledOnce            sync.Once
+	returnedOnce            sync.Once
+	selectorOnce            sync.Once
+	selectorWaitCount       atomic.Int32
+	handlerCanceled         atomic.Bool
+	recoveryRan             atomic.Bool
+	firstSelectorExecuted   atomic.Bool
+	secondSelectorExecuted  atomic.Bool
+	blockingInvocations     atomic.Int32
+}
+
+func newCancellationState(scenario cancellationScenario) *cancellationState {
+	return &cancellationState{
+		scenario:                scenario,
+		blockingStarted:         make(chan struct{}),
+		cancellationObserved:    make(chan struct{}),
+		lateHandlerReturned:     make(chan struct{}),
+		selectorWaitsRegistered: make(chan struct{}),
+	}
+}
+
+func cancellationStateFor(ctx dex.Context) (*cancellationState, error) {
+	value, found := cancellationStates.Load(ctx.FlowID())
+	if !found {
+		return nil, fmt.Errorf("missing cancellation state for %s", ctx.FlowID())
+	}
+	return value.(*cancellationState), nil
+}
+
+type stepCancellationFlow struct {
+	dex.FlowDefaults
+}
+
+func (stepCancellationFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{
+		dex.DefineStartStep(cancellationStartStep{}),
+		dex.DefineStep(cancellationBlockingExecuteStep{}),
+		dex.DefineStep(cancellationBlockingWaitForStep{}),
+		dex.DefineStep(cancellationWinnerStep{}),
+		dex.DefineStep(cancellationRecoveryStep{}),
+		dex.DefineStep(cancellationFinalStep{}),
+		dex.DefineStep(cancellationFirstParentStep{}),
+		dex.DefineStep(cancellationSecondParentStep{}),
+		dex.DefineStep(cancellationSelectorWinnerStep{}),
+		dex.DefineStep(cancellationSelectorWaitingStep{}),
+	}
+}
+
+func (stepCancellationFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{Attributes: []dex.AttributeDef{cancellationLateWrite}}
+}
+
+type cancellationStartStep struct {
+	dex.StepDefaultsNoWaitFor[cancellationScenario]
+}
+
+func (cancellationStartStep) Execute(
+	_ dex.Context,
+	scenario cancellationScenario,
+) (*dex.StepDecision, error) {
+	switch scenario {
+	case cancelHeartbeatWaitFor:
+		return dex.GoToMulti(
+			dex.MovementOf(cancellationBlockingWaitForStep{}, scenario),
+			dex.MovementOf(cancellationWinnerStep{}, scenario),
+		), nil
+	case cancelGlobalSelector, cancelSiblingSelector:
+		return dex.GoToMulti(
+			dex.MovementOf(cancellationFirstParentStep{}, scenario),
+			dex.MovementOf(cancellationSecondParentStep{}, scenario),
+		), nil
+	default:
+		return dex.GoToMulti(
+			dex.MovementOf(
+				cancellationBlockingExecuteStep{},
+				scenario,
+				dex.WithStepOptions(cancellationExecuteOptions(scenario)),
+			),
+			dex.MovementOf(cancellationWinnerStep{}, scenario),
+		), nil
+	}
+}
+
+func cancellationExecuteOptions(scenario cancellationScenario) *dex.StepOptions {
+	options := &dex.StepOptions{ExecuteDurability: dex.StepDurabilitySync}
+	switch scenario {
+	case cancelHeartbeatExecute:
+		options.HeartbeatTimeout = cancellationHeartbeat
+	case cancelLocalExecute:
+		options.ExecuteDurability = dex.StepDurabilityAsync
+	case cancelLocalFallback:
+		options.ExecuteDurability = dex.StepDurabilityAsync
+		options.HeartbeatTimeout = cancellationHeartbeat
+	}
+	return options
+}
+
+type cancellationBlockingExecuteStep struct {
+	dex.StepDefaultsNoWaitFor[cancellationScenario]
+}
+
+func (cancellationBlockingExecuteStep) Execute(
+	ctx dex.Context,
+	scenario cancellationScenario,
+) (*dex.StepDecision, error) {
+	state, err := cancellationStateFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	state.blockingInvocations.Add(1)
+	state.startedOnce.Do(func() { close(state.blockingStarted) })
+	duration := 10 * time.Second
+	if scenario == cancelNoHeartbeat {
+		duration = 7 * time.Second
+	}
+	select {
+	case <-ctx.Done():
+		state.handlerCanceled.Store(true)
+		state.canceledOnce.Do(func() { close(state.cancellationObserved) })
+	case <-time.After(duration):
+	}
+	if err := cancellationLateWrite.Set(ctx, "late"); err != nil {
+		return nil, err
+	}
+	state.returnedOnce.Do(func() { close(state.lateHandlerReturned) })
+	return dex.GoTo(cancellationRecoveryStep{}, scenario), nil
+}
+
+func (cancellationBlockingExecuteStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		ExecuteMethodTimeout: cancellationHandlerTimeout,
+		ExecuteFailure: dex.ProceedToOnExecuteFailure(
+			cancellationRecoveryStep{},
+			nil,
+		),
+	}
+}
+
+type cancellationBlockingWaitForStep struct {
+	dex.DefaultStepType
+}
+
+func (cancellationBlockingWaitForStep) WaitFor(
+	ctx dex.Context,
+	_ cancellationScenario,
+) (*dex.Wait, error) {
+	state, err := cancellationStateFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	state.blockingInvocations.Add(1)
+	state.startedOnce.Do(func() { close(state.blockingStarted) })
+	select {
+	case <-ctx.Done():
+		state.handlerCanceled.Store(true)
+		state.canceledOnce.Do(func() { close(state.cancellationObserved) })
+	case <-time.After(10 * time.Second):
+	}
+	return dex.SkipWaitImmediately(), nil
+}
+
+func (cancellationBlockingWaitForStep) Execute(
+	ctx dex.Context,
+	_ cancellationScenario,
+) (*dex.StepDecision, error) {
+	state, err := cancellationStateFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	state.recoveryRan.Store(true)
+	return dex.ForceFail("canceled WaitFor execution continued"), nil
+}
+
+func (cancellationBlockingWaitForStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		WaitForMethodTimeout: cancellationHandlerTimeout,
+		HeartbeatTimeout:     cancellationHeartbeat,
+		WaitForFailure:       dex.ProceedOnWaitForFailure,
+		WaitForDurability:    dex.StepDurabilitySync,
+	}
+}
+
+type cancellationWinnerStep struct {
+	dex.StepDefaults
+}
+
+func (cancellationWinnerStep) WaitFor(
+	_ dex.Context,
+	scenario cancellationScenario,
+) (*dex.Wait, error) {
+	if scenario == cancelLocalExecute {
+		return dex.SkipWaitImmediately(), nil
+	}
+	return dex.Until(dex.Timer(cancellationWinnerDelay)), nil
+}
+
+func (cancellationWinnerStep) Execute(
+	ctx dex.Context,
+	scenario cancellationScenario,
+) (*dex.StepDecision, error) {
+	if scenario == cancelLocalExecute {
+		state, err := cancellationStateFor(ctx)
+		if err != nil {
+			return nil, err
+		}
+		select {
+		case <-state.blockingStarted:
+		case <-time.After(10 * time.Second):
+			return nil, fmt.Errorf("local loser did not start")
+		}
+		time.Sleep(time.Second)
+	}
+	selected := dex.StepSelector(cancellationBlockingExecuteStep{})
+	if scenario == cancelHeartbeatWaitFor {
+		selected = cancellationBlockingWaitForStep{}
+	}
+	return dex.GoTo(cancellationFinalStep{}, scenario).CancelSteps(selected), nil
+}
+
+type cancellationRecoveryStep struct {
+	dex.StepDefaultsNoWaitFor[cancellationScenario]
+}
+
+func (cancellationRecoveryStep) Execute(
+	ctx dex.Context,
+	_ cancellationScenario,
+) (*dex.StepDecision, error) {
+	state, err := cancellationStateFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	state.recoveryRan.Store(true)
+	return dex.ForceFail("canceled execution reached recovery"), nil
+}
+
+type cancellationFinalStep struct {
+	dex.StepDefaults
+}
+
+func (cancellationFinalStep) WaitFor(
+	_ dex.Context,
+	_ cancellationScenario,
+) (*dex.Wait, error) {
+	return dex.Until(dex.Timer(time.Second)), nil
+}
+
+func (cancellationFinalStep) Execute(
+	_ dex.Context,
+	scenario cancellationScenario,
+) (*dex.StepDecision, error) {
+	return dex.GracefulComplete(string(scenario)), nil
+}
+
+type cancellationFirstParentStep struct {
+	dex.StepDefaultsNoWaitFor[cancellationScenario]
+}
+
+func (cancellationFirstParentStep) Execute(
+	_ dex.Context,
+	scenario cancellationScenario,
+) (*dex.StepDecision, error) {
+	return dex.GoToMulti(
+		dex.MovementOf(cancellationSelectorWinnerStep{}, scenario),
+		dex.MovementOf(cancellationSelectorWaitingStep{}, "first"),
+	), nil
+}
+
+type cancellationSecondParentStep struct {
+	dex.StepDefaultsNoWaitFor[cancellationScenario]
+}
+
+func (cancellationSecondParentStep) Execute(
+	_ dex.Context,
+	scenario cancellationScenario,
+) (*dex.StepDecision, error) {
+	return dex.GoTo(cancellationSelectorWaitingStep{}, "second"), nil
+}
+
+type cancellationSelectorWinnerStep struct {
+	dex.StepDefaults
+}
+
+func (cancellationSelectorWinnerStep) WaitFor(
+	_ dex.Context,
+	_ cancellationScenario,
+) (*dex.Wait, error) {
+	return dex.Until(dex.Timer(time.Second)), nil
+}
+
+func (cancellationSelectorWinnerStep) Execute(
+	ctx dex.Context,
+	scenario cancellationScenario,
+) (*dex.StepDecision, error) {
+	state, err := cancellationStateFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	select {
+	case <-state.selectorWaitsRegistered:
+	case <-time.After(10 * time.Second):
+		return nil, fmt.Errorf("selector Steps did not reach waiting")
+	}
+	decision := dex.GoTo(cancellationFinalStep{}, scenario)
+	if scenario == cancelGlobalSelector {
+		return decision.CancelSteps(cancellationSelectorWaitingStep{}), nil
+	}
+	return decision.CancelSiblingSteps(cancellationSelectorWaitingStep{}), nil
+}
+
+type cancellationSelectorWaitingStep struct {
+	dex.StepDefaults
+}
+
+func (cancellationSelectorWaitingStep) WaitFor(
+	ctx dex.Context,
+	input string,
+) (*dex.Wait, error) {
+	state, err := cancellationStateFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if state.selectorWaitCount.Add(1) == 2 {
+		state.selectorOnce.Do(func() { close(state.selectorWaitsRegistered) })
+	}
+	duration := 2 * time.Second
+	if input == "first" {
+		duration = 30 * time.Second
+	}
+	return dex.Until(dex.Timer(duration)), nil
+}
+
+func (cancellationSelectorWaitingStep) Execute(
+	ctx dex.Context,
+	input string,
+) (*dex.StepDecision, error) {
+	state, err := cancellationStateFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if input == "first" {
+		state.firstSelectorExecuted.Store(true)
+	} else {
+		state.secondSelectorExecuted.Store(true)
+	}
+	return dex.DeadEnd(), nil
+}
+
+func TestStepCancellation(t *testing.T) {
+	scenarios := []cancellationScenario{
+		cancelHeartbeatExecute,
+		cancelHeartbeatWaitFor,
+		cancelLocalExecute,
+		cancelLocalFallback,
+		cancelNoHeartbeat,
+		cancelGlobalSelector,
+		cancelSiblingSelector,
+	}
+	for _, scenario := range scenarios {
+		t.Run(string(scenario), func(t *testing.T) {
+			runCancellationScenario(t, scenario)
+		})
+	}
+}
+
+func runCancellationScenario(t *testing.T, scenario cancellationScenario) {
+	t.Helper()
+	flowID := newFlowID(t, "go-cancellation-"+string(scenario))
+	state := newCancellationState(scenario)
+	cancellationStates.Store(flowID, state)
+	t.Cleanup(func() { cancellationStates.Delete(flowID) })
+	_, err := integClient.StartFlow(
+		integrationContext(t),
+		stepCancellationFlow{},
+		flowID,
+		scenario,
+		dex.StartFlowOptions{},
+	)
+	require.NoError(t, err)
+
+	if scenario != cancelGlobalSelector && scenario != cancelSiblingSelector {
+		requireChannel(t, state.blockingStarted, 10*time.Second)
+		stepType := dex.GetFinalStepType(cancellationBlockingExecuteStep{})
+		if scenario == cancelHeartbeatWaitFor {
+			stepType = dex.GetFinalStepType(cancellationBlockingWaitForStep{})
+		}
+		require.NoError(t, integClient.WaitForStepCompletion(
+			integrationContext(t),
+			flowID,
+			dex.StepExecutionID{StepType: stepType},
+			dex.WaitOptions{Timeout: 30 * time.Second},
+		))
+	}
+
+	result := waitForFlow(t, flowID, true)
+	require.Equal(t, dex.FlowCompleted, result.Status)
+	require.Len(t, result.Completions, 1)
+	var output string
+	require.NoError(t, result.Completions[0].Output.Decode(&output))
+	require.Equal(t, string(scenario), output)
+
+	switch scenario {
+	case cancelGlobalSelector:
+		require.False(t, state.firstSelectorExecuted.Load())
+		require.False(t, state.secondSelectorExecuted.Load())
+	case cancelSiblingSelector:
+		require.False(t, state.firstSelectorExecuted.Load())
+		require.True(t, state.secondSelectorExecuted.Load())
+	case cancelNoHeartbeat:
+		require.False(t, state.handlerCanceled.Load())
+		select {
+		case <-state.lateHandlerReturned:
+			t.Fatal("handler returned before Flow completed")
+		default:
+		}
+		requireChannel(t, state.lateHandlerReturned, 8*time.Second)
+	default:
+		requireChannel(t, state.cancellationObserved, 8*time.Second)
+		require.True(t, state.handlerCanceled.Load())
+	}
+	if scenario != cancelGlobalSelector && scenario != cancelSiblingSelector {
+		require.False(t, state.recoveryRan.Load())
+		require.Equal(t, int32(1), state.blockingInvocations.Load())
+		var late string
+		found, getErr := integClient.GetAttribute(
+			context.Background(),
+			flowID,
+			cancellationLateWrite,
+			&late,
+		)
+		require.NoError(t, getErr)
+		require.False(t, found)
+	}
+}
+
+func requireChannel(t *testing.T, channel <-chan struct{}, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-channel:
+	case <-time.After(timeout):
+		t.Fatalf("condition was not observed within %s", timeout)
+	}
+}

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -121,6 +121,42 @@ attempts, total duration, and 1-based attempt numbers. Fallback starts
 immediately; later regular retries continue the backoff sequence at the
 cumulative attempt.
 
+### Canceling Step executions
+
+A successful Step can cancel queued or active executions while continuing with
+its normal decision:
+
+```python
+return (
+    dex.go_to(self.record_quote, quote)
+    .with_canceling_sibling_steps(self.carrier_a, self.carrier_b)
+    .with_canceling_steps(self.global_quote_timeout)
+)
+```
+
+`with_canceling_steps` selects every current execution of each registered Step
+type. `with_canceling_sibling_steps` selects only executions with the same
+`Context.from_step_execution_id` as the current execution. Decisions are
+immutable; repeated calls form a union, and Flow-wide selection wins for the
+same Step type. Unregistered selectors produce an invalid Step result.
+
+Dex resolves one snapshot after the current execution succeeds. Completed,
+already-canceled, and absent targets are no-ops. Next Steps created by the same
+decision are outside the snapshot. Dex immediately applies the next or close
+action; late decisions, writes, retries, and recovery Steps are discarded.
+
+Set `StepOptions.heartbeat_timeout` on long-running regular Steps so
+cancellation reaches the Worker promptly. It applies to `wait_for` and
+`execute`; local activities ignore it, while an ASYNC fallback uses it. `None`
+and zero disable heartbeats, and positive values must be whole seconds in the
+signed int32 range. `AsyncWorker` cancels the handler's asyncio task. A handler
+may catch `asyncio.CancelledError` for cleanup; synchronous CPU-bound handlers
+may check `Context.is_cancellation_requested()` at natural boundaries.
+
+`RPCResult.with_canceling_steps` provides the Flow-wide selector for RPCs.
+RPCs do not support sibling selection because they have no Step execution
+lineage.
+
 `Registry` validates every Flow, Step, RPC signature, durable name, lock, and
 codec before Client or Worker startup. `Client` methods use these typed objects
 instead of raw Flow, Step, or RPC strings.

--- a/sdk-python/dex/_async_worker_dispatcher.py
+++ b/sdk-python/dex/_async_worker_dispatcher.py
@@ -9,14 +9,14 @@
 from __future__ import annotations
 
 from inspect import isawaitable
-from typing import Any
+from typing import Any, Callable
 
 from dex._async_value_hydrator import AsyncValueHydrator
 from dex._invocation_context import InvocationContext, InvocationMethod
 from dex._value_mapper import ValueMapper
 from dex._worker_dispatcher import WorkerDispatcher
 from dex.dexpb import dex_pb2 as pb
-from dex.flow import RPCResult, Registry
+from dex.flow import Registry, RPCResult
 from dex.runtime_errors import InvalidStepResultError, ValueMappingError
 from dex.step import StepDecision
 from dex.wait import Wait
@@ -36,6 +36,7 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
     async def invoke_wait_for(  # type: ignore[override]
         self,
         original: pb.InvokeWaitForMethodRequest,
+        is_active: Callable[[], bool] | None = None,
     ) -> pb.InvokeWaitForMethodResponse:
         request = await self._async_hydrator.wait_for_request(original)
         flow = self._registry._flow_by_type(request.flow_type)
@@ -46,6 +47,7 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             request.context,
             self._values,
             request.attributes,
+            is_active=is_active,
         )
         input = self._values.decode(request.step_input, step.input_codec)
         wait = step.step.wait_for(context, input)
@@ -72,6 +74,7 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
     async def invoke_execute(  # type: ignore[override]
         self,
         original: pb.InvokeExecuteMethodRequest,
+        is_active: Callable[[], bool] | None = None,
     ) -> pb.InvokeExecuteMethodResponse:
         request = await self._async_hydrator.execute_request(original)
         flow = self._registry._flow_by_type(request.flow_type)
@@ -87,6 +90,7 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             request.attributes,
             request.step_exe_locals,
             condition_results,
+            is_active=is_active,
         )
         input = self._values.decode(request.step_input, step.input_codec)
         decision: Any = step.step.execute(context, input)
@@ -110,6 +114,7 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
     async def invoke_rpc(  # type: ignore[override]
         self,
         original: pb.InvokeWorkerRPCRequest,
+        is_active: Callable[[], bool] | None = None,
     ) -> pb.InvokeWorkerRPCResponse:
         request = await self._async_hydrator.rpc_request(original)
         flow = self._registry._flow_by_type(request.flow_type)
@@ -121,6 +126,7 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             self._values,
             request.attributes,
             channel_infos=dict(request.channel_infos),
+            is_active=is_active,
         )
         arguments: list[object] = [context]
         if rpc.input_codec is not None:
@@ -144,6 +150,11 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
                     response.step_decision.next_steps.extend(
                         self._map_movements(flow, returned.next_steps)
                     )
+                response.step_decision.cancel_step_types.extend(
+                    self._map_cancellation_steps(flow, returned.canceling_steps)
+                )
+                if not returned.next_steps and not returned.canceling_steps:
+                    response.ClearField("step_decision")
             elif returned is None and rpc.output_codec is None:
                 response.output.CopyFrom(self._values.encode_dynamic(None))
             else:

--- a/sdk-python/dex/_async_worker_service.py
+++ b/sdk-python/dex/_async_worker_service.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import logging
+from asyncio import CancelledError, current_task
 from collections.abc import Awaitable, Callable
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import grpc
 
@@ -27,39 +28,71 @@ class AsyncWorkerService(dex_pb2_grpc.WorkerServiceServicer):
     def __init__(self, dispatcher: AsyncWorkerDispatcher) -> None:
         self._dispatcher = dispatcher
 
-    async def InvokeWaitForMethod(  # type: ignore[override]
+    async def InvokeWaitForMethod(
         self,
         request: pb.InvokeWaitForMethodRequest,
-        context: grpc.aio.ServicerContext,
+        context: grpc.aio.ServicerContext[
+            pb.InvokeWaitForMethodRequest,
+            pb.InvokeWaitForMethodResponse,
+        ],
     ) -> pb.InvokeWaitForMethodResponse:
         return await self._invoke(
-            context, lambda: self._dispatcher.invoke_wait_for(request)
+            context,
+            lambda: self._dispatcher.invoke_wait_for(
+                request, lambda: self._is_active(context)
+            ),
         )
 
-    async def InvokeExecuteMethod(  # type: ignore[override]
+    async def InvokeExecuteMethod(
         self,
         request: pb.InvokeExecuteMethodRequest,
-        context: grpc.aio.ServicerContext,
+        context: grpc.aio.ServicerContext[
+            pb.InvokeExecuteMethodRequest,
+            pb.InvokeExecuteMethodResponse,
+        ],
     ) -> pb.InvokeExecuteMethodResponse:
         return await self._invoke(
-            context, lambda: self._dispatcher.invoke_execute(request)
+            context,
+            lambda: self._dispatcher.invoke_execute(
+                request, lambda: self._is_active(context)
+            ),
         )
 
-    async def InvokeWorkerRPC(  # type: ignore[override]
+    async def InvokeWorkerRPC(
         self,
         request: pb.InvokeWorkerRPCRequest,
-        context: grpc.aio.ServicerContext,
+        context: grpc.aio.ServicerContext[
+            pb.InvokeWorkerRPCRequest,
+            pb.InvokeWorkerRPCResponse,
+        ],
     ) -> pb.InvokeWorkerRPCResponse:
-        return await self._invoke(context, lambda: self._dispatcher.invoke_rpc(request))
+        return await self._invoke(
+            context,
+            lambda: self._dispatcher.invoke_rpc(
+                request, lambda: self._is_active(context)
+            ),
+        )
+
+    @staticmethod
+    def _is_active(context: grpc.aio.ServicerContext[Any, Any]) -> bool:
+        task = current_task()
+        return not context.cancelled() and (task is None or task.cancelling() == 0)
 
     @staticmethod
     async def _invoke(
-        context: grpc.aio.ServicerContext,
+        context: grpc.aio.ServicerContext[Any, Any],
         invocation: Callable[[], Awaitable[ResponseT]],
     ) -> ResponseT:
         try:
             return await invocation()
+        except CancelledError:
+            raise
         except BaseException as error:
+            if not AsyncWorkerService._is_active(context):
+                await context.abort(
+                    grpc.StatusCode.CANCELLED,
+                    "Python AsyncWorker invocation canceled",
+                )
             _LOGGER.exception("Python AsyncWorker invocation failed")
             await async_abort_worker_error(context, error)
             raise RuntimeError("gRPC abort returned unexpectedly") from error

--- a/sdk-python/dex/_invocation_context.py
+++ b/sdk-python/dex/_invocation_context.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Sequence, TypeVar, cast
+from typing import Any, Callable, Sequence, TypeVar, cast
 from urllib.parse import unquote
 
 from dex._utils import require_name
@@ -42,6 +42,7 @@ class InvocationContext:
         locals: Sequence[pb.KV] = (),
         condition_results: pb.ConditionResults | None = None,
         channel_infos: dict[str, pb.ChannelInfo] | None = None,
+        is_active: Callable[[], bool] | None = None,
     ) -> None:
         self._method = method
         self._flow = flow
@@ -51,6 +52,7 @@ class InvocationContext:
         self._locals = self._map_values("step-execution local", locals)
         self._condition_results = condition_results
         self._channel_infos = dict(channel_infos or {})
+        self._is_active = is_active or _always_active
         self.attribute_writes: dict[str, pb.AttributeWrite] = {}
         self.local_writes: dict[str, pb.KV] = {}
         self.events: list[pb.KV] = []
@@ -116,6 +118,9 @@ class InvocationContext:
     def sub_flow_id(self, index: int = 0) -> str:
         self.sub_flow_result(index)
         return f"SubFlow:{self.flow_id}-{self.step_execution_id}-{index}"
+
+    def is_cancellation_requested(self) -> bool:
+        return not self._is_active()
 
     def set_step_execution_local(self, key: str, value: object) -> None:
         require_name(key)
@@ -323,3 +328,7 @@ class InvocationContext:
         if value_type is float:
             return 0.0
         return None
+
+
+def _always_active() -> bool:
+    return True

--- a/sdk-python/dex/_worker_dispatcher.py
+++ b/sdk-python/dex/_worker_dispatcher.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from inspect import isawaitable
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 from dex._invocation_context import InvocationContext, InvocationMethod
 from dex._value_hydrator import ValueHydrator
@@ -26,6 +26,7 @@ from dex.runtime_errors import InvalidStepResultError, ValueMappingError
 from dex.step import (
     DecisionKind,
     RetryPolicy,
+    Step,
     StepDecision,
     StepDurability,
     StepMovement,
@@ -49,6 +50,7 @@ class WorkerDispatcher:
     def invoke_wait_for(
         self,
         original: pb.InvokeWaitForMethodRequest,
+        is_active: Callable[[], bool] | None = None,
     ) -> pb.InvokeWaitForMethodResponse:
         request = self._hydrator.wait_for_request(original)
         flow = self._registry._flow_by_type(request.flow_type)
@@ -59,6 +61,7 @@ class WorkerDispatcher:
             request.context,
             self._values,
             request.attributes,
+            is_active=is_active,
         )
         input = self._values.decode(request.step_input, step.input_codec)
         wait = step.step.wait_for(context, input)
@@ -87,6 +90,7 @@ class WorkerDispatcher:
     def invoke_execute(
         self,
         original: pb.InvokeExecuteMethodRequest,
+        is_active: Callable[[], bool] | None = None,
     ) -> pb.InvokeExecuteMethodResponse:
         request = self._hydrator.execute_request(original)
         flow = self._registry._flow_by_type(request.flow_type)
@@ -102,6 +106,7 @@ class WorkerDispatcher:
             request.attributes,
             request.step_exe_locals,
             condition_results,
+            is_active=is_active,
         )
         input = self._values.decode(request.step_input, step.input_codec)
         decision = step.step.execute(context, input)
@@ -127,6 +132,7 @@ class WorkerDispatcher:
     def invoke_rpc(
         self,
         original: pb.InvokeWorkerRPCRequest,
+        is_active: Callable[[], bool] | None = None,
     ) -> pb.InvokeWorkerRPCResponse:
         request = self._hydrator.rpc_request(original)
         flow = self._registry._flow_by_type(request.flow_type)
@@ -138,6 +144,7 @@ class WorkerDispatcher:
             self._values,
             request.attributes,
             channel_infos=dict(request.channel_infos),
+            is_active=is_active,
         )
         arguments: list[object] = [context]
         if rpc.input_codec is not None:
@@ -163,6 +170,11 @@ class WorkerDispatcher:
                     response.step_decision.next_steps.extend(
                         self._map_movements(flow, returned.next_steps)
                     )
+                response.step_decision.cancel_step_types.extend(
+                    self._map_cancellation_steps(flow, returned.canceling_steps)
+                )
+                if not returned.next_steps and not returned.canceling_steps:
+                    response.ClearField("step_decision")
             elif returned is None and rpc.output_codec is None:
                 response.output.CopyFrom(self._values.encode_dynamic(None))
             else:
@@ -206,6 +218,10 @@ class WorkerDispatcher:
         if options.execute_method_timeout is not None:
             mapped.execute_timeout_seconds = self._seconds32(
                 options.execute_method_timeout
+            )
+        if options.heartbeat_timeout is not None:
+            mapped.heartbeat_timeout_seconds = self._seconds32(
+                options.heartbeat_timeout
             )
         if options.wait_for_retry is not None:
             mapped.wait_for_retry_policy.CopyFrom(
@@ -428,7 +444,33 @@ class WorkerDispatcher:
             mapped.next_steps.append(self._map_movement(flow, decision.fallback))
         else:
             raise ValueError("unsupported StepDecision kind")
+        mapped.cancel_step_types.extend(
+            self._map_cancellation_steps(flow, decision.canceling_steps)
+        )
+        global_types = set(mapped.cancel_step_types)
+        mapped.cancel_sibling_step_types.extend(
+            step_type
+            for step_type in self._map_cancellation_steps(
+                flow, decision.canceling_sibling_steps
+            )
+            if step_type not in global_types
+        )
         return mapped
+
+    def _map_cancellation_steps(
+        self,
+        flow: _RegisteredFlow,
+        steps: tuple[Step[Any], ...],
+    ) -> list[str]:
+        step_types: list[str] = []
+        seen: set[str] = set()
+        for step in steps:
+            step_type = self._registered_movement_target(flow, step).name
+            if step_type in seen:
+                continue
+            seen.add(step_type)
+            step_types.append(step_type)
+        return step_types
 
     def _close(
         self,

--- a/sdk-python/dex/_worker_service.py
+++ b/sdk-python/dex/_worker_service.py
@@ -31,21 +31,30 @@ class WorkerService(dex_pb2_grpc.WorkerServiceServicer):
         request: pb.InvokeWaitForMethodRequest,
         context: grpc.ServicerContext,
     ) -> pb.InvokeWaitForMethodResponse:
-        return self._invoke(context, lambda: self._dispatcher.invoke_wait_for(request))
+        return self._invoke(
+            context,
+            lambda: self._dispatcher.invoke_wait_for(request, context.is_active),
+        )
 
     def InvokeExecuteMethod(
         self,
         request: pb.InvokeExecuteMethodRequest,
         context: grpc.ServicerContext,
     ) -> pb.InvokeExecuteMethodResponse:
-        return self._invoke(context, lambda: self._dispatcher.invoke_execute(request))
+        return self._invoke(
+            context,
+            lambda: self._dispatcher.invoke_execute(request, context.is_active),
+        )
 
     def InvokeWorkerRPC(
         self,
         request: pb.InvokeWorkerRPCRequest,
         context: grpc.ServicerContext,
     ) -> pb.InvokeWorkerRPCResponse:
-        return self._invoke(context, lambda: self._dispatcher.invoke_rpc(request))
+        return self._invoke(
+            context,
+            lambda: self._dispatcher.invoke_rpc(request, context.is_active),
+        )
 
     @staticmethod
     def _invoke(
@@ -55,6 +64,11 @@ class WorkerService(dex_pb2_grpc.WorkerServiceServicer):
         try:
             return invocation()
         except BaseException as error:
+            if not context.is_active():
+                context.abort(
+                    grpc.StatusCode.CANCELLED,
+                    "Python Worker invocation canceled",
+                )
             _LOGGER.exception("Python Worker invocation failed")
             abort_worker_error(context, error)
             raise RuntimeError("gRPC abort returned unexpectedly") from error

--- a/sdk-python/dex/context.py
+++ b/sdk-python/dex/context.py
@@ -92,6 +92,18 @@ class Context(Protocol):
         """
         ...
 
+    def is_cancellation_requested(self) -> bool:
+        """Report whether Dex canceled the active handler call.
+
+        Async handlers are normally canceled by their task. Synchronous handlers cannot be
+        forcefully interrupted by Python; long CPU-bound work may check this at natural
+        boundaries. External effects still require idempotency or compensation.
+
+        Returns:
+            ``True`` after the Worker gRPC call has been canceled.
+        """
+        ...
+
     def set_step_execution_local(self, key: str, value: object) -> None:
         """Store process-local data for this Step execution.
 

--- a/sdk-python/dex/flow.py
+++ b/sdk-python/dex/flow.py
@@ -11,7 +11,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import timedelta
 from inspect import iscoroutinefunction, signature
 from types import MappingProxyType
@@ -118,15 +118,36 @@ def rpc(
 
 @dataclass(frozen=True)
 class RPCResult(Generic[OutputT]):
-    """Return a typed RPC output and optional next-Step movements.
+    """Return typed RPC output, next-Step movements, and Step cancellation.
 
     Attributes:
         output: The value decoded into the Client caller's expected output type.
         next_steps: Step movements applied atomically with handler persistence writes.
+        canceling_steps: Flow-wide Step types canceled before next Steps are queued.
     """
 
     output: OutputT
     next_steps: tuple[StepMovement[Any], ...] = ()
+    canceling_steps: tuple[Step[Any], ...] = ()
+
+    def with_canceling_steps(self, *steps: Step[Any]) -> RPCResult[OutputT]:
+        """Return a result canceling all current executions of selected Step types.
+
+        Dex resolves the selection after RPC persistence commits and before ``next_steps``.
+        Finished, already-canceled, and absent executions are no-ops. RPCs cannot select
+        siblings because an RPC has no Step execution lineage.
+
+        Args:
+            *steps: Exact Step instances registered with the current Flow.
+
+        Returns:
+            A new RPCResult containing the combined cancellation selectors.
+        """
+        combined = list(self.canceling_steps)
+        for step in steps:
+            if all(step is not current for current in combined):
+                combined.append(step)
+        return replace(self, canceling_steps=tuple(combined))
 
 
 @dataclass(frozen=True)

--- a/sdk-python/dex/step.py
+++ b/sdk-python/dex/step.py
@@ -87,6 +87,7 @@ class StepOptions:
     Attributes:
         wait_for_method_timeout: Maximum duration of one ``wait_for`` attempt.
         execute_method_timeout: Maximum duration of one ``execute`` attempt.
+        heartbeat_timeout: Cooperative cancellation heartbeat for regular activities.
         wait_for_retry: Optional retry policy for ``wait_for``.
         execute_retry: Optional retry policy for ``execute``.
         wait_for_failure: Behavior after all ``wait_for`` attempts fail.
@@ -98,6 +99,7 @@ class StepOptions:
 
     wait_for_method_timeout: timedelta | None = None
     execute_method_timeout: timedelta | None = None
+    heartbeat_timeout: timedelta | None = None
     wait_for_retry: RetryPolicy | None = None
     execute_retry: RetryPolicy | None = None
     wait_for_failure: WaitForFailurePolicy = WaitForFailurePolicy.FAIL_FLOW
@@ -330,6 +332,8 @@ class StepDecision:
         reason: Human-readable force-failure reason.
         empty_channels: Channels that must be empty for conditional completion.
         fallback: Movement used when conditional completion cannot proceed.
+        canceling_steps: Flow-wide Step type cancellation selectors.
+        canceling_sibling_steps: Same-source Step type cancellation selectors.
     """
 
     kind: DecisionKind
@@ -338,9 +342,68 @@ class StepDecision:
     reason: str = ""
     empty_channels: tuple[Channel[Any] | ChannelMap[Any], ...] = ()
     fallback: StepMovement[Any] | None = None
+    canceling_steps: tuple[Step[Any], ...] = ()
+    canceling_sibling_steps: tuple[Step[Any], ...] = ()
 
     def _has_output(self) -> bool:
         return self.output is not _NO_OUTPUT
+
+    def with_canceling_steps(self, *steps: Step[Any]) -> StepDecision:
+        """Return a decision canceling all current executions of selected Step types.
+
+        Dex resolves one snapshot after this Execute succeeds. Finished, already-canceled,
+        and absent executions are no-ops. Steps scheduled by this decision are excluded.
+        Repeated calls take the union, and Flow-wide selection supersedes sibling selection.
+
+        Args:
+            *steps: Exact Step instances registered with the current Flow.
+
+        Returns:
+            A new decision containing the combined Flow-wide selectors.
+        """
+        global_steps = _union_steps(self.canceling_steps, steps)
+        sibling_steps = tuple(
+            step
+            for step in self.canceling_sibling_steps
+            if all(step is not global_step for global_step in global_steps)
+        )
+        return replace(
+            self,
+            canceling_steps=global_steps,
+            canceling_sibling_steps=sibling_steps,
+        )
+
+    def with_canceling_sibling_steps(self, *steps: Step[Any]) -> StepDecision:
+        """Return a decision canceling selected same-source Step executions.
+
+        A sibling has the same ``Context.from_step_execution_id`` as the execution
+        returning this decision. Snapshot and no-op behavior match
+        ``with_canceling_steps``. Flow-wide selection wins for the same Step type.
+
+        Args:
+            *steps: Exact Step instances registered with the current Flow.
+
+        Returns:
+            A new decision containing the combined sibling selectors.
+        """
+        siblings = _union_steps(self.canceling_sibling_steps, steps)
+        siblings = tuple(
+            step
+            for step in siblings
+            if all(step is not global_step for global_step in self.canceling_steps)
+        )
+        return replace(self, canceling_sibling_steps=siblings)
+
+
+def _union_steps(
+    existing: tuple[Step[Any], ...],
+    added: tuple[Step[Any], ...],
+) -> tuple[Step[Any], ...]:
+    combined = list(existing)
+    for step in added:
+        if all(step is not current for current in combined):
+            combined.append(step)
+    return tuple(combined)
 
 
 def go_to(step: Step[InputT], input: InputT) -> StepDecision:

--- a/sdk-python/tests/integ/step_cancellation_flow.py
+++ b/sdk-python/tests/integ/step_cancellation_flow.py
@@ -1,0 +1,307 @@
+# Portions of this file are derived from indeedeng/iwf-java-sdk.
+# Those portions are licensed under the Apache License, Version 2.0.
+# See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+#
+# Modifications Copyright (c) 2026 Super Durable, Inc.
+#
+# Modifications are licensed under the Super Durable Source License 1.0.
+# Third-Party Materials remain under the Apache License, Version 2.0.
+# See LICENSE and LEGACY_NOTICES.md.
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from enum import Enum
+from typing import Any
+
+from dex import (
+    Attribute,
+    Context,
+    Flow,
+    PersistenceSchema,
+    Step,
+    StepDecision,
+    StepDurability,
+    StepList,
+    StepMovement,
+    StepOptions,
+    Timer,
+    Wait,
+    WaitForFailurePolicy,
+    dead_end,
+    force_fail,
+    go_to,
+    go_to_multi,
+    graceful_complete,
+)
+
+
+class CancellationScenario(Enum):
+    HEARTBEAT_EXECUTE = "heartbeat-execute"
+    HEARTBEAT_WAIT_FOR = "heartbeat-wait-for"
+    LOCAL_EXECUTE = "local-execute"
+    LOCAL_TIMEOUT_FALLBACK = "local-timeout-fallback"
+    NO_HEARTBEAT = "no-heartbeat"
+    GLOBAL_SELECTOR = "global-selector"
+    SIBLING_SELECTOR = "sibling-selector"
+
+
+class CancellationStart(Step[str]):
+    def __init__(self, flow: StepCancellationFlow) -> None:
+        self.flow = flow
+
+    def execute(self, context: Context, input: str) -> StepDecision:
+        del context, input
+        scenario = self.flow.scenario
+        if scenario is CancellationScenario.HEARTBEAT_WAIT_FOR:
+            return go_to_multi(
+                StepMovement.of(self.flow.blocking_wait_for, None),
+                StepMovement.of(self.flow.winner, None),
+            )
+        if scenario in {
+            CancellationScenario.GLOBAL_SELECTOR,
+            CancellationScenario.SIBLING_SELECTOR,
+        }:
+            return go_to_multi(
+                StepMovement.of(self.flow.first_parent, None),
+                StepMovement.of(self.flow.second_parent, None),
+            )
+        return go_to_multi(
+            StepMovement.of(self.flow.blocking_execute, None),
+            StepMovement.of(self.flow.winner, None),
+        )
+
+
+class CancellationBlockingExecute(Step[None]):
+    def __init__(self, flow: StepCancellationFlow) -> None:
+        self.flow = flow
+
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: None
+    ) -> StepDecision:
+        del input
+        self.flow.blocking_invocations += 1
+        self.flow.blocking_started.set()
+        duration = 7 if self.flow.scenario is CancellationScenario.NO_HEARTBEAT else 10
+        try:
+            await asyncio.sleep(duration)
+        except asyncio.CancelledError:
+            self.flow.handler_canceled = True
+            self.flow.context_reported_cancellation = (
+                context.is_cancellation_requested()
+            )
+            self.flow.cancellation_observed.set()
+        self.flow.late_write.set(context, "late")
+        self.flow.late_handler_returned.set()
+        return go_to(self.flow.recovery, None)
+
+    def get_step_options(self) -> StepOptions:
+        options = StepOptions(
+            execute_method_timeout=timedelta(seconds=15),
+            heartbeat_timeout=(
+                timedelta(seconds=2)
+                if self.flow.scenario
+                in {
+                    CancellationScenario.HEARTBEAT_EXECUTE,
+                    CancellationScenario.LOCAL_TIMEOUT_FALLBACK,
+                }
+                else None
+            ),
+            execute_durability=(
+                StepDurability.ASYNC
+                if self.flow.scenario
+                in {
+                    CancellationScenario.LOCAL_EXECUTE,
+                    CancellationScenario.LOCAL_TIMEOUT_FALLBACK,
+                }
+                else StepDurability.SYNC
+            ),
+        )
+        return options.on_execute_failure_proceed_to(self.flow.recovery)
+
+
+class CancellationBlockingWaitFor(Step[None]):
+    def __init__(self, flow: StepCancellationFlow) -> None:
+        self.flow = flow
+
+    async def wait_for(  # type: ignore[override]
+        self, context: Context, input: None
+    ) -> Wait:
+        del input
+        self.flow.blocking_invocations += 1
+        self.flow.blocking_started.set()
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            self.flow.handler_canceled = True
+            self.flow.context_reported_cancellation = (
+                context.is_cancellation_requested()
+            )
+            self.flow.cancellation_observed.set()
+        return Wait.skip_immediately()
+
+    def execute(self, context: Context, input: None) -> StepDecision:
+        del context, input
+        self.flow.recovery_ran = True
+        return force_fail("canceled wait_for execution continued")
+
+    def get_step_options(self) -> StepOptions:
+        return StepOptions(
+            wait_for_method_timeout=timedelta(seconds=15),
+            heartbeat_timeout=timedelta(seconds=2),
+            wait_for_failure=WaitForFailurePolicy.PROCEED,
+            wait_for_durability=StepDurability.SYNC,
+        )
+
+
+class CancellationWinner(Step[None]):
+    def __init__(self, flow: StepCancellationFlow) -> None:
+        self.flow = flow
+
+    def wait_for(self, context: Context, input: None) -> Wait:
+        del context, input
+        if self.flow.scenario is CancellationScenario.LOCAL_EXECUTE:
+            return Wait.skip_immediately()
+        return Wait.until(Timer.by_duration(timedelta(seconds=3)))
+
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: None
+    ) -> StepDecision:
+        del context, input
+        if self.flow.scenario is CancellationScenario.LOCAL_EXECUTE:
+            await asyncio.wait_for(self.flow.blocking_started.wait(), timeout=10)
+            await asyncio.sleep(1)
+        selected: Step[Any] = self.flow.blocking_execute
+        if self.flow.scenario is CancellationScenario.HEARTBEAT_WAIT_FOR:
+            selected = self.flow.blocking_wait_for
+        return go_to(self.flow.final, self.flow.scenario.value).with_canceling_steps(
+            selected
+        )
+
+
+class CancellationRecovery(Step[None]):
+    def __init__(self, flow: StepCancellationFlow) -> None:
+        self.flow = flow
+
+    def execute(self, context: Context, input: None) -> StepDecision:
+        del context, input
+        self.flow.recovery_ran = True
+        return force_fail("canceled execution reached recovery")
+
+
+class CancellationFinal(Step[str]):
+    def wait_for(self, context: Context, input: str) -> Wait:
+        del context, input
+        return Wait.until(Timer.by_duration(timedelta(seconds=1)))
+
+    def execute(self, context: Context, input: str) -> StepDecision:
+        del context
+        return graceful_complete(input)
+
+
+class CancellationFirstParent(Step[None]):
+    def __init__(self, flow: StepCancellationFlow) -> None:
+        self.flow = flow
+
+    def execute(self, context: Context, input: None) -> StepDecision:
+        del context, input
+        return go_to_multi(
+            StepMovement.of(self.flow.selector_winner, None),
+            StepMovement.of(self.flow.selector_waiting, "first"),
+        )
+
+
+class CancellationSecondParent(Step[None]):
+    def __init__(self, flow: StepCancellationFlow) -> None:
+        self.flow = flow
+
+    def execute(self, context: Context, input: None) -> StepDecision:
+        del context, input
+        return go_to(self.flow.selector_waiting, "second")
+
+
+class CancellationSelectorWinner(Step[None]):
+    def __init__(self, flow: StepCancellationFlow) -> None:
+        self.flow = flow
+
+    def wait_for(self, context: Context, input: None) -> Wait:
+        del context, input
+        return Wait.until(Timer.by_duration(timedelta(seconds=1)))
+
+    async def execute(  # type: ignore[override]
+        self, context: Context, input: None
+    ) -> StepDecision:
+        del context, input
+        await asyncio.wait_for(self.flow.selector_waits_registered.wait(), timeout=10)
+        decision = go_to(self.flow.final, self.flow.scenario.value)
+        if self.flow.scenario is CancellationScenario.GLOBAL_SELECTOR:
+            return decision.with_canceling_steps(self.flow.selector_waiting)
+        return decision.with_canceling_sibling_steps(self.flow.selector_waiting)
+
+
+class CancellationSelectorWaiting(Step[str]):
+    def __init__(self, flow: StepCancellationFlow) -> None:
+        self.flow = flow
+
+    def wait_for(self, context: Context, input: str) -> Wait:
+        del context
+        self.flow.selector_wait_count += 1
+        if self.flow.selector_wait_count == 2:
+            self.flow.selector_waits_registered.set()
+        duration = 30 if input == "first" else 2
+        return Wait.until(Timer.by_duration(timedelta(seconds=duration)))
+
+    def execute(self, context: Context, input: str) -> StepDecision:
+        del context
+        if input == "first":
+            self.flow.first_selector_executed = True
+        else:
+            self.flow.second_selector_executed = True
+        return dead_end()
+
+
+class StepCancellationFlow(Flow[str]):
+    def __init__(self, scenario: CancellationScenario) -> None:
+        self.scenario = scenario
+        self.late_write = Attribute("python-cancellation-late-write", str)
+        self.blocking_started = asyncio.Event()
+        self.cancellation_observed = asyncio.Event()
+        self.late_handler_returned = asyncio.Event()
+        self.selector_waits_registered = asyncio.Event()
+        self.handler_canceled = False
+        self.context_reported_cancellation = False
+        self.recovery_ran = False
+        self.first_selector_executed = False
+        self.second_selector_executed = False
+        self.blocking_invocations = 0
+        self.selector_wait_count = 0
+        self.recovery = CancellationRecovery(self)
+        self.blocking_execute = CancellationBlockingExecute(self)
+        self.blocking_wait_for = CancellationBlockingWaitFor(self)
+        self.winner = CancellationWinner(self)
+        self.final = CancellationFinal()
+        self.first_parent = CancellationFirstParent(self)
+        self.second_parent = CancellationSecondParent(self)
+        self.selector_winner = CancellationSelectorWinner(self)
+        self.selector_waiting = CancellationSelectorWaiting(self)
+        self.start = CancellationStart(self)
+
+    def get_flow_type(self) -> str:
+        return f"PythonStepCancellation{self.scenario.name}"
+
+    def get_steps(self) -> StepList[str]:
+        return StepList.start_step(self.start).other_steps(
+            self.blocking_execute,
+            self.blocking_wait_for,
+            self.winner,
+            self.recovery,
+            self.final,
+            self.first_parent,
+            self.second_parent,
+            self.selector_winner,
+            self.selector_waiting,
+        )
+
+    def get_persistence_schema(self) -> PersistenceSchema:
+        return PersistenceSchema.of(self.late_write)

--- a/sdk-python/tests/integ/test_step_cancellation_runtime.py
+++ b/sdk-python/tests/integ/test_step_cancellation_runtime.py
@@ -1,0 +1,75 @@
+# Portions of this file are derived from indeedeng/iwf-java-sdk.
+# Those portions are licensed under the Apache License, Version 2.0.
+# See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+#
+# Modifications Copyright (c) 2026 Super Durable, Inc.
+#
+# Modifications are licensed under the Super Durable Source License 1.0.
+# Third-Party Materials remain under the Apache License, Version 2.0.
+# See LICENSE and LEGACY_NOTICES.md.
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+
+import pytest
+
+from dex import StepExecutionId
+
+from .async_environment import AsyncDexDevTestEnvironment
+from .shared import unique_id
+from .step_cancellation_flow import CancellationScenario, StepCancellationFlow
+
+
+@pytest.mark.parametrize("scenario", list(CancellationScenario))
+def test_step_cancellation(scenario: CancellationScenario) -> None:
+    asyncio.run(_run_step_cancellation(scenario))
+
+
+async def _run_step_cancellation(scenario: CancellationScenario) -> None:
+    flow = StepCancellationFlow(scenario)
+    async with AsyncDexDevTestEnvironment(
+        flow, allow_async_handlers=True
+    ) as environment:
+        flow_id = unique_id(f"python-cancellation-{scenario.value}")
+        await environment.client.start_flow(flow, flow_id, scenario.value)
+
+        if scenario not in {
+            CancellationScenario.GLOBAL_SELECTOR,
+            CancellationScenario.SIBLING_SELECTOR,
+        }:
+            await asyncio.wait_for(flow.blocking_started.wait(), timeout=10)
+            selected = (
+                flow.blocking_wait_for
+                if scenario is CancellationScenario.HEARTBEAT_WAIT_FOR
+                else flow.blocking_execute
+            )
+            await environment.client.wait_for_step_completion(
+                flow_id,
+                StepExecutionId(selected.get_step_type()),
+                timedelta(seconds=30),
+            )
+
+        result = await environment.client.wait_for_flow(flow_id, timedelta(seconds=30))
+        assert result.single_output(str) == scenario.value
+
+        if scenario is CancellationScenario.GLOBAL_SELECTOR:
+            assert not flow.first_selector_executed
+            assert not flow.second_selector_executed
+            return
+        if scenario is CancellationScenario.SIBLING_SELECTOR:
+            assert not flow.first_selector_executed
+            assert flow.second_selector_executed
+            return
+        if scenario is CancellationScenario.NO_HEARTBEAT:
+            assert not flow.handler_canceled
+            assert not flow.late_handler_returned.is_set()
+            await asyncio.wait_for(flow.late_handler_returned.wait(), timeout=8)
+        else:
+            await asyncio.wait_for(flow.cancellation_observed.wait(), timeout=8)
+            assert flow.handler_canceled
+            assert flow.context_reported_cancellation
+        assert flow.blocking_invocations == 1
+        assert not flow.recovery_ran
+        assert await environment.client.get_attribute(flow_id, flow.late_write) is None

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -147,6 +147,39 @@ blocking executor, so they do not occupy gRPC I/O tasks. Long-running handlers
 can call `Context::wait_for_cancellation` or poll `Context::is_cancelled` to
 observe method deadlines and disconnected callers.
 
+### Canceling Step executions
+
+A successful Step can cancel queued or active executions while continuing with
+its normal decision:
+
+```rust
+Ok(StepDecision::go_to(&self.record_quote, quote)
+    .cancel_sibling_step(&self.carrier_a)
+    .cancel_sibling_step(&self.carrier_b)
+    .cancel_step(&self.global_quote_timeout))
+```
+
+`cancel_step` selects every current execution of one registered Step type.
+`cancel_sibling_step` selects only executions whose
+`Context::from_step_execution_id()` matches the current execution. Chain the
+builders to select multiple types; Flow-wide selection wins for the same type.
+The Worker rejects unregistered Step types as invalid results.
+
+Dex resolves one snapshot after the current execution succeeds. Completed,
+already-canceled, and absent targets are no-ops. Next Steps created by that
+decision are outside the snapshot. Dex immediately applies the next or close
+action; late decisions, writes, retries, and recovery Steps are discarded.
+
+Set `StepOptions::heartbeat_timeout` on long-running regular Steps so
+cancellation reaches the Worker promptly. Zero disables heartbeats, and
+positive values must be whole seconds in the signed int32 range. Local
+activities ignore the setting, while an ASYNC fallback uses it. Blocking
+handlers can call `Context::wait_for_cancellation`; batch handlers may check
+`Context::is_cancelled()` at natural boundaries.
+
+`RpcResult::cancel_step` provides Flow-wide selection for RPCs. RPCs do not
+support sibling selection because they have no Step execution lineage.
+
 Opt an Attribute or AttributeMap into Attribute Store synchronization and
 select the Server-configured Store for the Flow:
 

--- a/sdk-rust/crates/dex-sdk/src/rpc.rs
+++ b/sdk-rust/crates/dex-sdk/src/rpc.rs
@@ -222,6 +222,7 @@ where
 pub struct RpcResult<Output> {
     output: Output,
     next_steps: Vec<StepMovement>,
+    cancel_step_types: Vec<&'static str>,
 }
 
 impl<Output: Value> RpcResult<Output> {
@@ -230,12 +231,28 @@ impl<Output: Value> RpcResult<Output> {
         Self {
             output,
             next_steps: Vec::new(),
+            cancel_step_types: Vec::new(),
         }
     }
 
     /// Appends one Step movement executed after the RPC succeeds.
     pub fn then(mut self, movement: StepMovement) -> Self {
         self.next_steps.push(movement);
+        self
+    }
+
+    /// Selects every queued or active execution of one registered Step type.
+    ///
+    /// Dex resolves cancellation after RPC persistence commits and before next Steps are queued.
+    /// Finished, already-canceled, and absent executions are no-ops. RPCs cannot select siblings.
+    pub fn cancel_step<SelectedStep>(mut self, step: &SelectedStep) -> Self
+    where
+        SelectedStep: crate::Step,
+    {
+        let step_type = step.step_type();
+        if !self.cancel_step_types.contains(&step_type) {
+            self.cancel_step_types.push(step_type);
+        }
         self
     }
 
@@ -253,6 +270,7 @@ impl<Output: Value> RpcResult<Output> {
 pub(crate) struct ErasedRpcResult {
     pub(crate) output: Box<dyn ErasedValue>,
     pub(crate) next_steps: Vec<StepMovement>,
+    pub(crate) cancel_step_types: Vec<&'static str>,
 }
 
 #[derive(Clone)]
@@ -309,6 +327,7 @@ where
         Ok(ErasedRpcResult {
             output: Box::new(TypedValue(result.output)),
             next_steps: result.next_steps,
+            cancel_step_types: result.cancel_step_types,
         })
     }
 }
@@ -349,6 +368,7 @@ where
         Ok(ErasedRpcResult {
             output: Box::new(TypedValue(result.output)),
             next_steps: result.next_steps,
+            cancel_step_types: result.cancel_step_types,
         })
     }
 }
@@ -441,6 +461,7 @@ fn empty_rpc_result() -> ErasedRpcResult {
     ErasedRpcResult {
         output: Box::new(TypedValue(())),
         next_steps: Vec::new(),
+        cancel_step_types: Vec::new(),
     }
 }
 

--- a/sdk-rust/crates/dex-sdk/src/step.rs
+++ b/sdk-rust/crates/dex-sdk/src/step.rs
@@ -186,6 +186,8 @@ impl StepMovement {
 /// or deliberately leaves the Flow at a dead end.
 pub struct StepDecision {
     pub(crate) kind: StepDecisionKind,
+    pub(crate) cancel_step_types: Vec<&'static str>,
+    pub(crate) cancel_sibling_step_types: Vec<&'static str>,
 }
 
 pub(crate) enum StepDecisionKind {
@@ -214,6 +216,8 @@ impl StepDecision {
     pub fn go_to_many(movements: impl IntoIterator<Item = StepMovement>) -> Self {
         Self {
             kind: StepDecisionKind::Next(movements.into_iter().collect()),
+            cancel_step_types: Vec::new(),
+            cancel_sibling_step_types: Vec::new(),
         }
     }
 
@@ -221,6 +225,8 @@ impl StepDecision {
     pub fn graceful_complete<Output: Value>(output: Output) -> Self {
         Self {
             kind: StepDecisionKind::GracefulComplete(Box::new(TypedValue(output))),
+            cancel_step_types: Vec::new(),
+            cancel_sibling_step_types: Vec::new(),
         }
     }
 
@@ -228,6 +234,8 @@ impl StepDecision {
     pub fn force_complete<Output: Value>(output: Output) -> Self {
         Self {
             kind: StepDecisionKind::ForceComplete(Box::new(TypedValue(output))),
+            cancel_step_types: Vec::new(),
+            cancel_sibling_step_types: Vec::new(),
         }
     }
 
@@ -243,6 +251,8 @@ impl StepDecision {
                 fallback: Box::new(fallback),
                 channels: channels.into_iter().collect(),
             },
+            cancel_step_types: Vec::new(),
+            cancel_sibling_step_types: Vec::new(),
         }
     }
 
@@ -250,6 +260,8 @@ impl StepDecision {
     pub fn force_fail(reason: impl Into<String>) -> Self {
         Self {
             kind: StepDecisionKind::ForceFail(reason.into()),
+            cancel_step_types: Vec::new(),
+            cancel_sibling_step_types: Vec::new(),
         }
     }
 
@@ -259,7 +271,45 @@ impl StepDecision {
     pub fn dead_end() -> Self {
         Self {
             kind: StepDecisionKind::DeadEnd,
+            cancel_step_types: Vec::new(),
+            cancel_sibling_step_types: Vec::new(),
         }
+    }
+
+    /// Selects every queued or active execution of one registered Step type.
+    ///
+    /// Dex resolves one snapshot after the current `execute` succeeds. Finished,
+    /// already-canceled, and absent executions are no-ops. Steps scheduled by this decision
+    /// are excluded. Call repeatedly to select multiple types; Flow-wide selection wins.
+    pub fn cancel_step<SelectedStep>(mut self, step: &SelectedStep) -> Self
+    where
+        SelectedStep: Step,
+    {
+        let step_type = step.step_type();
+        if !self.cancel_step_types.contains(&step_type) {
+            self.cancel_step_types.push(step_type);
+        }
+        self.cancel_sibling_step_types
+            .retain(|selected| *selected != step_type);
+        self
+    }
+
+    /// Selects same-source executions of one registered Step type.
+    ///
+    /// A sibling has the same [`Context::from_step_execution_id`](crate::Context::from_step_execution_id)
+    /// as the execution returning this decision. Snapshot and no-op behavior match
+    /// [`Self::cancel_step`]. Call repeatedly to select multiple Step types.
+    pub fn cancel_sibling_step<SelectedStep>(mut self, step: &SelectedStep) -> Self
+    where
+        SelectedStep: Step,
+    {
+        let step_type = step.step_type();
+        if !self.cancel_step_types.contains(&step_type)
+            && !self.cancel_sibling_step_types.contains(&step_type)
+        {
+            self.cancel_sibling_step_types.push(step_type);
+        }
+        self
     }
 }
 

--- a/sdk-rust/crates/dex-sdk/src/step_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/step_options.rs
@@ -34,6 +34,7 @@ use crate::{RetryPolicy, Step, Value};
 pub struct StepOptions<Input> {
     pub(crate) wait_for_method_timeout: Option<Duration>,
     pub(crate) execute_method_timeout: Option<Duration>,
+    pub(crate) heartbeat_timeout: Option<Duration>,
     pub(crate) wait_for_retry: Option<RetryPolicy>,
     pub(crate) execute_retry: Option<RetryPolicy>,
     pub(crate) wait_for_failure: WaitForFailurePolicy,
@@ -49,6 +50,7 @@ pub struct StepOptions<Input> {
 pub(crate) struct ErasedStepOptions {
     pub(crate) wait_for_method_timeout: Option<Duration>,
     pub(crate) execute_method_timeout: Option<Duration>,
+    pub(crate) heartbeat_timeout: Option<Duration>,
     pub(crate) wait_for_retry: Option<RetryPolicy>,
     pub(crate) execute_retry: Option<RetryPolicy>,
     pub(crate) wait_for_failure: WaitForFailurePolicy,
@@ -64,6 +66,7 @@ impl<Input> From<StepOptions<Input>> for ErasedStepOptions {
         Self {
             wait_for_method_timeout: options.wait_for_method_timeout,
             execute_method_timeout: options.execute_method_timeout,
+            heartbeat_timeout: options.heartbeat_timeout,
             wait_for_retry: options.wait_for_retry,
             execute_retry: options.execute_retry,
             wait_for_failure: options.wait_for_failure,
@@ -82,6 +85,7 @@ impl<Input: Value> StepOptions<Input> {
         Self {
             wait_for_method_timeout: None,
             execute_method_timeout: None,
+            heartbeat_timeout: None,
             wait_for_retry: None,
             execute_retry: None,
             wait_for_failure: WaitForFailurePolicy::FailFlow,
@@ -103,6 +107,15 @@ impl<Input: Value> StepOptions<Input> {
     /// Sets the maximum duration of one `execute` handler attempt.
     pub fn execute_method_timeout(mut self, value: Duration) -> Self {
         self.execute_method_timeout = Some(value);
+        self
+    }
+
+    /// Enables cooperative cancellation heartbeats for regular `wait_for` and `execute` activities.
+    ///
+    /// Zero disables heartbeats. Positive values must be whole seconds within the int32 range.
+    /// Local activities ignore this option; an asynchronous fallback to regular activity uses it.
+    pub fn heartbeat_timeout(mut self, value: Duration) -> Self {
+        self.heartbeat_timeout = Some(value);
         self
     }
 

--- a/sdk-rust/crates/dex-sdk/src/worker_dispatcher.rs
+++ b/sdk-rust/crates/dex-sdk/src/worker_dispatcher.rs
@@ -171,7 +171,8 @@ impl WorkerDispatcher {
         run_handler(cancellation, move || {
             let result = rpc.handler.invoke(&mut context, &input)?;
             let output = encode_rpc_output(result.output.as_ref()).map_err(handler_error)?;
-            let decision = if result.next_steps.is_empty() {
+            let cancel_step_types = map_cancellation_step_types(&flow, result.cancel_step_types)?;
+            let decision = if result.next_steps.is_empty() && cancel_step_types.is_empty() {
                 None
             } else {
                 Some(ProtoStepDecision {
@@ -179,7 +180,7 @@ impl WorkerDispatcher {
                         HandlerError::invalid_step_result(flow.name, None, "rpc", error)
                     })?,
                     close_decision: None,
-                    cancel_step_types: Vec::new(),
+                    cancel_step_types,
                     cancel_sibling_step_types: Vec::new(),
                 })
             };
@@ -356,6 +357,7 @@ fn map_step_options_without_recovery(
     Ok(ProtoStepOptions {
         wait_for_timeout_seconds: optional_seconds(options.wait_for_method_timeout)?,
         execute_timeout_seconds: optional_seconds(options.execute_method_timeout)?,
+        heartbeat_timeout_seconds: optional_seconds(options.heartbeat_timeout)?,
         wait_for_retry_policy: options.wait_for_retry.map(map_retry).transpose()?,
         execute_retry_policy: options.execute_retry.map(map_retry).transpose()?,
         wait_for_failure_policy: match options.wait_for_failure {
@@ -378,7 +380,6 @@ fn map_step_options_without_recovery(
             .iter()
             .map(|lock| lock.physical_name())
             .collect(),
-        heartbeat_timeout_seconds: 0,
     })
 }
 
@@ -454,7 +455,14 @@ fn map_decision(
     flow: &RegisteredFlow,
     decision: crate::StepDecision,
 ) -> HandlerResult<ProtoStepDecision> {
-    match decision.kind {
+    let cancel_step_types = map_cancellation_step_types(flow, decision.cancel_step_types)?;
+    let global_types: HashSet<&str> = cancel_step_types.iter().map(String::as_str).collect();
+    let cancel_sibling_step_types =
+        map_cancellation_step_types(flow, decision.cancel_sibling_step_types)?
+            .into_iter()
+            .filter(|step_type| !global_types.contains(step_type.as_str()))
+            .collect();
+    let mut mapped = match decision.kind {
         StepDecisionKind::Next(movements) => {
             if movements.is_empty() {
                 return Err(HandlerError::new("go_to_many requires a movement"));
@@ -505,7 +513,30 @@ fn map_decision(
             cancel_step_types: Vec::new(),
             cancel_sibling_step_types: Vec::new(),
         }),
+    }?;
+    mapped.cancel_step_types = cancel_step_types;
+    mapped.cancel_sibling_step_types = cancel_sibling_step_types;
+    Ok(mapped)
+}
+
+fn map_cancellation_step_types(
+    flow: &RegisteredFlow,
+    selected: Vec<&'static str>,
+) -> HandlerResult<Vec<String>> {
+    let mut step_types = Vec::with_capacity(selected.len());
+    let mut seen = HashSet::with_capacity(selected.len());
+    for step_type in selected {
+        if !flow.steps.contains_key(step_type) {
+            return Err(HandlerError::new(
+                "cancellation Step does not belong to Flow",
+            ));
+        }
+        if !seen.insert(step_type) {
+            continue;
+        }
+        step_types.push(step_type.to_string());
     }
+    Ok(step_types)
 }
 
 fn close_decision(

--- a/sdk-rust/crates/dex-sdk/tests/integ.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ.rs
@@ -95,6 +95,10 @@ mod state_recovery_no_wait_workflow;
 mod state_recovery_test;
 #[path = "integ/state_recovery_workflow.rs"]
 mod state_recovery_workflow;
+#[path = "integ/step_cancellation_test.rs"]
+mod step_cancellation_test;
+#[path = "integ/step_cancellation_workflow.rs"]
+mod step_cancellation_workflow;
 #[path = "integ/subflow_test.rs"]
 mod subflow_test;
 #[path = "integ/subflow_workflow.rs"]

--- a/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_test.rs
@@ -1,0 +1,112 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use dex_sdk::{Registry, StepExecutionId};
+
+use crate::step_cancellation_workflow::{
+    CancellationBlockingExecute, CancellationBlockingWaitFor, CancellationScenario,
+    CancellationState, StepCancellationWorkflow,
+};
+use crate::support::{DexDevTestEnvironment, flow_id};
+
+#[test]
+#[ignore = "requires dexcli dev"]
+fn test_step_cancellation() {
+    for scenario in CancellationScenario::ALL {
+        run_scenario(scenario);
+    }
+}
+
+fn run_scenario(scenario: CancellationScenario) {
+    let state = CancellationState::new(scenario);
+    let workflow = StepCancellationWorkflow::new(Arc::clone(&state));
+    let late_write = workflow.late_write.clone();
+    let environment = DexDevTestEnvironment::start(Registry::new().register(workflow));
+    let client_workflow = StepCancellationWorkflow::new(Arc::clone(&state));
+    let flow_id = flow_id(&format!("rust-cancellation-{}", scenario.name()));
+    environment
+        .client
+        .start_flow(&client_workflow, &flow_id, scenario.name().to_string())
+        .expect("start cancellation Flow");
+
+    if !matches!(
+        scenario,
+        CancellationScenario::GlobalSelector | CancellationScenario::SiblingSelector
+    ) {
+        assert!(state.blocking_started.wait(Duration::from_secs(10)));
+        if scenario == CancellationScenario::HeartbeatWaitFor {
+            environment
+                .client
+                .wait_for_step_completion(
+                    &flow_id,
+                    StepExecutionId::of(&CancellationBlockingWaitFor(Arc::clone(&state))),
+                    Duration::from_secs(30),
+                )
+                .expect("wait for canceled WaitFor Step");
+        } else {
+            environment
+                .client
+                .wait_for_step_completion(
+                    &flow_id,
+                    StepExecutionId::of(&CancellationBlockingExecute {
+                        state: Arc::clone(&state),
+                        late_write: late_write.clone(),
+                    }),
+                    Duration::from_secs(30),
+                )
+                .expect("wait for canceled Execute Step");
+        }
+    }
+
+    assert_eq!(
+        scenario.name(),
+        environment
+            .client
+            .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
+            .and_then(|result| result.single_output::<String>())
+            .expect("complete cancellation Flow")
+    );
+
+    match scenario {
+        CancellationScenario::GlobalSelector => {
+            assert!(!state.first_selector_executed.load(Ordering::SeqCst));
+            assert!(!state.second_selector_executed.load(Ordering::SeqCst));
+            return;
+        }
+        CancellationScenario::SiblingSelector => {
+            assert!(!state.first_selector_executed.load(Ordering::SeqCst));
+            assert!(state.second_selector_executed.load(Ordering::SeqCst));
+            return;
+        }
+        CancellationScenario::NoHeartbeat => {
+            assert!(!state.handler_canceled.load(Ordering::SeqCst));
+            assert!(!state.late_handler_returned.is_set());
+            assert!(state.late_handler_returned.wait(Duration::from_secs(8)));
+        }
+        _ => {
+            assert!(state.cancellation_observed.wait(Duration::from_secs(8)));
+            assert!(state.handler_canceled.load(Ordering::SeqCst));
+            assert!(state.context_reported_cancellation.load(Ordering::SeqCst));
+        }
+    }
+    assert_eq!(1, state.blocking_invocations.load(Ordering::SeqCst));
+    assert!(!state.recovery_ran.load(Ordering::SeqCst));
+    assert_eq!(
+        None,
+        environment
+            .client
+            .get_attribute::<String>(&flow_id, &late_write)
+            .expect("read late Attribute")
+    );
+}

--- a/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_workflow.rs
@@ -1,0 +1,428 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use dex_sdk::{
+    Attribute, Context, Flow, HandlerError, HandlerResult, PersistenceSchema, Step, StepDecision,
+    StepList, StepMovement, StepOptions, Timer, Wait, WaitForFailurePolicy,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CancellationScenario {
+    HeartbeatExecute,
+    HeartbeatWaitFor,
+    LocalExecute,
+    LocalTimeoutFallback,
+    NoHeartbeat,
+    GlobalSelector,
+    SiblingSelector,
+}
+
+impl CancellationScenario {
+    pub(crate) const ALL: [Self; 7] = [
+        Self::HeartbeatExecute,
+        Self::HeartbeatWaitFor,
+        Self::LocalExecute,
+        Self::LocalTimeoutFallback,
+        Self::NoHeartbeat,
+        Self::GlobalSelector,
+        Self::SiblingSelector,
+    ];
+
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::HeartbeatExecute => "heartbeat-execute",
+            Self::HeartbeatWaitFor => "heartbeat-wait-for",
+            Self::LocalExecute => "local-execute",
+            Self::LocalTimeoutFallback => "local-timeout-fallback",
+            Self::NoHeartbeat => "no-heartbeat",
+            Self::GlobalSelector => "global-selector",
+            Self::SiblingSelector => "sibling-selector",
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct Event {
+    ready: Mutex<bool>,
+    condition: Condvar,
+}
+
+impl Event {
+    pub(crate) fn set(&self) {
+        *self.ready.lock().expect("event lock") = true;
+        self.condition.notify_all();
+    }
+
+    pub(crate) fn wait(&self, timeout: Duration) -> bool {
+        let ready = self.ready.lock().expect("event lock");
+        let (ready, _) = self
+            .condition
+            .wait_timeout_while(ready, timeout, |ready| !*ready)
+            .expect("event wait");
+        *ready
+    }
+
+    pub(crate) fn is_set(&self) -> bool {
+        *self.ready.lock().expect("event lock")
+    }
+}
+
+pub(crate) struct CancellationState {
+    pub(crate) scenario: CancellationScenario,
+    pub(crate) blocking_started: Event,
+    pub(crate) cancellation_observed: Event,
+    pub(crate) late_handler_returned: Event,
+    pub(crate) selector_waits_registered: Event,
+    pub(crate) handler_canceled: AtomicBool,
+    pub(crate) context_reported_cancellation: AtomicBool,
+    pub(crate) recovery_ran: AtomicBool,
+    pub(crate) first_selector_executed: AtomicBool,
+    pub(crate) second_selector_executed: AtomicBool,
+    pub(crate) blocking_invocations: AtomicU32,
+    selector_wait_count: AtomicU32,
+}
+
+impl CancellationState {
+    pub(crate) fn new(scenario: CancellationScenario) -> Arc<Self> {
+        Arc::new(Self {
+            scenario,
+            blocking_started: Event::default(),
+            cancellation_observed: Event::default(),
+            late_handler_returned: Event::default(),
+            selector_waits_registered: Event::default(),
+            handler_canceled: AtomicBool::new(false),
+            context_reported_cancellation: AtomicBool::new(false),
+            recovery_ran: AtomicBool::new(false),
+            first_selector_executed: AtomicBool::new(false),
+            second_selector_executed: AtomicBool::new(false),
+            blocking_invocations: AtomicU32::new(0),
+            selector_wait_count: AtomicU32::new(0),
+        })
+    }
+}
+
+pub(crate) struct StepCancellationWorkflow {
+    pub(crate) late_write: Attribute<String>,
+    start: CancellationStart,
+    blocking_execute: CancellationBlockingExecute,
+    blocking_wait_for: CancellationBlockingWaitFor,
+    winner: CancellationWinner,
+    recovery: CancellationRecovery,
+    final_step: CancellationFinal,
+    first_parent: CancellationFirstParent,
+    second_parent: CancellationSecondParent,
+    selector_winner: CancellationSelectorWinner,
+    selector_waiting: CancellationSelectorWaiting,
+}
+
+impl StepCancellationWorkflow {
+    pub(crate) fn new(state: Arc<CancellationState>) -> Self {
+        let late_write = Attribute::new("rust-cancellation-late-write");
+        Self {
+            start: CancellationStart(Arc::clone(&state)),
+            blocking_execute: CancellationBlockingExecute {
+                state: Arc::clone(&state),
+                late_write: late_write.clone(),
+            },
+            blocking_wait_for: CancellationBlockingWaitFor(Arc::clone(&state)),
+            winner: CancellationWinner(Arc::clone(&state)),
+            recovery: CancellationRecovery(Arc::clone(&state)),
+            final_step: CancellationFinal,
+            first_parent: CancellationFirstParent(Arc::clone(&state)),
+            second_parent: CancellationSecondParent(Arc::clone(&state)),
+            selector_winner: CancellationSelectorWinner(Arc::clone(&state)),
+            selector_waiting: CancellationSelectorWaiting(Arc::clone(&state)),
+            late_write,
+        }
+    }
+}
+
+impl Flow for StepCancellationWorkflow {
+    type StartInput = String;
+
+    fn steps(&self) -> StepList<'_, Self::StartInput> {
+        StepList::start(&self.start)
+            .and(&self.blocking_execute)
+            .and(&self.blocking_wait_for)
+            .and(&self.winner)
+            .and(&self.recovery)
+            .and(&self.final_step)
+            .and(&self.first_parent)
+            .and(&self.second_parent)
+            .and(&self.selector_winner)
+            .and(&self.selector_waiting)
+    }
+
+    fn persistence(&self) -> PersistenceSchema {
+        PersistenceSchema::new().attribute(&self.late_write)
+    }
+}
+
+pub(crate) struct CancellationStart(Arc<CancellationState>);
+
+impl Step for CancellationStart {
+    type Input = String;
+
+    fn execute(&self, _context: &mut Context, _input: String) -> HandlerResult<StepDecision> {
+        let state = Arc::clone(&self.0);
+        let decision = match state.scenario {
+            CancellationScenario::HeartbeatWaitFor => StepDecision::go_to_many([
+                StepMovement::to(&CancellationBlockingWaitFor(Arc::clone(&state)), ()),
+                StepMovement::to(&CancellationWinner(state), ()),
+            ]),
+            CancellationScenario::GlobalSelector | CancellationScenario::SiblingSelector => {
+                StepDecision::go_to_many([
+                    StepMovement::to(&CancellationFirstParent(Arc::clone(&state)), ()),
+                    StepMovement::to(&CancellationSecondParent(state), ()),
+                ])
+            }
+            _ => StepDecision::go_to_many([
+                StepMovement::to(
+                    &CancellationBlockingExecute {
+                        state: Arc::clone(&state),
+                        late_write: Attribute::new("rust-cancellation-late-write"),
+                    },
+                    (),
+                ),
+                StepMovement::to(&CancellationWinner(state), ()),
+            ]),
+        };
+        Ok(decision)
+    }
+}
+
+pub(crate) struct CancellationBlockingExecute {
+    pub(crate) state: Arc<CancellationState>,
+    pub(crate) late_write: Attribute<String>,
+}
+
+impl Step for CancellationBlockingExecute {
+    type Input = ();
+
+    fn execute(&self, context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        self.state
+            .blocking_invocations
+            .fetch_add(1, Ordering::SeqCst);
+        self.state.blocking_started.set();
+        if self.state.scenario == CancellationScenario::NoHeartbeat {
+            thread::sleep(Duration::from_secs(7));
+        } else {
+            context.wait_for_cancellation();
+            self.state.handler_canceled.store(true, Ordering::SeqCst);
+            self.state
+                .context_reported_cancellation
+                .store(context.is_cancelled(), Ordering::SeqCst);
+            self.state.cancellation_observed.set();
+        }
+        self.late_write.set(context, "late".to_string())?;
+        self.state.late_handler_returned.set();
+        Ok(StepDecision::go_to(
+            &CancellationRecovery(Arc::clone(&self.state)),
+            (),
+        ))
+    }
+
+    fn options(&self) -> StepOptions<Self::Input> {
+        let mut options = StepOptions::new()
+            .execute_method_timeout(Duration::from_secs(15))
+            .on_execute_failure_proceed_to(&CancellationRecovery(Arc::clone(&self.state)));
+        if matches!(
+            self.state.scenario,
+            CancellationScenario::HeartbeatExecute | CancellationScenario::LocalTimeoutFallback
+        ) {
+            options = options.heartbeat_timeout(Duration::from_secs(2));
+        }
+        if matches!(
+            self.state.scenario,
+            CancellationScenario::LocalExecute | CancellationScenario::LocalTimeoutFallback
+        ) {
+            options = options.execute_durability(dex_sdk::StepDurability::Async);
+        } else {
+            options = options.execute_durability(dex_sdk::StepDurability::Sync);
+        }
+        options
+    }
+}
+
+pub(crate) struct CancellationBlockingWaitFor(pub(crate) Arc<CancellationState>);
+
+impl Step for CancellationBlockingWaitFor {
+    type Input = ();
+
+    fn wait_for(&self, context: &mut Context, _input: ()) -> HandlerResult<Wait> {
+        self.0.blocking_invocations.fetch_add(1, Ordering::SeqCst);
+        self.0.blocking_started.set();
+        context.wait_for_cancellation();
+        self.0.handler_canceled.store(true, Ordering::SeqCst);
+        self.0
+            .context_reported_cancellation
+            .store(context.is_cancelled(), Ordering::SeqCst);
+        self.0.cancellation_observed.set();
+        Ok(Wait::skip_immediately())
+    }
+
+    fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        self.0.recovery_ran.store(true, Ordering::SeqCst);
+        Ok(StepDecision::force_fail(
+            "canceled wait_for execution continued",
+        ))
+    }
+
+    fn options(&self) -> StepOptions<Self::Input> {
+        StepOptions::new()
+            .wait_for_method_timeout(Duration::from_secs(15))
+            .heartbeat_timeout(Duration::from_secs(2))
+            .wait_for_failure(WaitForFailurePolicy::Proceed)
+            .wait_for_durability(dex_sdk::StepDurability::Sync)
+    }
+}
+
+struct CancellationWinner(Arc<CancellationState>);
+
+impl Step for CancellationWinner {
+    type Input = ();
+
+    fn wait_for(&self, _context: &mut Context, _input: ()) -> HandlerResult<Wait> {
+        if self.0.scenario == CancellationScenario::LocalExecute {
+            return Ok(Wait::skip_immediately());
+        }
+        Ok(Wait::until(Timer::by_duration(Duration::from_secs(3))))
+    }
+
+    fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        if self.0.scenario == CancellationScenario::LocalExecute {
+            if !self.0.blocking_started.wait(Duration::from_secs(10)) {
+                return Err(HandlerError::new("local loser did not start"));
+            }
+            thread::sleep(Duration::from_secs(1));
+        }
+        let decision = StepDecision::go_to(&CancellationFinal, self.0.scenario.name().to_string());
+        if self.0.scenario == CancellationScenario::HeartbeatWaitFor {
+            return Ok(decision.cancel_step(&CancellationBlockingWaitFor(Arc::clone(&self.0))));
+        }
+        Ok(decision.cancel_step(&CancellationBlockingExecute {
+            state: Arc::clone(&self.0),
+            late_write: Attribute::new("rust-cancellation-late-write"),
+        }))
+    }
+}
+
+struct CancellationRecovery(Arc<CancellationState>);
+
+impl Step for CancellationRecovery {
+    type Input = ();
+
+    fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        self.0.recovery_ran.store(true, Ordering::SeqCst);
+        Ok(StepDecision::force_fail(
+            "canceled execution reached recovery",
+        ))
+    }
+}
+
+struct CancellationFinal;
+
+impl Step for CancellationFinal {
+    type Input = String;
+
+    fn wait_for(&self, _context: &mut Context, _input: String) -> HandlerResult<Wait> {
+        Ok(Wait::until(Timer::by_duration(Duration::from_secs(1))))
+    }
+
+    fn execute(&self, _context: &mut Context, input: String) -> HandlerResult<StepDecision> {
+        Ok(StepDecision::graceful_complete(input))
+    }
+}
+
+struct CancellationFirstParent(Arc<CancellationState>);
+
+impl Step for CancellationFirstParent {
+    type Input = ();
+
+    fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        Ok(StepDecision::go_to_many([
+            StepMovement::to(&CancellationSelectorWinner(Arc::clone(&self.0)), ()),
+            StepMovement::to(
+                &CancellationSelectorWaiting(Arc::clone(&self.0)),
+                "first".to_string(),
+            ),
+        ]))
+    }
+}
+
+struct CancellationSecondParent(Arc<CancellationState>);
+
+impl Step for CancellationSecondParent {
+    type Input = ();
+
+    fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        Ok(StepDecision::go_to(
+            &CancellationSelectorWaiting(Arc::clone(&self.0)),
+            "second".to_string(),
+        ))
+    }
+}
+
+struct CancellationSelectorWinner(Arc<CancellationState>);
+
+impl Step for CancellationSelectorWinner {
+    type Input = ();
+
+    fn wait_for(&self, _context: &mut Context, _input: ()) -> HandlerResult<Wait> {
+        Ok(Wait::until(Timer::by_duration(Duration::from_secs(1))))
+    }
+
+    fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        if !self
+            .0
+            .selector_waits_registered
+            .wait(Duration::from_secs(10))
+        {
+            return Err(HandlerError::new("selector Steps did not reach waiting"));
+        }
+        let decision = StepDecision::go_to(&CancellationFinal, self.0.scenario.name().to_string());
+        if self.0.scenario == CancellationScenario::GlobalSelector {
+            return Ok(decision.cancel_step(&CancellationSelectorWaiting(Arc::clone(&self.0))));
+        }
+        Ok(decision.cancel_sibling_step(&CancellationSelectorWaiting(Arc::clone(&self.0))))
+    }
+}
+
+struct CancellationSelectorWaiting(Arc<CancellationState>);
+
+impl Step for CancellationSelectorWaiting {
+    type Input = String;
+
+    fn wait_for(&self, _context: &mut Context, input: String) -> HandlerResult<Wait> {
+        if self.0.selector_wait_count.fetch_add(1, Ordering::SeqCst) == 1 {
+            self.0.selector_waits_registered.set();
+        }
+        let duration = if input == "first" { 30 } else { 2 };
+        Ok(Wait::until(Timer::by_duration(Duration::from_secs(
+            duration,
+        ))))
+    }
+
+    fn execute(&self, _context: &mut Context, input: String) -> HandlerResult<StepDecision> {
+        if input == "first" {
+            self.0.first_selector_executed.store(true, Ordering::SeqCst);
+        } else {
+            self.0
+                .second_selector_executed
+                .store(true, Ordering::SeqCst);
+        }
+        Ok(StepDecision::dead_end())
+    }
+}

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -67,6 +67,46 @@ failure or the default 120-second deadline aborts startup. An indexed
 `StepOptions.waitForMethodTimeoutMs` and `executeMethodTimeoutMs` bound the two
 handler calls. Timer and channel conditions determine how long a Step waits.
 
+### Canceling Step executions
+
+A successful Step can cancel queued or active executions while continuing with
+its normal decision:
+
+```typescript
+return withCancelingSteps(
+  withCancelingSiblingSteps(
+    goTo(this.recordQuote, quote),
+    this.carrierA,
+    this.carrierB,
+  ),
+  this.globalQuoteTimeout,
+);
+```
+
+`withCancelingSteps` selects every current execution of each registered Step
+type. `withCancelingSiblingSteps` selects only executions whose
+`Context.fromStepExecutionId` matches the current execution. Both helpers return
+a new decision; repeated calls form a union, and Flow-wide selection wins for
+the same Step object. Unregistered selectors produce an invalid Step result.
+
+Dex resolves one snapshot after the current execution succeeds. Completed,
+already-canceled, and absent targets are no-ops. Next Steps created by that
+decision are outside the snapshot. Dex immediately applies the next or close
+action; late decisions, writes, retries, and recovery Steps are discarded.
+
+Set `StepOptions.heartbeatTimeoutMs` on long-running regular Steps so
+cancellation reaches the Worker promptly. The value is milliseconds but must
+represent whole seconds in the signed int32 range. Zero disables heartbeats.
+Local activities ignore the setting, while an ASYNC fallback uses it. The
+Worker aborts `Context.cancellationSignal`; pass it to abort-aware APIs:
+
+```typescript
+const response = await fetch(url, { signal: context.cancellationSignal });
+```
+
+An RPC result may set `cancelingSteps` for Flow-wide selection. RPCs do not
+support sibling selection because they have no Step execution lineage.
+
 Opt an Attribute or AttributeMap into Attribute Store synchronization, then
 select the Server-configured Store for the Flow:
 

--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -840,6 +840,7 @@ function mapStepOptions(
   return ProtoStepOptions.create({
     waitForTimeoutSeconds: seconds(options?.waitForMethodTimeoutMs),
     executeTimeoutSeconds: seconds(options?.executeMethodTimeoutMs),
+    heartbeatTimeoutSeconds: heartbeatSeconds(options?.heartbeatTimeoutMs),
     waitForRetryPolicy: mapRetryPolicy(options?.waitForRetry),
     executeRetryPolicy: mapRetryPolicy(options?.executeRetry),
     waitForFailurePolicy:
@@ -1049,6 +1050,14 @@ function seconds(milliseconds: number | undefined): number {
     throw new RangeError("duration must be a non-negative whole number of seconds");
   }
   return milliseconds / 1_000;
+}
+
+function heartbeatSeconds(milliseconds: number | undefined): number {
+  const value = seconds(milliseconds);
+  if (value > 2_147_483_647) {
+    throw new RangeError("heartbeat timeout exceeds int32 seconds");
+  }
+  return value;
 }
 
 function number64(value: bigint | undefined): number {

--- a/sdk-typescript/src/context.ts
+++ b/sdk-typescript/src/context.ts
@@ -30,6 +30,13 @@ export interface Context {
   /** One-based handler retry attempt number. */
   readonly attempt: number;
   /**
+   * Signal aborted when Dex cancels the active Worker call.
+   *
+   * Pass it to abort-aware APIs or inspect it at natural CPU-work boundaries. JavaScript
+   * cannot forcibly stop synchronous code, and cancellation cannot make external effects atomic.
+   */
+  readonly cancellationSignal: AbortSignal;
+  /**
    * Reports whether a Timer made the current Wait ready.
    * @param index - Optional zero-based Timer index; checks any Timer when omitted.
    * @returns Whether the selected Timer fired.

--- a/sdk-typescript/src/invocation-context.ts
+++ b/sdk-typescript/src/invocation-context.ts
@@ -38,6 +38,7 @@ export class InvocationContext implements Context {
   public readonly fromStepExecutionId: string;
   public readonly firstAttemptAt: Date;
   public readonly attempt: number;
+  public readonly cancellationSignal: AbortSignal;
 
   private readonly attributes: Map<string, Value>;
   private readonly locals: Map<string, Value>;
@@ -56,6 +57,7 @@ export class InvocationContext implements Context {
     locals: readonly KV[] = [],
     private readonly conditionResults?: ConditionResults,
     channelInfos: Readonly<Record<string, ChannelInfo>> = {},
+    cancellationSignal: AbortSignal = new AbortController().signal,
   ) {
     if (metadata === undefined) {
       throw new TypeError("Worker request Context is required");
@@ -67,6 +69,7 @@ export class InvocationContext implements Context {
     this.fromStepExecutionId = metadata.fromStepExecutionId;
     this.firstAttemptAt = secondsDate(metadata.firstAttemptTimestamp);
     this.attempt = metadata.attempt;
+    this.cancellationSignal = cancellationSignal;
     this.attributes = mapValues("Attribute", attributes);
     this.locals = mapValues("step-execution local", locals);
     this.channelInfos = new Map(Object.entries(channelInfos));

--- a/sdk-typescript/src/rpc.ts
+++ b/sdk-typescript/src/rpc.ts
@@ -10,7 +10,7 @@ import type { Codec } from "./codec.js";
 import type { Context } from "./context.js";
 import type { Flow } from "./flow.js";
 import type { AttributeLock } from "./persistence.js";
-import type { StepMovement } from "./step.js";
+import type { Step, StepMovement } from "./step.js";
 import { requireName } from "./validation.js";
 
 /**
@@ -22,6 +22,8 @@ export interface RPCResult<Output> {
   readonly output: Output;
   /** Step movements applied atomically with handler persistence writes. */
   readonly nextSteps?: readonly StepMovement<unknown>[];
+  /** Registered Step types canceled before `nextSteps` are scheduled. */
+  readonly cancelingSteps?: readonly Step<any>[];
 }
 
 /**

--- a/sdk-typescript/src/step.ts
+++ b/sdk-typescript/src/step.ts
@@ -61,6 +61,8 @@ export interface StepOptions {
   readonly waitForMethodTimeoutMs?: number;
   /** Maximum duration of one `execute` attempt in milliseconds. */
   readonly executeMethodTimeoutMs?: number;
+  /** Regular-activity heartbeat in milliseconds; must represent whole seconds. */
+  readonly heartbeatTimeoutMs?: number;
   /** Optional retry policy for `waitFor`. */
   readonly waitForRetry?: RetryPolicy;
   /** Optional retry policy for `execute`. */
@@ -234,8 +236,16 @@ export const StepMovement = Object.freeze({
   },
 });
 
+/** Selects queued or active Step executions canceled by a decision. */
+export interface StepCancellationSelection {
+  /** Registered Step types canceled across the current Flow. */
+  readonly cancelingSteps?: readonly Step<any>[];
+  /** Registered Step types canceled only when they share the current scheduling source. */
+  readonly cancelingSiblingSteps?: readonly Step<any>[];
+}
+
 /** Describes the durable transition returned by `Step.execute`. */
-export type StepDecision =
+export type StepDecision = (
   | Readonly<{
       /** Schedules next Step movements. */
       kind: "next";
@@ -267,7 +277,7 @@ export type StepDecision =
   | Readonly<{
       /** Ends this path without scheduling work or closing the Flow. */
       kind: "deadEnd";
-    }>;
+    }>) & Readonly<StepCancellationSelection>;
 
 /**
  * Creates a decision scheduling one next Step.
@@ -331,3 +341,56 @@ export const forceFail = (reason: string): StepDecision => ({ kind: "forceFail",
  * @returns A decision ending this path without closing the Flow.
  */
 export const deadEnd = (): StepDecision => ({ kind: "deadEnd" });
+
+/**
+ * Returns a copy selecting every current execution of the supplied Step types.
+ *
+ * Dex resolves one snapshot after `execute` succeeds. Finished, already-canceled,
+ * and absent executions are no-ops. Steps scheduled by the same decision are excluded.
+ * Repeated calls take the union, and Flow-wide selection supersedes sibling selection.
+ * @param decision - Decision to copy.
+ * @param steps - Exact Step instances registered with the current Flow.
+ * @returns A new decision containing the combined Flow-wide selectors.
+ */
+export const withCancelingSteps = (
+  decision: StepDecision,
+  ...steps: readonly Step<any>[]
+): StepDecision => {
+  const cancelingSteps = unionSteps(decision.cancelingSteps, steps);
+  const cancelingSiblingSteps = (decision.cancelingSiblingSteps ?? []).filter(
+    (step) => !cancelingSteps.includes(step),
+  );
+  return { ...decision, cancelingSteps, cancelingSiblingSteps };
+};
+
+/**
+ * Returns a copy selecting same-source executions of the supplied Step types.
+ *
+ * A sibling has the same `Context.fromStepExecutionId` as the execution returning
+ * the decision. Snapshot and no-op behavior match {@link withCancelingSteps}.
+ * @param decision - Decision to copy.
+ * @param steps - Exact Step instances registered with the current Flow.
+ * @returns A new decision containing the combined sibling selectors.
+ */
+export const withCancelingSiblingSteps = (
+  decision: StepDecision,
+  ...steps: readonly Step<any>[]
+): StepDecision => ({
+  ...decision,
+  cancelingSiblingSteps: unionSteps(decision.cancelingSiblingSteps, steps).filter(
+    (step) => !(decision.cancelingSteps ?? []).includes(step),
+  ),
+});
+
+function unionSteps(
+  existing: readonly Step<any>[] | undefined,
+  added: readonly Step<any>[],
+): readonly Step<any>[] {
+  const combined = [...(existing ?? [])];
+  for (const step of added) {
+    if (!combined.includes(step)) {
+      combined.push(step);
+    }
+  }
+  return combined;
+}

--- a/sdk-typescript/src/worker-dispatcher.ts
+++ b/sdk-typescript/src/worker-dispatcher.ts
@@ -58,6 +58,7 @@ import { SubFlowReusePolicy, type SubFlowOptions } from "./subflow.js";
 import type { RegisteredRPC } from "./rpc.js";
 import type {
   RetryPolicy,
+  Step,
   StepDecision,
   StepMovement,
   StepOptions,
@@ -79,11 +80,22 @@ export class WorkerDispatcher {
 
   public async invokeWaitFor(
     original: InvokeWaitForMethodRequest,
+    cancellationSignal: AbortSignal = new AbortController().signal,
   ): Promise<InvokeWaitForMethodResponse> {
     const request = await this.hydrateWaitFor(original);
+    cancellationSignal.throwIfAborted();
     const flow = registeredFlowByName(this.registry, request.flowType);
     const step = registeredStep(flow, request.stepType);
-    const context = new InvocationContext("waitFor", flow, request.context, request.attributes);
+    const context = new InvocationContext(
+      "waitFor",
+      flow,
+      request.context,
+      request.attributes,
+      [],
+      undefined,
+      {},
+      cancellationSignal,
+    );
     const input = decodeValue(step.step.inputCodec, requireValue(request.stepInput, "Step input"));
     if (step.step.waitFor === undefined) {
       throw new TypeError(`Step ${step.name} does not implement waitFor`);
@@ -104,8 +116,10 @@ export class WorkerDispatcher {
 
   public async invokeExecute(
     original: InvokeExecuteMethodRequest,
+    cancellationSignal: AbortSignal = new AbortController().signal,
   ): Promise<InvokeExecuteMethodResponse> {
     const request = await this.hydrateExecute(original);
+    cancellationSignal.throwIfAborted();
     const flow = registeredFlowByName(this.registry, request.flowType);
     const step = registeredStep(flow, request.stepType);
     const context = new InvocationContext(
@@ -115,6 +129,8 @@ export class WorkerDispatcher {
       request.attributes,
       request.stepExeLocals,
       request.conditionResults,
+      {},
+      cancellationSignal,
     );
     const input = decodeValue(step.step.inputCodec, requireValue(request.stepInput, "Step input"));
     const decision = await step.step.execute(context, input);
@@ -131,8 +147,12 @@ export class WorkerDispatcher {
     }
   }
 
-  public async invokeRPC(original: InvokeWorkerRPCRequest): Promise<InvokeWorkerRPCResponse> {
+  public async invokeRPC(
+    original: InvokeWorkerRPCRequest,
+    cancellationSignal: AbortSignal = new AbortController().signal,
+  ): Promise<InvokeWorkerRPCResponse> {
     const request = await this.hydrateRPC(original);
+    cancellationSignal.throwIfAborted();
     const flow = registeredFlowByName(this.registry, request.flowType);
     const rpc = registeredRPCByName(flow, request.rpcName);
     const context = new InvocationContext(
@@ -143,6 +163,7 @@ export class WorkerDispatcher {
       [],
       undefined,
       request.channelInfos,
+      cancellationSignal,
     );
     const returned = await invokeRPC(flow, rpc, context, request.input);
     try {
@@ -152,10 +173,7 @@ export class WorkerDispatcher {
           rpc.options.outputCodec === undefined
             ? encodeUnknown(undefined)
             : encodeValue(rpc.options.outputCodec, result?.output),
-        stepDecision:
-          result?.nextSteps === undefined || result.nextSteps.length === 0
-            ? undefined
-            : ProtoStepDecision.create({ nextSteps: mapMovements(flow, result.nextSteps) }),
+        stepDecision: rpcDecision(flow, result),
         upsertAttributes: [...context.getAttributeWrites()],
         recordEvents: [...context.getEvents()],
         publishToChannel: [...context.getPublications()],
@@ -310,14 +328,18 @@ function mapDecision(flow: RegisteredFlow, decision: StepDecision | undefined): 
     if (decision.movements.length === 0) {
       throw new TypeError("goToMulti requires a movement");
     }
-    return ProtoStepDecision.create({ nextSteps: mapMovements(flow, decision.movements) });
+    return withCancellationSelection(
+      flow,
+      decision,
+      ProtoStepDecision.create({ nextSteps: mapMovements(flow, decision.movements) }),
+    );
   }
   if (decision.kind === "deadEnd") {
-    return ProtoStepDecision.create({
+    return withCancellationSelection(flow, decision, ProtoStepDecision.create({
       closeDecision: CloseDecision.create({
         closeDecisionType: CloseDecisionType.CLOSE_DECISION_TYPE_DEAD_END,
       }),
-    });
+    }));
   }
   if (decision.kind === "forceCompleteIfChannelsEmpty") {
     const channels = decision.channels.map((channel) => {
@@ -326,7 +348,7 @@ function mapDecision(flow: RegisteredFlow, decision: StepDecision | undefined): 
       }
       return channel.name;
     });
-    return ProtoStepDecision.create({
+    return withCancellationSelection(flow, decision, ProtoStepDecision.create({
       nextSteps: [mapMovement(flow, decision.fallback)],
       closeDecision: CloseDecision.create({
         closeDecisionType:
@@ -334,7 +356,7 @@ function mapDecision(flow: RegisteredFlow, decision: StepDecision | undefined): 
         conditionalChannelNames: channels,
         closeInput: encodeUnknown(decision.output),
       }),
-    });
+    }));
   }
   const closeTypes = {
     gracefulComplete: CloseDecisionType.CLOSE_DECISION_TYPE_GRACEFUL_COMPLETE,
@@ -346,12 +368,62 @@ function mapDecision(flow: RegisteredFlow, decision: StepDecision | undefined): 
     : decision.output === undefined
       ? undefined
       : encodeUnknown(decision.output);
-  return ProtoStepDecision.create({
+  return withCancellationSelection(flow, decision, ProtoStepDecision.create({
     closeDecision: CloseDecision.create({
       closeDecisionType: closeTypes[decision.kind],
       closeInput,
     }),
-  });
+  }));
+}
+
+function withCancellationSelection(
+  flow: RegisteredFlow,
+  decision: StepDecision,
+  mapped: ProtoStepDecision,
+): ProtoStepDecision {
+  mapped.cancelStepTypes = mapCancellationSteps(flow, decision.cancelingSteps);
+  const globalTypes = new Set(mapped.cancelStepTypes);
+  mapped.cancelSiblingStepTypes = mapCancellationSteps(
+    flow,
+    decision.cancelingSiblingSteps,
+  ).filter((stepType) => !globalTypes.has(stepType));
+  return mapped;
+}
+
+function mapCancellationSteps(
+  flow: RegisteredFlow,
+  steps: readonly Step<any>[] | undefined,
+): string[] {
+  const stepTypes: string[] = [];
+  const seen = new Set<string>();
+  for (const step of steps ?? []) {
+    const target = flow.steps.find((candidate) => candidate.step === step);
+    if (target === undefined) {
+      throw new TypeError("cancellation Step must belong to the Flow");
+    }
+    if (seen.has(target.name)) {
+      continue;
+    }
+    seen.add(target.name);
+    stepTypes.push(target.name);
+  }
+  return stepTypes;
+}
+
+function rpcDecision(
+  flow: RegisteredFlow,
+  result: { nextSteps?: readonly StepMovement<unknown>[]; cancelingSteps?: readonly Step<any>[] }
+    | undefined,
+): ProtoStepDecision | undefined {
+  if (result === undefined) {
+    return undefined;
+  }
+  const nextSteps = mapMovements(flow, result.nextSteps ?? []);
+  const cancelStepTypes = mapCancellationSteps(flow, result.cancelingSteps);
+  if (nextSteps.length === 0 && cancelStepTypes.length === 0) {
+    return undefined;
+  }
+  return ProtoStepDecision.create({ nextSteps, cancelStepTypes });
 }
 
 function mapMovements(
@@ -394,6 +466,7 @@ function mapStepOptions(
   return ProtoStepOptions.create({
     waitForTimeoutSeconds: seconds(options?.waitForMethodTimeoutMs),
     executeTimeoutSeconds: seconds(options?.executeMethodTimeoutMs),
+    heartbeatTimeoutSeconds: heartbeatSeconds(options?.heartbeatTimeoutMs),
     waitForRetryPolicy: mapRetry(options?.waitForRetry),
     executeRetryPolicy: mapRetry(options?.executeRetry),
     waitForFailurePolicy:
@@ -693,6 +766,14 @@ function seconds(milliseconds: number | undefined): number {
     throw new RangeError("duration must be a non-negative whole number of seconds");
   }
   return milliseconds / 1_000;
+}
+
+function heartbeatSeconds(milliseconds: number | undefined): number {
+  const value = seconds(milliseconds);
+  if (value > 2_147_483_647) {
+    throw new RangeError("heartbeat timeout exceeds int32 seconds");
+  }
+  return value;
 }
 
 function invalidStepResult(

--- a/sdk-typescript/src/worker.ts
+++ b/sdk-typescript/src/worker.ts
@@ -11,6 +11,7 @@ import {
   ServerCredentials,
   Metadata,
   credentials,
+  type ServerUnaryCall,
   type sendUnaryData,
 } from "@grpc/grpc-js";
 
@@ -166,25 +167,42 @@ function syncAttributeIndexes(
 function workerService(dispatcher: WorkerDispatcher): WorkerServiceServer {
   return {
     invokeWaitForMethod(call, callback) {
-      invoke(() => dispatcher.invokeWaitFor(call.request), callback);
+      invoke(call, (signal) => dispatcher.invokeWaitFor(call.request, signal), callback);
     },
     invokeExecuteMethod(call, callback) {
-      invoke(() => dispatcher.invokeExecute(call.request), callback);
+      invoke(call, (signal) => dispatcher.invokeExecute(call.request, signal), callback);
     },
     invokeWorkerRpc(call, callback) {
-      invoke(() => dispatcher.invokeRPC(call.request), callback);
+      invoke(call, (signal) => dispatcher.invokeRPC(call.request, signal), callback);
     },
   };
 }
 
-function invoke<Response>(
-  invocation: () => Promise<Response>,
+function invoke<Request, Response>(
+  call: ServerUnaryCall<Request, Response>,
+  invocation: (signal: AbortSignal) => Promise<Response>,
   callback: sendUnaryData<Response>,
 ): void {
-  invocation().then(
-    (response) => callback(null, response),
-    (failure: unknown) => callback(workerServiceError(failure), null),
-  );
+  const controller = new AbortController();
+  const cancel = (): void => controller.abort();
+  call.once("cancelled", cancel);
+  if (call.cancelled) {
+    cancel();
+  }
+  invocation(controller.signal)
+    .then(
+      (response) => {
+        if (!controller.signal.aborted) {
+          callback(null, response);
+        }
+      },
+      (failure: unknown) => {
+        if (!controller.signal.aborted) {
+          callback(workerServiceError(failure), null);
+        }
+      },
+    )
+    .finally(() => call.off("cancelled", cancel));
 }
 
 function bind(server: Server, address: string): Promise<number> {

--- a/sdk-typescript/test/integ/step-cancellation.integration.test.ts
+++ b/sdk-typescript/test/integ/step-cancellation.integration.test.ts
@@ -1,0 +1,87 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { StepExecutionId, stringCodec } from "../../src/index.js";
+import { flowId, withEnvironment } from "./environment.js";
+import {
+  StepCancellationFlow,
+  cancellationScenarios,
+} from "./step_cancellation_flow.js";
+
+for (const scenario of cancellationScenarios) {
+  test(`Step cancellation ${scenario}`, async () => {
+    const flow = new StepCancellationFlow(scenario);
+    await withEnvironment([flow], async ({ client }) => {
+      const id = flowId(`typescript-cancellation-${scenario}`);
+      await client.startFlow(flow, id, scenario);
+
+      if (scenario !== "global-selector" && scenario !== "sibling-selector") {
+        await withTimeout(flow.blockingStarted, 10_000);
+        const selected = scenario === "heartbeat-wait-for"
+          ? flow.blockingWaitFor
+          : flow.blockingExecute;
+        await client.waitForStepCompletion(id, StepExecutionId.of(selected.getStepType()), 30_000);
+      }
+
+      assert.equal(
+        await client.waitForFlow(id, 30_000).then((result) => result.singleOutput(stringCodec)),
+        scenario,
+      );
+
+      if (scenario === "global-selector") {
+        assert.equal(flow.firstSelectorExecuted, false);
+        assert.equal(flow.secondSelectorExecuted, false);
+        return;
+      }
+      if (scenario === "sibling-selector") {
+        assert.equal(flow.firstSelectorExecuted, false);
+        assert.equal(flow.secondSelectorExecuted, true);
+        return;
+      }
+      if (scenario === "no-heartbeat") {
+        assert.equal(flow.handlerCanceled, false);
+        let returned = false;
+        void flow.lateHandlerReturned.then(() => { returned = true; });
+        await Promise.resolve();
+        assert.equal(returned, false);
+        await withTimeout(flow.lateHandlerReturned, 8_000);
+      } else {
+        await withTimeout(flow.cancellationObserved, 8_000);
+        assert.equal(flow.handlerCanceled, true);
+        assert.equal(flow.contextReportedCancellation, true);
+      }
+      assert.equal(flow.blockingInvocations, 1);
+      assert.equal(flow.recoveryRan, false);
+      assert.equal(await client.getAttribute(id, flow.lateWrite), undefined);
+    });
+  });
+}
+
+async function withTimeout<T>(promise: Promise<T>, milliseconds: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`timed out after ${milliseconds}ms`)),
+      milliseconds,
+    );
+    void promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (failure: unknown) => {
+        clearTimeout(timer);
+        reject(failure);
+      },
+    );
+  });
+}

--- a/sdk-typescript/test/integ/step_cancellation_flow.ts
+++ b/sdk-typescript/test/integ/step_cancellation_flow.ts
@@ -1,0 +1,408 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+import {
+  Attribute,
+  ExecuteFailure,
+  StepList,
+  StepMovement,
+  Timer,
+  Wait,
+  deadEnd,
+  forceFail,
+  goTo,
+  goToMulti,
+  gracefulComplete,
+  stringCodec,
+  voidCodec,
+  withCancelingSiblingSteps,
+  withCancelingSteps,
+  type Context,
+  type Flow,
+  type PersistenceSchema,
+  type Step,
+  type StepDecision,
+  type StepOptions,
+} from "../../src/index.js";
+
+export type CancellationScenario =
+  | "heartbeat-execute"
+  | "heartbeat-wait-for"
+  | "local-execute"
+  | "local-timeout-fallback"
+  | "no-heartbeat"
+  | "global-selector"
+  | "sibling-selector";
+
+export const cancellationScenarios: readonly CancellationScenario[] = [
+  "heartbeat-execute",
+  "heartbeat-wait-for",
+  "local-execute",
+  "local-timeout-fallback",
+  "no-heartbeat",
+  "global-selector",
+  "sibling-selector",
+];
+
+class CancellationStart implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public constructor(private readonly flow: StepCancellationFlow) {}
+
+  public getStepType(): string {
+    return "TypeScriptCancellationStart";
+  }
+
+  public execute(_context: Context, _input: string): StepDecision {
+    if (this.flow.scenario === "heartbeat-wait-for") {
+      return goToMulti(
+        StepMovement.of(this.flow.blockingWaitFor, undefined),
+        StepMovement.of(this.flow.winner, undefined),
+      );
+    }
+    if (this.flow.scenario === "global-selector" || this.flow.scenario === "sibling-selector") {
+      return goToMulti(
+        StepMovement.of(this.flow.firstParent, undefined),
+        StepMovement.of(this.flow.secondParent, undefined),
+      );
+    }
+    return goToMulti(
+      StepMovement.of(this.flow.blockingExecute, undefined),
+      StepMovement.of(this.flow.winner, undefined),
+    );
+  }
+}
+
+class CancellationBlockingExecute implements Step<void> {
+  public readonly inputCodec = voidCodec;
+
+  public constructor(private readonly flow: StepCancellationFlow) {}
+
+  public getStepType(): string {
+    return "TypeScriptCancellationBlockingExecute";
+  }
+
+  public getStepOptions(): StepOptions {
+    return {
+      executeMethodTimeoutMs: 15_000,
+      ...(
+        this.flow.scenario === "heartbeat-execute" ||
+          this.flow.scenario === "local-timeout-fallback"
+          ? { heartbeatTimeoutMs: 2_000 }
+          : {}
+      ),
+      executeDurability:
+        this.flow.scenario === "local-execute" ||
+          this.flow.scenario === "local-timeout-fallback"
+          ? "async"
+          : "sync",
+      executeFailure: ExecuteFailure.proceedTo(this.flow.recovery),
+    };
+  }
+
+  public async execute(context: Context, _input: void): Promise<StepDecision> {
+    this.flow.blockingInvocations += 1;
+    this.flow.markBlockingStarted();
+    try {
+      if (this.flow.scenario === "no-heartbeat") {
+        await delay(7_000);
+      } else {
+        await delay(10_000, context.cancellationSignal);
+      }
+    } catch (failure) {
+      if (!context.cancellationSignal.aborted) {
+        throw failure;
+      }
+      this.flow.handlerCanceled = true;
+      this.flow.contextReportedCancellation = context.cancellationSignal.aborted;
+      this.flow.markCancellationObserved();
+    }
+    this.flow.lateWrite.set(context, "late");
+    this.flow.markLateHandlerReturned();
+    return goTo(this.flow.recovery, undefined);
+  }
+}
+
+class CancellationBlockingWaitFor implements Step<void> {
+  public readonly inputCodec = voidCodec;
+
+  public constructor(private readonly flow: StepCancellationFlow) {}
+
+  public getStepType(): string {
+    return "TypeScriptCancellationBlockingWaitFor";
+  }
+
+  public getStepOptions(): StepOptions {
+    return {
+      waitForMethodTimeoutMs: 15_000,
+      heartbeatTimeoutMs: 2_000,
+      waitForFailure: "proceed",
+      waitForDurability: "sync",
+    };
+  }
+
+  public async waitFor(context: Context, _input: void): Promise<Wait> {
+    this.flow.blockingInvocations += 1;
+    this.flow.markBlockingStarted();
+    try {
+      await delay(10_000, context.cancellationSignal);
+    } catch (failure) {
+      if (!context.cancellationSignal.aborted) {
+        throw failure;
+      }
+      this.flow.handlerCanceled = true;
+      this.flow.contextReportedCancellation = context.cancellationSignal.aborted;
+      this.flow.markCancellationObserved();
+    }
+    return Wait.skipImmediately();
+  }
+
+  public execute(_context: Context, _input: void): StepDecision {
+    this.flow.recoveryRan = true;
+    return forceFail("canceled waitFor execution continued");
+  }
+}
+
+class CancellationWinner implements Step<void> {
+  public readonly inputCodec = voidCodec;
+
+  public constructor(private readonly flow: StepCancellationFlow) {}
+
+  public getStepType(): string {
+    return "TypeScriptCancellationWinner";
+  }
+
+  public waitFor(_context: Context, _input: void): Wait {
+    return this.flow.scenario === "local-execute"
+      ? Wait.skipImmediately()
+      : Wait.until(Timer.byDuration(3_000));
+  }
+
+  public async execute(_context: Context, _input: void): Promise<StepDecision> {
+    if (this.flow.scenario === "local-execute") {
+      await this.flow.blockingStarted;
+      await delay(1_000);
+    }
+    const selected: Step<any> = this.flow.scenario === "heartbeat-wait-for"
+      ? this.flow.blockingWaitFor
+      : this.flow.blockingExecute;
+    return withCancelingSteps(goTo(this.flow.final, this.flow.scenario), selected);
+  }
+}
+
+class CancellationRecovery implements Step<void> {
+  public readonly inputCodec = voidCodec;
+
+  public constructor(private readonly flow: StepCancellationFlow) {}
+
+  public getStepType(): string {
+    return "TypeScriptCancellationRecovery";
+  }
+
+  public execute(_context: Context, _input: void): StepDecision {
+    this.flow.recoveryRan = true;
+    return forceFail("canceled execution reached recovery");
+  }
+}
+
+class CancellationFinal implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public getStepType(): string {
+    return "TypeScriptCancellationFinal";
+  }
+
+  public waitFor(_context: Context, _input: string): Wait {
+    return Wait.until(Timer.byDuration(1_000));
+  }
+
+  public execute(_context: Context, input: string): StepDecision {
+    return gracefulComplete(input);
+  }
+}
+
+class CancellationFirstParent implements Step<void> {
+  public readonly inputCodec = voidCodec;
+
+  public constructor(private readonly flow: StepCancellationFlow) {}
+
+  public getStepType(): string {
+    return "TypeScriptCancellationFirstParent";
+  }
+
+  public execute(_context: Context, _input: void): StepDecision {
+    return goToMulti(
+      StepMovement.of(this.flow.selectorWinner, undefined),
+      StepMovement.of(this.flow.selectorWaiting, "first"),
+    );
+  }
+}
+
+class CancellationSecondParent implements Step<void> {
+  public readonly inputCodec = voidCodec;
+
+  public constructor(private readonly flow: StepCancellationFlow) {}
+
+  public getStepType(): string {
+    return "TypeScriptCancellationSecondParent";
+  }
+
+  public execute(_context: Context, _input: void): StepDecision {
+    return goTo(this.flow.selectorWaiting, "second");
+  }
+}
+
+class CancellationSelectorWinner implements Step<void> {
+  public readonly inputCodec = voidCodec;
+
+  public constructor(private readonly flow: StepCancellationFlow) {}
+
+  public getStepType(): string {
+    return "TypeScriptCancellationSelectorWinner";
+  }
+
+  public waitFor(_context: Context, _input: void): Wait {
+    return Wait.until(Timer.byDuration(1_000));
+  }
+
+  public async execute(_context: Context, _input: void): Promise<StepDecision> {
+    await this.flow.selectorWaitsRegistered;
+    const decision = goTo(this.flow.final, this.flow.scenario);
+    return this.flow.scenario === "global-selector"
+      ? withCancelingSteps(decision, this.flow.selectorWaiting)
+      : withCancelingSiblingSteps(decision, this.flow.selectorWaiting);
+  }
+}
+
+class CancellationSelectorWaiting implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public constructor(private readonly flow: StepCancellationFlow) {}
+
+  public getStepType(): string {
+    return "TypeScriptCancellationSelectorWaiting";
+  }
+
+  public waitFor(_context: Context, input: string): Wait {
+    this.flow.markSelectorWaiting();
+    return Wait.until(Timer.byDuration(input === "first" ? 30_000 : 2_000));
+  }
+
+  public execute(_context: Context, input: string): StepDecision {
+    if (input === "first") {
+      this.flow.firstSelectorExecuted = true;
+    } else {
+      this.flow.secondSelectorExecuted = true;
+    }
+    return deadEnd();
+  }
+}
+
+export class StepCancellationFlow implements Flow<string> {
+  public readonly lateWrite = new Attribute("typescript-cancellation-late-write", stringCodec);
+  public readonly recovery = new CancellationRecovery(this);
+  public readonly blockingExecute = new CancellationBlockingExecute(this);
+  public readonly blockingWaitFor = new CancellationBlockingWaitFor(this);
+  public readonly winner = new CancellationWinner(this);
+  public readonly final = new CancellationFinal();
+  public readonly firstParent = new CancellationFirstParent(this);
+  public readonly secondParent = new CancellationSecondParent(this);
+  public readonly selectorWinner = new CancellationSelectorWinner(this);
+  public readonly selectorWaiting = new CancellationSelectorWaiting(this);
+  public handlerCanceled = false;
+  public contextReportedCancellation = false;
+  public recoveryRan = false;
+  public firstSelectorExecuted = false;
+  public secondSelectorExecuted = false;
+  public blockingInvocations = 0;
+  public readonly blockingStarted: Promise<void>;
+  public readonly cancellationObserved: Promise<void>;
+  public readonly lateHandlerReturned: Promise<void>;
+  public readonly selectorWaitsRegistered: Promise<void>;
+
+  private readonly start = new CancellationStart(this);
+  private resolveBlockingStarted!: () => void;
+  private resolveCancellationObserved!: () => void;
+  private resolveLateHandlerReturned!: () => void;
+  private resolveSelectorWaitsRegistered!: () => void;
+  private selectorWaitCount = 0;
+
+  public constructor(public readonly scenario: CancellationScenario) {
+    this.blockingStarted = new Promise((resolve) => { this.resolveBlockingStarted = resolve; });
+    this.cancellationObserved = new Promise((resolve) => { this.resolveCancellationObserved = resolve; });
+    this.lateHandlerReturned = new Promise((resolve) => { this.resolveLateHandlerReturned = resolve; });
+    this.selectorWaitsRegistered = new Promise((resolve) => {
+      this.resolveSelectorWaitsRegistered = resolve;
+    });
+  }
+
+  public getFlowType(): string {
+    return `TypeScriptStepCancellation-${this.scenario}`;
+  }
+
+  public getSteps() {
+    return StepList.startStep(this.start).otherSteps(
+      this.blockingExecute,
+      this.blockingWaitFor,
+      this.winner,
+      this.recovery,
+      this.final,
+      this.firstParent,
+      this.secondParent,
+      this.selectorWinner,
+      this.selectorWaiting,
+    );
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return { attributes: [this.lateWrite] };
+  }
+
+  public markBlockingStarted(): void {
+    this.resolveBlockingStarted();
+  }
+
+  public markCancellationObserved(): void {
+    this.resolveCancellationObserved();
+  }
+
+  public markLateHandlerReturned(): void {
+    this.resolveLateHandlerReturned();
+  }
+
+  public markSelectorWaiting(): void {
+    this.selectorWaitCount += 1;
+    if (this.selectorWaitCount === 2) {
+      this.resolveSelectorWaitsRegistered();
+    }
+  }
+}
+
+function delay(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const complete = (): void => {
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    };
+    const timer = setTimeout(complete, milliseconds);
+    const abort = (): void => {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
+    if (signal === undefined) {
+      return;
+    }
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}


### PR DESCRIPTION
## Summary

- add Flow-wide and sibling Step cancellation selectors to the Go, Python, TypeScript, and Rust SDKs
- map heartbeat timeouts and expose each language native handler cancellation mechanism
- support Flow-wide cancellation from RPC results
- add the same seven runtime scenarios used by the Java SDK across all four integration suites
- document APIs, snapshot behavior, heartbeats, ASYNC local fallback, and RPC limitations

## Validation

- Go docs, unit, worker/client integration, and full coverage integration
- Python public docs, contracts, mypy, pyright, pre-commit, and full coverage integration
- TypeScript public docs, typecheck, contracts, and full coverage integration
- Rust fmt, docs, clippy, tests, and full coverage integration
- Docusaurus production build and smoke tests
- copyright and copyright-check