### PR TITLE
Fix TypeScript examples on Node 22

### DIFF
--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -11,9 +11,9 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "start": "npm run build && node dist/src/main.js",
-    "test": "npm run build && node --test --test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/workflow/**/*.test.js'",
-    "test:integ": "npm run build && node --test --test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/integ/*.test.js'",
-    "smoke": "npm run build && node --test --test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/e2e/all-routes.test.js'"
+    "test": "npm run build && node --test --experimental-test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/workflow/**/*.test.js'",
+    "test:integ": "npm run build && node --test --experimental-test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/integ/*.test.js'",
+    "smoke": "npm run build && node --test --experimental-test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/e2e/all-routes.test.js'"
   },
   "dependencies": {
     "@superdurable/dex": "0.1.5",


### PR DESCRIPTION
## Summary

- use Node 22's supported `--experimental-test-isolation` spelling in TypeScript example test scripts
- retain compatibility with newer Node releases, where the old spelling remains an alias
- cover unit, integration, and smoke test entry points

## Rationale

The full main CI run installs Node 22.23.2. Node renamed this flag to `--test-isolation` in v23.6, so Node 22 rejects the newer spelling before any test executes.

## User impact

TypeScript examples now run on their declared Node 22 and Node 24 support range. Released SDK dependencies are unchanged.

## Validation

- `npm test` (7 passed)
- `./run-integration-tests.sh` (6 integration and 22 smoke/E2E tests passed)
- `make copyright-check`
