### PR TITLE
Improve large Step graph layout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 cli/dexcli
+web/large-step-graph
 examples/go/dex-samples
 examples/go/deepverify
 sdk-typescript/node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 cli/dexcli
 web/large-step-graph
+web/fan-out-90
 examples/go/dex-samples
 examples/go/deepverify
 sdk-typescript/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dex-server
 examples/go/dex-samples
 examples/go/deepverify
 cli/dexcli
+web/large-step-graph
 .bin/
 .build/
 vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ examples/go/dex-samples
 examples/go/deepverify
 cli/dexcli
 web/large-step-graph
+web/fan-out-90
 .bin/
 .build/
 vendor/

--- a/web/README.md
+++ b/web/README.md
@@ -66,8 +66,8 @@ The Flows page provides Basic and Advanced visibility queries, pagination,
 saved queries, configurable columns, Indexed Attributes, and timezone
 preferences.
 
-The Run page provides Overview (Live Flow State beside Selected event, then
-Run input beside Identity), Step graph, Timeline, attributes, timers, queued
+The Run page opens on Step graph and also provides Overview (Live Flow State
+beside Selected event, then Run input beside Identity), Timeline, attributes, timers, queued
 steps, channels, completed outputs, stop, and reset. Timeline and Step graph keep
 Selected event in the sidebar.
 Continued runs link to their previous run from Timeline and Step graph.
@@ -76,6 +76,8 @@ Flow continued, RPC, Step decision, or recovery event that scheduled it.
 Selecting the first event reveals that source link; selecting a
 WaitFor event also reveals its outgoing WaitFor-to-Execute link.
 Step graph nodes separate WaitFor and Execute with distinct colors, channel names, condition icons, and individual event details.
+Large Step graphs extend down the page at readable size. Parallel ranks wrap to
+two nodes per row so fan-out and fan-in topologies do not require wide horizontal panning.
 Persisted Step decisions add planned graph branches. A selector-matched branch without a Step event appears Canceled with no execution ID.
 SubFlow conditions appear as linked leaf nodes and compact WaitFor cards. Running
 and terminal nodes display and link by their generated Flow ID. Original WaitFor

--- a/web/README.md
+++ b/web/README.md
@@ -29,6 +29,8 @@ this mode.
 
 To populate Web with a 90-execution Flow containing serial, fan-out, and fan-in
 sections, run the [Large Step Graph demo](./demo/large-step-graph).
+To exercise the widest layout, run the [90-way fan-out demo](./demo/fan-out-90),
+which creates `Step1`, 90 parallel Steps, and no close-decision graph edges.
 
 ## Frontend development
 

--- a/web/README.md
+++ b/web/README.md
@@ -27,6 +27,9 @@ dexcli dev
 Open [http://127.0.0.1:8802](http://127.0.0.1:8802). No Node.js process runs in
 this mode.
 
+To populate Web with a 90-execution Flow containing serial, fan-out, and fan-in
+sections, run the [Large Step Graph demo](./demo/large-step-graph).
+
 ## Frontend development
 
 Requirements are Node.js 22+ and a local `dexcli` build.
@@ -77,8 +80,8 @@ Selecting the first event reveals that source link; selecting a
 WaitFor event also reveals its outgoing WaitFor-to-Execute link.
 Step graph nodes separate WaitFor and Execute with distinct colors, channel names, condition icons, and individual event details.
 Selecting a Step execution emphasizes it in green, its previous Step in blue, its next Steps in orange, and their connecting arrows.
-Large Step graphs extend down the page at readable size. Parallel ranks wrap to
-two nodes per row so fan-out and fan-in topologies do not require wide horizontal panning.
+Large Step graphs extend down the page at readable size. Fan-out ranks spread
+horizontally and scale down to fit when possible, with a minimum one-third zoom.
 Persisted Step decisions add planned graph branches. A selector-matched branch without a Step event appears Canceled with no execution ID.
 SubFlow conditions appear as linked leaf nodes and compact WaitFor cards. Running
 and terminal nodes display and link by their generated Flow ID. Original WaitFor

--- a/web/README.md
+++ b/web/README.md
@@ -76,6 +76,7 @@ Flow continued, RPC, Step decision, or recovery event that scheduled it.
 Selecting the first event reveals that source link; selecting a
 WaitFor event also reveals its outgoing WaitFor-to-Execute link.
 Step graph nodes separate WaitFor and Execute with distinct colors, channel names, condition icons, and individual event details.
+Selecting a Step execution emphasizes it in green, its previous Step in blue, its next Steps in orange, and their connecting arrows.
 Large Step graphs extend down the page at readable size. Parallel ranks wrap to
 two nodes per row so fan-out and fan-in topologies do not require wide horizontal panning.
 Persisted Step decisions add planned graph branches. A selector-matched branch without a Step event appears Canceled with no execution ID.

--- a/web/README.md
+++ b/web/README.md
@@ -80,6 +80,7 @@ Selecting the first event reveals that source link; selecting a
 WaitFor event also reveals its outgoing WaitFor-to-Execute link.
 Step graph nodes separate WaitFor and Execute with distinct colors, channel names, condition icons, and individual event details.
 Selecting a Step execution emphasizes it in green, its previous Step in blue, its next Steps in orange, and their connecting arrows.
+Close decisions remain in event details and do not create misleading Step graph edges.
 Large Step graphs extend down the page at readable size. Fan-out ranks spread
 horizontally and scale down to fit when possible, with a minimum one-third zoom.
 Persisted Step decisions add planned graph branches. A selector-matched branch without a Step event appears Canceled with no execution ID.

--- a/web/api/handlers.go
+++ b/web/api/handlers.go
@@ -398,8 +398,17 @@ func writeGRPCError(response http.ResponseWriter, err error, operation string) {
 	if message == "" {
 		message = operation + " failed"
 	}
+	message = flowRunNotFoundMessage(statusError.Code(), message)
 	grpcCode := int32(statusError.Code())
 	WriteError(response, httpStatus, message, &grpcCode)
+}
+
+func flowRunNotFoundMessage(code codes.Code, message string) string {
+	const temporalPrefix = "workflow execution not found for workflow ID "
+	if code != codes.NotFound || !strings.HasPrefix(message, temporalPrefix) {
+		return message
+	}
+	return "Flow run is not found for flow ID " + strings.TrimPrefix(message, temporalPrefix)
 }
 
 func WriteError(response http.ResponseWriter, statusCode int, message string, grpcCode *int32) {

--- a/web/app/components/AppHeader.tsx
+++ b/web/app/components/AppHeader.tsx
@@ -23,9 +23,11 @@ export function AppHeader() {
             height={72}
           />
         </Link>
-        <div>
-          <Link to="/" className="brand-name">Super Durable</Link>
-        </div>
+        <Link to="/" className="brand-name">
+          <span>Super Durable</span>
+          <i aria-hidden="true">·</i>
+          <b>Dex</b>
+        </Link>
       </div>
       <nav className="header-nav" aria-label="Primary navigation">
         <Link to="/">Flows</Link>

--- a/web/app/flows/FlowSearchPage.tsx
+++ b/web/app/flows/FlowSearchPage.tsx
@@ -264,13 +264,6 @@ export function FlowSearchPage() {
 
   return (
     <div className="page-shell">
-      <section className="page-heading">
-        <div>
-          <h1>Dex</h1>
-          <p>Redefine Durable Execution. Dead Simple. More Power.</p>
-        </div>
-      </section>
-
       <section className="card query-card">
         <div className="query-toolbar">
           <div className="segmented" role="tablist" aria-label="Query mode">

--- a/web/app/flows/RunDetailsPage.tsx
+++ b/web/app/flows/RunDetailsPage.tsx
@@ -88,7 +88,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
   const [state, setState] = useState<FlowState | null>(null);
   const [nextPageToken, setNextPageToken] = useState('');
   const [nextInternalEventId, setNextInternalEventId] = useState(0);
-  const [tab, setTab] = useState<RunTab>('timeline');
+  const [tab, setTab] = useState<RunTab>('steps');
   const [selectedEvent, setSelectedEvent] = useState<FlowHistoryEvent | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -295,7 +295,7 @@ export function StepGraph({
           <SubFlowNodeLabel flow={node} />
         ) : (
           <div className="graph-node-label">
-            <span>{node.kind === 'source' ? 'Source' : node.kind === 'terminal' ? 'Terminal' : node.status}</span>
+            <span>{node.kind === 'source' ? 'Source' : node.status}</span>
             {node.previousRunId ? (
               <>
                 <b>

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -22,7 +22,12 @@ import {
 } from '@xyflow/react';
 import { buildStepGraph, stepGraphSelection } from '@/lib/graph';
 import type { FlowHistoryEvent, FlowState, StepGraphNode } from '@/lib/types';
-import { graphBounds, layoutGraph } from './graphLayout';
+import {
+  defaultGraphZoom,
+  graphBounds,
+  layoutGraph,
+  minimumGraphZoom,
+} from './graphLayout';
 
 interface StepNodeData extends Record<string, unknown> {
   label: React.ReactNode;
@@ -241,6 +246,7 @@ export function StepGraph({
   onSelectEvent: (event: FlowHistoryEvent | null) => void;
 }) {
   const graphCanvas = useRef<HTMLDivElement>(null);
+  const [canvasWidth, setCanvasWidth] = useState(0);
   const [isMiniMapExpanded, setIsMiniMapExpanded] = useState(false);
   const [flowInstance, setFlowInstance] = useState<ReactFlowInstance<Node<StepNodeData>, Edge> | null>(null);
   const graph = useMemo(
@@ -311,16 +317,26 @@ export function StepGraph({
     return layoutGraph(raw, edges);
   }, [edges, graph.nodes, onSelectEvent, selection]);
   const bounds = useMemo(() => graphBounds(nodes), [nodes]);
+  const initialZoom = defaultGraphZoom(bounds.width, canvasWidth);
 
   useEffect(() => {
-    if (!flowInstance) return;
-    const canvasWidth = graphCanvas.current?.clientWidth ?? bounds.width;
-    const viewport = flowInstance.getViewport();
+    const canvas = graphCanvas.current;
+    if (!canvas) return undefined;
+    const updateWidth = () => setCanvasWidth(canvas.clientWidth);
+    updateWidth();
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(canvas);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!flowInstance || canvasWidth <= 0) return;
     void flowInstance.setViewport({
-      ...viewport,
-      x: Math.max(0, (canvasWidth - bounds.width * viewport.zoom) / 2),
+      x: Math.max(0, (canvasWidth - bounds.width * initialZoom) / 2),
+      y: 0,
+      zoom: initialZoom,
     });
-  }, [bounds.width, flowInstance]);
+  }, [bounds.width, canvasWidth, flowInstance, initialZoom]);
 
   if (!nodes.length) return <div className="card empty-state"><h3>No step topology loaded</h3></div>;
   return (
@@ -340,12 +356,12 @@ export function StepGraph({
       <div
         className="graph-canvas"
         ref={graphCanvas}
-        style={{ height: Math.max(650, bounds.height) }}
+        style={{ height: Math.max(650, bounds.height * initialZoom) }}
       >
         <ReactFlow
           nodes={nodes}
           edges={edges}
-          minZoom={0.15}
+          minZoom={minimumGraphZoom}
           maxZoom={2}
           elementsSelectable={false}
           nodesDraggable={false}

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -20,7 +20,7 @@ import {
   type Node,
   type ReactFlowInstance,
 } from '@xyflow/react';
-import { buildStepGraph } from '@/lib/graph';
+import { buildStepGraph, stepGraphSelection } from '@/lib/graph';
 import type { FlowHistoryEvent, FlowState, StepGraphNode } from '@/lib/types';
 import { graphBounds, layoutGraph } from './graphLayout';
 
@@ -30,6 +30,10 @@ interface StepNodeData extends Record<string, unknown> {
 }
 
 type MethodStatus = 'Started' | 'Waiting' | 'Running' | 'Pending' | 'Completed' | 'Failed' | 'Canceled' | 'Not started';
+
+const graphEdgeColor = '#78909c';
+const previousStepColor = '#3f78a8';
+const nextStepColor = '#c16f24';
 
 function waitingCondition(node: StepGraphNode): Record<string, unknown> {
   const output = node.waitFor?.payload.output;
@@ -243,17 +247,35 @@ export function StepGraph({
     () => buildStepGraph(events, state?.activeStepExecutions ?? [], flowId),
     [events, flowId, state],
   );
-  const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => ({
-    ...edge,
-    type: 'smoothstep',
-    markerEnd: { type: MarkerType.ArrowClosed, width: 18, height: 18, color: '#78909c' },
-    style: { stroke: '#78909c', strokeWidth: 1.5 },
-  })), [graph.edges]);
+  const selection = useMemo(
+    () => stepGraphSelection(graph.nodes, graph.edges, selectedEvent),
+    [graph.edges, graph.nodes, selectedEvent],
+  );
+  const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => {
+    const isIncoming = selection.incomingEdgeIDs.has(edge.id);
+    const isOutgoing = selection.outgoingEdgeIDs.has(edge.id);
+    const color = isIncoming ? previousStepColor : isOutgoing ? nextStepColor : graphEdgeColor;
+    return {
+      ...edge,
+      className: isIncoming ? 'graph-edge-incoming' : isOutgoing ? 'graph-edge-outgoing' : undefined,
+      type: 'smoothstep',
+      markerEnd: { type: MarkerType.ArrowClosed, width: 18, height: 18, color },
+      style: { stroke: color, strokeWidth: isIncoming || isOutgoing ? 3 : 1.5 },
+      zIndex: isIncoming || isOutgoing ? 2 : 0,
+    };
+  }), [graph.edges, selection]);
   const nodes = useMemo(() => {
     const raw: Array<Node<StepNodeData>> = graph.nodes.map((node) => ({
       id: node.id,
       position: { x: 0, y: 0 },
-      className: `step-flow-node node-${node.kind} node-${node.status.toLowerCase()}`,
+      className: [
+        'step-flow-node',
+        `node-${node.kind}`,
+        `node-${node.status.toLowerCase()}`,
+        node.id === selection.selectedStepExecutionID ? 'graph-node-current' : '',
+        selection.previousStepExecutionIDs.has(node.id) ? 'graph-node-previous' : '',
+        selection.nextStepExecutionIDs.has(node.id) ? 'graph-node-next' : '',
+      ].filter(Boolean).join(' '),
       style: {
         width: node.kind === 'step' ? 300 : 220,
         height: node.kind === 'step' && node.execute && !node.waitFor && !node.pendingWaitFor
@@ -287,7 +309,7 @@ export function StepGraph({
       },
     }));
     return layoutGraph(raw, edges);
-  }, [edges, graph.nodes, onSelectEvent]);
+  }, [edges, graph.nodes, onSelectEvent, selection]);
   const bounds = useMemo(() => graphBounds(nodes), [nodes]);
 
   useEffect(() => {
@@ -325,6 +347,7 @@ export function StepGraph({
           edges={edges}
           minZoom={0.15}
           maxZoom={2}
+          elementsSelectable={false}
           nodesDraggable={false}
           preventScrolling={false}
           zoomOnScroll={false}
@@ -351,12 +374,12 @@ export function StepGraph({
             <button
               aria-expanded={isMiniMapExpanded}
               aria-label={isMiniMapExpanded ? 'Collapse Mini Map' : 'Expand Mini Map'}
-              className="graph-minimap-toggle"
+              className="graph-minimap-toggle nodrag nopan"
               onClick={() => setIsMiniMapExpanded((expanded) => !expanded)}
               title={isMiniMapExpanded ? 'Collapse Mini Map' : 'Expand Mini Map'}
               type="button"
             >
-              {isMiniMapExpanded ? <span aria-hidden="true">×</span> : 'Mini Map'}
+              {isMiniMapExpanded ? 'Close ×' : 'Mini Map'}
             </button>
           </div>
         </ReactFlow>

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -8,7 +8,7 @@
 
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Background,
@@ -18,10 +18,11 @@ import {
   ReactFlow,
   type Edge,
   type Node,
+  type ReactFlowInstance,
 } from '@xyflow/react';
 import { buildStepGraph } from '@/lib/graph';
 import type { FlowHistoryEvent, FlowState, StepGraphNode } from '@/lib/types';
-import { layoutGraph } from './graphLayout';
+import { graphBounds, layoutGraph } from './graphLayout';
 
 interface StepNodeData extends Record<string, unknown> {
   label: React.ReactNode;
@@ -152,7 +153,7 @@ function StepNodeLabel({
       || (!skipsWaitFor(node) && (node.active || node.isPlanned) && !node.execute),
   );
   return (
-    <div className="graph-step-label">
+    <div className={`graph-step-label${showWaitFor ? '' : ' graph-step-label--execute-only'}`}>
       <div className="graph-step-heading">
         <span>{node.status}</span>
         <b>{node.label}</b>
@@ -235,7 +236,9 @@ export function StepGraph({
   selectedEvent: FlowHistoryEvent | null;
   onSelectEvent: (event: FlowHistoryEvent | null) => void;
 }) {
+  const graphCanvas = useRef<HTMLDivElement>(null);
   const [isMiniMapExpanded, setIsMiniMapExpanded] = useState(false);
+  const [flowInstance, setFlowInstance] = useState<ReactFlowInstance<Node<StepNodeData>, Edge> | null>(null);
   const graph = useMemo(
     () => buildStepGraph(events, state?.activeStepExecutions ?? [], flowId),
     [events, flowId, state],
@@ -251,7 +254,11 @@ export function StepGraph({
       id: node.id,
       position: { x: 0, y: 0 },
       className: `step-flow-node node-${node.kind} node-${node.status.toLowerCase()}`,
-      style: { width: node.kind === 'step' ? 340 : 220 },
+      style: {
+        width: node.kind === 'step' ? 300 : 220,
+        height: node.kind === 'step' && node.execute && !node.waitFor && !node.pendingWaitFor
+          ? 116 : node.kind === 'step' ? 158 : 90,
+      },
       data: {
         model: node,
         label: node.kind === 'step' ? (
@@ -281,6 +288,17 @@ export function StepGraph({
     }));
     return layoutGraph(raw, edges);
   }, [edges, graph.nodes, onSelectEvent]);
+  const bounds = useMemo(() => graphBounds(nodes), [nodes]);
+
+  useEffect(() => {
+    if (!flowInstance) return;
+    const canvasWidth = graphCanvas.current?.clientWidth ?? bounds.width;
+    const viewport = flowInstance.getViewport();
+    void flowInstance.setViewport({
+      ...viewport,
+      x: Math.max(0, (canvasWidth - bounds.width * viewport.zoom) / 2),
+    });
+  }, [bounds.width, flowInstance]);
 
   if (!nodes.length) return <div className="card empty-state"><h3>No step topology loaded</h3></div>;
   return (
@@ -297,19 +315,25 @@ export function StepGraph({
           <span><i className="legend-subflow" />SubFlow</span>
         </div>
       </div>
-      <div className="graph-canvas">
+      <div
+        className="graph-canvas"
+        ref={graphCanvas}
+        style={{ height: Math.max(650, bounds.height) }}
+      >
         <ReactFlow
           nodes={nodes}
           edges={edges}
-          fitView
           minZoom={0.15}
           maxZoom={2}
+          nodesDraggable={false}
+          preventScrolling={false}
+          zoomOnScroll={false}
+          onInit={setFlowInstance}
           onNodeClick={(_, node) => {
             const model = (node.data as StepNodeData).model;
             if (model.kind === 'subflow') return;
             onSelectEvent(model.execute ?? model.pendingExecute ?? model.waitFor ?? model.pendingWaitFor ?? null);
           }}
-          nodesDraggable
         >
           <Background gap={22} size={1} color="#dfe7e5" />
           <Controls position="top-right" />

--- a/web/app/flows/details/graphLayout.test.ts
+++ b/web/app/flows/details/graphLayout.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+import type { Edge, Node } from '@xyflow/react';
+import { describe, expect, it } from 'vitest';
+import { graphBounds, layoutGraph } from './graphLayout';
+
+function testNode(id: string): Node<Record<string, unknown>> {
+  return {
+    id,
+    data: {},
+    position: { x: 0, y: 0 },
+    style: { height: 116, width: 300 },
+  };
+}
+
+describe('step graph layout', () => {
+  it('keeps a 90-execution fan-out and fan-in flow narrow and vertically readable', () => {
+    const nodes: Array<Node<Record<string, unknown>>> = [testNode('start')];
+    const edges: Edge[] = [];
+    let parent = 'start';
+    for (let index = 1; index <= 30; index += 1) {
+      const id = `serial-before-${index}`;
+      nodes.push(testNode(id));
+      edges.push({ id: `${parent}->${id}`, source: parent, target: id });
+      parent = id;
+    }
+
+    const parallelIDs = Array.from({ length: 12 }, (_, index) => `parallel-${index + 1}`);
+    for (const id of parallelIDs) {
+      nodes.push(testNode(id));
+      edges.push({ id: `${parent}->${id}`, source: parent, target: id });
+    }
+    nodes.push(testNode('fan-in'));
+    for (const id of parallelIDs) {
+      edges.push({ id: `${id}->fan-in`, source: id, target: 'fan-in' });
+    }
+    parent = 'fan-in';
+
+    for (let index = 1; index <= 47; index += 1) {
+      const id = `serial-after-${index}`;
+      nodes.push(testNode(id));
+      edges.push({ id: `${parent}->${id}`, source: parent, target: id });
+      parent = id;
+    }
+
+    const layouted = layoutGraph(nodes, edges);
+    const bounds = graphBounds(layouted);
+    const positions = new Set(layouted.map((node) => `${node.position.x}:${node.position.y}`));
+    const parallelRows = new Map<number, number>();
+    for (const node of layouted.filter((node) => node.id.startsWith('parallel-'))) {
+      parallelRows.set(node.position.y, (parallelRows.get(node.position.y) ?? 0) + 1);
+    }
+
+    expect(layouted).toHaveLength(91);
+    expect(positions.size).toBe(91);
+    expect(bounds.width).toBeLessThanOrEqual(700);
+    expect(bounds.height).toBeGreaterThan(14_000);
+    expect(Math.max(...parallelRows.values())).toBeLessThanOrEqual(2);
+    expect(parallelRows.size).toBe(6);
+  });
+
+  it('keeps uneven fan-out branches together', () => {
+    const nodes = [
+      testNode('source'),
+      ...Array.from({ length: 6 }, (_, index) => testNode(`branch-${index + 1}`)),
+      testNode('long-2'),
+      testNode('long-3'),
+      testNode('terminal'),
+    ];
+    const edges: Edge[] = Array.from({ length: 6 }, (_, index) => ({
+      id: `source->branch-${index + 1}`,
+      source: 'source',
+      target: `branch-${index + 1}`,
+    }));
+    edges.push(
+      { id: 'branch-1->long-2', source: 'branch-1', target: 'long-2' },
+      { id: 'long-2->long-3', source: 'long-2', target: 'long-3' },
+      { id: 'long-3->terminal', source: 'long-3', target: 'terminal' },
+      ...Array.from({ length: 5 }, (_, index) => ({
+        id: `branch-${index + 2}->terminal`,
+        source: `branch-${index + 2}`,
+        target: 'terminal',
+      })),
+    );
+
+    const layouted = layoutGraph(nodes, edges);
+    const branchRows = new Set(layouted
+      .filter((node) => node.id.startsWith('branch-'))
+      .map((node) => node.position.y));
+
+    expect(branchRows.size).toBe(3);
+    expect(Math.max(...branchRows) - Math.min(...branchRows)).toBe(360);
+  });
+});

--- a/web/app/flows/details/graphLayout.test.ts
+++ b/web/app/flows/details/graphLayout.test.ts
@@ -8,7 +8,12 @@
 
 import type { Edge, Node } from '@xyflow/react';
 import { describe, expect, it } from 'vitest';
-import { graphBounds, layoutGraph } from './graphLayout';
+import {
+  defaultGraphZoom,
+  graphBounds,
+  layoutGraph,
+  minimumGraphZoom,
+} from './graphLayout';
 
 function testNode(id: string): Node<Record<string, unknown>> {
   return {
@@ -20,7 +25,7 @@ function testNode(id: string): Node<Record<string, unknown>> {
 }
 
 describe('step graph layout', () => {
-  it('keeps a 90-execution fan-out and fan-in flow narrow and vertically readable', () => {
+  it('keeps a 90-execution fan-out and fan-in flow vertically readable', () => {
     const nodes: Array<Node<Record<string, unknown>>> = [testNode('start')];
     const edges: Edge[] = [];
     let parent = 'start';
@@ -59,10 +64,12 @@ describe('step graph layout', () => {
 
     expect(layouted).toHaveLength(91);
     expect(positions.size).toBe(91);
-    expect(bounds.width).toBeLessThanOrEqual(700);
-    expect(bounds.height).toBeGreaterThan(14_000);
-    expect(Math.max(...parallelRows.values())).toBeLessThanOrEqual(2);
-    expect(parallelRows.size).toBe(6);
+    expect(bounds.width).toBe(4_060);
+    expect(bounds.height).toBeGreaterThan(10_000);
+    expect(Math.max(...parallelRows.values())).toBe(12);
+    expect(parallelRows.size).toBe(1);
+    expect(defaultGraphZoom(bounds.width, 1_200)).toBe(minimumGraphZoom);
+    expect(defaultGraphZoom(bounds.width, 1_800)).toBeGreaterThan(minimumGraphZoom);
   });
 
   it('keeps uneven fan-out branches together', () => {
@@ -94,7 +101,11 @@ describe('step graph layout', () => {
       .filter((node) => node.id.startsWith('branch-'))
       .map((node) => node.position.y));
 
-    expect(branchRows.size).toBe(3);
-    expect(Math.max(...branchRows) - Math.min(...branchRows)).toBe(360);
+    expect(branchRows.size).toBe(1);
+  });
+
+  it('does not enlarge a graph or shrink it past three times', () => {
+    expect(defaultGraphZoom(600, 1_200)).toBe(1);
+    expect(defaultGraphZoom(3_000, 600)).toBe(minimumGraphZoom);
   });
 });

--- a/web/app/flows/details/graphLayout.ts
+++ b/web/app/flows/details/graphLayout.ts
@@ -9,29 +9,128 @@
 import dagre from 'dagre';
 import type { Edge, Node } from '@xyflow/react';
 
+const horizontalGap = 36;
+const verticalGap = 64;
+const horizontalMargin = 32;
+const verticalMargin = 32;
+const maximumNodesPerRow = 2;
+
+interface LayoutNode<NodeData extends Record<string, unknown>> {
+  height: number;
+  node: Node<NodeData>;
+  order: number;
+  width: number;
+}
+
+function logicalRanks<NodeData extends Record<string, unknown>>(
+  nodes: Array<Node<NodeData>>,
+  edges: Edge[],
+): Map<string, number> {
+  const nodeIDs = new Set(nodes.map((node) => node.id));
+  const incomingCounts = new Map(nodes.map((node) => [node.id, 0]));
+  const outgoing = new Map(nodes.map((node) => [node.id, [] as string[]]));
+  for (const edge of edges) {
+    if (!nodeIDs.has(edge.source) || !nodeIDs.has(edge.target)) continue;
+    incomingCounts.set(edge.target, (incomingCounts.get(edge.target) ?? 0) + 1);
+    outgoing.get(edge.source)?.push(edge.target);
+  }
+  const ranks = new Map(nodes.map((node) => [node.id, 0]));
+  const ready = nodes
+    .filter((node) => incomingCounts.get(node.id) === 0)
+    .map((node) => node.id);
+  for (let index = 0; index < ready.length; index += 1) {
+    const source = ready[index];
+    const nextRank = (ranks.get(source) ?? 0) + 1;
+    for (const target of outgoing.get(source) ?? []) {
+      ranks.set(target, Math.max(ranks.get(target) ?? 0, nextRank));
+      const incomingCount = (incomingCounts.get(target) ?? 0) - 1;
+      incomingCounts.set(target, incomingCount);
+      if (incomingCount === 0) ready.push(target);
+    }
+  }
+  return ranks;
+}
+
+function nodeWidth<NodeData extends Record<string, unknown>>(node: Node<NodeData>): number {
+  return typeof node.style?.width === 'number' ? node.style.width : 220;
+}
+
+function nodeHeight<NodeData extends Record<string, unknown>>(node: Node<NodeData>): number {
+  if (typeof node.style?.height === 'number') return node.style.height;
+  return node.data.model && typeof node.data.model === 'object'
+    && (node.data.model as { kind?: string }).kind === 'step' ? 158 : 90;
+}
+
 export function layoutGraph<NodeData extends Record<string, unknown>>(
   nodes: Array<Node<NodeData>>,
   edges: Edge[],
-  direction: 'TB' | 'LR' = 'TB',
 ): Array<Node<NodeData>> {
+  if (nodes.length === 0) return [];
   const graph = new dagre.graphlib.Graph();
   graph.setDefaultEdgeLabel(() => ({}));
-  graph.setGraph({ rankdir: direction, ranksep: 80, nodesep: 44, marginx: 30, marginy: 30 });
+  graph.setGraph({ rankdir: 'TB', ranksep: verticalGap, nodesep: horizontalGap });
   nodes.forEach((node) => graph.setNode(node.id, {
-    width: typeof node.style?.width === 'number' ? node.style.width : 220,
-    height: node.data.model && typeof node.data.model === 'object'
-      && (node.data.model as { kind?: string }).kind === 'step' ? 158 : 90,
+    width: nodeWidth(node),
+    height: nodeHeight(node),
   }));
   edges.forEach((edge) => graph.setEdge(edge.source, edge.target));
   dagre.layout(graph);
-  return nodes.map((node) => {
+
+  const nodeRanks = logicalRanks(nodes, edges);
+  const rankMembers = new Map<number, Array<LayoutNode<NodeData>>>();
+  for (const node of nodes) {
     const position = graph.node(node.id);
-    const width = typeof node.style?.width === 'number' ? node.style.width : 220;
-    const height = node.data.model && typeof node.data.model === 'object'
-      && (node.data.model as { kind?: string }).kind === 'step' ? 158 : 90;
-    return {
-      ...node,
-      position: { x: position.x - width / 2, y: position.y - height / 2 },
-    };
-  });
+    const rank = nodeRanks.get(node.id)
+      ?? Math.round(position.y);
+    const members = rankMembers.get(rank) ?? [];
+    members.push({
+      height: nodeHeight(node),
+      node,
+      order: position.x,
+      width: nodeWidth(node),
+    });
+    rankMembers.set(rank, members);
+  }
+
+  const rows = [...rankMembers.entries()]
+    .sort(([left], [right]) => left - right)
+    .flatMap(([, members]) => {
+      const ordered = members.sort((left, right) => left.order - right.order);
+      const chunks: Array<Array<LayoutNode<NodeData>>> = [];
+      for (let index = 0; index < ordered.length; index += maximumNodesPerRow) {
+        chunks.push(ordered.slice(index, index + maximumNodesPerRow));
+      }
+      return chunks;
+    });
+  const contentWidth = Math.max(...rows.map((row) => (
+    row.reduce((width, member) => width + member.width, 0)
+      + horizontalGap * Math.max(0, row.length - 1)
+  )));
+  const positions = new Map<string, { x: number; y: number }>();
+  let rowTop = verticalMargin;
+  for (const row of rows) {
+    const rowHeight = Math.max(...row.map((member) => member.height));
+    const rowWidth = row.reduce((width, member) => width + member.width, 0)
+      + horizontalGap * Math.max(0, row.length - 1);
+    let nodeLeft = horizontalMargin + (contentWidth - rowWidth) / 2;
+    for (const member of row) {
+      positions.set(member.node.id, {
+        x: nodeLeft,
+        y: rowTop + (rowHeight - member.height) / 2,
+      });
+      nodeLeft += member.width + horizontalGap;
+    }
+    rowTop += rowHeight + verticalGap;
+  }
+
+  return nodes.map((node) => ({ ...node, position: positions.get(node.id) ?? node.position }));
+}
+
+export function graphBounds<NodeData extends Record<string, unknown>>(
+  nodes: Array<Node<NodeData>>,
+): { height: number; width: number } {
+  return {
+    height: Math.max(0, ...nodes.map((node) => node.position.y + nodeHeight(node))) + verticalMargin,
+    width: Math.max(0, ...nodes.map((node) => node.position.x + nodeWidth(node))) + horizontalMargin,
+  };
 }

--- a/web/app/flows/details/graphLayout.ts
+++ b/web/app/flows/details/graphLayout.ts
@@ -13,7 +13,7 @@ const horizontalGap = 36;
 const verticalGap = 64;
 const horizontalMargin = 32;
 const verticalMargin = 32;
-const maximumNodesPerRow = 2;
+export const minimumGraphZoom = 1 / 3;
 
 interface LayoutNode<NodeData extends Record<string, unknown>> {
   height: number;
@@ -94,14 +94,7 @@ export function layoutGraph<NodeData extends Record<string, unknown>>(
 
   const rows = [...rankMembers.entries()]
     .sort(([left], [right]) => left - right)
-    .flatMap(([, members]) => {
-      const ordered = members.sort((left, right) => left.order - right.order);
-      const chunks: Array<Array<LayoutNode<NodeData>>> = [];
-      for (let index = 0; index < ordered.length; index += maximumNodesPerRow) {
-        chunks.push(ordered.slice(index, index + maximumNodesPerRow));
-      }
-      return chunks;
-    });
+    .map(([, members]) => members.sort((left, right) => left.order - right.order));
   const contentWidth = Math.max(...rows.map((row) => (
     row.reduce((width, member) => width + member.width, 0)
       + horizontalGap * Math.max(0, row.length - 1)
@@ -124,6 +117,12 @@ export function layoutGraph<NodeData extends Record<string, unknown>>(
   }
 
   return nodes.map((node) => ({ ...node, position: positions.get(node.id) ?? node.position }));
+}
+
+export function defaultGraphZoom(contentWidth: number, viewportWidth: number): number {
+  if (contentWidth <= 0 || viewportWidth <= 0) return 1;
+  const availableWidth = Math.max(0, viewportWidth - horizontalMargin * 2);
+  return Math.max(minimumGraphZoom, Math.min(1, availableWidth / contentWidth));
 }
 
 export function graphBounds<NodeData extends Record<string, unknown>>(

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2041,7 +2041,7 @@ pre {
 }
 
 .graph-canvas {
-  height: 650px;
+  min-height: 650px;
   overflow: hidden;
   border: 1px solid var(--line);
   border-radius: 12px;
@@ -2246,6 +2246,14 @@ pre {
 
 .graph-step-label {
   min-height: 136px;
+}
+
+.graph-step-label--execute-only {
+  min-height: 114px;
+}
+
+.graph-step-label--execute-only .graph-method {
+  min-height: 58px;
 }
 
 .graph-step-heading {
@@ -2625,7 +2633,7 @@ pre {
   }
 
   .graph-canvas {
-    height: 520px;
+    min-height: 520px;
   }
 
   .load-more {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2170,11 +2170,6 @@ pre {
   background: #f5f1fb;
 }
 
-.react-flow__node.node-terminal {
-  border-color: #4e81a9;
-  background: #eef5f9;
-}
-
 .react-flow__node.node-subflow {
   border-color: #4f7ba7;
   background: #f2f7fb;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -125,13 +125,29 @@ a {
 }
 
 .brand-name {
-  display: block;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
   color: var(--brand-dark);
   font-size: 14px;
   font-weight: 790;
   letter-spacing: 0.055em;
   line-height: 1.1;
+}
+
+.brand-name > span {
   text-transform: uppercase;
+}
+
+.brand-name > i {
+  color: #8da09b;
+  font-style: normal;
+  font-weight: 600;
+}
+
+.brand-name > b {
+  font-size: 15px;
+  letter-spacing: -0.015em;
 }
 
 .header-nav {
@@ -188,12 +204,6 @@ a {
   padding: 34px 0 60px;
 }
 
-.page-heading {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 20px;
-}
-
 h1,
 h2,
 h3,
@@ -219,7 +229,6 @@ h3 {
   font-size: 15px;
 }
 
-.page-heading p,
 .view-toolbar p,
 .modal > p {
   margin-bottom: 0;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2059,6 +2059,7 @@ pre {
 .graph-minimap-shell.expanded {
   width: 200px;
   height: 150px;
+  pointer-events: auto;
 }
 
 .graph-canvas .react-flow__minimap.graph-minimap {
@@ -2097,13 +2098,24 @@ pre {
 
 .graph-minimap-shell.expanded .graph-minimap-toggle {
   position: absolute;
+  z-index: 6;
   top: 7px;
   right: 7px;
-  min-width: 30px;
+  min-width: 66px;
   min-height: 30px;
-  padding: 0;
-  font-size: 18px;
+  padding: 0 9px;
+  border-color: #244b2a;
+  color: white;
+  background: #365f2b;
+  box-shadow: 0 3px 12px rgba(28, 51, 45, 0.34);
+  font-size: 11px;
   line-height: 1;
+}
+
+.graph-minimap-shell.expanded .graph-minimap-toggle:hover {
+  border-color: #173a1e;
+  color: white;
+  background: #244b2a;
 }
 
 .react-flow__node.step-flow-node {
@@ -2165,6 +2177,35 @@ pre {
 .react-flow__node.node-subflow.node-terminated {
   border-color: #c95252;
   background: #fff5f4;
+}
+
+.react-flow__node.step-flow-node.graph-node-previous {
+  border-width: 2px;
+  border-color: #3f78a8;
+  background: linear-gradient(90deg, #e9f4fb, #fff 48%);
+  box-shadow: 0 0 0 3px rgba(63, 120, 168, 0.2), 0 11px 25px rgba(38, 88, 130, 0.14);
+}
+
+.react-flow__node.step-flow-node.graph-node-next {
+  border-width: 2px;
+  border-color: #c16f24;
+  background: linear-gradient(90deg, #fff0df, #fff 48%);
+  box-shadow: 0 0 0 3px rgba(193, 111, 36, 0.2), 0 11px 25px rgba(128, 76, 28, 0.14);
+}
+
+.react-flow__node.step-flow-node.graph-node-current {
+  border-width: 2px;
+  border-color: var(--brand);
+  background: linear-gradient(90deg, #e8f4da, #fff 48%);
+  box-shadow: inset 5px 0 0 var(--brand-bright), 0 0 0 5px rgba(111, 160, 54, 0.24), 0 14px 30px rgba(79, 129, 39, 0.2);
+}
+
+.react-flow__edge.graph-edge-incoming .react-flow__edge-path {
+  filter: drop-shadow(0 1px 2px rgba(38, 88, 130, 0.28));
+}
+
+.react-flow__edge.graph-edge-outgoing .react-flow__edge-path {
+  filter: drop-shadow(0 1px 2px rgba(128, 76, 28, 0.28));
 }
 
 .graph-sub-flow-link {

--- a/web/demo/fan-out-90/README.md
+++ b/web/demo/fan-out-90/README.md
@@ -1,0 +1,17 @@
+# 90-way fan-out demo
+
+This demo runs one execute-only `Step1`, fans out to 90 execute-only Steps, and
+lets every branch request `GracefulComplete`. The resulting Flow contains 91
+Step executions, uses no `WaitFor` conditions or Channels, and remains below
+the continue-as-new threshold of 100.
+
+Start Dex and Web, then run the demo from `web/`:
+
+```bash
+dexcli dev
+GOWORK=off go run ./demo/fan-out-90
+```
+
+The command waits for completion and prints the Flow ID, Run ID, status, and a
+direct Web URL. Set `DEX_FLOW_SERVICE_ADDRESS` or `DEX_WEB_URL` to override the
+default local addresses.

--- a/web/demo/fan-out-90/main.go
+++ b/web/demo/fan-out-90/main.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/superdurable/dex/gen/dexpb"
+	"github.com/superdurable/dex/service/common/ptr"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	flowType      = "web-step1-fanout-90"
+	startStepType = "Step1"
+	fanOutCount   = 90
+)
+
+type worker struct {
+	dexpb.UnimplementedWorkerServiceServer
+}
+
+func main() {
+	if err := run(); err != nil {
+		panic(err)
+	}
+}
+
+func run() (returnErr error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return err
+	}
+	workerServer := grpc.NewServer()
+	dexpb.RegisterWorkerServiceServer(workerServer, &worker{})
+	serverErrors := make(chan error, 1)
+	go func() {
+		serverErrors <- workerServer.Serve(listener)
+	}()
+	defer func() {
+		workerServer.GracefulStop()
+		if serveErr := <-serverErrors; serveErr != nil && returnErr == nil {
+			returnErr = serveErr
+		}
+	}()
+
+	flowServiceAddress := environmentOrDefault("DEX_FLOW_SERVICE_ADDRESS", "127.0.0.1:8801")
+	connection, err := grpc.NewClient(
+		flowServiceAddress,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := connection.Close(); closeErr != nil && returnErr == nil {
+			returnErr = closeErr
+		}
+	}()
+
+	requestContext, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	flowClient := dexpb.NewFlowServiceClient(connection)
+	flowID := fmt.Sprintf("web-step1-fanout-90-%d", time.Now().Unix())
+	started, err := flowClient.StartFlow(requestContext, &dexpb.StartFlowRequest{
+		RequestId:          uuid.NewString(),
+		FlowId:             flowID,
+		FlowType:           flowType,
+		FlowTimeoutSeconds: 180,
+		StartStepType:      startStepType,
+		StepOptions:        executeOnlyOptions(),
+		FlowStartOptions: &dexpb.FlowStartOptions{
+			FlowConfigOverride: &dexpb.FlowConfig{
+				ContinueAsNewThreshold: ptr.Any(int32(100)),
+				StepDurability: ptr.Any(
+					dexpb.StepDurability_STEP_DURABILITY_SYNC,
+				),
+				WorkerTarget: &dexpb.WorkerTarget{Address: listener.Addr().String()},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	result, err := flowClient.WaitForFlow(requestContext, &dexpb.WaitForFlowRequest{
+		FlowId:          flowID,
+		RunId:           started.GetRunId(),
+		WaitTimeSeconds: 150,
+	})
+	if err != nil {
+		return err
+	}
+	webAddress := strings.TrimRight(environmentOrDefault("DEX_WEB_URL", "http://127.0.0.1:8802"), "/")
+	_, err = fmt.Printf(
+		"flow_id=%s\nrun_id=%s\nstatus=%s\nurl=%s/flows/%s/%s\n",
+		flowID,
+		started.GetRunId(),
+		result.GetFlowStatus(),
+		webAddress,
+		url.PathEscape(flowID),
+		url.PathEscape(started.GetRunId()),
+	)
+	return err
+}
+
+func (w *worker) InvokeExecuteMethod(
+	_ context.Context,
+	request *dexpb.InvokeExecuteMethodRequest,
+) (*dexpb.InvokeExecuteMethodResponse, error) {
+	if request.GetFlowType() != flowType {
+		return nil, status.Error(codes.InvalidArgument, "unexpected flow type")
+	}
+	if request.GetStepType() == startStepType {
+		movements := make([]*dexpb.StepMovement, 0, fanOutCount)
+		for index := 1; index <= fanOutCount; index++ {
+			movements = append(movements, &dexpb.StepMovement{
+				StepType:    fmt.Sprintf("FanOut-%03d", index),
+				StepOptions: executeOnlyOptions(),
+			})
+		}
+		return &dexpb.InvokeExecuteMethodResponse{
+			StepDecision: &dexpb.StepDecision{NextSteps: movements},
+		}, nil
+	}
+	if !strings.HasPrefix(request.GetStepType(), "FanOut-") {
+		return nil, status.Error(codes.InvalidArgument, "unexpected step type")
+	}
+	return &dexpb.InvokeExecuteMethodResponse{
+		StepDecision: &dexpb.StepDecision{
+			CloseDecision: &dexpb.CloseDecision{
+				CloseDecisionType: dexpb.CloseDecisionType_CLOSE_DECISION_TYPE_GRACEFUL_COMPLETE,
+			},
+		},
+	}, nil
+}
+
+func executeOnlyOptions() *dexpb.StepOptions {
+	return &dexpb.StepOptions{SkipWaitFor: true}
+}
+
+func environmentOrDefault(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/web/demo/large-step-graph/README.md
+++ b/web/demo/large-step-graph/README.md
@@ -1,0 +1,16 @@
+# Large Step Graph demo
+
+This demo creates exactly 90 execute-only Step executions: 30 serial Steps, six
+parallel branches with five Steps each, then 30 serial Steps. It uses no
+`WaitFor` conditions or Channels, and sets the continue-as-new threshold to 100.
+
+Start Dex and Web, then run the demo from `web/`:
+
+```bash
+dexcli dev
+GOWORK=off go run ./demo/large-step-graph
+```
+
+The command waits for completion and prints the Flow ID, Run ID, status, and a
+direct Web URL. Set `DEX_FLOW_SERVICE_ADDRESS` or `DEX_WEB_URL` to override the
+default local addresses.

--- a/web/demo/large-step-graph/main.go
+++ b/web/demo/large-step-graph/main.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/superdurable/dex/gen/dexpb"
+	"github.com/superdurable/dex/service/common/ptr"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	flowType         = "web-large-step-graph-90"
+	parallelBranches = 6
+	branchDepth      = 5
+	serialBefore     = 30
+	serialAfter      = 30
+)
+
+type worker struct {
+	dexpb.UnimplementedWorkerServiceServer
+}
+
+func main() {
+	if err := run(); err != nil {
+		panic(err)
+	}
+}
+
+func run() (returnErr error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return err
+	}
+	workerServer := grpc.NewServer()
+	dexpb.RegisterWorkerServiceServer(workerServer, &worker{})
+	serverErrors := make(chan error, 1)
+	go func() {
+		serverErrors <- workerServer.Serve(listener)
+	}()
+	defer func() {
+		workerServer.GracefulStop()
+		if serveErr := <-serverErrors; serveErr != nil && returnErr == nil {
+			returnErr = serveErr
+		}
+	}()
+
+	flowServiceAddress := environmentOrDefault("DEX_FLOW_SERVICE_ADDRESS", "127.0.0.1:8801")
+	connection, err := grpc.NewClient(
+		flowServiceAddress,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := connection.Close(); closeErr != nil && returnErr == nil {
+			returnErr = closeErr
+		}
+	}()
+
+	requestContext, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	flowClient := dexpb.NewFlowServiceClient(connection)
+	flowID := fmt.Sprintf("web-large-step-graph-90-%d", time.Now().Unix())
+	start, err := flowClient.StartFlow(
+		requestContext,
+		&dexpb.StartFlowRequest{
+			RequestId:          uuid.NewString(),
+			FlowId:             flowID,
+			FlowType:           flowType,
+			FlowTimeoutSeconds: 150,
+			StartStepType:      serialBeforeStep(1),
+			StepOptions:        executeOnlyOptions(),
+			FlowStartOptions: &dexpb.FlowStartOptions{
+				FlowConfigOverride: &dexpb.FlowConfig{
+					ContinueAsNewThreshold: ptr.Any(int32(100)),
+					StepDurability: ptr.Any(
+						dexpb.StepDurability_STEP_DURABILITY_SYNC,
+					),
+					WorkerTarget: &dexpb.WorkerTarget{Address: listener.Addr().String()},
+				},
+			},
+		},
+	)
+	if err != nil {
+		return err
+	}
+	result, err := flowClient.WaitForFlow(
+		requestContext,
+		&dexpb.WaitForFlowRequest{
+			FlowId:          flowID,
+			RunId:           start.GetRunId(),
+			WaitTimeSeconds: 120,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	webAddress := strings.TrimRight(environmentOrDefault("DEX_WEB_URL", "http://127.0.0.1:8802"), "/")
+	_, err = fmt.Printf(
+		"flow_id=%s\nrun_id=%s\nstatus=%s\nurl=%s/flows/%s/%s\n",
+		flowID,
+		start.GetRunId(),
+		result.GetFlowStatus(),
+		webAddress,
+		url.PathEscape(flowID),
+		url.PathEscape(start.GetRunId()),
+	)
+	return err
+}
+
+func (w *worker) InvokeExecuteMethod(
+	_ context.Context,
+	request *dexpb.InvokeExecuteMethodRequest,
+) (*dexpb.InvokeExecuteMethodResponse, error) {
+	if request.GetFlowType() != flowType {
+		return nil, status.Error(codes.InvalidArgument, "unexpected flow type")
+	}
+	stepType := request.GetStepType()
+	switch {
+	case strings.HasPrefix(stepType, "SerialBefore-"):
+		index, parseErr := stepIndex(stepType)
+		if parseErr != nil {
+			return nil, status.Error(codes.InvalidArgument, "invalid serial-before step")
+		}
+		if index < serialBefore {
+			return nextSteps(serialBeforeStep(index + 1)), nil
+		}
+		branches := make([]string, 0, parallelBranches)
+		for branch := 1; branch <= parallelBranches; branch++ {
+			branches = append(branches, branchStep(branch, 1))
+		}
+		return nextSteps(branches...), nil
+	case strings.HasPrefix(stepType, "Branch-"):
+		branch, depth, parseErr := branchIndexes(stepType)
+		if parseErr != nil {
+			return nil, status.Error(codes.InvalidArgument, "invalid branch step")
+		}
+		if depth < branchDepth {
+			return nextSteps(branchStep(branch, depth+1)), nil
+		}
+		if branch == 1 {
+			return nextSteps(serialAfterStep(1)), nil
+		}
+		return closeGracefully(), nil
+	case strings.HasPrefix(stepType, "SerialAfter-"):
+		index, parseErr := stepIndex(stepType)
+		if parseErr != nil {
+			return nil, status.Error(codes.InvalidArgument, "invalid serial-after step")
+		}
+		if index < serialAfter {
+			return nextSteps(serialAfterStep(index + 1)), nil
+		}
+		return closeGracefully(), nil
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unexpected step type %q", stepType)
+	}
+}
+
+func nextSteps(stepTypes ...string) *dexpb.InvokeExecuteMethodResponse {
+	movements := make([]*dexpb.StepMovement, 0, len(stepTypes))
+	for _, stepType := range stepTypes {
+		movements = append(movements, &dexpb.StepMovement{
+			StepType:    stepType,
+			StepOptions: executeOnlyOptions(),
+		})
+	}
+	return &dexpb.InvokeExecuteMethodResponse{
+		StepDecision: &dexpb.StepDecision{NextSteps: movements},
+	}
+}
+
+func executeOnlyOptions() *dexpb.StepOptions {
+	return &dexpb.StepOptions{SkipWaitFor: true}
+}
+
+func closeGracefully() *dexpb.InvokeExecuteMethodResponse {
+	return &dexpb.InvokeExecuteMethodResponse{
+		StepDecision: &dexpb.StepDecision{
+			CloseDecision: &dexpb.CloseDecision{
+				CloseDecisionType: dexpb.CloseDecisionType_CLOSE_DECISION_TYPE_GRACEFUL_COMPLETE,
+			},
+		},
+	}
+}
+
+func serialBeforeStep(index int) string {
+	return fmt.Sprintf("SerialBefore-%03d", index)
+}
+
+func serialAfterStep(index int) string {
+	return fmt.Sprintf("SerialAfter-%03d", index)
+}
+
+func branchStep(branch, depth int) string {
+	return fmt.Sprintf("Branch-%d-%02d", branch, depth)
+}
+
+func stepIndex(stepType string) (int, error) {
+	parts := strings.Split(stepType, "-")
+	return strconv.Atoi(parts[len(parts)-1])
+}
+
+func branchIndexes(stepType string) (int, int, error) {
+	parts := strings.Split(stepType, "-")
+	if len(parts) != 3 {
+		return 0, 0, fmt.Errorf("invalid branch step %q", stepType)
+	}
+	branch, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, err
+	}
+	depth, err := strconv.Atoi(parts[2])
+	return branch, depth, err
+}
+
+func environmentOrDefault(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/web/go.mod
+++ b/web/go.mod
@@ -3,6 +3,7 @@ module github.com/superdurable/dex/web
 go 1.24.0
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/superdurable/dex v0.0.0
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11

--- a/web/lib/graph.test.ts
+++ b/web/lib/graph.test.ts
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import { describe, expect, it } from 'vitest';
-import { buildStepGraph, END_NODE_ID, stepGraphSelection } from './graph';
+import { buildStepGraph, stepGraphSelection } from './graph';
 import type { FlowHistoryEvent } from './types';
 
 function event(
@@ -128,7 +128,7 @@ describe('step graph', () => {
     });
   });
 
-  it('connects only the step with a close decision to the terminal node', () => {
+  it('does not create topology edges for close decisions', () => {
     const graph = buildStepGraph([
       event(1, 'StepWaitForCompleted', {
         stepExecutionId: 'trial-1',
@@ -150,11 +150,19 @@ describe('step graph', () => {
       event(4, 'FlowClosed'),
     ]);
 
-    expect(graph.edges.filter((edge) => edge.target === END_NODE_ID)).toEqual([{
-      id: 'cancel-1->__end__',
-      source: 'cancel-1',
-      target: '__end__',
-    }]);
+    expect(graph.nodes.map((node) => node.id)).not.toContain('__end__');
+    expect(graph.edges).toEqual([
+      {
+        id: '__start__->trial-1',
+        source: '__start__',
+        target: 'trial-1',
+      },
+      {
+        id: '__start__->cancel-1',
+        source: '__start__',
+        target: 'cancel-1',
+      },
+    ]);
   });
 
   it('retains a step method that was still pending when the flow closed', () => {

--- a/web/lib/graph.test.ts
+++ b/web/lib/graph.test.ts
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import { describe, expect, it } from 'vitest';
-import { buildStepGraph, END_NODE_ID } from './graph';
+import { buildStepGraph, END_NODE_ID, stepGraphSelection } from './graph';
 import type { FlowHistoryEvent } from './types';
 
 function event(
@@ -20,6 +20,54 @@ function event(
 }
 
 describe('step graph', () => {
+  it('selects adjacent Step executions and their connecting edges', () => {
+    const selectedEvent = event(2, 'StepExecuteCompleted', {
+      stepExecutionId: 'Root-1',
+      fromStepExecutionId: 'Previous-1',
+      stepType: 'Root',
+    }, {
+      output: { stepDecision: { nextSteps: [{
+        stepType: 'Left',
+        fromStepExecutionIdInternalOnly: 'Root-1',
+      }, {
+        stepType: 'Right',
+        fromStepExecutionIdInternalOnly: 'Root-1',
+      }] } },
+    });
+    const graph = buildStepGraph([
+      event(1, 'StepExecuteCompleted', {
+        stepExecutionId: 'Previous-1',
+        fromStepExecutionId: '__start__',
+        stepType: 'Previous',
+      }),
+      selectedEvent,
+      event(3, 'StepExecuteCompleted', {
+        stepExecutionId: 'Left-1',
+        fromStepExecutionId: 'Root-1',
+        stepType: 'Left',
+      }),
+      event(4, 'StepExecuteCompleted', {
+        stepExecutionId: 'Right-1',
+        fromStepExecutionId: 'Root-1',
+        stepType: 'Right',
+      }),
+    ]);
+
+    const selection = stepGraphSelection(graph.nodes, graph.edges, selectedEvent);
+
+    expect(selection.selectedStepExecutionID).toBe('Root-1');
+    expect([...selection.previousStepExecutionIDs]).toEqual(['Previous-1']);
+    expect([...selection.nextStepExecutionIDs]).toEqual([
+      'Left-1',
+      'Right-1',
+    ]);
+    expect([...selection.incomingEdgeIDs]).toEqual(['Previous-1->Root-1']);
+    expect([...selection.outgoingEdgeIDs]).toEqual([
+      'Root-1->Left-1',
+      'Root-1->Right-1',
+    ]);
+  });
+
   it('uses the same lineage model for semantic SYNC and ASYNC events', () => {
     const events = [
       event(1, 'StepExecuteCompleted', {

--- a/web/lib/graph.ts
+++ b/web/lib/graph.ts
@@ -16,7 +16,6 @@ import { subFlowReusePolicyLabel, subFlowStatusName } from './semantic';
 import { generatedSubFlowID } from './subflows';
 
 export const START_NODE_ID = '__start__';
-export const END_NODE_ID = '__end__';
 
 const stepEventTypes = new Set([
   'StepWaitForCompleted',
@@ -56,7 +55,6 @@ export function buildStepGraph(
 ): { nodes: StepGraphNode[]; edges: StepGraphEdge[] } {
   const nodes = new Map<string, StepGraphNode>();
   const plannedNodesByLineage = new Map<string, string[]>();
-  const closingStepExecutionIDs = new Set<string>();
   nodes.set(START_NODE_ID, {
     id: START_NODE_ID,
     label: 'Flow start',
@@ -68,10 +66,6 @@ export function buildStepGraph(
   for (const event of events) {
     if (stepEventTypes.has(event.type)) {
       addStepEvent(nodes, plannedNodesByLineage, event);
-      const stepExecutionID = stringField(stepContext(event).stepExecutionId);
-      if (stepExecutionID && event.type === 'StepExecuteCompleted' && hasCloseDecision(event)) {
-        closingStepExecutionIDs.add(stepExecutionID);
-      }
     }
     const decision = stepDecision(event);
     if (!decision) continue;
@@ -110,16 +104,6 @@ export function buildStepGraph(
     addSubFlowNodes(nodes, stepNode, parentFlowID);
   }
 
-  const closed = events.findLast((event) => event.type === 'FlowClosed');
-  if (closed) {
-    nodes.set(END_NODE_ID, {
-      id: END_NODE_ID,
-      label: 'Flow closed',
-      kind: 'terminal',
-      status: 'Terminal',
-    });
-  }
-
   for (const node of [...nodes.values()]) {
     const source = node.fromStepExecutionId;
     if (!source?.startsWith('__rpc/')) continue;
@@ -147,16 +131,6 @@ export function buildStepGraph(
     const requestedSource = node.fromStepExecutionId || START_NODE_ID;
     const source = nodes.has(requestedSource) ? requestedSource : START_NODE_ID;
     edges.push({ id: `${source}->${node.id}`, source, target: node.id });
-  }
-
-  if (closed) {
-    for (const stepExecutionID of closingStepExecutionIDs) {
-      edges.push({
-        id: `${stepExecutionID}->${END_NODE_ID}`,
-        source: stepExecutionID,
-        target: END_NODE_ID,
-      });
-    }
   }
 
   return { nodes: [...nodes.values()], edges };
@@ -389,13 +363,4 @@ function addSubFlowNodes(
       reusePolicy: subFlowReusePolicyLabel(options.reusePolicy),
     });
   });
-}
-
-function hasCloseDecision(event: FlowHistoryEvent): boolean {
-  const output = event.payload.output;
-  if (!output || typeof output !== 'object') return false;
-  const stepDecision = (output as Record<string, unknown>).stepDecision;
-  if (!stepDecision || typeof stepDecision !== 'object') return false;
-  const closeDecision = (stepDecision as Record<string, unknown>).closeDecision;
-  return Boolean(closeDecision && typeof closeDecision === 'object');
 }

--- a/web/lib/graph.ts
+++ b/web/lib/graph.ts
@@ -162,6 +162,56 @@ export function buildStepGraph(
   return { nodes: [...nodes.values()], edges };
 }
 
+export function stepGraphSelection(
+  nodes: StepGraphNode[],
+  edges: StepGraphEdge[],
+  selectedEvent: FlowHistoryEvent | null,
+): {
+  selectedStepExecutionID: string;
+  previousStepExecutionIDs: Set<string>;
+  nextStepExecutionIDs: Set<string>;
+  incomingEdgeIDs: Set<string>;
+  outgoingEdgeIDs: Set<string>;
+} {
+  const selectedStepExecutionID = selectedEvent
+    ? stringField(stepContext(selectedEvent).stepExecutionId)
+    : '';
+  const stepExecutionIDs = new Set(
+    nodes.filter((node) => node.kind === 'step' && !node.isPlanned).map((node) => node.id),
+  );
+  const previousStepExecutionIDs = new Set<string>();
+  const nextStepExecutionIDs = new Set<string>();
+  const incomingEdgeIDs = new Set<string>();
+  const outgoingEdgeIDs = new Set<string>();
+  if (!stepExecutionIDs.has(selectedStepExecutionID)) {
+    return {
+      selectedStepExecutionID: '',
+      previousStepExecutionIDs,
+      nextStepExecutionIDs,
+      incomingEdgeIDs,
+      outgoingEdgeIDs,
+    };
+  }
+
+  for (const edge of edges) {
+    if (edge.target === selectedStepExecutionID && stepExecutionIDs.has(edge.source)) {
+      previousStepExecutionIDs.add(edge.source);
+      incomingEdgeIDs.add(edge.id);
+    }
+    if (edge.source === selectedStepExecutionID && stepExecutionIDs.has(edge.target)) {
+      nextStepExecutionIDs.add(edge.target);
+      outgoingEdgeIDs.add(edge.id);
+    }
+  }
+  return {
+    selectedStepExecutionID,
+    previousStepExecutionIDs,
+    nextStepExecutionIDs,
+    incomingEdgeIDs,
+    outgoingEdgeIDs,
+  };
+}
+
 function addStepEvent(
   nodes: Map<string, StepGraphNode>,
   plannedNodesByLineage: Map<string, string[]>,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -102,8 +102,8 @@ export interface FlowState {
 export interface StepGraphNode {
   id: string;
   label: string;
-  kind: 'source' | 'step' | 'subflow' | 'terminal';
-  status: 'Source' | 'Active' | 'Waiting' | 'Pending' | 'Completed' | 'Failed' | 'Canceled' | 'Terminal';
+  kind: 'source' | 'step' | 'subflow';
+  status: 'Source' | 'Active' | 'Waiting' | 'Pending' | 'Completed' | 'Failed' | 'Canceled';
   previousRunId?: string;
   stepType?: string;
   fromStepExecutionId?: string;

--- a/web/server_integ_test.go
+++ b/web/server_integ_test.go
@@ -92,6 +92,22 @@ func TestWebServerMapsGRPCErrors(t *testing.T) {
 	if result.Error != "invalid flow" || result.GRPCCode != int32(codes.InvalidArgument) {
 		t.Fatalf("unexpected error response: %+v", result)
 	}
+
+	missing := get(
+		t,
+		harness.http.URL+"/api/flows/summary?flowId=missing-flow&runId=missing-run",
+	)
+	defer missing.Body.Close()
+	if missing.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing summary status = %d", missing.StatusCode)
+	}
+	decodeResponse(t, missing, &result)
+	if result.Error != `Flow run is not found for flow ID "missing-flow" and run ID "missing-run"` {
+		t.Fatalf("missing summary error = %q", result.Error)
+	}
+	if result.GRPCCode != int32(codes.NotFound) {
+		t.Fatalf("missing summary gRPC code = %d", result.GRPCCode)
+	}
 }
 
 func TestWebServerScopesSearchesToEngineWorkflows(t *testing.T) {
@@ -288,9 +304,17 @@ func (s *flowService) SearchFlows(
 }
 
 func (s *flowService) GetFlowSummary(
-	context.Context,
-	*dexpb.GetFlowSummaryRequest,
+	_ context.Context,
+	request *dexpb.GetFlowSummaryRequest,
 ) (*dexpb.GetFlowSummaryResponse, error) {
+	if request.GetFlowId() == "missing-flow" {
+		return nil, status.Errorf(
+			codes.NotFound,
+			`workflow execution not found for workflow ID %q and run ID %q`,
+			request.GetFlowId(),
+			request.GetRunId(),
+		)
+	}
 	return nil, status.Error(codes.InvalidArgument, "invalid flow")
 }
 


### PR DESCRIPTION
## Summary

- open Flow runs on Step graph by default
- render large graphs at readable scale with page-level vertical scrolling
- cap parallel ranks at two nodes per row and preserve logical lineage ranks for uneven fan-out/fan-in branches
- compact execute-only Step cards and keep graphs horizontally centered as history loads
- add regression coverage for a 90-execution graph and uneven parallel branches

## User impact

Flows with dozens of Step executions remain readable without horizontal panning. Mouse-wheel scrolling over the graph moves down the page instead of changing graph zoom.

## Validation

- `cd web && npm run check` (52 tests)
- `cd web && npm run build`
- `make copyright-check`
- Browser verification against a completed 90-execution Flow with six-way fan-out: 90 Execute cards, 0 WaitFor cards, no document-level horizontal overflow, and page scrolling without graph zoom
