### PR TITLE
build(examples): pin all SDKs to 0.1.10

### DIFF
--- a/.github/workflows/examples-python-ci.yml
+++ b/.github/workflows/examples-python-ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: uv sync --locked
       - name: Verify published package
         run: |
-          uv run --frozen python -c "import dex, importlib.metadata as m; print(m.version('dex-python-sdk')); assert m.version('dex-python-sdk') == '0.1.4'"
+          uv run --frozen python -c "import dex, importlib.metadata as m; print(m.version('dex-python-sdk')); assert m.version('dex-python-sdk') == '0.1.10'"
       - name: Integ tests with dexcli dev
         run: ./run-integ-tests.sh
       - name: Upload service logs

--- a/.github/workflows/examples-python-ci.yml
+++ b/.github/workflows/examples-python-ci.yml
@@ -43,10 +43,11 @@ jobs:
           import tomllib
           from pathlib import Path
 
+          pyproject = tomllib.loads(Path("pyproject.toml").read_text())
           declared = next(
               (
                   dependency.removeprefix("dex-python-sdk==")
-                  for dependency in tomllib.loads(Path("pyproject.toml").read_bytes())["project"]["dependencies"]
+                  for dependency in pyproject["project"]["dependencies"]
                   if dependency.startswith("dex-python-sdk==")
               ),
               None,
@@ -56,7 +57,7 @@ jobs:
 
           package = next(
               package
-              for package in tomllib.loads(Path("uv.lock").read_bytes())["package"]
+              for package in tomllib.loads(Path("uv.lock").read_text())["package"]
               if package["name"] == "dex-python-sdk"
           )
           if "registry" not in package.get("source", {}):

--- a/.github/workflows/examples-python-ci.yml
+++ b/.github/workflows/examples-python-ci.yml
@@ -37,7 +37,38 @@ jobs:
         run: uv sync --locked
       - name: Verify published package
         run: |
-          uv run --frozen python -c "import dex, importlib.metadata as m; print(m.version('dex-python-sdk')); assert m.version('dex-python-sdk') == '0.1.10'"
+          set -euo pipefail
+          uv run --frozen python - <<'PY'
+          import importlib.metadata as metadata
+          import tomllib
+          from pathlib import Path
+
+          declared = next(
+              (
+                  dependency.removeprefix("dex-python-sdk==")
+                  for dependency in tomllib.loads(Path("pyproject.toml").read_bytes())["project"]["dependencies"]
+                  if dependency.startswith("dex-python-sdk==")
+              ),
+              None,
+          )
+          if declared is None:
+              raise SystemExit("examples/python must depend on dex-python-sdk")
+
+          package = next(
+              package
+              for package in tomllib.loads(Path("uv.lock").read_bytes())["package"]
+              if package["name"] == "dex-python-sdk"
+          )
+          if "registry" not in package.get("source", {}):
+              raise SystemExit("examples/python must depend on published dex-python-sdk, not a path dependency")
+
+          installed = metadata.version("dex-python-sdk")
+          print(f"dex-python-sdk {installed}")
+          if installed != declared or installed != package["version"]:
+              raise SystemExit(
+                  f"installed {installed}, pyproject.toml {declared}, uv.lock {package['version']}"
+              )
+          PY
       - name: Integ tests with dexcli dev
         run: ./run-integ-tests.sh
       - name: Upload service logs

--- a/.github/workflows/examples-rust-ci.yml
+++ b/.github/workflows/examples-rust-ci.yml
@@ -29,8 +29,9 @@ jobs:
         run: rustup toolchain install 1.97.1 --profile minimal --component rustfmt,clippy
       - name: Verify published SDK dependency
         run: |
+          set -euo pipefail
           cargo tree --locked -p dex-sdk | tee /tmp/dex-examples-rust-sdk-tree.txt
-          grep -q '^dex-sdk v0\.1\.10$' /tmp/dex-examples-rust-sdk-tree.txt
+          grep -qE '^dex-sdk v[0-9]' /tmp/dex-examples-rust-sdk-tree.txt
           if grep -q '(/' /tmp/dex-examples-rust-sdk-tree.txt; then
             echo "examples/rust must depend on published dex-sdk, not a path dependency"
             exit 1

--- a/.github/workflows/examples-rust-ci.yml
+++ b/.github/workflows/examples-rust-ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Verify published SDK dependency
         run: |
           cargo tree --locked -p dex-sdk | tee /tmp/dex-examples-rust-sdk-tree.txt
-          grep -q '^dex-sdk v0\.0\.2$' /tmp/dex-examples-rust-sdk-tree.txt
+          grep -q '^dex-sdk v0\.1\.10$' /tmp/dex-examples-rust-sdk-tree.txt
           if grep -q '(/' /tmp/dex-examples-rust-sdk-tree.txt; then
             echo "examples/rust must depend on published dex-sdk, not a path dependency"
             exit 1

--- a/.github/workflows/examples-typescript-ci.yml
+++ b/.github/workflows/examples-typescript-ci.yml
@@ -32,8 +32,8 @@ jobs:
           declared_version="$(node -p "require('./package.json').dependencies['@superdurable/dex']")"
           resolved_version="$(npm ls --json --depth=0 @superdurable/dex | jq -r '.dependencies["@superdurable/dex"].version')"
           resolved_source="$(node -p "require('./package-lock.json').packages['node_modules/@superdurable/dex'].resolved")"
-          if [[ "$declared_version" != "0.1.5" || "$resolved_version" != "0.1.5" || "$resolved_source" != "https://registry.npmjs.org/@superdurable/dex/-/dex-0.1.5.tgz" ]]; then
-            echo "examples/typescript must use published @superdurable/dex 0.1.5"
+          if [[ "$declared_version" != "0.1.10" || "$resolved_version" != "0.1.10" || "$resolved_source" != "https://registry.npmjs.org/@superdurable/dex/-/dex-0.1.10.tgz" ]]; then
+            echo "examples/typescript must use published @superdurable/dex 0.1.10"
             exit 1
           fi
       - name: Typecheck

--- a/.github/workflows/examples-typescript-ci.yml
+++ b/.github/workflows/examples-typescript-ci.yml
@@ -29,11 +29,21 @@ jobs:
         run: npm ci
       - name: Verify published SDK dependency
         run: |
+          set -euo pipefail
           declared_version="$(node -p "require('./package.json').dependencies['@superdurable/dex']")"
           resolved_version="$(npm ls --json --depth=0 @superdurable/dex | jq -r '.dependencies["@superdurable/dex"].version')"
           resolved_source="$(node -p "require('./package-lock.json').packages['node_modules/@superdurable/dex'].resolved")"
-          if [[ "$declared_version" != "0.1.10" || "$resolved_version" != "0.1.10" || "$resolved_source" != "https://registry.npmjs.org/@superdurable/dex/-/dex-0.1.10.tgz" ]]; then
-            echo "examples/typescript must use published @superdurable/dex 0.1.10"
+          if [[ -z "$declared_version" || "$declared_version" == "undefined" ]]; then
+            echo "examples/typescript must depend on @superdurable/dex"
+            exit 1
+          fi
+          if [[ "$resolved_version" != "$declared_version" ]]; then
+            echo "examples/typescript resolves @superdurable/dex $resolved_version, expected $declared_version"
+            exit 1
+          fi
+          expected_source="https://registry.npmjs.org/@superdurable/dex/-/dex-${declared_version}.tgz"
+          if [[ "$resolved_source" != "$expected_source" ]]; then
+            echo "examples/typescript must use published @superdurable/dex, not $resolved_source"
             exit 1
           fi
       - name: Typecheck

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -1,6 +1,6 @@
 # Dex Go examples
 
-These examples target `github.com/superdurable/dex/sdk-go v0.1.3`.
+These examples target `github.com/superdurable/dex/sdk-go v0.1.10`.
 
 `dex.None` marks a nil-only Step, RPC, or Channel payload. Calls pass `nil`.
 

--- a/examples/go/cmd/deepverify/main.go
+++ b/examples/go/cmd/deepverify/main.go
@@ -1044,19 +1044,18 @@ func verifyRecovery(ctx context.Context, client *dex.Client, stamp string) resul
 	if err != nil {
 		return fail(name, "", err)
 	}
-	_, err = client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
+	result, err := client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
 		NeedsResults: true,
 		Timeout:      90 * time.Second,
 	})
-	var uncompleted *dex.FlowUncompletedError
-	if !errors.As(err, &uncompleted) {
+	if err != nil {
 		return fail(name, "", err)
 	}
-	if uncompleted.Status != dex.FlowFailed {
-		return fail(name, fmt.Sprintf("expected FlowFailed got %v msg=%s", uncompleted.Status, uncompleted.ErrorMessage), nil)
+	if result.Status != dex.FlowFailed {
+		return fail(name, fmt.Sprintf("expected FlowFailed got %v msg=%s", result.Status, result.ErrorMessage), nil)
 	}
-	if !strings.Contains(uncompleted.ErrorMessage, "Failed to process transaction") {
-		return fail(name, "msg="+uncompleted.ErrorMessage, nil)
+	if !strings.Contains(result.ErrorMessage, "Failed to process transaction") {
+		return fail(name, "msg="+result.ErrorMessage, nil)
 	}
 	return pass(name, "payment fail → void → ForceFail as designed")
 }
@@ -1241,19 +1240,18 @@ func verifyTimeoutFail(ctx context.Context, client *dex.Client, stamp string) re
 		return fail(name, "", err)
 	}
 	// 1m ForceFail + worker backlog under reminder load needs headroom.
-	_, err = client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
+	result, err := client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
 		NeedsResults: true,
 		Timeout:      3 * time.Minute,
 	})
-	var uncompleted *dex.FlowUncompletedError
-	if !errors.As(err, &uncompleted) {
+	if err != nil {
 		return fail(name, "", err)
 	}
-	if uncompleted.Status != dex.FlowFailed {
-		return fail(name, fmt.Sprintf("expected failed got %v msg=%s", uncompleted.Status, uncompleted.ErrorMessage), nil)
+	if result.Status != dex.FlowFailed {
+		return fail(name, fmt.Sprintf("expected failed got %v msg=%s", result.Status, result.ErrorMessage), nil)
 	}
-	if !strings.Contains(uncompleted.ErrorMessage, "did not finish the task in time") {
-		return fail(name, "msg="+uncompleted.ErrorMessage, nil)
+	if !strings.Contains(result.ErrorMessage, "did not finish the task in time") {
+		return fail(name, "msg="+result.ErrorMessage, nil)
 	}
 	return pass(name, "1m timeout ForceFail as designed")
 }
@@ -1279,12 +1277,11 @@ func verifyCron(ctx context.Context, client *dex.Client) result {
 		NeedsResults: true,
 		Timeout:      60 * time.Second,
 	})
-	outcome := "completed"
 	if err != nil {
-		var uncompleted *dex.FlowUncompletedError
-		if !errors.As(err, &uncompleted) || uncompleted.Status != dex.FlowContinuedAsNew {
-			return fail(name, "WaitForFlow "+tickID, err)
-		}
+		return fail(name, "WaitForFlow "+tickID, err)
+	}
+	outcome := "completed"
+	if wait.Status == dex.FlowContinuedAsNew {
 		outcome = "continued as new"
 	} else if wait.Status != dex.FlowCompleted {
 		return fail(name, fmt.Sprintf("status=%v msg=%s", wait.Status, wait.ErrorMessage), nil)
@@ -1339,7 +1336,7 @@ func waitCompleted(
 	client *dex.Client,
 	flowID string,
 	timeout time.Duration,
-) (dex.WaitForFlowResult, error) {
+) (dex.FlowResult, error) {
 	wait, err := client.WaitForFlow(ctx, flowID, dex.WaitForFlowOptions{
 		NeedsResults: true,
 		Timeout:      timeout,
@@ -1355,7 +1352,7 @@ func waitCompleted(
 	return wait, nil
 }
 
-func decodeStringCompletion(wait dex.WaitForFlowResult) (string, error) {
+func decodeStringCompletion(wait dex.FlowResult) (string, error) {
 	if len(wait.Completions) == 0 {
 		return "", fmt.Errorf("no completions")
 	}

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/stretchr/testify v1.11.1
 	github.com/superdurable/dex/blob-cache-go v0.1.0
-	github.com/superdurable/dex/sdk-go v0.1.3
+	github.com/superdurable/dex/sdk-go v0.1.10
 )
 
 require (

--- a/examples/go/go.sum
+++ b/examples/go/go.sum
@@ -90,8 +90,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/superdurable/dex/blob-cache-go v0.1.0 h1:+c3H5YBWG3DlICOHbgT9IUM5vTlfLYGP5Vd5sWr7WTY=
 github.com/superdurable/dex/blob-cache-go v0.1.0/go.mod h1:Atepb7+sztvDCztVKmlvEKCSKFCkHKtDhoFYjaFmtEw=
-github.com/superdurable/dex/sdk-go v0.1.3 h1:smFgav0Mng1Lr0pc6V0E4FAajCd7L/1fSu0iMHVN5FU=
-github.com/superdurable/dex/sdk-go v0.1.3/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
+github.com/superdurable/dex/sdk-go v0.1.10 h1:uS0Svo+BTw7IXeqBBbicrYaTiUql8ltHmLsmzD0Dz9c=
+github.com/superdurable/dex/sdk-go v0.1.10/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=

--- a/examples/go/integ/main_test.go
+++ b/examples/go/integ/main_test.go
@@ -221,7 +221,7 @@ func newFlowID(t *testing.T, prefix string) string {
 	return prefix + "-" + strconv.FormatInt(time.Now().UnixNano(), 10) + "-" + strconv.FormatInt(sequence, 10)
 }
 
-func waitForFlow(t *testing.T, flowID string) dex.WaitForFlowResult {
+func waitForFlow(t *testing.T, flowID string) dex.FlowResult {
 	t.Helper()
 	result, err := integClient.WaitForFlow(
 		integrationContext(t),

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -1,6 +1,6 @@
 # Dex Java examples
 
-These examples target `io.superdurable:dex-sdk:0.0.5` (`io.superdurable.dex`).
+These examples target `io.superdurable:dex-sdk:0.1.10` (`io.superdurable.dex`).
 
 The sample process hosts one gRPC Worker on `127.0.0.1:8803` and an HTTP
 controller on port `8080`. One Registry and disk BlobCache are shared by its

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "io.superdurable:dex-sdk:0.0.7"
+    implementation "io.superdurable:dex-sdk:0.1.10"
 
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,6 +1,6 @@
 # Dex Python examples
 
-These examples target [`dex-python-sdk==0.1.4`](https://pypi.org/project/dex-python-sdk/0.1.4/)
+These examples target [`dex-python-sdk==0.1.10`](https://pypi.org/project/dex-python-sdk/0.1.10/)
 (`import dex`). Requires Python 3.11+.
 
 The primary sample process hosts one asyncio `AsyncWorker` on `127.0.0.1:8803` and a

--- a/examples/python/pyproject.toml
+++ b/examples/python/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "dex-python-sdk==0.1.4",
+    "dex-python-sdk==0.1.10",
     "flask>=3.0,<4",
     "openai>=1.66.2,<2",
     "openai-agents>=0.0.4,<0.0.5",

--- a/examples/python/sync-python/README.md
+++ b/examples/python/sync-python/README.md
@@ -3,7 +3,7 @@
 Showcase of the **sync** Dex Python SDK surface (`Client` / `Worker`) next to
 the primary async examples under `examples/python/`.
 
-Targets [`dex-python-sdk==0.1.4`](https://pypi.org/project/dex-python-sdk/0.1.4/).
+Targets [`dex-python-sdk==0.1.10`](https://pypi.org/project/dex-python-sdk/0.1.10/).
 Requires Python 3.11+.
 
 The samples use concrete SDK errors for missing, inactive, and duplicate Flows

--- a/examples/python/tests/integ/test_patterns.py
+++ b/examples/python/tests/integ/test_patterns.py
@@ -170,8 +170,6 @@ async def test_failure_recovery(
     client: AsyncClient,
     new_flow_id: Callable[[str], str],
 ) -> None:
-    from dex import FlowStatus, FlowUncompletedError
-
     flow_id = new_flow_id("recovery")
     await client.start_flow(
         app.failure_recovery,
@@ -179,10 +177,9 @@ async def test_failure_recovery(
         FailureRecoveryWorkflowInput("widget", 2),
         start_options(),
     )
-    with pytest.raises(FlowUncompletedError) as captured:
-        await client.wait_for_flow(flow_id, WAIT_TIMEOUT)
-    assert captured.value.status is FlowStatus.FAILED
-    assert "Failed to process transaction" in str(captured.value)
+    result = await client.wait_for_flow(flow_id, WAIT_TIMEOUT)
+    assert result.status is FlowStatus.FAILED
+    assert "Failed to process transaction" in (result.error_message or "")
 
 
 async def test_reminder_accept(

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -293,7 +293,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dex-python-sdk", specifier = "==0.1.4" },
+    { name = "dex-python-sdk", specifier = "==0.1.10" },
     { name = "flask", specifier = ">=3.0,<4" },
     { name = "openai", specifier = ">=1.66.2,<2" },
     { name = "openai-agents", specifier = ">=0.0.4,<0.0.5" },
@@ -312,20 +312,20 @@ dev = [
 
 [[package]]
 name = "dex-python-sdk"
-version = "0.1.4"
+version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "grpcio-status" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/cb/02c7873d9a3dfe11e27d3a99afe796cca287fa776d057af57323e0df6be4/dex_python_sdk-0.1.4.tar.gz", hash = "sha256:6ff5b64b204b6f2a2205b46ee2c41cc5158cc8b7a01b81e2407fd62008051bbd", size = 139139, upload-time = "2026-08-14T00:54:41.001Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/23/bc5e43fab4374322aa38855b3b16630418d5eb0507d2003adb9543ea82f2/dex_python_sdk-0.1.10.tar.gz", hash = "sha256:c87fe85b30588566887f8a6883d592160933912bae35177e4da14a32b1a15394", size = 147920, upload-time = "2026-08-17T19:28:08.004Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/58/b295af7b243cec8dec78834ade06f94086722aacdca9da7280495c1685a7/dex_python_sdk-0.1.4-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e039fb0544d57146fd6cf0ef68857d3a817c97509c5434aa4bcdc7d7e7444d0d", size = 619247, upload-time = "2026-08-14T00:54:33.868Z" },
-    { url = "https://files.pythonhosted.org/packages/23/75/9d310194b57169e5d24c84b8024f104e6d7caa46afad4639b43062ca9290/dex_python_sdk-0.1.4-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:f9aecab13ac475d8168352fa26d85ca56ac162cdd153575bf024d94d3d32f55e", size = 597763, upload-time = "2026-08-14T00:54:35.504Z" },
-    { url = "https://files.pythonhosted.org/packages/71/5f/608b98776b1a298e86a469cf5772c71908bda6b82fb9b409ad93c6d8b3d9/dex_python_sdk-0.1.4-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd8166227a6be34dda784c78138be985d383f3a5a2b801dc0231606fae2f649e", size = 660700, upload-time = "2026-08-14T00:54:37.019Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/c4/d1948be947d58e11d040e717e46c4d43f01eb8393733bddd03e34ab49624/dex_python_sdk-0.1.4-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6474952a50c34bfef8c95611069c6524d301898fd1f0f72ca636ea28a310192f", size = 663002, upload-time = "2026-08-14T00:54:38.179Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/b2/e0e3ba0587683334bd2fe7e18ba98701e2c7faacde36281c2be8d8af6fda/dex_python_sdk-0.1.4-cp311-abi3-win_amd64.whl", hash = "sha256:ee35f98cc44802318ab1980ca7cc08d9e76a083ad29f630c3ca4b4cbe7034e4c", size = 506813, upload-time = "2026-08-14T00:54:39.59Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/5b500d23ddbe4d95b54b92361f4fa8223bfb467a862ef73836ee37248200/dex_python_sdk-0.1.10-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:da49c5293f03a57ff7cd730e8ef3b23797e826f042766cf36e47bce383882cc7", size = 630029, upload-time = "2026-08-17T19:27:59.723Z" },
+    { url = "https://files.pythonhosted.org/packages/95/41/d2646b20ab7130db3ab0e489ce8d2eba1eb0286b227bd66a7cbdd7d264d1/dex_python_sdk-0.1.10-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:f6563b7d992f4955d08301473f7db0962bb9b165ac08a1a98e56b181aa9e2e2c", size = 608545, upload-time = "2026-08-17T19:28:01.519Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f6/bfad126ae2f94c6da1d005be19ccd173ae8e4aa18e176bbdcf74cab5cb1e/dex_python_sdk-0.1.10-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d9cefd1b91b50344fdff958667c80f85a4cb91ca4ebe63833dd58e0294a9944", size = 671484, upload-time = "2026-08-17T19:28:03.009Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/20/6f878425ebe7572e697adec0d7bb3aaf397dffd73e70c7ab1c457f9a248a/dex_python_sdk-0.1.10-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8d875d9805f65d699d5245ab3cb2e049a7aea8fff76307f48ab0dd7420d01f5", size = 673785, upload-time = "2026-08-17T19:28:04.289Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/7bc622d8c69ac70f3e9e6ed20e44d9bf88dea14db3f75412d45f70da7b99/dex_python_sdk-0.1.10-cp311-abi3-win_amd64.whl", hash = "sha256:e9c1565212a6aa128df2b957e31563a918586b6ae402c7819dcf50e969957b23", size = 517665, upload-time = "2026-08-17T19:28:06.024Z" },
 ]
 
 [[package]]

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "dex-blob-cache"
-version = "0.0.2"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d58df5bc95275cae1a491a8ab80d4c647c2b3fd3ea7b2c5d18191d21caace"
+checksum = "1572d311bb028f3c631278497e1afa7f59fa0c51b89741eb36598df419103908"
 dependencies = [
  "crc32c",
  "sha2",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "dex-protocol"
-version = "0.0.2"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1178bad581fc151827fe171b771582adc7c9c34cd0715d1e1737af8f78c14a9d"
+checksum = "c7837df8451b89c226af7103d16a7958a82c49b86a7012ddea5b80b2a481ef56"
 dependencies = [
  "prost",
  "prost-types",
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "dex-sdk"
-version = "0.0.2"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0ca1287a08c70c55a45270337c9d3ff5f38cb20c989e6374df8aa0722abacc"
+checksum = "5c741ef8850772e299b45366b749abd46b1ef621e5c8b70ee50e190afadc4535"
 dependencies = [
  "dex-blob-cache",
  "dex-protocol",

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 rust-version = "1.97"
 
 [dependencies]
-dex-sdk = "=0.0.2"
+dex-sdk = "=0.1.10"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -1,7 +1,7 @@
 # Rust examples
 
 This application mirrors the examples shared by the Java, Python, and TypeScript
-applications. It intentionally depends on the published `dex-sdk = "=0.0.2"`
+applications. It intentionally depends on the published `dex-sdk = "=0.1.10"`
 crate without a repository path override.
 
 ## Run

--- a/examples/rust/tests/catalog_integration.rs
+++ b/examples/rust/tests/catalog_integration.rs
@@ -111,6 +111,6 @@ fn catalog_matches_every_cross_language_example() {
 #[test]
 fn manifest_uses_the_published_sdk_only() {
     let manifest = include_str!("../Cargo.toml");
-    assert!(manifest.contains("dex-sdk = \"=0.0.2\""));
+    assert!(manifest.contains("dex-sdk = \"=0.1.10\""));
     assert!(!manifest.contains("path ="));
 }

--- a/examples/rust/tests/catalog_integration.rs
+++ b/examples/rust/tests/catalog_integration.rs
@@ -111,6 +111,16 @@ fn catalog_matches_every_cross_language_example() {
 #[test]
 fn manifest_uses_the_published_sdk_only() {
     let manifest = include_str!("../Cargo.toml");
-    assert!(manifest.contains("dex-sdk = \"=0.1.10\""));
-    assert!(!manifest.contains("path ="));
+    let dex_sdk = manifest
+        .lines()
+        .find(|line| line.trim_start().starts_with("dex-sdk ="))
+        .expect("examples/rust must depend on dex-sdk");
+    assert!(
+        dex_sdk.contains("\"="),
+        "examples/rust must pin a published dex-sdk version: {dex_sdk}"
+    );
+    assert!(
+        !dex_sdk.contains("path"),
+        "examples/rust must depend on published dex-sdk, not a path dependency"
+    );
 }

--- a/examples/rust/tests/dex_integration.rs
+++ b/examples/rust/tests/dex_integration.rs
@@ -157,7 +157,9 @@ fn money_transfer_completes_with_released_sdk() {
     let output: TransferRequest = environment
         .client
         .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
-        .expect("complete Rust Money Transfer Flow");
+        .expect("complete Rust Money Transfer Flow")
+        .single_output()
+        .expect("decode Rust Money Transfer output");
     assert_eq!(output.from_account, "released-sdk-source");
     assert_eq!(output.to_account, "released-sdk-destination");
     assert_eq!(output.amount_cents, 4_200);
@@ -202,7 +204,7 @@ fn engagement_invokes_rpcs_and_completes() {
         .expect("accept Rust Engagement Flow");
     environment
         .client
-        .wait_for_flow_with_timeout::<()>(&flow_id, Duration::from_secs(30))
+        .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
         .expect("complete Rust Engagement Flow");
     assert_eq!(
         environment
@@ -256,7 +258,7 @@ fn microservice_swaps_data_and_completes_when_ready() {
         .expect("release Rust Microservice Flow");
     environment
         .client
-        .wait_for_flow_with_timeout::<()>(&flow_id, Duration::from_secs(30))
+        .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
         .expect("complete Rust Microservice Flow");
 }
 
@@ -283,7 +285,9 @@ fn polling_completes_all_tasks() {
     let output: String = environment
         .client
         .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
-        .expect("complete Rust Polling Flow");
+        .expect("complete Rust Polling Flow")
+        .single_output()
+        .expect("decode Rust Polling output");
     assert_eq!(output, "task-c");
     assert_eq!(
         environment
@@ -332,7 +336,9 @@ fn subscription_updates_charge_and_cancels() {
     let output: SubscriptionState = environment
         .client
         .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
-        .expect("complete Rust Subscription Flow");
+        .expect("complete Rust Subscription Flow")
+        .single_output()
+        .expect("decode Rust Subscription output");
     assert_eq!(output.charge_cents, 250);
     assert_eq!(output.periods_charged, 0);
     assert!(output.cancelled);
@@ -353,7 +359,9 @@ fn failure_recovery_retries_and_compensates() {
     let output: String = environment
         .client
         .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
-        .expect("complete Rust Failure Recovery Flow");
+        .expect("complete Rust Failure Recovery Flow")
+        .single_output()
+        .expect("decode Rust Failure Recovery output");
     assert_eq!(output, "compensated");
     assert_eq!(
         environment

--- a/examples/rust/tests/dex_integration.rs
+++ b/examples/rust/tests/dex_integration.rs
@@ -282,11 +282,16 @@ fn polling_completes_all_tasks() {
         .invoke_rpc(&flow_id, POLLING_COMPLETE_TASK, "b".to_string())
         .expect("complete Rust Polling task b");
 
-    let output: String = environment
+    let result = environment
         .client
         .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
-        .expect("complete Rust Polling Flow")
-        .single_output()
+        .expect("complete Rust Polling Flow");
+    assert_eq!(result.status(), FlowStatus::Completed);
+    let output: String = result
+        .completions()
+        .last()
+        .expect("polling Flow has completions")
+        .decode()
         .expect("decode Rust Polling output");
     assert_eq!(output, "task-c");
     assert_eq!(

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,6 +1,6 @@
 # Dex TypeScript examples
 
-These examples target [`@superdurable/dex@0.1.5`](https://www.npmjs.com/package/@superdurable/dex).
+These examples target [`@superdurable/dex@0.1.10`](https://www.npmjs.com/package/@superdurable/dex).
 
 The sample process hosts one gRPC Worker (default `127.0.0.1:8803`) and an HTTP
 controller on port `8080`. Step `execute` / `waitFor` / RPC handlers may

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@superdurable/dex-examples-typescript",
       "version": "0.0.0",
       "dependencies": {
-        "@superdurable/dex": "0.1.5",
+        "@superdurable/dex": "0.1.10",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -125,9 +125,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@superdurable/dex": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.1.5.tgz",
-      "integrity": "sha512-O7EMt9NW/cwmqWteRjVtx0ZjMLr8fh4GdSh2qmL8PrB4loA6S9u1gQXorYHZvovflgQR8YQ2WwOBPSJ70ygBTQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.1.10.tgz",
+      "integrity": "sha512-P0AhInm49jKiILzDMqXdb5WiZyz2fv8UVXy+AlY3w/GAfADfKz9Ns0TFfA9UnfFBuyozAYUbOAoTVMtuQNhJjg==",
       "license": "LicenseRef-Super-Durable-1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.13.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -16,7 +16,7 @@
     "smoke": "npm run build && node --test --experimental-test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/e2e/all-routes.test.js'"
   },
   "dependencies": {
-    "@superdurable/dex": "0.1.5",
+    "@superdurable/dex": "0.1.10",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/examples/typescript/src/patterns/workflow/parentchild/parent-flow-v2.ts
+++ b/examples/typescript/src/patterns/workflow/parentchild/parent-flow-v2.ts
@@ -142,7 +142,6 @@ class AwaitChildWorkflowCompletion implements Step<WaitForChildInput> {
     try {
       await getClient().waitForFlow(
         input.childWFId,
-        voidCodec,
         Math.max(input.timerSeconds, 1) * 1000,
       );
     } catch (error) {

--- a/examples/typescript/test/integ/engagement.test.ts
+++ b/examples/typescript/test/integ/engagement.test.ts
@@ -81,6 +81,8 @@ test("engagementStartChannelRpcAndStatus", async () => {
     "engagement status not Accepted",
   );
 
-  const output = await environment.client.waitForFlow(flowId, stringCodec, 45_000);
+  const output = await environment.client.waitForFlow(flowId, 45_000).then((result) =>
+    result.singleOutput(stringCodec),
+  );
   assert.equal(output, "done");
 });

--- a/examples/typescript/test/integ/failure-recovery.test.ts
+++ b/examples/typescript/test/integ/failure-recovery.test.ts
@@ -17,8 +17,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { FlowUncompletedError, voidCodec } from "@superdurable/dex";
-
 import {
   acquireIntegEnvironment,
   releaseIntegEnvironment,
@@ -46,15 +44,9 @@ test("failureRecoveryRetriesCompensatesAndFails", async () => {
   );
   assert.ok(runId.length > 0);
 
-  await assert.rejects(
-    environment.client.waitForFlow(flowId, voidCodec, 45_000),
-    (error: unknown) => {
-      assert.ok(error instanceof FlowUncompletedError);
-      assert.equal(error.status, "failed");
-      assert.match(error.message, /Failed to process transaction/);
-      return true;
-    },
-  );
+  const result = await environment.client.waitForFlow(flowId, 45_000);
+  assert.equal(result.status, "failed");
+  assert.match(result.errorMessage ?? "", /Failed to process transaction/);
 
   const summary = await environment.client.describeFlow(flowId);
   assert.equal(summary.status, "failed");

--- a/examples/typescript/test/integ/microservice.test.ts
+++ b/examples/typescript/test/integ/microservice.test.ts
@@ -56,6 +56,8 @@ test("microserviceStartRpcAndChannel", async () => {
   assert.equal(previous, "initial-data");
 
   await environment.client.publish(flowId, flow.ready, undefined);
-  const output = await environment.client.waitForFlow(flowId, stringCodec, 45_000);
+  const output = await environment.client.waitForFlow(flowId, 45_000).then((result) =>
+    result.singleOutput(stringCodec),
+  );
   assert.equal(output, "updated-data");
 });

--- a/examples/typescript/test/integ/money-transfer.test.ts
+++ b/examples/typescript/test/integ/money-transfer.test.ts
@@ -47,7 +47,9 @@ test("moneyTransferStart", async () => {
     environment.startOptions(),
   );
   assert.ok(runId.length > 0);
-  const output = await environment.client.waitForFlow(flowId, stringCodec, 45_000);
+  const output = await environment.client.waitForFlow(flowId, 45_000).then((result) =>
+    result.singleOutput(stringCodec),
+  );
   assert.match(output, /transfer is done/);
   assert.match(output, /from-ci/);
   assert.match(output, /to-ci/);

--- a/examples/typescript/test/integ/polling.test.ts
+++ b/examples/typescript/test/integ/polling.test.ts
@@ -47,7 +47,9 @@ test("pollingStartAndChannels", async () => {
   await environment.client.publish(flowId, flow.taskACompleted, undefined);
   await environment.client.publish(flowId, flow.taskBCompleted, undefined);
 
-  const output = await environment.client.waitForFlow(flowId, stringCodec, 45_000);
+  const output = await environment.client.waitForFlow(flowId, 45_000).then((result) =>
+    result.singleOutput(stringCodec),
+  );
   assert.equal(output, "all tasks completed");
 
   const polls = await environment.client.getAttribute(flowId, flow.currentPolls);

--- a/examples/typescript/test/integ/subscription.test.ts
+++ b/examples/typescript/test/integ/subscription.test.ts
@@ -81,6 +81,8 @@ test("subscriptionStartRpcAndChannels", async () => {
   );
 
   await environment.client.publish(flowId, flow.cancelSubscription, undefined);
-  const output = await environment.client.waitForFlow(flowId, stringCodec, 45_000);
+  const output = await environment.client.waitForFlow(flowId, 45_000).then((result) =>
+    result.singleOutput(stringCodec),
+  );
   assert.equal(output, "subscription canceled");
 });


### PR DESCRIPTION
## Summary
- Pin Go, Java, Python, TypeScript, and Rust examples to the unified SDK `0.1.10` releases.
- Refresh lockfiles and example CI version checks so they resolve the published packages, not older pins.

## Test plan
- [ ] Example CI jobs resolve `0.1.10` from the public registries (Go module, Maven Central, PyPI, npm, crates.io).
- [ ] Go / Java / Python / TypeScript / Rust example unit or catalog checks pass.
- [ ] Example integration jobs against `dexcli dev` pass.


Made with [Cursor](https://cursor.com)