### PR TITLE
Cancel active Steps before terminal producer drain

### DIFF
--- a/server/integ/terminal_producer_drain_test.go
+++ b/server/integ/terminal_producer_drain_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package integ
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superdurable/dex/gen/dexpb"
+	"github.com/superdurable/dex/service"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	terminalProducerDrainFlowType    = "terminal-producer-drain"
+	terminalProducerDrainStepType    = "blocking-execute"
+	terminalProducerDrainProbeRPC    = "terminal-producer-drain-probe"
+	terminalProducerDrainFailureText = "stop while Execute is active"
+)
+
+type terminalProducerDrainHandler struct {
+	dexpb.UnimplementedWorkerServiceServer
+	executeStartedOnce sync.Once
+	executeStarted     chan struct{}
+}
+
+func newTerminalProducerDrainHandler() *terminalProducerDrainHandler {
+	return &terminalProducerDrainHandler{executeStarted: make(chan struct{})}
+}
+
+func TestTerminalProducerDrainTemporal(t *testing.T) {
+	if !*temporalIntegTest {
+		t.Skip()
+	}
+	testTerminalProducerDrain(t, service.BackendTypeTemporal)
+}
+
+func TestTerminalProducerDrainCadence(t *testing.T) {
+	if !*cadenceIntegTest {
+		t.Skip()
+	}
+	testTerminalProducerDrain(t, service.BackendTypeCadence)
+}
+
+func testTerminalProducerDrain(t *testing.T, backendType service.BackendType) {
+	handler := newTerminalProducerDrainHandler()
+	workerTarget := startWorker(t, handler)
+	runtime := startDexService(t, DexServiceTestConfig{
+		BackendType:                            backendType,
+		UseTemporalSynchronousUpdateForAllRPCs: true,
+	})
+	flowID := terminalProducerDrainFlowType + "-" + uuid.NewString()
+	cleanupTerminalProducerDrainFlow(t, runtime.FlowClient, flowID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	_, err := runtime.FlowClient.StartFlow(ctx, &dexpb.StartFlowRequest{
+		RequestId:          newRequestID(),
+		FlowId:             flowID,
+		FlowType:           terminalProducerDrainFlowType,
+		FlowTimeoutSeconds: 30,
+		StartStepType:      terminalProducerDrainStepType,
+		StepOptions:        &dexpb.StepOptions{SkipWaitFor: true},
+		FlowStartOptions:   withWorkerTarget(nil, workerTarget),
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-handler.executeStarted:
+	case <-ctx.Done():
+		require.FailNow(t, "Execute did not start", ctx.Err())
+	}
+	_, err = runtime.FlowClient.StopFlow(ctx, &dexpb.StopFlowRequest{
+		FlowId:   flowID,
+		StopType: dexpb.StopType_STOP_TYPE_FAIL,
+		Reason:   terminalProducerDrainFailureText,
+	})
+	require.NoError(t, err)
+
+	result, waitErr := runtime.FlowClient.WaitForFlow(ctx, &dexpb.WaitForFlowRequest{
+		FlowId:          flowID,
+		WaitTimeSeconds: 5,
+	})
+	if waitErr != nil {
+		confirmTerminalFinalizationStarted(t, ctx, runtime.FlowClient, flowID, backendType)
+		t.Fatalf(
+			"Flow remained running because an active Execute Step blocked terminal producer drain: %v",
+			waitErr,
+		)
+	}
+	require.Equal(t, dexpb.FlowStatus_FLOW_STATUS_FAILED, result.GetFlowStatus())
+	require.Equal(
+		t,
+		dexpb.FlowErrorType_FLOW_ERROR_TYPE_CLIENT_API_FAILING_FLOW,
+		result.GetErrorType(),
+	)
+	require.Equal(t, terminalProducerDrainFailureText, result.GetErrorMessage())
+}
+
+func cleanupTerminalProducerDrainFlow(
+	t *testing.T,
+	flowClient dexpb.FlowServiceClient,
+	flowID string,
+) {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := flowClient.StopFlow(ctx, &dexpb.StopFlowRequest{
+			FlowId:   flowID,
+			StopType: dexpb.StopType_STOP_TYPE_TERMINATE,
+		})
+		if err != nil && status.Code(err) != codes.NotFound {
+			t.Logf("terminal producer drain cleanup failed: %v", err)
+		}
+	})
+}
+
+func confirmTerminalFinalizationStarted(
+	t *testing.T,
+	ctx context.Context,
+	flowClient dexpb.FlowServiceClient,
+	flowID string,
+	backendType service.BackendType,
+) {
+	t.Helper()
+	if backendType != service.BackendTypeTemporal {
+		return
+	}
+	require.Eventually(t, func() bool {
+		_, err := flowClient.InvokeRPC(ctx, &dexpb.InvokeRPCRequest{
+			RequestId: newRequestID(),
+			FlowId:    flowID,
+			RpcName:   terminalProducerDrainProbeRPC,
+		})
+		return status.Code(err) == codes.FailedPrecondition &&
+			strings.Contains(err.Error(), "flow terminal cleanup is in progress")
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
+func (h *terminalProducerDrainHandler) InvokeWorkerRPC(
+	_ context.Context,
+	request *dexpb.InvokeWorkerRPCRequest,
+) (*dexpb.InvokeWorkerRPCResponse, error) {
+	if request.GetRpcName() != terminalProducerDrainProbeRPC {
+		return nil, status.Errorf(codes.InvalidArgument, "unexpected RPC name %q", request.GetRpcName())
+	}
+	return &dexpb.InvokeWorkerRPCResponse{}, nil
+}
+
+func (h *terminalProducerDrainHandler) InvokeExecuteMethod(
+	ctx context.Context,
+	_ *dexpb.InvokeExecuteMethodRequest,
+) (*dexpb.InvokeExecuteMethodResponse, error) {
+	h.executeStartedOnce.Do(func() { close(h.executeStarted) })
+	<-ctx.Done()
+	return nil, status.Error(codes.Canceled, "Execute canceled")
+}

--- a/server/integ/terminal_producer_drain_test.go
+++ b/server/integ/terminal_producer_drain_test.go
@@ -24,20 +24,33 @@ import (
 )
 
 const (
-	terminalProducerDrainFlowType    = "terminal-producer-drain"
-	terminalProducerDrainStepType    = "blocking-execute"
-	terminalProducerDrainProbeRPC    = "terminal-producer-drain-probe"
-	terminalProducerDrainFailureText = "stop while Execute is active"
+	terminalProducerDrainFlowType            = "terminal-producer-drain"
+	terminalProducerDrainBlockingStepType    = "blocking-execute"
+	terminalProducerDrainTimerStartStepType  = "timer-start"
+	terminalProducerDrainWaitingStepType     = "waiting-timer"
+	terminalProducerDrainFailingStepType     = "failing-timer"
+	terminalProducerDrainWakeupStepType      = "wakeup-timer"
+	terminalProducerDrainProbeRPC            = "terminal-producer-drain-probe"
+	terminalProducerDrainStopFailureText     = "stop while Execute is active"
+	terminalProducerDrainDecisionFailureText = "fail while timer Step is waiting"
+	terminalProducerDrainLongTimerSeconds    = 60
+	terminalProducerDrainFailureTimerSeconds = 1
+	terminalProducerDrainWakeupTimerSeconds  = 2
 )
 
 type terminalProducerDrainHandler struct {
 	dexpb.UnimplementedWorkerServiceServer
-	executeStartedOnce sync.Once
-	executeStarted     chan struct{}
+	executeStartedOnce      sync.Once
+	waitingTimerStartedOnce sync.Once
+	executeStarted          chan struct{}
+	waitingTimerStarted     chan struct{}
 }
 
 func newTerminalProducerDrainHandler() *terminalProducerDrainHandler {
-	return &terminalProducerDrainHandler{executeStarted: make(chan struct{})}
+	return &terminalProducerDrainHandler{
+		executeStarted:      make(chan struct{}),
+		waitingTimerStarted: make(chan struct{}),
+	}
 }
 
 func TestTerminalProducerDrainTemporal(t *testing.T) {
@@ -55,6 +68,15 @@ func TestTerminalProducerDrainCadence(t *testing.T) {
 }
 
 func testTerminalProducerDrain(t *testing.T, backendType service.BackendType) {
+	t.Run("active Execute", func(t *testing.T) {
+		testTerminalActiveExecuteProducerDrain(t, backendType)
+	})
+	t.Run("waiting timer", func(t *testing.T) {
+		testTerminalWaitingTimerProducerDrain(t, backendType)
+	})
+}
+
+func testTerminalActiveExecuteProducerDrain(t *testing.T, backendType service.BackendType) {
 	handler := newTerminalProducerDrainHandler()
 	workerTarget := startWorker(t, handler)
 	runtime := startDexService(t, DexServiceTestConfig{
@@ -71,7 +93,7 @@ func testTerminalProducerDrain(t *testing.T, backendType service.BackendType) {
 		FlowId:             flowID,
 		FlowType:           terminalProducerDrainFlowType,
 		FlowTimeoutSeconds: 30,
-		StartStepType:      terminalProducerDrainStepType,
+		StartStepType:      terminalProducerDrainBlockingStepType,
 		StepOptions:        &dexpb.StepOptions{SkipWaitFor: true},
 		FlowStartOptions:   withWorkerTarget(nil, workerTarget),
 	})
@@ -85,7 +107,7 @@ func testTerminalProducerDrain(t *testing.T, backendType service.BackendType) {
 	_, err = runtime.FlowClient.StopFlow(ctx, &dexpb.StopFlowRequest{
 		FlowId:   flowID,
 		StopType: dexpb.StopType_STOP_TYPE_FAIL,
-		Reason:   terminalProducerDrainFailureText,
+		Reason:   terminalProducerDrainStopFailureText,
 	})
 	require.NoError(t, err)
 
@@ -106,7 +128,49 @@ func testTerminalProducerDrain(t *testing.T, backendType service.BackendType) {
 		dexpb.FlowErrorType_FLOW_ERROR_TYPE_CLIENT_API_FAILING_FLOW,
 		result.GetErrorType(),
 	)
-	require.Equal(t, terminalProducerDrainFailureText, result.GetErrorMessage())
+	require.Equal(t, terminalProducerDrainStopFailureText, result.GetErrorMessage())
+}
+
+func testTerminalWaitingTimerProducerDrain(t *testing.T, backendType service.BackendType) {
+	handler := newTerminalProducerDrainHandler()
+	workerTarget := startWorker(t, handler)
+	runtime := startDexService(t, DexServiceTestConfig{
+		BackendType:                            backendType,
+		UseTemporalSynchronousUpdateForAllRPCs: true,
+	})
+	flowID := terminalProducerDrainFlowType + "-timer-" + uuid.NewString()
+	cleanupTerminalProducerDrainFlow(t, runtime.FlowClient, flowID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	_, err := runtime.FlowClient.StartFlow(ctx, &dexpb.StartFlowRequest{
+		RequestId:          newRequestID(),
+		FlowId:             flowID,
+		FlowType:           terminalProducerDrainFlowType,
+		FlowTimeoutSeconds: 30,
+		StartStepType:      terminalProducerDrainTimerStartStepType,
+		FlowStartOptions:   withWorkerTarget(nil, workerTarget),
+	})
+	require.NoError(t, err)
+
+	result, waitErr := runtime.FlowClient.WaitForFlow(ctx, &dexpb.WaitForFlowRequest{
+		FlowId:          flowID,
+		WaitTimeSeconds: 8,
+	})
+	if waitErr != nil {
+		confirmTerminalFinalizationStarted(t, ctx, runtime.FlowClient, flowID, backendType)
+		t.Fatalf(
+			"Flow remained running because a waiting timer Step blocked terminal producer drain: %v",
+			waitErr,
+		)
+	}
+	require.Equal(t, dexpb.FlowStatus_FLOW_STATUS_FAILED, result.GetFlowStatus())
+	require.Equal(
+		t,
+		dexpb.FlowErrorType_FLOW_ERROR_TYPE_STEP_DECISION_FAILING_FLOW,
+		result.GetErrorType(),
+	)
+	require.Equal(t, terminalProducerDrainDecisionFailureText, result.GetErrorMessage())
 }
 
 func cleanupTerminalProducerDrainFlow(
@@ -160,11 +224,82 @@ func (h *terminalProducerDrainHandler) InvokeWorkerRPC(
 	return &dexpb.InvokeWorkerRPCResponse{}, nil
 }
 
+func (h *terminalProducerDrainHandler) InvokeWaitForMethod(
+	ctx context.Context,
+	request *dexpb.InvokeWaitForMethodRequest,
+) (*dexpb.InvokeWaitForMethodResponse, error) {
+	switch request.GetStepType() {
+	case terminalProducerDrainTimerStartStepType:
+		return terminalProducerDrainTimerResponse(0), nil
+	case terminalProducerDrainWaitingStepType:
+		h.waitingTimerStartedOnce.Do(func() { close(h.waitingTimerStarted) })
+		return terminalProducerDrainTimerResponse(terminalProducerDrainLongTimerSeconds), nil
+	case terminalProducerDrainFailingStepType:
+		select {
+		case <-h.waitingTimerStarted:
+		case <-ctx.Done():
+			return nil, status.Error(codes.Canceled, "waiting timer Step did not start")
+		}
+		return terminalProducerDrainTimerResponse(terminalProducerDrainFailureTimerSeconds), nil
+	case terminalProducerDrainWakeupStepType:
+		return terminalProducerDrainTimerResponse(terminalProducerDrainWakeupTimerSeconds), nil
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unexpected WaitFor Step type %q", request.GetStepType())
+	}
+}
+
+func terminalProducerDrainTimerResponse(durationSeconds int64) *dexpb.InvokeWaitForMethodResponse {
+	condition := &dexpb.WaitingCondition{
+		WaitingConditionType: dexpb.WaitingConditionType_WAITING_CONDITION_TYPE_ALL_COMPLETED,
+	}
+	if durationSeconds > 0 {
+		condition.TimerConditions = []*dexpb.TimerCondition{{
+			ConditionId:     "timer",
+			DurationSeconds: durationSeconds,
+		}}
+	}
+	return &dexpb.InvokeWaitForMethodResponse{WaitingCondition: condition}
+}
+
 func (h *terminalProducerDrainHandler) InvokeExecuteMethod(
 	ctx context.Context,
-	_ *dexpb.InvokeExecuteMethodRequest,
+	request *dexpb.InvokeExecuteMethodRequest,
 ) (*dexpb.InvokeExecuteMethodResponse, error) {
-	h.executeStartedOnce.Do(func() { close(h.executeStarted) })
-	<-ctx.Done()
-	return nil, status.Error(codes.Canceled, "Execute canceled")
+	switch request.GetStepType() {
+	case terminalProducerDrainBlockingStepType:
+		h.executeStartedOnce.Do(func() { close(h.executeStarted) })
+		<-ctx.Done()
+		return nil, status.Error(codes.Canceled, "Execute canceled")
+	case terminalProducerDrainTimerStartStepType:
+		return &dexpb.InvokeExecuteMethodResponse{
+			StepDecision: &dexpb.StepDecision{
+				NextSteps: []*dexpb.StepMovement{
+					{StepType: terminalProducerDrainWaitingStepType},
+					{StepType: terminalProducerDrainFailingStepType},
+					{StepType: terminalProducerDrainWakeupStepType},
+				},
+			},
+		}, nil
+	case terminalProducerDrainFailingStepType:
+		return &dexpb.InvokeExecuteMethodResponse{
+			StepDecision: &dexpb.StepDecision{
+				CloseDecision: &dexpb.CloseDecision{
+					CloseDecisionType: dexpb.CloseDecisionType_CLOSE_DECISION_TYPE_FORCE_FAIL,
+					CloseInput: &dexpb.Value{Kind: &dexpb.Value_StringValue{
+						StringValue: terminalProducerDrainDecisionFailureText,
+					}},
+				},
+			},
+		}, nil
+	case terminalProducerDrainWakeupStepType:
+		return &dexpb.InvokeExecuteMethodResponse{
+			StepDecision: &dexpb.StepDecision{
+				CloseDecision: &dexpb.CloseDecision{
+					CloseDecisionType: dexpb.CloseDecisionType_CLOSE_DECISION_TYPE_DEAD_END,
+				},
+			},
+		}, nil
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unexpected Execute Step type %q", request.GetStepType())
+	}
 }

--- a/server/integ/wf_stop_test.go
+++ b/server/integ/wf_stop_test.go
@@ -148,7 +148,9 @@ func doTestWorkflowCancelWaitsForProducer(
 		StopType: dexpb.StopType_STOP_TYPE_CANCEL,
 	})
 	require.NoError(t, err)
-	close(workerHandler.releaseExecute)
+	if flowConfig != nil {
+		close(workerHandler.releaseExecute)
+	}
 
 	response, err := flowClient.WaitForFlow(ctx, &dexpb.WaitForFlowRequest{FlowId: flowID})
 	require.NoError(t, err)

--- a/server/service/interpreter/stepExecutionRegistry.go
+++ b/server/service/interpreter/stepExecutionRegistry.go
@@ -80,6 +80,10 @@ func (r *StepExecutionRegistry) Unregister(stepExecutionID string) {
 	delete(r.canceledExecutionIDs, stepExecutionID)
 }
 
+func (r *StepExecutionRegistry) CancelAll(ctx interfaces.UnifiedContext) error {
+	return r.doCancel(ctx, newAllStepCancellationSelector())
+}
+
 func (r *StepExecutionRegistry) CancelByStepTypesAndSiblingStepTypes(
 	ctx interfaces.UnifiedContext,
 	decision *dexpb.StepDecision,
@@ -191,9 +195,14 @@ func (r *StepExecutionRegistry) cancelActive(
 }
 
 type stepCancellationSelector struct {
+	matchesAllSteps     bool
 	globalStepTypes     map[string]bool
 	siblingStepTypes    map[string]bool
 	fromStepExecutionID string
+}
+
+func newAllStepCancellationSelector() *stepCancellationSelector {
+	return &stepCancellationSelector{matchesAllSteps: true}
 }
 
 func newStepCancellationSelector(
@@ -222,14 +231,15 @@ func newStepCancellationSelector(
 }
 
 func (s *stepCancellationSelector) isEmpty() bool {
-	return len(s.globalStepTypes) == 0 && len(s.siblingStepTypes) == 0
+	return !s.matchesAllSteps && len(s.globalStepTypes) == 0 && len(s.siblingStepTypes) == 0
 }
 
 func (s *stepCancellationSelector) matches(
 	movement *dexpb.StepMovement,
 ) bool {
 	stepType := movement.GetStepType()
-	return s.globalStepTypes[stepType] ||
+	return s.matchesAllSteps ||
+		s.globalStepTypes[stepType] ||
 		(s.siblingStepTypes[stepType] &&
 			movement.GetFromStepExecutionIdInternalOnly() == s.fromStepExecutionID)
 }

--- a/server/service/interpreter/terminalCoordinator.go
+++ b/server/service/interpreter/terminalCoordinator.go
@@ -11,12 +11,12 @@ package interpreter
 import "github.com/superdurable/dex/service/interpreter/interfaces"
 
 type TerminalCoordinator struct {
-	provider          interfaces.WorkflowProvider
-	continueAsNewer   *ContinueAsNewer
-	attributeSyncer   *AttributeSynchronizer
-	signalReceiver    *SignalReceiver
-	forceComplete     *bool
-	startedFinalizing bool
+	provider              interfaces.WorkflowProvider
+	continueAsNewer       *ContinueAsNewer
+	attributeSyncer       *AttributeSynchronizer
+	signalReceiver        *SignalReceiver
+	stepExecutionRegistry *StepExecutionRegistry
+	startedFinalizing     bool
 }
 
 func NewTerminalCoordinator(
@@ -24,17 +24,18 @@ func NewTerminalCoordinator(
 	continueAsNewer *ContinueAsNewer,
 	attributeSyncer *AttributeSynchronizer,
 	signalReceiver *SignalReceiver,
-	forceComplete *bool,
+	stepExecutionRegistry *StepExecutionRegistry,
 ) *TerminalCoordinator {
-	if provider == nil || continueAsNewer == nil || attributeSyncer == nil || signalReceiver == nil || forceComplete == nil {
+	if provider == nil || continueAsNewer == nil || attributeSyncer == nil ||
+		signalReceiver == nil || stepExecutionRegistry == nil {
 		panic("TerminalCoordinator requires non-nil dependencies")
 	}
 	return &TerminalCoordinator{
-		provider:        provider,
-		continueAsNewer: continueAsNewer,
-		attributeSyncer: attributeSyncer,
-		signalReceiver:  signalReceiver,
-		forceComplete:   forceComplete,
+		provider:              provider,
+		continueAsNewer:       continueAsNewer,
+		attributeSyncer:       attributeSyncer,
+		signalReceiver:        signalReceiver,
+		stepExecutionRegistry: stepExecutionRegistry,
 	}
 }
 
@@ -46,9 +47,11 @@ func (c *TerminalCoordinator) CoordinateAndFinalizeError(
 		return retErr
 	}
 	c.startedFinalizing = true
+	if err := c.stepExecutionRegistry.CancelAll(ctx); err != nil {
+		return err
+	}
 	if err := c.provider.Await(ctx, func() bool {
-		return *c.forceComplete ||
-			(c.attributeSyncer.ProducersDrained() && c.continueAsNewer.inflightUpdateOperations == 0)
+		return c.attributeSyncer.ProducersDrained() && c.continueAsNewer.inflightUpdateOperations == 0
 	}); err != nil {
 		return err
 	}

--- a/server/service/interpreter/workflowImpl.go
+++ b/server/service/interpreter/workflowImpl.go
@@ -220,7 +220,7 @@ func (i *Interpreter) StartEngineFlow(
 		continueAsNewer,
 		attributeSynchronizer,
 		signalReceiver,
-		&forceCompleteWf,
+		stepExecutionRegistry,
 	)
 	updateErr := NewWorkflowUpdater(
 		&i.sharedConfig.Api,


### PR DESCRIPTION
## Summary

- cover terminal finalization with both an active Execute Step and a waiting timer Step on Temporal and Cadence
- cancel every queued and active Step execution before waiting for producer drain
- preserve the existing continue-as-new drain path

The first two commits intentionally reproduced the main-branch stall and failed CI. The final commit fixes every non-continue-as-new terminal path by canceling queued and active Step executions before producer drain and Attribute Sync flush.

## Tests

- make -C server temporalIntegTests integrationCoverageArgs=-run\ ^TestTerminalProducerDrainTemporal$
- make -C server cadenceIntegTests integrationCoverageArgs=-run\ ^TestTerminalProducerDrainCadence$
- make -C server temporalIntegTests integrationCoverageArgs=-run\ ^TestWorkflowCanceledTemporal$
- make -C server cadenceIntegTests integrationCoverageArgs=-run\ ^TestWorkflowCanceledCadence$
- make -C server unitTests
- make copyright-check

Before the fix, both new scenarios timed out in Temporal and Cadence because terminal finalization waited for producers owned by Steps that were never canceled. After the fix, all targeted regression tests pass.