### PR TITLE
Isolate concurrent dexcli dev stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ dexcli dev --open
 
 Open Dex Web at [http://127.0.0.1:8802](http://127.0.0.1:8802). This starts
 the complete local Dex environment, including its internal workflow backend.
-Dex step inputs and large values persist by default in `$HOME/.dex/blobs`.
+If 8802 is already taken, `dexcli dev` prints the port it selected instead.
 
 See [cli/README.md](cli/README.md) for Dex endpoints and persistence options.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -54,6 +54,13 @@ dexcli dev --blob-store-dir ./dex-blobs
 `--blob-store-dir` takes precedence over the directory derived from
 `--temporal-db-filename`.
 
+Capture local Temporal server and Web logs, including the bound Temporal ports
+and SQLite directory, with:
+
+```bash
+dexcli dev --temporal-log-file ./temporal.log
+```
+
 Configure local Attribute Store projection with the same YAML section accepted
 by Dex Server:
 
@@ -81,6 +88,7 @@ must exist and be reachable before startup.
 --dex-port int                 Dex gRPC port (default 8801)
 --web-port int                 Dex Web port (default 8802)
 --temporal-db-filename string  local Temporal SQLite file (default $HOME/.dex/dev/<temporal-port>/temporal.db)
+--temporal-log-file string     write local Temporal server and Web logs to this file
 --blob-store-dir string        persistent Dex blob storage directory (default <temporal-db-filename>.dex-blobs)
 --attribute-store-config string  Dex YAML file supplying Attribute Store settings
 --open                         open Dex Web after readiness

--- a/cli/README.md
+++ b/cli/README.md
@@ -26,20 +26,26 @@ The default endpoints are:
 | Dex Web | `http://127.0.0.1:8802` |
 | Dex Server | `127.0.0.1:8801` |
 
+If a default port is already in use, `dexcli dev` binds the next free port and
+prints the addresses it selected. Running several `dexcli dev` processes on the
+same machine therefore starts isolated stacks: distinct Dex ports, a distinct
+local Temporal server, and a distinct SQLite database. Point later CLI commands
+at a non-default stack with `--server` or `DEX_FLOW_SERVICE_ADDRESS`.
+
 Use `--open` to open Dex Web after every component becomes ready. Ctrl+C stops
 Dex Web, Dex Server, and all internal processes owned by `dexcli`.
 
-Persist local Dex executions in SQLite:
+Local Temporal state persists in
+`$HOME/.dex/dev/<temporal-port>/temporal.db`. Dex Web step inputs and values
+larger than 1 KB persist next to that database in `temporal.db.dex-blobs`, so
+execution history and its blobs share a lifecycle. Override the database path
+with:
 
 ```bash
 dexcli dev --temporal-db-filename ./temporal.db
 ```
 
-Dex Web step inputs and values larger than 1 KB use the bundled local blob
-store. By default they persist across `dexcli` restarts in `$HOME/.dex/blobs`.
-With the command above they instead persist in `./temporal.db.dex-blobs`, so
-execution history and its blobs share a lifecycle. Choose another directory
-with:
+Choose another blob directory with:
 
 ```bash
 dexcli dev --blob-store-dir ./dex-blobs
@@ -74,8 +80,8 @@ must exist and be reachable before startup.
 --bind-address string          local bind IP (default 127.0.0.1)
 --dex-port int                 Dex gRPC port (default 8801)
 --web-port int                 Dex Web port (default 8802)
---temporal-db-filename string  local Temporal SQLite file
---blob-store-dir string        persistent Dex blob storage directory (default $HOME/.dex/blobs)
+--temporal-db-filename string  local Temporal SQLite file (default $HOME/.dex/dev/<temporal-port>/temporal.db)
+--blob-store-dir string        persistent Dex blob storage directory (default <temporal-db-filename>.dex-blobs)
 --attribute-store-config string  Dex YAML file supplying Attribute Store settings
 --open                         open Dex Web after readiness
 ```
@@ -172,7 +178,9 @@ binary does not read `web/`, `node_modules`, or the source tree.
 ## Troubleshooting
 
 - “workflow backend CLI was not found”: reinstall `dexcli` with Homebrew.
-- “address is already in use”: stop the listed service or select another port.
+- “address is already in use”: an explicit `--dex-port`, `--web-port`,
+  `--temporal-port`, or `--temporal-ui-port` is taken. Stop that process or pass
+  another port. Unspecified ports are assigned automatically.
 - “attribute index synchronization failed”: operators should verify that Dex
   can list and add backend visibility indexes. Workers never require a manual
   registration command.

--- a/cli/README.md
+++ b/cli/README.md
@@ -35,14 +35,13 @@ at a non-default stack with `--server` or `DEX_FLOW_SERVICE_ADDRESS`.
 Use `--open` to open Dex Web after every component becomes ready. Ctrl+C stops
 Dex Web, Dex Server, and all internal processes owned by `dexcli`.
 
-Local Temporal state persists in
-`$HOME/.dex/dev/<temporal-port>/temporal.db`. Dex Web step inputs and values
-larger than 1 KB persist next to that database in `temporal.db.dex-blobs`, so
-execution history and its blobs share a lifecycle. Override the database path
-with:
+Local state persists in `$HOME/.dex/dev/<temporal-port>/dex.sqlite.db`.
+Dex Web step inputs and values larger than 1 KB persist next to that database
+in `dex.blobs`, so execution history and its blobs share a lifecycle. Override
+the database path with:
 
 ```bash
-dexcli dev --temporal-db-filename ./temporal.db
+dexcli dev --temporal-db-filename ./dex.sqlite.db
 ```
 
 Choose another blob directory with:
@@ -87,9 +86,9 @@ must exist and be reachable before startup.
 --bind-address string          local bind IP (default 127.0.0.1)
 --dex-port int                 Dex gRPC port (default 8801)
 --web-port int                 Dex Web port (default 8802)
---temporal-db-filename string  local Temporal SQLite file (default $HOME/.dex/dev/<temporal-port>/temporal.db)
+--temporal-db-filename string  local Temporal SQLite file (default $HOME/.dex/dev/<temporal-port>/dex.sqlite.db)
 --temporal-log-file string     write local Temporal server and Web logs to this file
---blob-store-dir string        persistent Dex blob storage directory (default <temporal-db-filename>.dex-blobs)
+--blob-store-dir string        persistent Dex blob storage directory (default $HOME/.dex/dev/<temporal-port>/dex.blobs)
 --attribute-store-config string  Dex YAML file supplying Attribute Store settings
 --open                         open Dex Web after readiness
 ```

--- a/cli/internal/dev/config.go
+++ b/cli/internal/dev/config.go
@@ -50,6 +50,8 @@ type Config struct {
 	TemporalUIPort int
 	// TemporalDBFilename defaults to $HOME/.dex/dev/<temporal-port>/temporal.db in local mode.
 	TemporalDBFilename string
+	// TemporalLogFile defaults empty and discards local Temporal process logs.
+	TemporalLogFile string
 	// StateDirectory defaults to $HOME/.dex and stores auto-assigned Temporal SQLite files.
 	StateDirectory string
 	// BlobStoreDirectory defaults to $HOME/.dex/blobs unless TemporalDBFilename selects its adjacent store.
@@ -89,6 +91,12 @@ func parseConfig(args []string, output io.Writer) (*Config, error) {
 		"local Temporal SQLite file (default $HOME/.dex/dev/<temporal-port>/temporal.db)",
 	)
 	flags.StringVar(
+		&cfg.TemporalLogFile,
+		"temporal-log-file",
+		"",
+		"write local Temporal server and Web logs to this file",
+	)
+	flags.StringVar(
 		&cfg.BlobStoreDirectory,
 		"blob-store-dir",
 		cfg.BlobStoreDirectory,
@@ -114,7 +122,7 @@ func parseConfig(args []string, output io.Writer) (*Config, error) {
 	cfg.explicitLocalFlags = make(map[string]bool)
 	flags.Visit(func(item *flag.Flag) {
 		switch item.Name {
-		case "dex-port", "web-port", "temporal-port", "temporal-ui-port", "temporal-db-filename":
+		case "dex-port", "web-port", "temporal-port", "temporal-ui-port", "temporal-db-filename", "temporal-log-file":
 			cfg.explicitLocalFlags[item.Name] = true
 		case "blob-store-dir":
 			cfg.blobStoreDirectoryDefault = false
@@ -190,10 +198,16 @@ func (c *Config) validate() error {
 		if _, _, err := net.SplitHostPort(c.TemporalAddress); err != nil {
 			return fmt.Errorf("temporal address must be host:port: %w", err)
 		}
-		for _, name := range []string{"temporal-port", "temporal-ui-port", "temporal-db-filename"} {
+		for _, name := range []string{"temporal-port", "temporal-ui-port", "temporal-db-filename", "temporal-log-file"} {
 			if c.explicitLocalFlags[name] {
 				return fmt.Errorf("--%s cannot be used with --temporal-address", name)
 			}
+		}
+	}
+	if c.TemporalLogFile != "" {
+		c.TemporalLogFile = strings.TrimSpace(c.TemporalLogFile)
+		if c.TemporalLogFile == "" {
+			return fmt.Errorf("temporal log file is required")
 		}
 	}
 	return validateDistinctAddresses(c.ownedAddresses())
@@ -252,4 +266,26 @@ func (c *Config) isExplicit(flagName string) bool {
 
 func (c *Config) autoTemporalDBFilename() string {
 	return filepath.Join(c.StateDirectory, "dev", strconv.Itoa(c.TemporalPort), "temporal.db")
+}
+
+func (c *Config) writeTemporalStartupRecord(logs io.Writer) error {
+	database := c.temporalDBDirectory()
+	if database == "" {
+		database = "in-memory"
+	}
+	_, err := fmt.Fprintf(
+		logs,
+		"Temporal:     %s\nTemporal Web: %s\nTemporal DB:  %s\n",
+		c.temporalAddress(),
+		"http://"+net.JoinHostPort(c.BindAddress, strconv.Itoa(c.TemporalUIPort)),
+		database,
+	)
+	return err
+}
+
+func (c *Config) temporalDBDirectory() string {
+	if c.TemporalDBFilename == "" {
+		return ""
+	}
+	return filepath.Dir(c.TemporalDBFilename)
 }

--- a/cli/internal/dev/config.go
+++ b/cli/internal/dev/config.go
@@ -48,8 +48,10 @@ type Config struct {
 	TemporalPort int
 	// TemporalUIPort defaults to 8233 in local mode.
 	TemporalUIPort int
-	// TemporalDBFilename defaults to in-memory storage.
+	// TemporalDBFilename defaults to $HOME/.dex/dev/<temporal-port>/temporal.db in local mode.
 	TemporalDBFilename string
+	// StateDirectory defaults to $HOME/.dex and stores auto-assigned Temporal SQLite files.
+	StateDirectory string
 	// BlobStoreDirectory defaults to $HOME/.dex/blobs unless TemporalDBFilename selects its adjacent store.
 	BlobStoreDirectory string
 	// AttributeStoreConfigPath defaults empty and loads Attribute Store settings from standard Dex YAML when set.
@@ -80,7 +82,12 @@ func parseConfig(args []string, output io.Writer) (*Config, error) {
 	flags.StringVar(&cfg.TemporalNamespace, "temporal-namespace", cfg.TemporalNamespace, "Temporal namespace")
 	flags.IntVar(&cfg.TemporalPort, "temporal-port", cfg.TemporalPort, "local Temporal gRPC port")
 	flags.IntVar(&cfg.TemporalUIPort, "temporal-ui-port", cfg.TemporalUIPort, "local Temporal Web port")
-	flags.StringVar(&cfg.TemporalDBFilename, "temporal-db-filename", "", "local Temporal SQLite file")
+	flags.StringVar(
+		&cfg.TemporalDBFilename,
+		"temporal-db-filename",
+		"",
+		"local Temporal SQLite file (default $HOME/.dex/dev/<temporal-port>/temporal.db)",
+	)
 	flags.StringVar(
 		&cfg.BlobStoreDirectory,
 		"blob-store-dir",
@@ -107,7 +114,7 @@ func parseConfig(args []string, output io.Writer) (*Config, error) {
 	cfg.explicitLocalFlags = make(map[string]bool)
 	flags.Visit(func(item *flag.Flag) {
 		switch item.Name {
-		case "temporal-port", "temporal-ui-port", "temporal-db-filename":
+		case "dex-port", "web-port", "temporal-port", "temporal-ui-port", "temporal-db-filename":
 			cfg.explicitLocalFlags[item.Name] = true
 		case "blob-store-dir":
 			cfg.blobStoreDirectoryDefault = false
@@ -120,7 +127,7 @@ func parseConfig(args []string, output io.Writer) (*Config, error) {
 }
 
 func defaultConfig() (*Config, error) {
-	blobStoreDirectory, err := defaultBlobStoreDirectory()
+	stateDirectory, err := defaultStateDirectory()
 	if err != nil {
 		return nil, err
 	}
@@ -131,19 +138,29 @@ func defaultConfig() (*Config, error) {
 		TemporalNamespace:         defaultTemporalNamespace,
 		TemporalPort:              defaultTemporalPort,
 		TemporalUIPort:            defaultTemporalUIPort,
-		BlobStoreDirectory:        blobStoreDirectory,
+		StateDirectory:            stateDirectory,
+		BlobStoreDirectory:        filepath.Join(stateDirectory, "blobs"),
 		StartupTimeout:            45 * time.Second,
 		ShutdownTimeout:           10 * time.Second,
+		explicitLocalFlags:        make(map[string]bool),
 		blobStoreDirectoryDefault: true,
 	}, nil
 }
 
-func defaultBlobStoreDirectory() (string, error) {
+func defaultStateDirectory() (string, error) {
 	homeDirectory, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("resolve home directory for Dex blob storage: %w", err)
+		return "", fmt.Errorf("resolve home directory for Dex state: %w", err)
 	}
-	return filepath.Join(homeDirectory, ".dex", "blobs"), nil
+	return filepath.Join(homeDirectory, ".dex"), nil
+}
+
+func defaultBlobStoreDirectory() (string, error) {
+	stateDirectory, err := defaultStateDirectory()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stateDirectory, "blobs"), nil
 }
 
 func (c *Config) validate() error {
@@ -227,4 +244,12 @@ func validateDistinctAddresses(addresses map[string]string) error {
 		owners[address] = name
 	}
 	return nil
+}
+
+func (c *Config) isExplicit(flagName string) bool {
+	return c.explicitLocalFlags[flagName]
+}
+
+func (c *Config) autoTemporalDBFilename() string {
+	return filepath.Join(c.StateDirectory, "dev", strconv.Itoa(c.TemporalPort), "temporal.db")
 }

--- a/cli/internal/dev/config.go
+++ b/cli/internal/dev/config.go
@@ -31,6 +31,8 @@ const (
 	defaultTemporalPort      = 7233
 	defaultTemporalUIPort    = 8233
 	defaultTemporalNamespace = "default"
+	localSQLiteFileName      = "dex.sqlite.db"
+	localBlobStoreName       = "dex.blobs"
 )
 
 type Config struct {
@@ -48,13 +50,13 @@ type Config struct {
 	TemporalPort int
 	// TemporalUIPort defaults to 8233 in local mode.
 	TemporalUIPort int
-	// TemporalDBFilename defaults to $HOME/.dex/dev/<temporal-port>/temporal.db in local mode.
+	// TemporalDBFilename defaults to $HOME/.dex/dev/<temporal-port>/dex.sqlite.db in local mode.
 	TemporalDBFilename string
 	// TemporalLogFile defaults empty and discards local Temporal process logs.
 	TemporalLogFile string
 	// StateDirectory defaults to $HOME/.dex and stores auto-assigned Temporal SQLite files.
 	StateDirectory string
-	// BlobStoreDirectory defaults to $HOME/.dex/blobs unless TemporalDBFilename selects its adjacent store.
+	// BlobStoreDirectory defaults to $HOME/.dex/blobs unless TemporalDBFilename selects its adjacent dex.blobs store.
 	BlobStoreDirectory string
 	// AttributeStoreConfigPath defaults empty and loads Attribute Store settings from standard Dex YAML when set.
 	AttributeStoreConfigPath string
@@ -88,7 +90,7 @@ func parseConfig(args []string, output io.Writer) (*Config, error) {
 		&cfg.TemporalDBFilename,
 		"temporal-db-filename",
 		"",
-		"local Temporal SQLite file (default $HOME/.dex/dev/<temporal-port>/temporal.db)",
+		"local Temporal SQLite file (default $HOME/.dex/dev/<temporal-port>/dex.sqlite.db)",
 	)
 	flags.StringVar(
 		&cfg.TemporalLogFile,
@@ -265,7 +267,11 @@ func (c *Config) isExplicit(flagName string) bool {
 }
 
 func (c *Config) autoTemporalDBFilename() string {
-	return filepath.Join(c.StateDirectory, "dev", strconv.Itoa(c.TemporalPort), "temporal.db")
+	return filepath.Join(c.StateDirectory, "dev", strconv.Itoa(c.TemporalPort), localSQLiteFileName)
+}
+
+func (c *Config) adjacentBlobStoreDirectory() string {
+	return filepath.Join(filepath.Dir(c.TemporalDBFilename), localBlobStoreName)
 }
 
 func (c *Config) writeTemporalStartupRecord(logs io.Writer) error {

--- a/cli/internal/dev/config_test.go
+++ b/cli/internal/dev/config_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/superdurable/dex/config"
@@ -68,5 +69,47 @@ func TestAttributeStoreConfigRequiresStore(t *testing.T) {
 	cliConfig := &Config{AttributeStoreConfigPath: configPath}
 	if _, err := cliConfig.loadAttributeStoreConfig(); err == nil {
 		t.Fatal("expected empty Attribute Store config to fail")
+	}
+}
+
+func TestTemporalLogFileFlag(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "logs", "temporal.log")
+	cfg, err := parseConfig([]string{"--temporal-log-file", logFile}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TemporalLogFile != logFile {
+		t.Fatalf("unexpected Temporal log file: %q", cfg.TemporalLogFile)
+	}
+}
+
+func TestTemporalLogFileRejectedWithExternalAddress(t *testing.T) {
+	_, err := parseConfig([]string{
+		"--temporal-address", "127.0.0.1:7233",
+		"--temporal-log-file", "temporal.log",
+	}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected --temporal-log-file to fail with --temporal-address")
+	}
+}
+
+func TestWriteTemporalStartupRecordIncludesPortsAndDatabase(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.TemporalPort = 7234
+	cfg.TemporalUIPort = 8234
+	cfg.TemporalDBFilename = filepath.Join(cfg.StateDirectory, "dev", "7234", "temporal.db")
+	var output bytes.Buffer
+	if err := cfg.writeTemporalStartupRecord(&output); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "127.0.0.1:7234") {
+		t.Fatalf("missing Temporal gRPC address: %s", text)
+	}
+	if !strings.Contains(text, "http://127.0.0.1:8234") {
+		t.Fatalf("missing Temporal Web address: %s", text)
+	}
+	if !strings.Contains(text, filepath.Join(cfg.StateDirectory, "dev", "7234")) {
+		t.Fatalf("missing Temporal DB directory: %s", text)
 	}
 }

--- a/cli/internal/dev/config_test.go
+++ b/cli/internal/dev/config_test.go
@@ -97,7 +97,7 @@ func TestWriteTemporalStartupRecordIncludesPortsAndDatabase(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.TemporalPort = 7234
 	cfg.TemporalUIPort = 8234
-	cfg.TemporalDBFilename = filepath.Join(cfg.StateDirectory, "dev", "7234", "temporal.db")
+	cfg.TemporalDBFilename = filepath.Join(cfg.StateDirectory, "dev", "7234", localSQLiteFileName)
 	var output bytes.Buffer
 	if err := cfg.writeTemporalStartupRecord(&output); err != nil {
 		t.Fatal(err)

--- a/cli/internal/dev/helpers_test.go
+++ b/cli/internal/dev/helpers_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package dev
+
+import "testing"
+
+func testConfig(t *testing.T) *Config {
+	t.Helper()
+	cfg, err := defaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.StateDirectory = t.TempDir()
+	return cfg
+}

--- a/cli/internal/dev/ports_test.go
+++ b/cli/internal/dev/ports_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package dev
+
+import (
+	"bytes"
+	"net"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+func TestReserveOwnedListenersSkipsOccupiedPorts(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := occupied.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	occupiedPort := occupied.Addr().(*net.TCPAddr).Port
+
+	cfg := testConfig(t)
+	cfg.DexPort = occupiedPort
+	listeners, err := reserveOwnedListeners(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := listeners.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if cfg.DexPort == occupiedPort {
+		t.Fatalf("allocated occupied Dex port %d", occupiedPort)
+	}
+	if cfg.TemporalDBFilename != cfg.autoTemporalDBFilename() {
+		t.Fatalf("unexpected Temporal database: %q", cfg.TemporalDBFilename)
+	}
+}
+
+func TestReserveOwnedListenersSkipsWildcardOccupiedPort(t *testing.T) {
+	occupied, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := occupied.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	occupiedPort := occupied.Addr().(*net.TCPAddr).Port
+
+	cfg := testConfig(t)
+	cfg.TemporalPort = occupiedPort
+	listeners, err := reserveOwnedListeners(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := listeners.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if cfg.TemporalPort == occupiedPort {
+		t.Fatalf("allocated wildcard-occupied Temporal port %d", occupiedPort)
+	}
+	if cfg.TemporalDBFilename != filepath.Join(cfg.StateDirectory, "dev", strconv.Itoa(cfg.TemporalPort), "temporal.db") {
+		t.Fatalf("unexpected Temporal database: %q", cfg.TemporalDBFilename)
+	}
+}
+
+func TestReserveOwnedListenersExplicitPortFailsWhenOccupied(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := occupied.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	occupiedPort := occupied.Addr().(*net.TCPAddr).Port
+
+	cfg := testConfig(t)
+	cfg.DexPort = occupiedPort
+	cfg.explicitLocalFlags["dex-port"] = true
+	if _, err := reserveOwnedListeners(cfg); err == nil {
+		t.Fatal("expected explicit occupied Dex port to fail")
+	}
+}
+
+func TestReserveOwnedListenersKeepsExplicitDatabase(t *testing.T) {
+	database := filepath.Join(t.TempDir(), "custom.db")
+	cfg, err := parseConfig([]string{"--temporal-db-filename", database}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.StateDirectory = t.TempDir()
+	listeners, err := reserveOwnedListeners(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := listeners.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if cfg.TemporalDBFilename != database {
+		t.Fatalf("explicit Temporal database was replaced: %q", cfg.TemporalDBFilename)
+	}
+}
+
+func TestReserveOwnedListenersExternalModeSkipsTemporalDatabase(t *testing.T) {
+	cfg, err := parseConfig([]string{"--temporal-address", "127.0.0.1:7233"}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.StateDirectory = t.TempDir()
+	listeners, err := reserveOwnedListeners(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := listeners.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if cfg.TemporalDBFilename != "" {
+		t.Fatalf("external mode assigned a Temporal database: %q", cfg.TemporalDBFilename)
+	}
+}
+
+func TestConcurrentReserveOwnedListenersUsesDistinctPortsAndDatabases(t *testing.T) {
+	configs := []*Config{testConfig(t), testConfig(t), testConfig(t)}
+	listeners := make([]*ownedListeners, len(configs))
+	errors := make([]error, len(configs))
+	var wg sync.WaitGroup
+	for i, cfg := range configs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			listeners[i], errors[i] = reserveOwnedListeners(cfg)
+		}()
+	}
+	wg.Wait()
+	t.Cleanup(func() {
+		for _, item := range listeners {
+			if item == nil {
+				continue
+			}
+			if err := item.Close(); err != nil {
+				t.Errorf("close listeners: %v", err)
+			}
+		}
+	})
+	ports := make(map[string]int)
+	databases := make(map[string]int)
+	for i, cfg := range configs {
+		if errors[i] != nil {
+			t.Fatalf("instance %d: %v", i, errors[i])
+		}
+		for name, address := range cfg.ownedAddresses() {
+			if owner, exists := ports[address]; exists {
+				t.Fatalf("%s address %s reused by instances %d and %d", name, address, owner, i)
+			}
+			ports[address] = i
+		}
+		if cfg.TemporalDBFilename == "" {
+			t.Fatalf("instance %d missing Temporal database", i)
+		}
+		if owner, exists := databases[cfg.TemporalDBFilename]; exists {
+			t.Fatalf("Temporal database %s reused by instances %d and %d", cfg.TemporalDBFilename, owner, i)
+		}
+		databases[cfg.TemporalDBFilename] = i
+	}
+}

--- a/cli/internal/dev/ports_test.go
+++ b/cli/internal/dev/ports_test.go
@@ -74,7 +74,7 @@ func TestReserveOwnedListenersSkipsWildcardOccupiedPort(t *testing.T) {
 	if cfg.TemporalPort == occupiedPort {
 		t.Fatalf("allocated wildcard-occupied Temporal port %d", occupiedPort)
 	}
-	if cfg.TemporalDBFilename != filepath.Join(cfg.StateDirectory, "dev", strconv.Itoa(cfg.TemporalPort), "temporal.db") {
+	if cfg.TemporalDBFilename != filepath.Join(cfg.StateDirectory, "dev", strconv.Itoa(cfg.TemporalPort), localSQLiteFileName) {
 		t.Fatalf("unexpected Temporal database: %q", cfg.TemporalDBFilename)
 	}
 }

--- a/cli/internal/dev/supervisor.go
+++ b/cli/internal/dev/supervisor.go
@@ -85,7 +85,18 @@ func (s *supervisor) Run(ctx context.Context) (runErr error) {
 		if err := listeners.releaseTemporalPorts(); err != nil {
 			return err
 		}
-		temporal, temporalClient, err = s.startLocalTemporal(startupCtx)
+		var temporalLogs io.Writer
+		logFile, err := openTemporalLogFile(s.cfg.TemporalLogFile)
+		if err != nil {
+			return err
+		}
+		if logFile != nil {
+			defer func() {
+				runErr = errors.Join(runErr, logFile.Close())
+			}()
+			temporalLogs = logFile
+		}
+		temporal, temporalClient, err = s.startLocalTemporal(startupCtx, temporalLogs)
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil
@@ -179,7 +190,7 @@ func (s *supervisor) Run(ctx context.Context) (runErr error) {
 	return s.shutdown(runCtx, cancelRun, webServer, dexRuntime, runErr)
 }
 
-func (s *supervisor) startLocalTemporal(ctx context.Context) (*temporalProcess, temporalclient.Client, error) {
+func (s *supervisor) startLocalTemporal(ctx context.Context, logs io.Writer) (*temporalProcess, temporalclient.Client, error) {
 	const maxAttempts = 5
 	var lastErr error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
@@ -194,7 +205,12 @@ func (s *supervisor) startLocalTemporal(ctx context.Context) (*temporalProcess, 
 				return nil, nil, err
 			}
 		}
-		process, err := startTemporalProcess(s.cfg)
+		if logs != nil {
+			if err := s.cfg.writeTemporalStartupRecord(logs); err != nil {
+				return nil, nil, fmt.Errorf("write Temporal log header: %w", err)
+			}
+		}
+		process, err := startTemporalProcess(s.cfg, logs)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cli/internal/dev/supervisor.go
+++ b/cli/internal/dev/supervisor.go
@@ -43,8 +43,10 @@ type supervisor struct {
 }
 
 type ownedListeners struct {
-	dex net.Listener
-	web net.Listener
+	dex        net.Listener
+	web        net.Listener
+	temporal   net.Listener
+	temporalUI net.Listener
 }
 
 type componentExit struct {
@@ -63,10 +65,6 @@ func newSupervisor(cfg *Config, stdout io.Writer, stderr io.Writer) *supervisor 
 }
 
 func (s *supervisor) Run(ctx context.Context) (runErr error) {
-	blobStoreDirectory, err := s.prepareBlobStoreDirectory()
-	if err != nil {
-		return err
-	}
 	listeners, err := reserveOwnedListeners(s.cfg)
 	if err != nil {
 		return err
@@ -74,26 +72,37 @@ func (s *supervisor) Run(ctx context.Context) (runErr error) {
 	defer func() {
 		runErr = errors.Join(runErr, listeners.Close())
 	}()
+	blobStoreDirectory, err := s.prepareBlobStoreDirectory()
+	if err != nil {
+		return err
+	}
 
+	startupCtx, cancelStartup := context.WithTimeout(ctx, s.cfg.StartupTimeout)
+	defer cancelStartup()
 	var temporal *temporalProcess
+	var temporalClient temporalclient.Client
 	if s.cfg.TemporalAddress == "" {
-		temporal, err = startTemporalProcess(s.cfg)
+		if err := listeners.releaseTemporalPorts(); err != nil {
+			return err
+		}
+		temporal, temporalClient, err = s.startLocalTemporal(startupCtx)
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
 			return err
 		}
 		defer func() {
 			runErr = errors.Join(runErr, temporal.Stop(s.cfg.ShutdownTimeout))
 		}()
-	}
-
-	startupCtx, cancelStartup := context.WithTimeout(ctx, s.cfg.StartupTimeout)
-	defer cancelStartup()
-	temporalClient, err := waitForTemporal(startupCtx, s.cfg, temporal)
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil
+	} else {
+		temporalClient, err = waitForTemporal(startupCtx, s.cfg, nil)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
 		}
-		return err
 	}
 	if temporal != nil {
 		temporalWebURL := "http://" + net.JoinHostPort(s.cfg.BindAddress, strconv.Itoa(s.cfg.TemporalUIPort))
@@ -168,6 +177,43 @@ func (s *supervisor) Run(ctx context.Context) (runErr error) {
 		}
 	}
 	return s.shutdown(runCtx, cancelRun, webServer, dexRuntime, runErr)
+}
+
+func (s *supervisor) startLocalTemporal(ctx context.Context) (*temporalProcess, temporalclient.Client, error) {
+	const maxAttempts = 5
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			if s.cfg.isExplicit("temporal-port") || s.cfg.isExplicit("temporal-ui-port") {
+				return nil, nil, lastErr
+			}
+			if err := rebindTemporalPorts(s.cfg); err != nil {
+				return nil, nil, err
+			}
+			if err := assignTemporalDBFilename(s.cfg); err != nil {
+				return nil, nil, err
+			}
+		}
+		process, err := startTemporalProcess(s.cfg)
+		if err != nil {
+			return nil, nil, err
+		}
+		client, err := waitForTemporal(ctx, s.cfg, process)
+		if err == nil {
+			return process, client, nil
+		}
+		exited := false
+		select {
+		case <-process.Done():
+			exited = true
+		default:
+		}
+		lastErr = errors.Join(err, process.Stop(s.cfg.ShutdownTimeout))
+		if ctx.Err() != nil || !exited {
+			return nil, nil, lastErr
+		}
+	}
+	return nil, nil, lastErr
 }
 
 func (s *supervisor) prepareBlobStoreDirectory() (string, error) {
@@ -272,51 +318,138 @@ func (s *supervisor) printReady(webURL string, dexAddress string) {
 }
 
 func reserveOwnedListeners(cfg *Config) (*ownedListeners, error) {
-	dexListener, err := listenFor("Dex Server", cfg.ownedAddresses()["Dex Server"])
+	allocated := make(map[string]string)
+	dexListener, err := bindServicePort("Dex Server", "dex-port", cfg, &cfg.DexPort, allocated)
 	if err != nil {
 		return nil, err
 	}
 	listeners := &ownedListeners{dex: dexListener}
-	webListener, err := listenFor("Dex Web", cfg.ownedAddresses()["Dex Web"])
+	webListener, err := bindServicePort("Dex Web", "web-port", cfg, &cfg.WebPort, allocated)
 	if err != nil {
-		closeErr := listeners.Close()
-		return nil, errors.Join(err, closeErr)
+		return nil, errors.Join(err, listeners.Close())
 	}
 	listeners.web = webListener
 	if cfg.TemporalAddress != "" {
 		return listeners, nil
 	}
-	for _, name := range []string{"Temporal", "Temporal Web"} {
-		probe, err := listenFor(name, cfg.ownedAddresses()[name])
-		if err != nil {
-			return nil, errors.Join(err, listeners.Close())
-		}
-		if err := probe.Close(); err != nil {
-			return nil, errors.Join(fmt.Errorf("release %s port: %w", name, err), listeners.Close())
-		}
+	temporalListener, err := bindServicePort("Temporal", "temporal-port", cfg, &cfg.TemporalPort, allocated)
+	if err != nil {
+		return nil, errors.Join(err, listeners.Close())
+	}
+	listeners.temporal = temporalListener
+	uiListener, err := bindServicePort("Temporal Web", "temporal-ui-port", cfg, &cfg.TemporalUIPort, allocated)
+	if err != nil {
+		return nil, errors.Join(err, listeners.Close())
+	}
+	listeners.temporalUI = uiListener
+	if err := assignTemporalDBFilename(cfg); err != nil {
+		return nil, errors.Join(err, listeners.Close())
 	}
 	return listeners, nil
 }
 
-func listenFor(name string, address string) (net.Listener, error) {
-	listener, err := net.Listen("tcp", address)
-	if err != nil {
-		return nil, fmt.Errorf("cannot start %s: %s is already in use: %w", name, address, err)
+func rebindTemporalPorts(cfg *Config) error {
+	if cfg.TemporalPort < 65535 {
+		cfg.TemporalPort++
 	}
-	return listener, nil
+	if cfg.TemporalUIPort < 65535 {
+		cfg.TemporalUIPort++
+	}
+	allocated := map[string]string{
+		net.JoinHostPort(cfg.BindAddress, strconv.Itoa(cfg.DexPort)): "Dex Server",
+		net.JoinHostPort(cfg.BindAddress, strconv.Itoa(cfg.WebPort)): "Dex Web",
+	}
+	temporalListener, err := bindServicePort("Temporal", "temporal-port", cfg, &cfg.TemporalPort, allocated)
+	if err != nil {
+		return err
+	}
+	uiListener, err := bindServicePort("Temporal Web", "temporal-ui-port", cfg, &cfg.TemporalUIPort, allocated)
+	if err != nil {
+		return errors.Join(err, closeListener(temporalListener))
+	}
+	return errors.Join(closeListener(temporalListener), closeListener(uiListener))
+}
+
+func bindServicePort(
+	name string,
+	flagName string,
+	cfg *Config,
+	port *int,
+	allocated map[string]string,
+) (net.Listener, error) {
+	explicit := cfg.isExplicit(flagName)
+	for candidate := *port; candidate <= 65535; candidate++ {
+		address := net.JoinHostPort(cfg.BindAddress, strconv.Itoa(candidate))
+		if owner, exists := allocated[address]; exists {
+			if explicit {
+				return nil, fmt.Errorf("%s and %s cannot both use %s", owner, name, address)
+			}
+			continue
+		}
+		if isAddressReachable(address) {
+			if explicit {
+				return nil, fmt.Errorf("cannot start %s: %s is already in use", name, address)
+			}
+			continue
+		}
+		listener, err := net.Listen("tcp", address)
+		if err != nil {
+			if explicit {
+				return nil, fmt.Errorf("cannot start %s: %s is already in use: %w", name, address, err)
+			}
+			continue
+		}
+		*port = candidate
+		allocated[address] = name
+		return listener, nil
+	}
+	return nil, fmt.Errorf("cannot start %s: no available port from %d", name, *port)
+}
+
+func assignTemporalDBFilename(cfg *Config) error {
+	if cfg.TemporalAddress != "" || cfg.isExplicit("temporal-db-filename") {
+		return nil
+	}
+	if cfg.StateDirectory == "" {
+		return fmt.Errorf("Dex state directory is required")
+	}
+	filename := cfg.autoTemporalDBFilename()
+	if err := os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
+		return fmt.Errorf("create Temporal database directory: %w", err)
+	}
+	cfg.TemporalDBFilename = filename
+	return nil
+}
+
+func isAddressReachable(address string) bool {
+	connection, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	// Closing the probe does not change that the port accepted a connection.
+	_ = connection.Close()
+	return true
+}
+
+func closeListener(listener net.Listener) error {
+	if listener == nil {
+		return nil
+	}
+	if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+		return err
+	}
+	return nil
+}
+
+func (l *ownedListeners) releaseTemporalPorts() error {
+	err := errors.Join(closeListener(l.temporal), closeListener(l.temporalUI))
+	l.temporal = nil
+	l.temporalUI = nil
+	return err
 }
 
 func (l *ownedListeners) Close() error {
-	var closeErr error
-	for _, listener := range []net.Listener{l.web, l.dex} {
-		if listener == nil {
-			continue
-		}
-		if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-			closeErr = errors.Join(closeErr, err)
-		}
-	}
-	return closeErr
+	return errors.Join(l.releaseTemporalPorts(), closeListener(l.web), closeListener(l.dex))
 }
 
 func waitForTemporal(

--- a/cli/internal/dev/supervisor.go
+++ b/cli/internal/dev/supervisor.go
@@ -82,9 +82,6 @@ func (s *supervisor) Run(ctx context.Context) (runErr error) {
 	var temporal *temporalProcess
 	var temporalClient temporalclient.Client
 	if s.cfg.TemporalAddress == "" {
-		if err := listeners.releaseTemporalPorts(); err != nil {
-			return err
-		}
 		var temporalLogs io.Writer
 		logFile, err := openTemporalLogFile(s.cfg.TemporalLogFile)
 		if err != nil {
@@ -95,6 +92,9 @@ func (s *supervisor) Run(ctx context.Context) (runErr error) {
 				runErr = errors.Join(runErr, logFile.Close())
 			}()
 			temporalLogs = logFile
+		}
+		if err := listeners.releaseTemporalPorts(); err != nil {
+			return err
 		}
 		temporal, temporalClient, err = s.startLocalTemporal(startupCtx, temporalLogs)
 		if err != nil {
@@ -164,7 +164,7 @@ func (s *supervisor) Run(ctx context.Context) (runErr error) {
 		return s.shutdown(runCtx, cancelRun, webServer, dexRuntime, err)
 	}
 
-	s.printReady(webURL, listeners.dex.Addr().String())
+	s.printReady(webURL, listeners.dex.Addr().String(), blobStoreDirectory)
 	if s.cfg.OpenBrowser {
 		if err := openBrowser(webURL); err != nil {
 			return s.shutdown(runCtx, cancelRun, webServer, dexRuntime, err)
@@ -235,7 +235,7 @@ func (s *supervisor) startLocalTemporal(ctx context.Context, logs io.Writer) (*t
 func (s *supervisor) prepareBlobStoreDirectory() (string, error) {
 	directory := s.cfg.BlobStoreDirectory
 	if s.cfg.TemporalDBFilename != "" && s.cfg.blobStoreDirectoryDefault {
-		directory = s.cfg.TemporalDBFilename + ".dex-blobs"
+		directory = s.cfg.adjacentBlobStoreDirectory()
 	}
 	directory, err := filepath.Abs(directory)
 	if err != nil {
@@ -323,12 +323,16 @@ func (s *supervisor) shutdown(
 	return runErr
 }
 
-func (s *supervisor) printReady(webURL string, dexAddress string) {
+func (s *supervisor) printReady(webURL string, dexAddress string, blobStoreDirectory string) {
 	fmt.Fprintln(s.stdout)
 	fmt.Fprintln(s.stdout, "Dex development environment is ready")
 	fmt.Fprintln(s.stdout)
 	fmt.Fprintf(s.stdout, "Dex Web:       %s\n", webURL)
 	fmt.Fprintf(s.stdout, "Dex Server:    %s\n", dexAddress)
+	if s.cfg.TemporalDBFilename != "" {
+		fmt.Fprintf(s.stdout, "Local DB:      %s\n", s.cfg.TemporalDBFilename)
+	}
+	fmt.Fprintf(s.stdout, "Blob store:    %s\n", blobStoreDirectory)
 	fmt.Fprintln(s.stdout)
 	fmt.Fprintln(s.stdout, "Press Ctrl+C to stop.")
 }

--- a/cli/internal/dev/supervisor_integ_test.go
+++ b/cli/internal/dev/supervisor_integ_test.go
@@ -125,9 +125,15 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 		t.Fatalf("missing readiness output: %s", output.String())
 	}
 	if strings.Contains(output.String(), "Temporal") ||
-		strings.Contains(output.String(), strconv.Itoa(cfg.TemporalPort)) ||
-		strings.Contains(output.String(), strconv.Itoa(cfg.TemporalUIPort)) {
+		strings.Contains(output.String(), cfg.temporalAddress()) ||
+		strings.Contains(output.String(), ":"+strconv.Itoa(cfg.TemporalUIPort)) {
 		t.Fatalf("workflow backend endpoint leaked in output: %s", output.String())
+	}
+	if !strings.Contains(output.String(), "Local DB:      "+cfg.TemporalDBFilename) {
+		t.Fatalf("missing Local DB path: %s", output.String())
+	}
+	if !strings.Contains(output.String(), "Blob store:    "+cfg.adjacentBlobStoreDirectory()) {
+		t.Fatalf("missing blob store path: %s", output.String())
 	}
 	logContents, err := os.ReadFile(cfg.TemporalLogFile)
 	if err != nil {
@@ -149,7 +155,7 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 	if _, err := os.Stat(cfg.TemporalDBFilename); err != nil {
 		t.Fatalf("Temporal database was not retained after shutdown: %v", err)
 	}
-	if _, err := os.Stat(cfg.TemporalDBFilename + ".dex-blobs"); err != nil {
+	if _, err := os.Stat(cfg.adjacentBlobStoreDirectory()); err != nil {
 		t.Fatalf("blob store was not retained after shutdown: %v", err)
 	}
 	for _, port := range ports {
@@ -202,11 +208,7 @@ func TestExternalTemporalRemainsRunning(t *testing.T) {
 	go func() {
 		runFinished <- newSupervisor(externalConfig, output, output).Run(runCtx)
 	}()
-	waitForHealthyWeb(
-		t,
-		"http://127.0.0.1:"+strconv.Itoa(externalConfig.WebPort)+"/healthz",
-		runFinished,
-	)
+	waitForReadyStack(t, output, runFinished)
 	cancelRun()
 	select {
 	case err := <-runFinished:
@@ -227,6 +229,12 @@ func TestExternalTemporalRemainsRunning(t *testing.T) {
 	cancelHealth()
 	if strings.Contains(output.String(), localConfig.temporalAddress()) {
 		t.Fatalf("external workflow backend endpoint leaked in output: %s", output.String())
+	}
+	if strings.Contains(output.String(), "Local DB:") {
+		t.Fatalf("external mode printed Local DB: %s", output.String())
+	}
+	if !strings.Contains(output.String(), "Blob store:") {
+		t.Fatalf("missing blob store path: %s", output.String())
 	}
 }
 
@@ -317,7 +325,7 @@ func TestBlobStoreDirectorySelection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if directory != databaseConfig.TemporalDBFilename+".dex-blobs" {
+	if directory != filepath.Join(root, localBlobStoreName) {
 		t.Fatalf("unexpected database directory: %q", directory)
 	}
 

--- a/cli/internal/dev/supervisor_integ_test.go
+++ b/cli/internal/dev/supervisor_integ_test.go
@@ -42,6 +42,7 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 	cfg.explicitLocalFlags["temporal-ui-port"] = true
 	cfg.explicitLocalFlags["dex-port"] = true
 	cfg.explicitLocalFlags["web-port"] = true
+	cfg.TemporalLogFile = filepath.Join(t.TempDir(), "temporal.log")
 	output := &synchronizedBuffer{}
 	runCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -128,6 +129,20 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 		strings.Contains(output.String(), strconv.Itoa(cfg.TemporalUIPort)) {
 		t.Fatalf("workflow backend endpoint leaked in output: %s", output.String())
 	}
+	logContents, err := os.ReadFile(cfg.TemporalLogFile)
+	if err != nil {
+		t.Fatalf("read Temporal log file: %v", err)
+	}
+	logText := string(logContents)
+	if !strings.Contains(logText, cfg.temporalAddress()) {
+		t.Fatalf("Temporal log missing gRPC address: %s", logText)
+	}
+	if !strings.Contains(logText, strconv.Itoa(cfg.TemporalUIPort)) {
+		t.Fatalf("Temporal log missing Web port: %s", logText)
+	}
+	if !strings.Contains(logText, cfg.temporalDBDirectory()) {
+		t.Fatalf("Temporal log missing DB directory: %s", logText)
+	}
 	if cfg.TemporalDBFilename == "" {
 		t.Fatal("missing Temporal database")
 	}
@@ -156,7 +171,7 @@ func TestExternalTemporalRemainsRunning(t *testing.T) {
 	localConfig.explicitLocalFlags["temporal-port"] = true
 	localConfig.explicitLocalFlags["temporal-ui-port"] = true
 	output := &synchronizedBuffer{}
-	temporal, err := startTemporalProcess(localConfig)
+	temporal, err := startTemporalProcess(localConfig, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/internal/dev/supervisor_integ_test.go
+++ b/cli/internal/dev/supervisor_integ_test.go
@@ -34,12 +34,14 @@ import (
 func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 	ports := freePorts(t, 4)
 	cfg := testConfig(t)
-	blobStoreDirectory := filepath.Join(t.TempDir(), "blobs")
-	cfg.BlobStoreDirectory = blobStoreDirectory
 	cfg.TemporalPort = ports[0]
 	cfg.TemporalUIPort = ports[1]
 	cfg.DexPort = ports[2]
 	cfg.WebPort = ports[3]
+	cfg.explicitLocalFlags["temporal-port"] = true
+	cfg.explicitLocalFlags["temporal-ui-port"] = true
+	cfg.explicitLocalFlags["dex-port"] = true
+	cfg.explicitLocalFlags["web-port"] = true
 	output := &synchronizedBuffer{}
 	runCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -126,7 +128,13 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 		strings.Contains(output.String(), strconv.Itoa(cfg.TemporalUIPort)) {
 		t.Fatalf("workflow backend endpoint leaked in output: %s", output.String())
 	}
-	if _, err := os.Stat(blobStoreDirectory); err != nil {
+	if cfg.TemporalDBFilename == "" {
+		t.Fatal("missing Temporal database")
+	}
+	if _, err := os.Stat(cfg.TemporalDBFilename); err != nil {
+		t.Fatalf("Temporal database was not retained after shutdown: %v", err)
+	}
+	if _, err := os.Stat(cfg.TemporalDBFilename + ".dex-blobs"); err != nil {
 		t.Fatalf("blob store was not retained after shutdown: %v", err)
 	}
 	for _, port := range ports {
@@ -145,6 +153,8 @@ func TestExternalTemporalRemainsRunning(t *testing.T) {
 	localConfig := testConfig(t)
 	localConfig.TemporalPort = ports[0]
 	localConfig.TemporalUIPort = ports[1]
+	localConfig.explicitLocalFlags["temporal-port"] = true
+	localConfig.explicitLocalFlags["temporal-ui-port"] = true
 	output := &synchronizedBuffer{}
 	temporal, err := startTemporalProcess(localConfig)
 	if err != nil {
@@ -169,6 +179,8 @@ func TestExternalTemporalRemainsRunning(t *testing.T) {
 	externalConfig.TemporalAddress = localConfig.temporalAddress()
 	externalConfig.DexPort = ports[2]
 	externalConfig.WebPort = ports[3]
+	externalConfig.explicitLocalFlags["dex-port"] = true
+	externalConfig.explicitLocalFlags["web-port"] = true
 	runCtx, cancelRun := context.WithCancel(context.Background())
 	defer cancelRun()
 	runFinished := make(chan error, 1)
@@ -200,6 +212,67 @@ func TestExternalTemporalRemainsRunning(t *testing.T) {
 	cancelHealth()
 	if strings.Contains(output.String(), localConfig.temporalAddress()) {
 		t.Fatalf("external workflow backend endpoint leaked in output: %s", output.String())
+	}
+}
+
+func TestConcurrentLocalStacksUseDistinctPortsAndDatabases(t *testing.T) {
+	stateDirectory := t.TempDir()
+	cfg1 := testConfig(t)
+	cfg1.StateDirectory = stateDirectory
+	cfg2 := testConfig(t)
+	cfg2.StateDirectory = stateDirectory
+	output1 := &synchronizedBuffer{}
+	output2 := &synchronizedBuffer{}
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	finished1 := make(chan error, 1)
+	finished2 := make(chan error, 1)
+	go func() {
+		finished1 <- newSupervisor(cfg1, output1, output1).Run(ctx1)
+	}()
+	go func() {
+		finished2 <- newSupervisor(cfg2, output2, output2).Run(ctx2)
+	}()
+
+	waitForReadyStack(t, output1, finished1)
+	waitForReadyStack(t, output2, finished2)
+	if cfg1.DexPort == cfg2.DexPort ||
+		cfg1.WebPort == cfg2.WebPort ||
+		cfg1.TemporalPort == cfg2.TemporalPort ||
+		cfg1.TemporalUIPort == cfg2.TemporalUIPort {
+		cancel1()
+		cancel2()
+		t.Fatalf("stacks reused ports: %+v vs %+v", cfg1, cfg2)
+	}
+	if cfg1.TemporalDBFilename == "" || cfg1.TemporalDBFilename == cfg2.TemporalDBFilename {
+		cancel1()
+		cancel2()
+		t.Fatalf("stacks reused Temporal databases: %q vs %q", cfg1.TemporalDBFilename, cfg2.TemporalDBFilename)
+	}
+	if _, err := os.Stat(cfg1.TemporalDBFilename); err != nil {
+		cancel1()
+		cancel2()
+		t.Fatalf("first Temporal database missing: %v", err)
+	}
+	if _, err := os.Stat(cfg2.TemporalDBFilename); err != nil {
+		cancel1()
+		cancel2()
+		t.Fatalf("second Temporal database missing: %v", err)
+	}
+
+	cancel1()
+	cancel2()
+	for _, finished := range []<-chan error{finished1, finished2} {
+		select {
+		case err := <-finished:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(20 * time.Second):
+			t.Fatal("local stack did not stop")
+		}
 	}
 }
 
@@ -254,13 +327,25 @@ func TestBlobStoreDirectorySelection(t *testing.T) {
 	}
 }
 
-func testConfig(t *testing.T) *Config {
+func waitForReadyStack(t *testing.T, output *synchronizedBuffer, runFinished <-chan error) {
 	t.Helper()
-	cfg, err := defaultConfig()
-	if err != nil {
-		t.Fatal(err)
+	deadline := time.NewTimer(60 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		text := output.String()
+		if strings.Contains(text, "Dex development environment is ready") {
+			return
+		}
+		select {
+		case err := <-runFinished:
+			t.Fatalf("local stack exited before readiness: %v\n%s", err, text)
+		case <-deadline.C:
+			t.Fatalf("local stack did not become ready: %s", text)
+		case <-ticker.C:
+		}
 	}
-	return cfg
 }
 
 func waitForHealthyWeb(t *testing.T, url string, runFinished <-chan error) {

--- a/cli/internal/dev/temporal_process.go
+++ b/cli/internal/dev/temporal_process.go
@@ -13,7 +13,9 @@ package dev
 import (
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"syscall"
@@ -27,7 +29,7 @@ type temporalProcess struct {
 	waitErr error
 }
 
-func startTemporalProcess(cfg *Config) (*temporalProcess, error) {
+func startTemporalProcess(cfg *Config, logs io.Writer) (*temporalProcess, error) {
 	temporalPath, err := exec.LookPath("temporal")
 	if err != nil {
 		return nil, fmt.Errorf("Temporal CLI was not found; reinstall dexcli with Homebrew: %w", err)
@@ -45,9 +47,12 @@ func startTemporalProcess(cfg *Config) (*temporalProcess, error) {
 	if cfg.TemporalDBFilename != "" {
 		arguments = append(arguments, "--db-filename", cfg.TemporalDBFilename)
 	}
+	if logs == nil {
+		logs = io.Discard
+	}
 	command := exec.Command(temporalPath, arguments...)
-	command.Stdout = io.Discard
-	command.Stderr = io.Discard
+	command.Stdout = logs
+	command.Stderr = logs
 	if err := command.Start(); err != nil {
 		return nil, fmt.Errorf("start workflow backend: %w", err)
 	}
@@ -108,4 +113,22 @@ func (p *temporalProcess) Stop(timeout time.Duration) error {
 		<-p.done
 		return nil
 	}
+}
+
+func openTemporalLogFile(path string) (*os.File, error) {
+	if path == "" {
+		return nil, nil
+	}
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve Temporal log file: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create Temporal log directory: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open Temporal log file: %w", err)
+	}
+	return file, nil
 }

--- a/docs/content/quick-start/index.mdx
+++ b/docs/content/quick-start/index.mdx
@@ -32,7 +32,7 @@ when those ports are free:
 | Dex Server | `127.0.0.1:8801` |
 
 A second `dexcli dev` on the same machine binds other free ports and uses its
-own Temporal SQLite database. Use the printed Dex Server address with
+own SQLite database. Use the printed Dex Server address with
 `--server`. See the [CLI README](https://github.com/superdurable/dex/blob/main/cli/README.md)
 for flags and persistence options.
 

--- a/docs/content/quick-start/index.mdx
+++ b/docs/content/quick-start/index.mdx
@@ -23,14 +23,18 @@ brew upgrade superdurable/tap/dexcli   # when you want the latest
 dexcli dev --open
 ```
 
-`dexcli` starts Dex Server, Dex Web, and the internal workflow backend. Defaults:
+`dexcli` starts Dex Server, Dex Web, and the internal workflow backend. Defaults
+when those ports are free:
 
 | Service | Address |
 | --- | --- |
 | Dex Web | `http://127.0.0.1:8802` |
 | Dex Server | `127.0.0.1:8801` |
 
-See the [CLI README](https://github.com/superdurable/dex/blob/main/cli/README.md) for flags and persistence options.
+A second `dexcli dev` on the same machine binds other free ports and uses its
+own Temporal SQLite database. Use the printed Dex Server address with
+`--server`. See the [CLI README](https://github.com/superdurable/dex/blob/main/cli/README.md)
+for flags and persistence options.
 
 ## 2. Hello Flow design
 

--- a/docs/design/plan/dexcli.md
+++ b/docs/design/plan/dexcli.md
@@ -266,8 +266,10 @@ Local `dexcli dev` 构造 typed `config.Config`，不生成临时 YAML：
 - internal service target 指向本次 Dex API listener。
 
 `--blob-store-dir` 指定持久目录；`--temporal-db-filename <db>` 默认使用
-`<db>.dex-blobs`。两者都未设置时使用固定的 `$HOME/.dex/blobs`，退出
-`dexcli dev` 不会删除。显式 `--blob-store-dir` 优先于 `<db>.dex-blobs`。
+`<db>.dex-blobs`。local mode 未指定数据库时使用
+`$HOME/.dex/dev/<temporal-port>/temporal.db`，blob 目录为
+`<db>.dex-blobs`。退出 `dexcli dev` 不会删除这些目录。显式
+`--blob-store-dir` 优先于 `<db>.dex-blobs`。
 
 高级 server 配置继续由现有 server binary/YAML 提供，不把所有 production config 暴露成 `dexcli dev` flags。
 
@@ -283,8 +285,8 @@ dexcli dev [flags]
 --temporal-namespace string    default default
 --temporal-port int            default 7233; local mode only
 --temporal-ui-port int         default 8233; local mode only
---temporal-db-filename string  empty uses in-memory SQLite
---blob-store-dir string        persistent Dex blob storage directory (default $HOME/.dex/blobs)
+--temporal-db-filename string  default $HOME/.dex/dev/<temporal-port>/temporal.db
+--blob-store-dir string        persistent Dex blob storage directory (default <temporal-db-filename>.dex-blobs)
 --open                         open Dex Web after readiness
 ```
 
@@ -309,14 +311,17 @@ temporal server start-dev \
   --ip 127.0.0.1 \
   --port 7233 \
   --ui-ip 127.0.0.1 \
-  --ui-port 8233
+  --ui-port 8233 \
+  --db-filename "$HOME/.dex/dev/7233/temporal.db"
 ```
 
 默认 namespace 已由 Temporal Dev Server 创建。只有用户传入非 `default` namespace 时才增加 namespace 参数。
 
 Process manager 必须：
 
-- 启动前验证 Temporal、Temporal UI、Dex 和 Dex Web owned ports；
+- 为每个 `dexcli dev` 进程分配互不冲突的 Dex、Dex Web、Temporal 和 Temporal UI 端口；未占用时使用默认值，已被占用且未显式指定时选择下一个空闲端口；
+- 为每个 local Temporal 使用独立 SQLite 文件（默认 `$HOME/.dex/dev/<temporal-port>/temporal.db`）；
+- 启动前预占 Dex 与 Dex Web listeners，并确认 Temporal 端口可绑定；
 - 丢弃 backend 子进程 stdout/stderr，避免向普通启动输出泄露内部 endpoint；
 - 通过 Temporal API readiness 检查，不根据日志文本判断 ready；
 - Dex Server 启动时注册并验证系统 Indexed Attributes；
@@ -335,7 +340,7 @@ Process manager 必须：
 
 ```text
 1. 解析并验证 flags
-2. 预占/检查所有 owned listeners
+2. 为 owned ports 分配空闲端口，预占 Dex 与 Dex Web listeners，并分配独立 Temporal SQLite 文件
 3. 启动 local Temporal，或检查 external Temporal
 4. 等待 Temporal ready
 5. 启动 Dex runtime
@@ -390,6 +395,8 @@ cannot start Dex Web: 127.0.0.1:8802 is already in use
 external Temporal is missing search attribute FlowType (Keyword)
 Temporal CLI was not found; reinstall dexcli with Homebrew
 ```
+
+显式 `--*-port` 被占用时返回 already in use。未指定的端口自动改绑到下一个空闲端口。
 
 ## 11. 实施阶段
 

--- a/docs/design/plan/dexcli.md
+++ b/docs/design/plan/dexcli.md
@@ -265,11 +265,11 @@ Local `dexcli dev` 构造 typed `config.Config`，不生成临时 YAML：
 - external storage 默认使用 local filesystem backend，threshold 为 1 KB；
 - internal service target 指向本次 Dex API listener。
 
-`--blob-store-dir` 指定持久目录；`--temporal-db-filename <db>` 默认使用
-`<db>.dex-blobs`。local mode 未指定数据库时使用
-`$HOME/.dex/dev/<temporal-port>/temporal.db`，blob 目录为
-`<db>.dex-blobs`。退出 `dexcli dev` 不会删除这些目录。显式
-`--blob-store-dir` 优先于 `<db>.dex-blobs`。
+`--blob-store-dir` 指定持久目录；未指定时使用数据库文件同目录下的
+`dex.blobs`。local mode 未指定数据库时使用
+`$HOME/.dex/dev/<temporal-port>/dex.sqlite.db` 与
+`$HOME/.dex/dev/<temporal-port>/dex.blobs`。退出 `dexcli dev` 不会删除这些目录。显式
+`--blob-store-dir` 优先于相邻的 `dex.blobs`。
 
 高级 server 配置继续由现有 server binary/YAML 提供，不把所有 production config 暴露成 `dexcli dev` flags。
 
@@ -285,9 +285,9 @@ dexcli dev [flags]
 --temporal-namespace string    default default
 --temporal-port int            default 7233; local mode only
 --temporal-ui-port int         default 8233; local mode only
---temporal-db-filename string  default $HOME/.dex/dev/<temporal-port>/temporal.db
+--temporal-db-filename string  default $HOME/.dex/dev/<temporal-port>/dex.sqlite.db
 --temporal-log-file string     write local Temporal server and Web logs to this file
---blob-store-dir string        persistent Dex blob storage directory (default <temporal-db-filename>.dex-blobs)
+--blob-store-dir string        persistent Dex blob storage directory (default $HOME/.dex/dev/<temporal-port>/dex.blobs)
 --open                         open Dex Web after readiness
 ```
 
@@ -313,7 +313,7 @@ temporal server start-dev \
   --port 7233 \
   --ui-ip 127.0.0.1 \
   --ui-port 8233 \
-  --db-filename "$HOME/.dex/dev/7233/temporal.db"
+  --db-filename "$HOME/.dex/dev/7233/dex.sqlite.db"
 ```
 
 默认 namespace 已由 Temporal Dev Server 创建。只有用户传入非 `default` namespace 时才增加 namespace 参数。
@@ -321,7 +321,7 @@ temporal server start-dev \
 Process manager 必须：
 
 - 为每个 `dexcli dev` 进程分配互不冲突的 Dex、Dex Web、Temporal 和 Temporal UI 端口；未占用时使用默认值，已被占用且未显式指定时选择下一个空闲端口；
-- 为每个 local Temporal 使用独立 SQLite 文件（默认 `$HOME/.dex/dev/<temporal-port>/temporal.db`）；
+- 为每个 local Temporal 使用独立 SQLite 文件（默认 `$HOME/.dex/dev/<temporal-port>/dex.sqlite.db`）；
 - `--temporal-log-file` 将 Temporal server 与 Web 的 stdout/stderr 写入指定文件，并记录实际 Temporal 端口和 SQLite 目录；默认丢弃这些日志，不向 `dexcli` 就绪输出泄露 Temporal endpoint；
 - 启动前预占 Dex 与 Dex Web listeners，并确认 Temporal 端口可绑定；
 - 丢弃 backend 子进程 stdout/stderr，避免向普通启动输出泄露内部 endpoint；
@@ -379,16 +379,13 @@ Dex development environment is ready
 
 Dex Web:       http://127.0.0.1:8802
 Dex Server:    127.0.0.1:8801
+Local DB:      $HOME/.dex/dev/7233/dex.sqlite.db
+Blob store:    $HOME/.dex/dev/7233/dex.blobs
 
 Press Ctrl+C to stop.
 ```
 
-External Temporal mode 使用相同输出，不展示 backend 类型或 endpoint：
-
-```text
-Dex Web:       http://127.0.0.1:8802
-Dex Server:    127.0.0.1:8801
-```
+Local mode 打印 SQLite 与 blob 路径，但不展示 Temporal 类型或 endpoint。External Temporal mode 省略 Local DB 行，仍打印 blob store，且不展示 backend 类型或 endpoint。
 
 错误必须指出 component 和修复方法，例如：
 
@@ -462,7 +459,7 @@ Temporal CLI was not found; reinstall dexcli with Homebrew
 - local Temporal 自动包含 `default` namespace 和 `FlowType=Keyword`。
 - `--temporal-db-filename` 重启后保留 Temporal executions。
 - local blob backend 使用安全路径编码和 atomic rename。
-- 默认 `$HOME/.dex/blobs`、`--blob-store-dir` 或 `<db>.dex-blobs` 重启后保留 step inputs 和大 Value。
+- 默认 `$HOME/.dex/blobs`、`--blob-store-dir` 或相邻的 `dex.blobs` 重启后保留 step inputs 和大 Value。
 - external mode 连接预先启动的 Temporal，不创建第二个 Temporal process。
 - 退出 external mode 后 external Temporal 仍然可用。
 - occupied 7233、8233、8801、8802 分别在部分启动前返回明确错误。

--- a/docs/design/plan/dexcli.md
+++ b/docs/design/plan/dexcli.md
@@ -286,6 +286,7 @@ dexcli dev [flags]
 --temporal-port int            default 7233; local mode only
 --temporal-ui-port int         default 8233; local mode only
 --temporal-db-filename string  default $HOME/.dex/dev/<temporal-port>/temporal.db
+--temporal-log-file string     write local Temporal server and Web logs to this file
 --blob-store-dir string        persistent Dex blob storage directory (default <temporal-db-filename>.dex-blobs)
 --open                         open Dex Web after readiness
 ```
@@ -321,6 +322,7 @@ Process manager 必须：
 
 - 为每个 `dexcli dev` 进程分配互不冲突的 Dex、Dex Web、Temporal 和 Temporal UI 端口；未占用时使用默认值，已被占用且未显式指定时选择下一个空闲端口；
 - 为每个 local Temporal 使用独立 SQLite 文件（默认 `$HOME/.dex/dev/<temporal-port>/temporal.db`）；
+- `--temporal-log-file` 将 Temporal server 与 Web 的 stdout/stderr 写入指定文件，并记录实际 Temporal 端口和 SQLite 目录；默认丢弃这些日志，不向 `dexcli` 就绪输出泄露 Temporal endpoint；
 - 启动前预占 Dex 与 Dex Web listeners，并确认 Temporal 端口可绑定；
 - 丢弃 backend 子进程 stdout/stderr，避免向普通启动输出泄露内部 endpoint；
 - 通过 Temporal API readiness 检查，不根据日志文本判断 ready；


### PR DESCRIPTION
## Summary
- Auto-bind free Dex, Web, Temporal, and Temporal UI ports when defaults are taken so multiple `dexcli dev` processes can run on one machine.
- Give each local Temporal instance its own SQLite file under `$HOME/.dex/dev/<temporal-port>/temporal.db` (and adjacent blob store).
- Document the behavior and cover concurrent port/DB allocation in unit and integration tests.

## Rationale
Shared fixed ports and a shared Temporal backend caused conflicting stacks (including OrbStack/`*:7233` collisions) and inconsistent Temporal state across restarts.

## User impact
Operators can start multiple `dexcli dev` sessions safely. Non-default stacks print their addresses; point later CLI commands with `--server` or `DEX_FLOW_SERVICE_ADDRESS`. Explicit `--*-port` flags still fail if those ports are occupied.

## Test plan
- [x] `make -C cli test`
- [x] `make -C cli integration-test`
- [ ] Manually start two `dexcli dev` processes and confirm distinct printed ports and separate Temporal DB paths


Made with [Cursor](https://cursor.com)