### PR TITLE
Simplify dexcli dev flags behind a shared server log folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Traditional databases persist only data. Durable Execution persists both data an
 
 ```bash
 brew install superdurable/tap/dexcli
-dexcli dev --open
+dexcli dev
 ```
 
-Open Dex Web at [http://127.0.0.1:8802](http://127.0.0.1:8802). This starts
-the complete local Dex environment, including its internal workflow backend.
+This starts the complete local Dex environment, including its internal
+workflow backend, and opens Dex Web at [http://127.0.0.1:8802](http://127.0.0.1:8802).
 If 8802 is already taken, `dexcli dev` prints the port it selected instead.
 
 See [cli/README.md](cli/README.md) for Dex endpoints and persistence options.

--- a/cli/README.md
+++ b/cli/README.md
@@ -32,8 +32,9 @@ same machine therefore starts isolated stacks: distinct Dex ports, a distinct
 local Temporal server, and a distinct SQLite database. Point later CLI commands
 at a non-default stack with `--server` or `DEX_FLOW_SERVICE_ADDRESS`.
 
-Use `--open` to open Dex Web after every component becomes ready. Ctrl+C stops
-Dex Web, Dex Server, and all internal processes owned by `dexcli`.
+Dex Web opens after every component becomes ready. Pass `--open=false` to skip
+that. Ctrl+C stops Dex Web, Dex Server, and all internal processes owned by
+`dexcli`.
 
 Local state persists in `$HOME/.dex/dev/<port>/dex.sqlite.db`.
 Dex Web step inputs and values larger than 1 KB persist next to that database
@@ -87,7 +88,7 @@ must exist and be reachable before startup.
 --bind-address string              local bind IP (default 127.0.0.1)
 --blob-store-dir string            persistent Dex blob storage directory (default $HOME/.dex/blobs)
 --dex-port int                     Dex gRPC port (default 8801)
---open                             open Dex Web after readiness
+--open                             open Dex Web after readiness (default true)
 --web-port int                     Dex Web port (default 8802)
 --sqlite-db-filename string        local SQLite file (default $HOME/.dex/dev/<port>/dex.sqlite.db)
 --server-log-folder string         keep server logs (default temp folder, deleted on exit)

--- a/cli/README.md
+++ b/cli/README.md
@@ -35,13 +35,13 @@ at a non-default stack with `--server` or `DEX_FLOW_SERVICE_ADDRESS`.
 Use `--open` to open Dex Web after every component becomes ready. Ctrl+C stops
 Dex Web, Dex Server, and all internal processes owned by `dexcli`.
 
-Local state persists in `$HOME/.dex/dev/<temporal-port>/dex.sqlite.db`.
+Local state persists in `$HOME/.dex/dev/<port>/dex.sqlite.db`.
 Dex Web step inputs and values larger than 1 KB persist next to that database
 in `dex.blobs`, so execution history and its blobs share a lifecycle. Override
 the database path with:
 
 ```bash
-dexcli dev --temporal-db-filename ./dex.sqlite.db
+dexcli dev --sqlite-db-filename ./dex.sqlite.db
 ```
 
 Choose another blob directory with:
@@ -51,13 +51,13 @@ dexcli dev --blob-store-dir ./dex-blobs
 ```
 
 `--blob-store-dir` takes precedence over the directory derived from
-`--temporal-db-filename`.
+`--sqlite-db-filename`.
 
-Capture local Temporal server and Web logs, including the bound Temporal ports
-and SQLite directory, with:
+Server logs go to a temp folder that `dexcli` prints on readiness and deletes
+when it exits. Keep them with:
 
 ```bash
-dexcli dev --temporal-log-file ./temporal.log
+dexcli dev --server-log-folder ./dex-logs
 ```
 
 Configure local Attribute Store projection with the same YAML section accepted
@@ -83,19 +83,22 @@ must exist and be reachable before startup.
 ## Application-facing flags
 
 ```text
---bind-address string          local bind IP (default 127.0.0.1)
---dex-port int                 Dex gRPC port (default 8801)
---web-port int                 Dex Web port (default 8802)
---temporal-db-filename string  local Temporal SQLite file (default $HOME/.dex/dev/<temporal-port>/dex.sqlite.db)
---temporal-log-file string     write local Temporal server and Web logs to this file
---blob-store-dir string        persistent Dex blob storage directory (default $HOME/.dex/dev/<temporal-port>/dex.blobs)
---attribute-store-config string  Dex YAML file supplying Attribute Store settings
---open                         open Dex Web after readiness
+--attribute-store-config string    Dex YAML file supplying Attribute Store settings
+--bind-address string              local bind IP (default 127.0.0.1)
+--blob-store-dir string            persistent Dex blob storage directory (default $HOME/.dex/blobs)
+--dex-port int                     Dex gRPC port (default 8801)
+--open                             open Dex Web after readiness
+--web-port int                     Dex Web port (default 8802)
+--sqlite-db-filename string        local SQLite file (default $HOME/.dex/dev/<port>/dex.sqlite.db)
+--server-log-folder string         keep server logs (default temp folder, deleted on exit)
+--external-temporal-address string      external Temporal host:port
+--external-temporal-namespace string    external Temporal namespace (default default)
 ```
 
-Operators hosting Dex can use the retained backend compatibility flags for
-external mode, namespaces, and internal ports. Dex does not print those
-endpoints, and application developers do not need them.
+Local Temporal gRPC and Web ports are assigned automatically. Operators can
+point Dex at an existing Temporal with `--external-temporal-address` and
+`--external-temporal-namespace`. Dex does not print those endpoints, and
+application developers do not need them.
 
 ## Operate flows
 
@@ -185,9 +188,9 @@ binary does not read `web/`, `node_modules`, or the source tree.
 ## Troubleshooting
 
 - “workflow backend CLI was not found”: reinstall `dexcli` with Homebrew.
-- “address is already in use”: an explicit `--dex-port`, `--web-port`,
-  `--temporal-port`, or `--temporal-ui-port` is taken. Stop that process or pass
-  another port. Unspecified ports are assigned automatically.
+- “address is already in use”: an explicit `--dex-port` or `--web-port` is
+  taken. Stop that process or pass another port. Unspecified Dex ports and all
+  local Temporal ports are assigned automatically.
 - “attribute index synchronization failed”: operators should verify that Dex
   can list and add backend visibility indexes. Workers never require a manual
   registration command.

--- a/cli/internal/dev/config.go
+++ b/cli/internal/dev/config.go
@@ -75,7 +75,7 @@ type Config struct {
 	BlobStoreDirectory string
 	// AttributeStoreConfigPath defaults empty and loads Attribute Store settings from standard Dex YAML when set.
 	AttributeStoreConfigPath string
-	// OpenBrowser defaults false and opens Dex Web after readiness.
+	// OpenBrowser defaults true and opens Dex Web after readiness.
 	OpenBrowser bool
 	// StartupTimeout defaults to 45 seconds.
 	StartupTimeout time.Duration
@@ -108,7 +108,7 @@ func parseConfig(args []string, output io.Writer) (*Config, error) {
 		"Dex blob storage directory",
 	)
 	flags.IntVar(&cfg.DexPort, "dex-port", cfg.DexPort, "Dex gRPC port")
-	flags.BoolVar(&cfg.OpenBrowser, "open", false, "open Dex Web after startup")
+	flags.BoolVar(&cfg.OpenBrowser, "open", true, "open Dex Web after startup")
 	flags.IntVar(&cfg.WebPort, "web-port", cfg.WebPort, "Dex Web port")
 	flags.StringVar(
 		&cfg.SQLiteDBFilename,
@@ -168,6 +168,7 @@ func defaultConfig() (*Config, error) {
 		TemporalUIPort:            defaultTemporalUIPort,
 		StateDirectory:            stateDirectory,
 		BlobStoreDirectory:        filepath.Join(stateDirectory, "blobs"),
+		OpenBrowser:               true,
 		StartupTimeout:            45 * time.Second,
 		ShutdownTimeout:           10 * time.Second,
 		explicitLocalFlags:        make(map[string]bool),

--- a/cli/internal/dev/config.go
+++ b/cli/internal/dev/config.go
@@ -25,15 +25,30 @@ import (
 )
 
 const (
-	defaultBindAddress       = "127.0.0.1"
-	defaultDexPort           = 8801
-	defaultWebPort           = 8802
-	defaultTemporalPort      = 7233
-	defaultTemporalUIPort    = 8233
-	defaultTemporalNamespace = "default"
-	localSQLiteFileName      = "dex.sqlite.db"
-	localBlobStoreName       = "dex.blobs"
+	defaultBindAddress        = "127.0.0.1"
+	defaultDexPort            = 8801
+	defaultWebPort            = 8802
+	defaultTemporalPort       = 7233
+	defaultTemporalUIPort     = 8233
+	defaultTemporalNamespace  = "default"
+	localSQLiteFileName       = "dex.sqlite.db"
+	localBlobStoreName        = "dex.blobs"
+	dexServerLogFileName      = "dex-server.log"
+	temporalEngineLogFileName = "temporal-engine-server.log"
 )
+
+var flagOrder = []string{
+	"attribute-store-config",
+	"bind-address",
+	"blob-store-dir",
+	"dex-port",
+	"open",
+	"web-port",
+	"sqlite-db-filename",
+	"server-log-folder",
+	"external-temporal-address",
+	"external-temporal-namespace",
+}
 
 type Config struct {
 	// BindAddress defaults to 127.0.0.1 for all owned listeners.
@@ -42,21 +57,21 @@ type Config struct {
 	DexPort int
 	// WebPort defaults to 8802 for Dex Web.
 	WebPort int
-	// TemporalAddress selects external Temporal when non-empty. Default is local mode.
-	TemporalAddress string
+	// ExternalTemporalAddress selects external Temporal when non-empty. Default is local mode.
+	ExternalTemporalAddress string
 	// TemporalNamespace defaults to default.
 	TemporalNamespace string
 	// TemporalPort defaults to 7233 in local mode.
 	TemporalPort int
 	// TemporalUIPort defaults to 8233 in local mode.
 	TemporalUIPort int
-	// TemporalDBFilename defaults to $HOME/.dex/dev/<temporal-port>/dex.sqlite.db in local mode.
-	TemporalDBFilename string
-	// TemporalLogFile defaults empty and discards local Temporal process logs.
-	TemporalLogFile string
+	// SQLiteDBFilename defaults to $HOME/.dex/dev/<temporal-port>/dex.sqlite.db in local mode.
+	SQLiteDBFilename string
+	// LogDirectory defaults to a temp directory deleted on clean exit.
+	LogDirectory string
 	// StateDirectory defaults to $HOME/.dex and stores auto-assigned Temporal SQLite files.
 	StateDirectory string
-	// BlobStoreDirectory defaults to $HOME/.dex/blobs unless TemporalDBFilename selects its adjacent dex.blobs store.
+	// BlobStoreDirectory defaults to $HOME/.dex/blobs unless SQLiteDBFilename selects its adjacent dex.blobs store.
 	BlobStoreDirectory string
 	// AttributeStoreConfigPath defaults empty and loads Attribute Store settings from standard Dex YAML when set.
 	AttributeStoreConfigPath string
@@ -68,7 +83,7 @@ type Config struct {
 	ShutdownTimeout time.Duration
 
 	explicitLocalFlags map[string]bool
-	// blobStoreDirectoryDefault defaults true and allows TemporalDBFilename to select its adjacent store.
+	// blobStoreDirectoryDefault defaults true and allows SQLiteDBFilename to select its adjacent store.
 	blobStoreDirectoryDefault bool
 }
 
@@ -79,41 +94,44 @@ func parseConfig(args []string, output io.Writer) (*Config, error) {
 	}
 	flags := flag.NewFlagSet("dexcli dev", flag.ContinueOnError)
 	flags.SetOutput(output)
-	flags.StringVar(&cfg.BindAddress, "bind-address", cfg.BindAddress, "address for local services")
-	flags.IntVar(&cfg.DexPort, "dex-port", cfg.DexPort, "Dex gRPC port")
-	flags.IntVar(&cfg.WebPort, "web-port", cfg.WebPort, "Dex Web port")
-	flags.StringVar(&cfg.TemporalAddress, "temporal-address", "", "external Temporal host:port")
-	flags.StringVar(&cfg.TemporalNamespace, "temporal-namespace", cfg.TemporalNamespace, "Temporal namespace")
-	flags.IntVar(&cfg.TemporalPort, "temporal-port", cfg.TemporalPort, "local Temporal gRPC port")
-	flags.IntVar(&cfg.TemporalUIPort, "temporal-ui-port", cfg.TemporalUIPort, "local Temporal Web port")
-	flags.StringVar(
-		&cfg.TemporalDBFilename,
-		"temporal-db-filename",
-		"",
-		"local Temporal SQLite file (default $HOME/.dex/dev/<temporal-port>/dex.sqlite.db)",
-	)
-	flags.StringVar(
-		&cfg.TemporalLogFile,
-		"temporal-log-file",
-		"",
-		"write local Temporal server and Web logs to this file",
-	)
-	flags.StringVar(
-		&cfg.BlobStoreDirectory,
-		"blob-store-dir",
-		cfg.BlobStoreDirectory,
-		"Dex blob storage directory",
-	)
 	flags.StringVar(
 		&cfg.AttributeStoreConfigPath,
 		"attribute-store-config",
 		"",
 		"Dex YAML file supplying attributeStore settings",
 	)
+	flags.StringVar(&cfg.BindAddress, "bind-address", cfg.BindAddress, "address for local services")
+	flags.StringVar(
+		&cfg.BlobStoreDirectory,
+		"blob-store-dir",
+		cfg.BlobStoreDirectory,
+		"Dex blob storage directory",
+	)
+	flags.IntVar(&cfg.DexPort, "dex-port", cfg.DexPort, "Dex gRPC port")
 	flags.BoolVar(&cfg.OpenBrowser, "open", false, "open Dex Web after startup")
+	flags.IntVar(&cfg.WebPort, "web-port", cfg.WebPort, "Dex Web port")
+	flags.StringVar(
+		&cfg.SQLiteDBFilename,
+		"sqlite-db-filename",
+		"",
+		"local SQLite file (default $HOME/.dex/dev/<port>/dex.sqlite.db)",
+	)
+	flags.StringVar(
+		&cfg.LogDirectory,
+		"server-log-folder",
+		"",
+		"keep server logs in this folder (default temp folder, deleted on exit)",
+	)
+	flags.StringVar(&cfg.ExternalTemporalAddress, "external-temporal-address", "", "external Temporal host:port")
+	flags.StringVar(
+		&cfg.TemporalNamespace,
+		"external-temporal-namespace",
+		cfg.TemporalNamespace,
+		"external Temporal namespace",
+	)
 	flags.Usage = func() {
 		fmt.Fprintln(output, "Usage: dexcli dev [flags]")
-		flags.PrintDefaults()
+		printFlags(output, flags, flagOrder)
 	}
 	if err := flags.Parse(args); err != nil {
 		return nil, err
@@ -124,7 +142,7 @@ func parseConfig(args []string, output io.Writer) (*Config, error) {
 	cfg.explicitLocalFlags = make(map[string]bool)
 	flags.Visit(func(item *flag.Flag) {
 		switch item.Name {
-		case "dex-port", "web-port", "temporal-port", "temporal-ui-port", "temporal-db-filename", "temporal-log-file":
+		case "dex-port", "web-port", "sqlite-db-filename", "server-log-folder", "external-temporal-namespace":
 			cfg.explicitLocalFlags[item.Name] = true
 		case "blob-store-dir":
 			cfg.blobStoreDirectoryDefault = false
@@ -183,8 +201,8 @@ func (c *Config) validate() error {
 	for name, port := range map[string]int{
 		"dex-port":         c.DexPort,
 		"web-port":         c.WebPort,
-		"temporal-port":    c.TemporalPort,
-		"temporal-ui-port": c.TemporalUIPort,
+		"Temporal port":    c.TemporalPort,
+		"Temporal UI port": c.TemporalUIPort,
 	} {
 		if port < 1 || port > 65535 {
 			return fmt.Errorf("%s must be between 1 and 65535", name)
@@ -193,23 +211,25 @@ func (c *Config) validate() error {
 	if c.TemporalNamespace == "" {
 		return fmt.Errorf("temporal namespace is required")
 	}
-	if c.TemporalAddress != "" {
-		if strings.Contains(c.TemporalAddress, "://") {
-			return fmt.Errorf("temporal address must be host:port, not a URL")
+	if c.ExternalTemporalAddress != "" {
+		if strings.Contains(c.ExternalTemporalAddress, "://") {
+			return fmt.Errorf("external Temporal address must be host:port, not a URL")
 		}
-		if _, _, err := net.SplitHostPort(c.TemporalAddress); err != nil {
-			return fmt.Errorf("temporal address must be host:port: %w", err)
+		if _, _, err := net.SplitHostPort(c.ExternalTemporalAddress); err != nil {
+			return fmt.Errorf("external Temporal address must be host:port: %w", err)
 		}
-		for _, name := range []string{"temporal-port", "temporal-ui-port", "temporal-db-filename", "temporal-log-file"} {
+		for _, name := range []string{"sqlite-db-filename"} {
 			if c.explicitLocalFlags[name] {
-				return fmt.Errorf("--%s cannot be used with --temporal-address", name)
+				return fmt.Errorf("--%s cannot be used with --external-temporal-address", name)
 			}
 		}
+	} else if c.explicitLocalFlags["external-temporal-namespace"] {
+		return fmt.Errorf("--external-temporal-namespace cannot be used without --external-temporal-address")
 	}
-	if c.TemporalLogFile != "" {
-		c.TemporalLogFile = strings.TrimSpace(c.TemporalLogFile)
-		if c.TemporalLogFile == "" {
-			return fmt.Errorf("temporal log file is required")
+	if c.explicitLocalFlags["server-log-folder"] {
+		c.LogDirectory = strings.TrimSpace(c.LogDirectory)
+		if c.LogDirectory == "" {
+			return fmt.Errorf("server log folder is required")
 		}
 	}
 	return validateDistinctAddresses(c.ownedAddresses())
@@ -220,7 +240,7 @@ func (c *Config) ownedAddresses() map[string]string {
 		"Dex Server": net.JoinHostPort(c.BindAddress, strconv.Itoa(c.DexPort)),
 		"Dex Web":    net.JoinHostPort(c.BindAddress, strconv.Itoa(c.WebPort)),
 	}
-	if c.TemporalAddress == "" {
+	if c.ExternalTemporalAddress == "" {
 		addresses["Temporal"] = net.JoinHostPort(c.BindAddress, strconv.Itoa(c.TemporalPort))
 		addresses["Temporal Web"] = net.JoinHostPort(c.BindAddress, strconv.Itoa(c.TemporalUIPort))
 	}
@@ -228,8 +248,8 @@ func (c *Config) ownedAddresses() map[string]string {
 }
 
 func (c *Config) temporalAddress() string {
-	if c.TemporalAddress != "" {
-		return c.TemporalAddress
+	if c.ExternalTemporalAddress != "" {
+		return c.ExternalTemporalAddress
 	}
 	return net.JoinHostPort(c.BindAddress, strconv.Itoa(c.TemporalPort))
 }
@@ -266,16 +286,24 @@ func (c *Config) isExplicit(flagName string) bool {
 	return c.explicitLocalFlags[flagName]
 }
 
-func (c *Config) autoTemporalDBFilename() string {
+func (c *Config) autoSQLiteDBFilename() string {
 	return filepath.Join(c.StateDirectory, "dev", strconv.Itoa(c.TemporalPort), localSQLiteFileName)
 }
 
 func (c *Config) adjacentBlobStoreDirectory() string {
-	return filepath.Join(filepath.Dir(c.TemporalDBFilename), localBlobStoreName)
+	return filepath.Join(filepath.Dir(c.SQLiteDBFilename), localBlobStoreName)
+}
+
+func (c *Config) dexServerLogPath() string {
+	return filepath.Join(c.LogDirectory, dexServerLogFileName)
+}
+
+func (c *Config) temporalEngineLogPath() string {
+	return filepath.Join(c.LogDirectory, temporalEngineLogFileName)
 }
 
 func (c *Config) writeTemporalStartupRecord(logs io.Writer) error {
-	database := c.temporalDBDirectory()
+	database := c.sqliteDBDirectory()
 	if database == "" {
 		database = "in-memory"
 	}
@@ -289,9 +317,32 @@ func (c *Config) writeTemporalStartupRecord(logs io.Writer) error {
 	return err
 }
 
-func (c *Config) temporalDBDirectory() string {
-	if c.TemporalDBFilename == "" {
+func (c *Config) sqliteDBDirectory() string {
+	if c.SQLiteDBFilename == "" {
 		return ""
 	}
-	return filepath.Dir(c.TemporalDBFilename)
+	return filepath.Dir(c.SQLiteDBFilename)
+}
+
+func printFlags(output io.Writer, flags *flag.FlagSet, names []string) {
+	for _, name := range names {
+		item := flags.Lookup(name)
+		if item == nil {
+			panic("missing flag " + name)
+		}
+		typeName, usage := flag.UnquoteUsage(item)
+		fmt.Fprintf(output, "  -%s", item.Name)
+		if typeName != "" {
+			fmt.Fprintf(output, " %s", typeName)
+		}
+		fmt.Fprintf(output, "\n        %s", usage)
+		if item.DefValue != "" && item.DefValue != "false" && item.DefValue != "0" {
+			if typeName == "string" {
+				fmt.Fprintf(output, " (default %q)", item.DefValue)
+			} else {
+				fmt.Fprintf(output, " (default %s)", item.DefValue)
+			}
+		}
+		fmt.Fprintln(output)
+	}
 }

--- a/cli/internal/dev/config_test.go
+++ b/cli/internal/dev/config_test.go
@@ -133,6 +133,36 @@ func TestHelpListsFlagsWithTemporalLast(t *testing.T) {
 			t.Fatalf("removed flag %s still documented:\n%s", name, text)
 		}
 	}
+	if !strings.Contains(text, "open Dex Web after startup (default true)") {
+		t.Fatalf("missing --open default in help:\n%s", text)
+	}
+}
+
+func TestOpenBrowserDefaultsTrue(t *testing.T) {
+	cfg, err := parseConfig(nil, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.OpenBrowser {
+		t.Fatal("expected --open to default true")
+	}
+}
+
+func TestOpenFalseDisablesBrowser(t *testing.T) {
+	cfg, err := parseConfig([]string{"--open=false"}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.OpenBrowser {
+		t.Fatal("expected --open=false to disable Dex Web")
+	}
+}
+
+func TestOpenFalseSeparateTokenIsRejected(t *testing.T) {
+	_, err := parseConfig([]string{"--open", "false"}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected --open false to fail")
+	}
 }
 
 func TestRemovedTemporalPortFlagsAreRejected(t *testing.T) {

--- a/cli/internal/dev/config_test.go
+++ b/cli/internal/dev/config_test.go
@@ -10,6 +10,8 @@ package dev
 
 import (
 	"bytes"
+	"errors"
+	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,24 +74,80 @@ func TestAttributeStoreConfigRequiresStore(t *testing.T) {
 	}
 }
 
-func TestTemporalLogFileFlag(t *testing.T) {
-	logFile := filepath.Join(t.TempDir(), "logs", "temporal.log")
-	cfg, err := parseConfig([]string{"--temporal-log-file", logFile}, &bytes.Buffer{})
+func TestServerLogFolderFlag(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "logs")
+	cfg, err := parseConfig([]string{"--server-log-folder", directory}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.TemporalLogFile != logFile {
-		t.Fatalf("unexpected Temporal log file: %q", cfg.TemporalLogFile)
+	if cfg.LogDirectory != directory {
+		t.Fatalf("unexpected server log folder: %q", cfg.LogDirectory)
 	}
 }
 
-func TestTemporalLogFileRejectedWithExternalAddress(t *testing.T) {
+func TestSQLiteDBFilenameRejectedWithExternalAddress(t *testing.T) {
 	_, err := parseConfig([]string{
-		"--temporal-address", "127.0.0.1:7233",
-		"--temporal-log-file", "temporal.log",
+		"--external-temporal-address", "127.0.0.1:7233",
+		"--sqlite-db-filename", "dex.sqlite.db",
 	}, &bytes.Buffer{})
 	if err == nil {
-		t.Fatal("expected --temporal-log-file to fail with --temporal-address")
+		t.Fatal("expected --sqlite-db-filename to fail with --external-temporal-address")
+	}
+}
+
+func TestExternalTemporalNamespaceRequiresAddress(t *testing.T) {
+	_, err := parseConfig([]string{"--external-temporal-namespace", "custom"}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected --external-temporal-namespace to fail without --external-temporal-address")
+	}
+}
+
+func TestHelpListsFlagsWithTemporalLast(t *testing.T) {
+	var output bytes.Buffer
+	_, err := parseConfig([]string{"-h"}, &output)
+	if err != nil && !errors.Is(err, flag.ErrHelp) {
+		t.Fatal(err)
+	}
+	text := output.String()
+	last := -1
+	for _, name := range flagOrder {
+		idx := strings.Index(text, "-"+name)
+		if idx < 0 {
+			t.Fatalf("missing flag %s in help:\n%s", name, text)
+		}
+		if idx < last {
+			t.Fatalf("flag %s is out of order in help:\n%s", name, text)
+		}
+		last = idx
+	}
+	for _, name := range []string{
+		"-temporal-port",
+		"-temporal-ui-port",
+		"-temporal-address",
+		"-temporal-db-filename",
+		"-temporal-namespace",
+		"-temporal-log-file",
+		"-log-dir",
+	} {
+		if strings.Contains(text, "  "+name+" ") || strings.Contains(text, "  "+name+"\n") {
+			t.Fatalf("removed flag %s still documented:\n%s", name, text)
+		}
+	}
+}
+
+func TestRemovedTemporalPortFlagsAreRejected(t *testing.T) {
+	for _, name := range []string{
+		"temporal-port",
+		"temporal-ui-port",
+		"temporal-address",
+		"temporal-db-filename",
+		"temporal-namespace",
+		"temporal-log-file",
+		"log-dir",
+	} {
+		if _, err := parseConfig([]string{"--" + name, "1"}, &bytes.Buffer{}); err == nil {
+			t.Fatalf("expected unknown flag %s to fail", name)
+		}
 	}
 }
 
@@ -97,7 +155,7 @@ func TestWriteTemporalStartupRecordIncludesPortsAndDatabase(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.TemporalPort = 7234
 	cfg.TemporalUIPort = 8234
-	cfg.TemporalDBFilename = filepath.Join(cfg.StateDirectory, "dev", "7234", localSQLiteFileName)
+	cfg.SQLiteDBFilename = filepath.Join(cfg.StateDirectory, "dev", "7234", localSQLiteFileName)
 	var output bytes.Buffer
 	if err := cfg.writeTemporalStartupRecord(&output); err != nil {
 		t.Fatal(err)

--- a/cli/internal/dev/helpers_test.go
+++ b/cli/internal/dev/helpers_test.go
@@ -17,5 +17,6 @@ func testConfig(t *testing.T) *Config {
 		t.Fatal(err)
 	}
 	cfg.StateDirectory = t.TempDir()
+	cfg.OpenBrowser = false
 	return cfg
 }

--- a/cli/internal/dev/ports_test.go
+++ b/cli/internal/dev/ports_test.go
@@ -43,8 +43,8 @@ func TestReserveOwnedListenersSkipsOccupiedPorts(t *testing.T) {
 	if cfg.DexPort == occupiedPort {
 		t.Fatalf("allocated occupied Dex port %d", occupiedPort)
 	}
-	if cfg.TemporalDBFilename != cfg.autoTemporalDBFilename() {
-		t.Fatalf("unexpected Temporal database: %q", cfg.TemporalDBFilename)
+	if cfg.SQLiteDBFilename != cfg.autoSQLiteDBFilename() {
+		t.Fatalf("unexpected Temporal database: %q", cfg.SQLiteDBFilename)
 	}
 }
 
@@ -74,8 +74,8 @@ func TestReserveOwnedListenersSkipsWildcardOccupiedPort(t *testing.T) {
 	if cfg.TemporalPort == occupiedPort {
 		t.Fatalf("allocated wildcard-occupied Temporal port %d", occupiedPort)
 	}
-	if cfg.TemporalDBFilename != filepath.Join(cfg.StateDirectory, "dev", strconv.Itoa(cfg.TemporalPort), localSQLiteFileName) {
-		t.Fatalf("unexpected Temporal database: %q", cfg.TemporalDBFilename)
+	if cfg.SQLiteDBFilename != filepath.Join(cfg.StateDirectory, "dev", strconv.Itoa(cfg.TemporalPort), localSQLiteFileName) {
+		t.Fatalf("unexpected Temporal database: %q", cfg.SQLiteDBFilename)
 	}
 }
 
@@ -101,7 +101,7 @@ func TestReserveOwnedListenersExplicitPortFailsWhenOccupied(t *testing.T) {
 
 func TestReserveOwnedListenersKeepsExplicitDatabase(t *testing.T) {
 	database := filepath.Join(t.TempDir(), "custom.db")
-	cfg, err := parseConfig([]string{"--temporal-db-filename", database}, &bytes.Buffer{})
+	cfg, err := parseConfig([]string{"--sqlite-db-filename", database}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,13 +115,13 @@ func TestReserveOwnedListenersKeepsExplicitDatabase(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	if cfg.TemporalDBFilename != database {
-		t.Fatalf("explicit Temporal database was replaced: %q", cfg.TemporalDBFilename)
+	if cfg.SQLiteDBFilename != database {
+		t.Fatalf("explicit Temporal database was replaced: %q", cfg.SQLiteDBFilename)
 	}
 }
 
 func TestReserveOwnedListenersExternalModeSkipsTemporalDatabase(t *testing.T) {
-	cfg, err := parseConfig([]string{"--temporal-address", "127.0.0.1:7233"}, &bytes.Buffer{})
+	cfg, err := parseConfig([]string{"--external-temporal-address", "127.0.0.1:7233"}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,8 +135,8 @@ func TestReserveOwnedListenersExternalModeSkipsTemporalDatabase(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	if cfg.TemporalDBFilename != "" {
-		t.Fatalf("external mode assigned a Temporal database: %q", cfg.TemporalDBFilename)
+	if cfg.SQLiteDBFilename != "" {
+		t.Fatalf("external mode assigned a Temporal database: %q", cfg.SQLiteDBFilename)
 	}
 }
 
@@ -175,12 +175,12 @@ func TestConcurrentReserveOwnedListenersUsesDistinctPortsAndDatabases(t *testing
 			}
 			ports[address] = i
 		}
-		if cfg.TemporalDBFilename == "" {
+		if cfg.SQLiteDBFilename == "" {
 			t.Fatalf("instance %d missing Temporal database", i)
 		}
-		if owner, exists := databases[cfg.TemporalDBFilename]; exists {
-			t.Fatalf("Temporal database %s reused by instances %d and %d", cfg.TemporalDBFilename, owner, i)
+		if owner, exists := databases[cfg.SQLiteDBFilename]; exists {
+			t.Fatalf("Temporal database %s reused by instances %d and %d", cfg.SQLiteDBFilename, owner, i)
 		}
-		databases[cfg.TemporalDBFilename] = i
+		databases[cfg.SQLiteDBFilename] = i
 	}
 }

--- a/cli/internal/dev/supervisor.go
+++ b/cli/internal/dev/supervisor.go
@@ -76,27 +76,27 @@ func (s *supervisor) Run(ctx context.Context) (runErr error) {
 	if err != nil {
 		return err
 	}
+	logDir, err := openServerLogDir(s.cfg)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		shouldRemove := logDir.isEphemeral && runErr == nil
+		if logDir.isEphemeral && runErr != nil {
+			runErr = fmt.Errorf("%w (server log folder %s)", runErr, logDir.directory)
+		}
+		runErr = errors.Join(runErr, logDir.Close(shouldRemove))
+	}()
 
 	startupCtx, cancelStartup := context.WithTimeout(ctx, s.cfg.StartupTimeout)
 	defer cancelStartup()
 	var temporal *temporalProcess
 	var temporalClient temporalclient.Client
-	if s.cfg.TemporalAddress == "" {
-		var temporalLogs io.Writer
-		logFile, err := openTemporalLogFile(s.cfg.TemporalLogFile)
-		if err != nil {
-			return err
-		}
-		if logFile != nil {
-			defer func() {
-				runErr = errors.Join(runErr, logFile.Close())
-			}()
-			temporalLogs = logFile
-		}
+	if s.cfg.ExternalTemporalAddress == "" {
 		if err := listeners.releaseTemporalPorts(); err != nil {
 			return err
 		}
-		temporal, temporalClient, err = s.startLocalTemporal(startupCtx, temporalLogs)
+		temporal, temporalClient, err = s.startLocalTemporal(startupCtx, logDir.engineLog)
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil
@@ -195,13 +195,10 @@ func (s *supervisor) startLocalTemporal(ctx context.Context, logs io.Writer) (*t
 	var lastErr error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if attempt > 0 {
-			if s.cfg.isExplicit("temporal-port") || s.cfg.isExplicit("temporal-ui-port") {
-				return nil, nil, lastErr
-			}
 			if err := rebindTemporalPorts(s.cfg); err != nil {
 				return nil, nil, err
 			}
-			if err := assignTemporalDBFilename(s.cfg); err != nil {
+			if err := assignSQLiteDBFilename(s.cfg); err != nil {
 				return nil, nil, err
 			}
 		}
@@ -234,7 +231,7 @@ func (s *supervisor) startLocalTemporal(ctx context.Context, logs io.Writer) (*t
 
 func (s *supervisor) prepareBlobStoreDirectory() (string, error) {
 	directory := s.cfg.BlobStoreDirectory
-	if s.cfg.TemporalDBFilename != "" && s.cfg.blobStoreDirectoryDefault {
+	if s.cfg.SQLiteDBFilename != "" && s.cfg.blobStoreDirectoryDefault {
 		directory = s.cfg.adjacentBlobStoreDirectory()
 	}
 	directory, err := filepath.Abs(directory)
@@ -259,9 +256,9 @@ func (s *supervisor) startDexRuntime(
 	}
 	dexConfig := &config.Config{
 		Log: config.Logger{
-			Stdout:   true,
-			Level:    "info",
-			Encoding: "console",
+			Level:      "info",
+			Encoding:   "console",
+			OutputFile: s.cfg.dexServerLogPath(),
 		},
 		Api: config.ApiConfig{Port: s.cfg.DexPort},
 		BlobStore: config.BlobStoreConfig{
@@ -329,40 +326,43 @@ func (s *supervisor) printReady(webURL string, dexAddress string, blobStoreDirec
 	fmt.Fprintln(s.stdout)
 	fmt.Fprintf(s.stdout, "Dex Web:       %s\n", webURL)
 	fmt.Fprintf(s.stdout, "Dex Server:    %s\n", dexAddress)
-	if s.cfg.TemporalDBFilename != "" {
-		fmt.Fprintf(s.stdout, "Local DB:      %s\n", s.cfg.TemporalDBFilename)
+	if s.cfg.SQLiteDBFilename != "" {
+		fmt.Fprintf(s.stdout, "Local DB:      %s\n", s.cfg.SQLiteDBFilename)
 	}
 	fmt.Fprintf(s.stdout, "Blob store:    %s\n", blobStoreDirectory)
+	if s.cfg.LogDirectory != "" {
+		fmt.Fprintf(s.stdout, "Server log folder: %s\n", s.cfg.LogDirectory)
+	}
 	fmt.Fprintln(s.stdout)
 	fmt.Fprintln(s.stdout, "Press Ctrl+C to stop.")
 }
 
 func reserveOwnedListeners(cfg *Config) (*ownedListeners, error) {
 	allocated := make(map[string]string)
-	dexListener, err := bindServicePort("Dex Server", "dex-port", cfg, &cfg.DexPort, allocated)
+	dexListener, err := bindServicePort("Dex Server", cfg.isExplicit("dex-port"), cfg, &cfg.DexPort, allocated)
 	if err != nil {
 		return nil, err
 	}
 	listeners := &ownedListeners{dex: dexListener}
-	webListener, err := bindServicePort("Dex Web", "web-port", cfg, &cfg.WebPort, allocated)
+	webListener, err := bindServicePort("Dex Web", cfg.isExplicit("web-port"), cfg, &cfg.WebPort, allocated)
 	if err != nil {
 		return nil, errors.Join(err, listeners.Close())
 	}
 	listeners.web = webListener
-	if cfg.TemporalAddress != "" {
+	if cfg.ExternalTemporalAddress != "" {
 		return listeners, nil
 	}
-	temporalListener, err := bindServicePort("Temporal", "temporal-port", cfg, &cfg.TemporalPort, allocated)
+	temporalListener, err := bindServicePort("Temporal", false, cfg, &cfg.TemporalPort, allocated)
 	if err != nil {
 		return nil, errors.Join(err, listeners.Close())
 	}
 	listeners.temporal = temporalListener
-	uiListener, err := bindServicePort("Temporal Web", "temporal-ui-port", cfg, &cfg.TemporalUIPort, allocated)
+	uiListener, err := bindServicePort("Temporal Web", false, cfg, &cfg.TemporalUIPort, allocated)
 	if err != nil {
 		return nil, errors.Join(err, listeners.Close())
 	}
 	listeners.temporalUI = uiListener
-	if err := assignTemporalDBFilename(cfg); err != nil {
+	if err := assignSQLiteDBFilename(cfg); err != nil {
 		return nil, errors.Join(err, listeners.Close())
 	}
 	return listeners, nil
@@ -379,11 +379,11 @@ func rebindTemporalPorts(cfg *Config) error {
 		net.JoinHostPort(cfg.BindAddress, strconv.Itoa(cfg.DexPort)): "Dex Server",
 		net.JoinHostPort(cfg.BindAddress, strconv.Itoa(cfg.WebPort)): "Dex Web",
 	}
-	temporalListener, err := bindServicePort("Temporal", "temporal-port", cfg, &cfg.TemporalPort, allocated)
+	temporalListener, err := bindServicePort("Temporal", false, cfg, &cfg.TemporalPort, allocated)
 	if err != nil {
 		return err
 	}
-	uiListener, err := bindServicePort("Temporal Web", "temporal-ui-port", cfg, &cfg.TemporalUIPort, allocated)
+	uiListener, err := bindServicePort("Temporal Web", false, cfg, &cfg.TemporalUIPort, allocated)
 	if err != nil {
 		return errors.Join(err, closeListener(temporalListener))
 	}
@@ -392,12 +392,11 @@ func rebindTemporalPorts(cfg *Config) error {
 
 func bindServicePort(
 	name string,
-	flagName string,
+	explicit bool,
 	cfg *Config,
 	port *int,
 	allocated map[string]string,
 ) (net.Listener, error) {
-	explicit := cfg.isExplicit(flagName)
 	for candidate := *port; candidate <= 65535; candidate++ {
 		address := net.JoinHostPort(cfg.BindAddress, strconv.Itoa(candidate))
 		if owner, exists := allocated[address]; exists {
@@ -426,18 +425,18 @@ func bindServicePort(
 	return nil, fmt.Errorf("cannot start %s: no available port from %d", name, *port)
 }
 
-func assignTemporalDBFilename(cfg *Config) error {
-	if cfg.TemporalAddress != "" || cfg.isExplicit("temporal-db-filename") {
+func assignSQLiteDBFilename(cfg *Config) error {
+	if cfg.ExternalTemporalAddress != "" || cfg.isExplicit("sqlite-db-filename") {
 		return nil
 	}
 	if cfg.StateDirectory == "" {
 		return fmt.Errorf("Dex state directory is required")
 	}
-	filename := cfg.autoTemporalDBFilename()
+	filename := cfg.autoSQLiteDBFilename()
 	if err := os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
 		return fmt.Errorf("create Temporal database directory: %w", err)
 	}
-	cfg.TemporalDBFilename = filename
+	cfg.SQLiteDBFilename = filename
 	return nil
 }
 

--- a/cli/internal/dev/supervisor_integ_test.go
+++ b/cli/internal/dev/supervisor_integ_test.go
@@ -38,11 +38,9 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 	cfg.TemporalUIPort = ports[1]
 	cfg.DexPort = ports[2]
 	cfg.WebPort = ports[3]
-	cfg.explicitLocalFlags["temporal-port"] = true
-	cfg.explicitLocalFlags["temporal-ui-port"] = true
 	cfg.explicitLocalFlags["dex-port"] = true
 	cfg.explicitLocalFlags["web-port"] = true
-	cfg.TemporalLogFile = filepath.Join(t.TempDir(), "temporal.log")
+	cfg.LogDirectory = t.TempDir()
 	output := &synchronizedBuffer{}
 	runCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -127,38 +125,44 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 	if strings.Contains(output.String(), "Temporal") ||
 		strings.Contains(output.String(), cfg.temporalAddress()) ||
 		strings.Contains(output.String(), ":"+strconv.Itoa(cfg.TemporalUIPort)) {
-		t.Fatalf("workflow backend endpoint leaked in output: %s", output.String())
+		t.Fatalf("workflow backend leaked in output: %s", output.String())
 	}
-	if !strings.Contains(output.String(), "Local DB:      "+cfg.TemporalDBFilename) {
+	if !strings.Contains(output.String(), "Local DB:      "+cfg.SQLiteDBFilename) {
 		t.Fatalf("missing Local DB path: %s", output.String())
 	}
 	if !strings.Contains(output.String(), "Blob store:    "+cfg.adjacentBlobStoreDirectory()) {
 		t.Fatalf("missing blob store path: %s", output.String())
 	}
-	logContents, err := os.ReadFile(cfg.TemporalLogFile)
+	if !strings.Contains(output.String(), "Server log folder: "+cfg.LogDirectory) {
+		t.Fatalf("missing server log folder: %s", output.String())
+	}
+	logContents, err := os.ReadFile(cfg.temporalEngineLogPath())
 	if err != nil {
-		t.Fatalf("read Temporal log file: %v", err)
+		t.Fatalf("read workflow engine log file: %v", err)
 	}
 	logText := string(logContents)
 	if !strings.Contains(logText, cfg.temporalAddress()) {
-		t.Fatalf("Temporal log missing gRPC address: %s", logText)
+		t.Fatalf("workflow engine log missing gRPC address: %s", logText)
 	}
 	if !strings.Contains(logText, strconv.Itoa(cfg.TemporalUIPort)) {
-		t.Fatalf("Temporal log missing Web port: %s", logText)
+		t.Fatalf("workflow engine log missing Web port: %s", logText)
 	}
-	if !strings.Contains(logText, cfg.temporalDBDirectory()) {
-		t.Fatalf("Temporal log missing DB directory: %s", logText)
+	if !strings.Contains(logText, cfg.sqliteDBDirectory()) {
+		t.Fatalf("workflow engine log missing DB directory: %s", logText)
 	}
-	if cfg.TemporalDBFilename == "" {
+	if _, err := os.Stat(cfg.dexServerLogPath()); err != nil {
+		t.Fatalf("Dex server log file missing: %v", err)
+	}
+	if cfg.SQLiteDBFilename == "" {
 		t.Fatal("missing Temporal database")
 	}
-	if _, err := os.Stat(cfg.TemporalDBFilename); err != nil {
+	if _, err := os.Stat(cfg.SQLiteDBFilename); err != nil {
 		t.Fatalf("Temporal database was not retained after shutdown: %v", err)
 	}
 	if _, err := os.Stat(cfg.adjacentBlobStoreDirectory()); err != nil {
 		t.Fatalf("blob store was not retained after shutdown: %v", err)
 	}
-	for _, port := range ports {
+	for _, port := range []int{cfg.DexPort, cfg.WebPort, cfg.TemporalPort, cfg.TemporalUIPort} {
 		listener, err := net.Listen("tcp", net.JoinHostPort(cfg.BindAddress, strconv.Itoa(port)))
 		if err != nil {
 			t.Fatalf("port %d was not released: %v", port, err)
@@ -174,8 +178,6 @@ func TestExternalTemporalRemainsRunning(t *testing.T) {
 	localConfig := testConfig(t)
 	localConfig.TemporalPort = ports[0]
 	localConfig.TemporalUIPort = ports[1]
-	localConfig.explicitLocalFlags["temporal-port"] = true
-	localConfig.explicitLocalFlags["temporal-ui-port"] = true
 	output := &synchronizedBuffer{}
 	temporal, err := startTemporalProcess(localConfig, nil)
 	if err != nil {
@@ -197,7 +199,7 @@ func TestExternalTemporalRemainsRunning(t *testing.T) {
 
 	externalConfig := testConfig(t)
 	externalConfig.BlobStoreDirectory = filepath.Join(t.TempDir(), "blobs")
-	externalConfig.TemporalAddress = localConfig.temporalAddress()
+	externalConfig.ExternalTemporalAddress = localConfig.temporalAddress()
 	externalConfig.DexPort = ports[2]
 	externalConfig.WebPort = ports[3]
 	externalConfig.explicitLocalFlags["dex-port"] = true
@@ -227,11 +229,15 @@ func TestExternalTemporalRemainsRunning(t *testing.T) {
 	}
 	temporalClient.Close()
 	cancelHealth()
-	if strings.Contains(output.String(), localConfig.temporalAddress()) {
-		t.Fatalf("external workflow backend endpoint leaked in output: %s", output.String())
+	if strings.Contains(output.String(), "Temporal") ||
+		strings.Contains(output.String(), localConfig.temporalAddress()) {
+		t.Fatalf("external workflow backend leaked in output: %s", output.String())
 	}
 	if strings.Contains(output.String(), "Local DB:") {
 		t.Fatalf("external mode printed Local DB: %s", output.String())
+	}
+	if !strings.Contains(output.String(), "Server log folder:") {
+		t.Fatalf("missing server log folder: %s", output.String())
 	}
 	if !strings.Contains(output.String(), "Blob store:") {
 		t.Fatalf("missing blob store path: %s", output.String())
@@ -261,6 +267,43 @@ func TestConcurrentLocalStacksUseDistinctPortsAndDatabases(t *testing.T) {
 
 	waitForReadyStack(t, output1, finished1)
 	waitForReadyStack(t, output2, finished2)
+	logDir1 := cfg1.LogDirectory
+	logDir2 := cfg2.LogDirectory
+	if logDir1 == "" || logDir1 == logDir2 {
+		cancel1()
+		cancel2()
+		t.Fatalf("stacks reused server log folders: %q vs %q", logDir1, logDir2)
+	}
+	if !strings.Contains(output1.String(), "Server log folder: "+logDir1) {
+		cancel1()
+		cancel2()
+		t.Fatalf("missing first server log folder: %s", output1.String())
+	}
+	if !strings.Contains(output2.String(), "Server log folder: "+logDir2) {
+		cancel1()
+		cancel2()
+		t.Fatalf("missing second server log folder: %s", output2.String())
+	}
+	if _, err := os.Stat(cfg1.temporalEngineLogPath()); err != nil {
+		cancel1()
+		cancel2()
+		t.Fatalf("first workflow engine log missing during run: %v", err)
+	}
+	if _, err := os.Stat(cfg2.temporalEngineLogPath()); err != nil {
+		cancel1()
+		cancel2()
+		t.Fatalf("second workflow engine log missing during run: %v", err)
+	}
+	if _, err := os.Stat(cfg1.dexServerLogPath()); err != nil {
+		cancel1()
+		cancel2()
+		t.Fatalf("first Dex server log missing during run: %v", err)
+	}
+	if _, err := os.Stat(cfg2.dexServerLogPath()); err != nil {
+		cancel1()
+		cancel2()
+		t.Fatalf("second Dex server log missing during run: %v", err)
+	}
 	if cfg1.DexPort == cfg2.DexPort ||
 		cfg1.WebPort == cfg2.WebPort ||
 		cfg1.TemporalPort == cfg2.TemporalPort ||
@@ -269,17 +312,17 @@ func TestConcurrentLocalStacksUseDistinctPortsAndDatabases(t *testing.T) {
 		cancel2()
 		t.Fatalf("stacks reused ports: %+v vs %+v", cfg1, cfg2)
 	}
-	if cfg1.TemporalDBFilename == "" || cfg1.TemporalDBFilename == cfg2.TemporalDBFilename {
+	if cfg1.SQLiteDBFilename == "" || cfg1.SQLiteDBFilename == cfg2.SQLiteDBFilename {
 		cancel1()
 		cancel2()
-		t.Fatalf("stacks reused Temporal databases: %q vs %q", cfg1.TemporalDBFilename, cfg2.TemporalDBFilename)
+		t.Fatalf("stacks reused Temporal databases: %q vs %q", cfg1.SQLiteDBFilename, cfg2.SQLiteDBFilename)
 	}
-	if _, err := os.Stat(cfg1.TemporalDBFilename); err != nil {
+	if _, err := os.Stat(cfg1.SQLiteDBFilename); err != nil {
 		cancel1()
 		cancel2()
 		t.Fatalf("first Temporal database missing: %v", err)
 	}
-	if _, err := os.Stat(cfg2.TemporalDBFilename); err != nil {
+	if _, err := os.Stat(cfg2.SQLiteDBFilename); err != nil {
 		cancel1()
 		cancel2()
 		t.Fatalf("second Temporal database missing: %v", err)
@@ -297,6 +340,12 @@ func TestConcurrentLocalStacksUseDistinctPortsAndDatabases(t *testing.T) {
 			t.Fatal("local stack did not stop")
 		}
 	}
+	if _, err := os.Stat(logDir1); !os.IsNotExist(err) {
+		t.Fatalf("ephemeral server log folder was kept: %s (%v)", logDir1, err)
+	}
+	if _, err := os.Stat(logDir2); !os.IsNotExist(err) {
+		t.Fatalf("ephemeral server log folder was kept: %s (%v)", logDir2, err)
+	}
 }
 
 func TestBlobStoreDirectorySelection(t *testing.T) {
@@ -306,7 +355,7 @@ func TestBlobStoreDirectorySelection(t *testing.T) {
 	explicitDirectory := filepath.Join(root, "explicit")
 	explicitConfig, err := parseConfig([]string{
 		"--blob-store-dir", explicitDirectory,
-		"--temporal-db-filename", filepath.Join(root, "ignored-temporal.db"),
+		"--sqlite-db-filename", filepath.Join(root, "ignored-temporal.db"),
 	}, output)
 	if err != nil {
 		t.Fatal(err)
@@ -320,7 +369,7 @@ func TestBlobStoreDirectorySelection(t *testing.T) {
 	}
 
 	databaseConfig := testConfig(t)
-	databaseConfig.TemporalDBFilename = filepath.Join(root, "temporal.db")
+	databaseConfig.SQLiteDBFilename = filepath.Join(root, "temporal.db")
 	directory, err = newSupervisor(databaseConfig, output, output).prepareBlobStoreDirectory()
 	if err != nil {
 		t.Fatal(err)

--- a/cli/internal/dev/supervisor_integ_test.go
+++ b/cli/internal/dev/supervisor_integ_test.go
@@ -173,7 +173,7 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 	}
 }
 
-func TestExternalTemporalRemainsRunning(t *testing.T) {
+func TestExternalWorkflowBackendRemainsRunning(t *testing.T) {
 	ports := freePorts(t, 4)
 	localConfig := testConfig(t)
 	localConfig.TemporalPort = ports[0]

--- a/cli/internal/dev/temporal_process.go
+++ b/cli/internal/dev/temporal_process.go
@@ -11,12 +11,14 @@
 package dev
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -44,8 +46,8 @@ func startTemporalProcess(cfg *Config, logs io.Writer) (*temporalProcess, error)
 	if cfg.TemporalNamespace != defaultTemporalNamespace {
 		arguments = append(arguments, "--namespace", cfg.TemporalNamespace)
 	}
-	if cfg.TemporalDBFilename != "" {
-		arguments = append(arguments, "--db-filename", cfg.TemporalDBFilename)
+	if cfg.SQLiteDBFilename != "" {
+		arguments = append(arguments, "--db-filename", cfg.SQLiteDBFilename)
 	}
 	if logs == nil {
 		logs = io.Discard
@@ -115,20 +117,52 @@ func (p *temporalProcess) Stop(timeout time.Duration) error {
 	}
 }
 
-func openTemporalLogFile(path string) (*os.File, error) {
-	if path == "" {
-		return nil, nil
+type serverLogDir struct {
+	directory   string
+	engineLog   *os.File
+	isEphemeral bool
+}
+
+func openServerLogDir(cfg *Config) (*serverLogDir, error) {
+	directory := strings.TrimSpace(cfg.LogDirectory)
+	isEphemeral := directory == ""
+	if isEphemeral {
+		created, err := os.MkdirTemp("", "dexcli-logs-*")
+		if err != nil {
+			return nil, fmt.Errorf("create server log directory: %w", err)
+		}
+		directory = created
+	} else {
+		absolute, err := filepath.Abs(directory)
+		if err != nil {
+			return nil, fmt.Errorf("resolve server log directory: %w", err)
+		}
+		if err := os.MkdirAll(absolute, 0o700); err != nil {
+			return nil, fmt.Errorf("create server log directory: %w", err)
+		}
+		directory = absolute
 	}
-	path, err := filepath.Abs(path)
+	cfg.LogDirectory = directory
+	logs := &serverLogDir{directory: directory, isEphemeral: isEphemeral}
+	if cfg.ExternalTemporalAddress != "" {
+		return logs, nil
+	}
+	file, err := os.OpenFile(cfg.temporalEngineLogPath(), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
-		return nil, fmt.Errorf("resolve Temporal log file: %w", err)
+		return nil, errors.Join(fmt.Errorf("open workflow engine log file: %w", err), logs.Close(isEphemeral))
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return nil, fmt.Errorf("create Temporal log directory: %w", err)
+	logs.engineLog = file
+	return logs, nil
+}
+
+func (d *serverLogDir) Close(shouldRemove bool) error {
+	var err error
+	if d.engineLog != nil {
+		err = d.engineLog.Close()
+		d.engineLog = nil
 	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("open Temporal log file: %w", err)
+	if shouldRemove {
+		err = errors.Join(err, os.RemoveAll(d.directory))
 	}
-	return file, nil
+	return err
 }

--- a/cli/internal/dev/temporal_process_test.go
+++ b/cli/internal/dev/temporal_process_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package dev
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEphemeralServerLogDirIsRemovedOnClose(t *testing.T) {
+	cfg := testConfig(t)
+	logDir, err := openServerLogDir(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !logDir.isEphemeral {
+		t.Fatal("expected ephemeral server log directory")
+	}
+	if cfg.LogDirectory != logDir.directory {
+		t.Fatalf("config directory %q does not match %q", cfg.LogDirectory, logDir.directory)
+	}
+	if _, err := os.Stat(cfg.temporalEngineLogPath()); err != nil {
+		t.Fatal(err)
+	}
+	if err := logDir.Close(true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(logDir.directory); !os.IsNotExist(err) {
+		t.Fatalf("ephemeral server log directory was kept: %v", err)
+	}
+}
+
+func TestExplicitServerLogDirIsKept(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "logs")
+	cfg := testConfig(t)
+	cfg.LogDirectory = directory
+	logDir, err := openServerLogDir(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if logDir.isEphemeral {
+		t.Fatal("explicit server log directory must not be ephemeral")
+	}
+	if err := logDir.Close(false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(directory); err != nil {
+		t.Fatalf("explicit server log directory was removed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, temporalEngineLogFileName)); err != nil {
+		t.Fatalf("workflow engine log file missing: %v", err)
+	}
+}
+
+func TestExternalTemporalSkipsEngineLogFile(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ExternalTemporalAddress = "127.0.0.1:7233"
+	logDir, err := openServerLogDir(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if logDir.engineLog != nil {
+		t.Fatal("external Temporal must not open a workflow engine log file")
+	}
+	if err := logDir.Close(true); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/docs/content/quick-start/index.mdx
+++ b/docs/content/quick-start/index.mdx
@@ -20,7 +20,7 @@ Use `@superdurable/dex` **^0.1.3+**. `waitFor`, `execute`, and RPC handlers may 
 ```bash
 brew install superdurable/tap/dexcli
 brew upgrade superdurable/tap/dexcli   # when you want the latest
-dexcli dev --open
+dexcli dev
 ```
 
 `dexcli` starts Dex Server, Dex Web, and the internal workflow backend. Defaults

--- a/docs/design/plan/dexcli.md
+++ b/docs/design/plan/dexcli.md
@@ -14,17 +14,12 @@ brew install dexcli
 dexcli dev
 ```
 
-`dexcli dev` 默认启动并管理 Dex Server、Dex Web 和内部 workflow backend。就绪输出只展示：
-
-```text
-Dex Server       127.0.0.1:8801
-Dex Web          http://127.0.0.1:8802
-```
+`dexcli dev` 默认启动并管理 Dex Server、Dex Web 和内部 workflow backend。就绪输出展示 Dex Web、Dex Server、Local DB、blob store 和 server log folder，不展示 Temporal endpoint。
 
 用户也可以连接已有 Temporal：
 
 ```bash
-dexcli dev --temporal-address localhost:7233
+dexcli dev --external-temporal-address localhost:7233
 ```
 
 此时不启动、不关闭 local Temporal；只管理 Dex Server 和 Dex Web。
@@ -267,8 +262,8 @@ Local `dexcli dev` 构造 typed `config.Config`，不生成临时 YAML：
 
 `--blob-store-dir` 指定持久目录；未指定时使用数据库文件同目录下的
 `dex.blobs`。local mode 未指定数据库时使用
-`$HOME/.dex/dev/<temporal-port>/dex.sqlite.db` 与
-`$HOME/.dex/dev/<temporal-port>/dex.blobs`。退出 `dexcli dev` 不会删除这些目录。显式
+`$HOME/.dex/dev/<port>/dex.sqlite.db` 与
+`$HOME/.dex/dev/<port>/dex.blobs`。退出 `dexcli dev` 不会删除这些目录。显式
 `--blob-store-dir` 优先于相邻的 `dex.blobs`。
 
 高级 server 配置继续由现有 server binary/YAML 提供，不把所有 production config 暴露成 `dexcli dev` flags。
@@ -281,17 +276,15 @@ dexcli dev [flags]
 --bind-address string          default 127.0.0.1
 --dex-port int                 default 8801
 --web-port int                 default 8802
---temporal-address string      non-empty selects external Temporal
---temporal-namespace string    default default
---temporal-port int            default 7233; local mode only
---temporal-ui-port int         default 8233; local mode only
---temporal-db-filename string  default $HOME/.dex/dev/<temporal-port>/dex.sqlite.db
---temporal-log-file string     write local Temporal server and Web logs to this file
---blob-store-dir string        persistent Dex blob storage directory (default $HOME/.dex/dev/<temporal-port>/dex.blobs)
+--blob-store-dir string        persistent Dex blob storage directory (default $HOME/.dex/blobs)
 --open                         open Dex Web after readiness
+--sqlite-db-filename string    default $HOME/.dex/dev/<port>/dex.sqlite.db
+--server-log-folder string     keep server logs (default temp folder, deleted on exit)
+--external-temporal-address string      non-empty selects external Temporal
+--external-temporal-namespace string    default default; external mode only
 ```
 
-`--temporal-address` 接受 `host:port`，不是 HTTP URL。设置后忽略 local Temporal port、UI port 和 DB flags，并为这些无效组合返回 `InvalidArgument` 风格 CLI error。
+`--external-temporal-address` 接受 `host:port`，不是 HTTP URL。设置后忽略 local SQLite flag，并为该无效组合返回 `InvalidArgument` 风格 CLI error。Local Temporal gRPC 与 Web 端口始终自动分配。
 
 第一阶段 external Temporal 支持 plaintext local/self-hosted endpoint。Temporal Cloud TLS/API key flags 后续单独设计，避免把 secret 放进 process arguments。
 
@@ -316,13 +309,13 @@ temporal server start-dev \
   --db-filename "$HOME/.dex/dev/7233/dex.sqlite.db"
 ```
 
-默认 namespace 已由 Temporal Dev Server 创建。只有用户传入非 `default` namespace 时才增加 namespace 参数。
+默认 namespace 已由 Temporal Dev Server 创建。Local mode 始终使用 `default`；只有 `--external-temporal-namespace` 才会覆盖 namespace。
 
 Process manager 必须：
 
-- 为每个 `dexcli dev` 进程分配互不冲突的 Dex、Dex Web、Temporal 和 Temporal UI 端口；未占用时使用默认值，已被占用且未显式指定时选择下一个空闲端口；
-- 为每个 local Temporal 使用独立 SQLite 文件（默认 `$HOME/.dex/dev/<temporal-port>/dex.sqlite.db`）；
-- `--temporal-log-file` 将 Temporal server 与 Web 的 stdout/stderr 写入指定文件，并记录实际 Temporal 端口和 SQLite 目录；默认丢弃这些日志，不向 `dexcli` 就绪输出泄露 Temporal endpoint；
+- 为每个 `dexcli dev` 进程分配互不冲突的 Dex、Dex Web、Temporal 和 Temporal UI 端口；未占用时使用默认值，Dex/Web 已被占用且未显式指定时选择下一个空闲端口，Local Temporal 端口始终自动分配；
+- 为每个 local Temporal 使用独立 SQLite 文件（默认 `$HOME/.dex/dev/<port>/dex.sqlite.db`）；
+- `--server-log-folder` 将 Dex Server 与 local workflow engine 日志写入同一目录；默认使用系统临时目录，就绪输出只打印 `Server log folder`，正常退出时删除；失败时保留并在错误中给出路径；
 - 启动前预占 Dex 与 Dex Web listeners，并确认 Temporal 端口可绑定；
 - 丢弃 backend 子进程 stdout/stderr，避免向普通启动输出泄露内部 endpoint；
 - 通过 Temporal API readiness 检查，不根据日志文本判断 ready；
@@ -381,11 +374,12 @@ Dex Web:       http://127.0.0.1:8802
 Dex Server:    127.0.0.1:8801
 Local DB:      $HOME/.dex/dev/7233/dex.sqlite.db
 Blob store:    $HOME/.dex/dev/7233/dex.blobs
+Server log folder: /tmp/dexcli-logs-123
 
 Press Ctrl+C to stop.
 ```
 
-Local mode 打印 SQLite 与 blob 路径，但不展示 Temporal 类型或 endpoint。External Temporal mode 省略 Local DB 行，仍打印 blob store，且不展示 backend 类型或 endpoint。
+Local mode 打印 SQLite、blob 与 server log folder，不展示 Temporal endpoint。External Temporal mode 省略 Local DB 行，仍打印 blob store 和 server log folder，且不展示 backend endpoint。
 
 错误必须指出 component 和修复方法，例如：
 
@@ -457,12 +451,12 @@ Temporal CLI was not found; reinstall dexcli with Homebrew
 
 - 默认 local mode 启动四个 endpoints，并能通过 Dex Web API 搜索一个实际 flow。
 - local Temporal 自动包含 `default` namespace 和 `FlowType=Keyword`。
-- `--temporal-db-filename` 重启后保留 Temporal executions。
+- `--sqlite-db-filename` 重启后保留 Temporal executions。
 - local blob backend 使用安全路径编码和 atomic rename。
 - 默认 `$HOME/.dex/blobs`、`--blob-store-dir` 或相邻的 `dex.blobs` 重启后保留 step inputs 和大 Value。
 - external mode 连接预先启动的 Temporal，不创建第二个 Temporal process。
 - 退出 external mode 后 external Temporal 仍然可用。
-- occupied 7233、8233、8801、8802 分别在部分启动前返回明确错误。
+- occupied 8801、8802 在显式指定且已被占用时返回明确错误；Local Temporal 端口被占用时自动选择下一个空闲端口。
 - Temporal child 非预期退出会停止 Dex runtime 和 Web server，并返回非零状态。
 - SIGINT/SIGTERM 后所有 owned ports 可立即被下一次启动复用。
 - 在 PATH 中没有 `node`/`npm` 时，release binary 仍可提供完整 Dex Web。
@@ -504,7 +498,7 @@ Temporal CLI was not found; reinstall dexcli with Homebrew
 
 1. `brew install dexcli` 是用户唯一的安装命令。
 2. `dexcli dev` 默认提供 Temporal、Temporal Web、Dex Server 和 Dex Web。
-3. `dexcli dev --temporal-address localhost:7233` 不启动或停止 local Temporal。
+3. `dexcli dev --external-temporal-address localhost:7233` 不启动或停止 local Temporal。
 4. Dex Web 默认运行在 `http://127.0.0.1:8802`。
 5. Release runtime 不依赖 Node.js，不存在 Next.js API server。
 6. `cli` import `web` Go module，不复制 Web API implementation。

--- a/docs/design/plan/dexcli.md
+++ b/docs/design/plan/dexcli.md
@@ -277,7 +277,7 @@ dexcli dev [flags]
 --dex-port int                 default 8801
 --web-port int                 default 8802
 --blob-store-dir string        persistent Dex blob storage directory (default $HOME/.dex/blobs)
---open                         open Dex Web after readiness
+--open                         open Dex Web after readiness (default true)
 --sqlite-db-filename string    default $HOME/.dex/dev/<port>/dex.sqlite.db
 --server-log-folder string     keep server logs (default temp folder, deleted on exit)
 --external-temporal-address string      non-empty selects external Temporal
@@ -487,7 +487,7 @@ Temporal CLI was not found; reinstall dexcli with Homebrew
 
 - Dex Web 的稳定默认入口是 `http://127.0.0.1:8802`。
 - `dexcli` 只在全部 services ready 后打印成功 banner。
-- `--open` 只打开 Dex Web，不自动打开 Temporal Web。
+- `dexcli dev` 默认打开 Dex Web，不自动打开 Temporal Web。使用 `--open=false` 跳过。
 - External Temporal 未提供 UI 地址时不显示猜测链接。
 - Browser API errors 使用当前页面内错误状态，不显示 Go/gRPC internal stack。
 - Local SYNC/ASYNC history、Step Graph、Timeline 和 Time Travel 的 UI 功能不得因静态 SPA 迁移减少。

--- a/examples/entity-store/README.md
+++ b/examples/entity-store/README.md
@@ -14,7 +14,7 @@ From this directory:
 docker compose up -d --wait
 dexcli dev \
   --attribute-store-config ./attribute-store.yaml \
-  --temporal-db-filename /tmp/dex-entity-store.db
+  --sqlite-db-filename /tmp/dex-entity-store.db
 ```
 
 Compose starts PostgreSQL 17 and creates `public.user_profiles` on

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -12,7 +12,7 @@ Start PostgreSQL and Dex, then build and run the examples:
 
 ```bash
 docker compose -f dataset-deal/docker-compose.yml up -d --wait
-dexcli dev --temporal-db-filename /tmp/dex-examples.db
+dexcli dev --sqlite-db-filename /tmp/dex-examples.db
 make bins
 ./dex-samples
 ```

--- a/examples/go/run-dataset-deal-demo.sh
+++ b/examples/go/run-dataset-deal-demo.sh
@@ -74,6 +74,7 @@ make bins
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$dex_web_port" \
+  -open=false \
   -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$dex_log" 2>&1 &
 dexcli_pid=$!

--- a/examples/go/run-dataset-deal-demo.sh
+++ b/examples/go/run-dataset-deal-demo.sh
@@ -27,8 +27,6 @@ dex_port="${DATASET_DEAL_DEX_PORT:-20801}"
 dex_web_port="${DATASET_DEAL_DEX_WEB_PORT:-20802}"
 worker_port="${DATASET_DEAL_WORKER_PORT:-20803}"
 api_port="${DATASET_DEAL_API_PORT:-20804}"
-temporal_port="${DATASET_DEAL_TEMPORAL_PORT:-20233}"
-temporal_ui_port="${DATASET_DEAL_TEMPORAL_UI_PORT:-20333}"
 dex_address="127.0.0.1:${dex_port}"
 api_address="127.0.0.1:${api_port}"
 postgres_url="postgres://dataset_deal:dataset_deal@127.0.0.1:${postgres_port}/dataset_deal?sslmode=disable"
@@ -76,9 +74,7 @@ make bins
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$dex_web_port" \
-  -temporal-port "$temporal_port" \
-  -temporal-ui-port "$temporal_ui_port" \
-  -temporal-db-filename "$test_dir/temporal.db" \
+  -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$dex_log" 2>&1 &
 dexcli_pid=$!
 
@@ -122,9 +118,8 @@ fi
 
 DATASET_DEAL_API_URL="http://${api_address}" ./trigger-dataset-deal-demo.sh
 
-echo "  Dex UI:  http://127.0.0.1:${dex_web_port}"
-echo "  Temporal: http://127.0.0.1:${temporal_ui_port}"
-echo "  logs:     ${dex_log}, ${app_log}"
+echo "  Dex UI: http://127.0.0.1:${dex_web_port}"
+echo "  logs:   ${dex_log}, ${app_log}"
 if [[ "${KEEP_DATASET_DEAL_DEMO:-0}" == "1" ]]; then
   echo "Services remain running. Press Ctrl+C to stop and clean up."
   wait "$app_pid"

--- a/examples/go/run-e2e-tests.sh
+++ b/examples/go/run-e2e-tests.sh
@@ -26,8 +26,6 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$script_dir/../.." && pwd)
 dex_port="${DEX_EXAMPLES_DEX_PORT:-19801}"
 web_port="${DEX_EXAMPLES_WEB_PORT:-19901}"
-temporal_port="${DEX_EXAMPLES_TEMPORAL_PORT:-19233}"
-temporal_ui_port="${DEX_EXAMPLES_TEMPORAL_UI_PORT:-19333}"
 postgres_port="${DEX_EXAMPLES_POSTGRES_PORT:-19432}"
 dex_address="127.0.0.1:${dex_port}"
 postgres_url="postgres://dataset_deal:dataset_deal@127.0.0.1:${postgres_port}/dataset_deal?sslmode=disable"
@@ -79,9 +77,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
-  -temporal-port "$temporal_port" \
-  -temporal-ui-port "$temporal_ui_port" \
-  -temporal-db-filename "$test_dir/temporal.db" \
+  -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 

--- a/examples/go/run-e2e-tests.sh
+++ b/examples/go/run-e2e-tests.sh
@@ -77,6 +77,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
+  -open=false \
   -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -9,7 +9,7 @@ Worker and Client.
 ## Run locally
 
 ```bash
-dexcli dev --temporal-db-filename /tmp/dex-examples.db
+dexcli dev --sqlite-db-filename /tmp/dex-examples.db
 ./gradlew bootRun
 ```
 

--- a/examples/java/run-integration-tests.sh
+++ b/examples/java/run-integration-tests.sh
@@ -20,8 +20,6 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$script_dir/../.." && pwd)
 dex_port="${DEX_JAVA_EXAMPLES_DEX_PORT:-19803}"
 web_port="${DEX_JAVA_EXAMPLES_WEB_PORT:-19903}"
-temporal_port="${DEX_JAVA_EXAMPLES_TEMPORAL_PORT:-19235}"
-temporal_ui_port="${DEX_JAVA_EXAMPLES_TEMPORAL_UI_PORT:-19335}"
 dex_address="127.0.0.1:${dex_port}"
 log_file="/tmp/test-java-examples-integration-services.log"
 test_dir=$(mktemp -d)
@@ -59,9 +57,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
-  -temporal-port "$temporal_port" \
-  -temporal-ui-port "$temporal_ui_port" \
-  -temporal-db-filename "$test_dir/temporal.db" \
+  -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 

--- a/examples/java/run-integration-tests.sh
+++ b/examples/java/run-integration-tests.sh
@@ -57,6 +57,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
+  -open=false \
   -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -17,7 +17,7 @@ For the sync `Client` / `Worker` surface (Flask, six Flows), see
 ## Run locally
 
 ```bash
-dexcli dev --temporal-db-filename /tmp/dex-examples-python.db
+dexcli dev --sqlite-db-filename /tmp/dex-examples-python.db
 uv sync --locked
 uv run --frozen python main.py
 ```

--- a/examples/python/run-e2e-tests.sh
+++ b/examples/python/run-e2e-tests.sh
@@ -42,6 +42,7 @@ make -C "$script_dir/../../cli" build
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
+  -open=false \
   -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!

--- a/examples/python/run-e2e-tests.sh
+++ b/examples/python/run-e2e-tests.sh
@@ -18,8 +18,6 @@ set -euo pipefail
 
 dex_port="${DEX_EXAMPLES_DEX_PORT:-19811}"
 web_port="${DEX_EXAMPLES_WEB_PORT:-19911}"
-temporal_port="${DEX_EXAMPLES_TEMPORAL_PORT:-19243}"
-temporal_ui_port="${DEX_EXAMPLES_TEMPORAL_UI_PORT:-19343}"
 dex_address="127.0.0.1:${dex_port}"
 log_file="/tmp/test-python-examples-e2e-services.log"
 test_log="/tmp/test-python-examples-e2e.log"
@@ -44,9 +42,7 @@ make -C "$script_dir/../../cli" build
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
-  -temporal-port "$temporal_port" \
-  -temporal-ui-port "$temporal_ui_port" \
-  -temporal-db-filename "$test_dir/temporal.db" \
+  -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 

--- a/examples/python/run-integ-tests.sh
+++ b/examples/python/run-integ-tests.sh
@@ -71,6 +71,7 @@ entity_store_started=true
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
+  -open=false \
   -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!

--- a/examples/python/run-integ-tests.sh
+++ b/examples/python/run-integ-tests.sh
@@ -22,8 +22,6 @@ entity_store_dir="$repo_root/examples/entity-store"
 compose_project="dex-python-examples-$$"
 dex_port="${DEX_EXAMPLES_DEX_PORT:-19802}"
 web_port="${DEX_EXAMPLES_WEB_PORT:-19902}"
-temporal_port="${DEX_EXAMPLES_TEMPORAL_PORT:-19234}"
-temporal_ui_port="${DEX_EXAMPLES_TEMPORAL_UI_PORT:-19334}"
 dex_address="127.0.0.1:${dex_port}"
 log_file="/tmp/test-python-examples-integ-services.log"
 test_dir=$(mktemp -d)
@@ -73,9 +71,7 @@ entity_store_started=true
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
-  -temporal-port "$temporal_port" \
-  -temporal-ui-port "$temporal_ui_port" \
-  -temporal-db-filename "$test_dir/temporal.db" \
+  -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 

--- a/examples/python/sync-python/README.md
+++ b/examples/python/sync-python/README.md
@@ -28,7 +28,7 @@ the async app on `8803` / `8080`).
 From `examples/python` (shared `uv` project):
 
 ```bash
-dexcli dev --temporal-db-filename /tmp/dex-examples-python.db
+dexcli dev --sqlite-db-filename /tmp/dex-examples-python.db
 # Indexed Attributes — same as the async README
 
 uv sync --locked

--- a/examples/rust/run-integration-tests.sh
+++ b/examples/rust/run-integration-tests.sh
@@ -20,8 +20,6 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$script_dir/../.." && pwd)
 dex_port="${DEX_RUST_EXAMPLES_DEX_PORT:-19804}"
 web_port="${DEX_RUST_EXAMPLES_WEB_PORT:-19904}"
-temporal_port="${DEX_RUST_EXAMPLES_TEMPORAL_PORT:-19236}"
-temporal_ui_port="${DEX_RUST_EXAMPLES_TEMPORAL_UI_PORT:-19336}"
 dex_address="127.0.0.1:${dex_port}"
 log_file="/tmp/test-rust-examples-integration-services.log"
 test_dir=$(mktemp -d)
@@ -59,9 +57,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
-  -temporal-port "$temporal_port" \
-  -temporal-ui-port "$temporal_ui_port" \
-  -temporal-db-filename "$test_dir/temporal.db" \
+  -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 

--- a/examples/rust/run-integration-tests.sh
+++ b/examples/rust/run-integration-tests.sh
@@ -57,6 +57,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
+  -open=false \
   -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -13,7 +13,7 @@ Controllers handle expected duplicate and missing-Flow failures through
 ## Run locally
 
 ```bash
-dexcli dev --temporal-db-filename /tmp/dex-examples.db
+dexcli dev --sqlite-db-filename /tmp/dex-examples.db
 cd examples/typescript
 npm install
 npm start

--- a/examples/typescript/run-integration-tests.sh
+++ b/examples/typescript/run-integration-tests.sh
@@ -71,6 +71,7 @@ entity_store_started=true
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
+  -open=false \
   -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!

--- a/examples/typescript/run-integration-tests.sh
+++ b/examples/typescript/run-integration-tests.sh
@@ -22,8 +22,6 @@ entity_store_dir="$repo_root/examples/entity-store"
 compose_project="dex-typescript-examples-$$"
 dex_port="${DEX_TYPESCRIPT_EXAMPLES_DEX_PORT:-19805}"
 web_port="${DEX_TYPESCRIPT_EXAMPLES_WEB_PORT:-19905}"
-temporal_port="${DEX_TYPESCRIPT_EXAMPLES_TEMPORAL_PORT:-19237}"
-temporal_ui_port="${DEX_TYPESCRIPT_EXAMPLES_TEMPORAL_UI_PORT:-19337}"
 dex_address="127.0.0.1:${dex_port}"
 log_file="/tmp/test-typescript-examples-integration-services.log"
 test_dir=$(mktemp -d)
@@ -73,9 +71,7 @@ entity_store_started=true
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
-  -temporal-port "$temporal_port" \
-  -temporal-ui-port "$temporal_ui_port" \
-  -temporal-db-filename "$test_dir/temporal.db" \
+  -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 

--- a/sdk-go/run-e2e-tests.sh
+++ b/sdk-go/run-e2e-tests.sh
@@ -35,8 +35,6 @@ cd "$script_dir"
 
 dex_port="${DEX_INTEG_DEX_PORT:-$(available_port)}"
 web_port="${DEX_INTEG_WEB_PORT:-$(available_port)}"
-temporal_port="${DEX_INTEG_TEMPORAL_PORT:-$(available_port)}"
-temporal_ui_port="${DEX_INTEG_TEMPORAL_UI_PORT:-$(available_port)}"
 dex_address="127.0.0.1:${dex_port}"
 log_file="/tmp/test-go-sdk-phase5-e2e-services.log"
 test_dir=$(mktemp -d)
@@ -86,9 +84,7 @@ make -C ../cli build
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
-  -temporal-port "$temporal_port" \
-  -temporal-ui-port "$temporal_ui_port" \
-  -temporal-db-filename "$test_dir/temporal.db" \
+  -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 

--- a/sdk-go/run-e2e-tests.sh
+++ b/sdk-go/run-e2e-tests.sh
@@ -84,6 +84,7 @@ make -C ../cli build
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
+  -open=false \
   -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!

--- a/sdk-java/run-integration-tests.sh
+++ b/sdk-java/run-integration-tests.sh
@@ -94,6 +94,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
+  -open=false \
   -external-temporal-address "$temporal_address" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!

--- a/sdk-java/run-integration-tests.sh
+++ b/sdk-java/run-integration-tests.sh
@@ -94,7 +94,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
-  -temporal-address "$temporal_address" \
+  -external-temporal-address "$temporal_address" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 

--- a/sdk-python/run-integration-tests.sh
+++ b/sdk-python/run-integration-tests.sh
@@ -69,6 +69,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
+  -open=false \
   -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!

--- a/sdk-python/run-integration-tests.sh
+++ b/sdk-python/run-integration-tests.sh
@@ -32,8 +32,6 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$script_dir/.." && pwd)
 dex_port="${DEX_INTEG_DEX_PORT:-18802}"
 web_port="${DEX_INTEG_WEB_PORT:-18902}"
-temporal_port="${DEX_INTEG_TEMPORAL_PORT:-17234}"
-temporal_ui_port="${DEX_INTEG_TEMPORAL_UI_PORT:-18234}"
 dex_address="127.0.0.1:${dex_port}"
 log_file="/tmp/test-python-sdk-integration-services.log"
 test_dir=$(mktemp -d)
@@ -71,9 +69,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
-  -temporal-port "$temporal_port" \
-  -temporal-ui-port "$temporal_ui_port" \
-  -temporal-db-filename "$test_dir/temporal.db" \
+  -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 

--- a/sdk-rust/run-integration-tests.sh
+++ b/sdk-rust/run-integration-tests.sh
@@ -61,6 +61,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
+  -open=false \
   -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!

--- a/sdk-rust/run-integration-tests.sh
+++ b/sdk-rust/run-integration-tests.sh
@@ -24,8 +24,6 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$script_dir/.." && pwd)
 dex_port="${DEX_INTEG_DEX_PORT:-18821}"
 web_port="${DEX_INTEG_WEB_PORT:-18921}"
-temporal_port="${DEX_INTEG_TEMPORAL_PORT:-17253}"
-temporal_ui_port="${DEX_INTEG_TEMPORAL_UI_PORT:-18253}"
 dex_address="127.0.0.1:${dex_port}"
 log_file="/tmp/test-rust-sdk-integration-services.log"
 test_dir=$(mktemp -d)
@@ -63,9 +61,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
-  -temporal-port "$temporal_port" \
-  -temporal-ui-port "$temporal_ui_port" \
-  -temporal-db-filename "$test_dir/temporal.db" \
+  -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 

--- a/sdk-typescript/run-integration-tests.sh
+++ b/sdk-typescript/run-integration-tests.sh
@@ -76,6 +76,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
+  -open=false \
   -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!

--- a/sdk-typescript/run-integration-tests.sh
+++ b/sdk-typescript/run-integration-tests.sh
@@ -28,8 +28,6 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$script_dir/.." && pwd)
 dex_port="${DEX_INTEG_DEX_PORT:-$(available_port)}"
 web_port="${DEX_INTEG_WEB_PORT:-$(available_port)}"
-temporal_port="${DEX_INTEG_TEMPORAL_PORT:-$(available_port)}"
-temporal_ui_port="${DEX_INTEG_TEMPORAL_UI_PORT:-$(available_port)}"
 dex_address="127.0.0.1:${dex_port}"
 log_file="/tmp/test-typescript-sdk-integration-services.log"
 test_dir=$(mktemp -d)
@@ -78,9 +76,7 @@ fi
   -bind-address 127.0.0.1 \
   -dex-port "$dex_port" \
   -web-port "$web_port" \
-  -temporal-port "$temporal_port" \
-  -temporal-ui-port "$temporal_ui_port" \
-  -temporal-db-filename "$test_dir/temporal.db" \
+  -sqlite-db-filename "$test_dir/temporal.db" \
   >>"$log_file" 2>&1 &
 dexcli_pid=$!
 

--- a/web/app/flows/FlowSearchPage.tsx
+++ b/web/app/flows/FlowSearchPage.tsx
@@ -481,6 +481,17 @@ export function FlowSearchPage() {
               <span>⌁</span>
               <h3>No flows found</h3>
               <p>Adjust the query or clear filters to search all visible executions.</p>
+              <p>
+                Getting started? Try the{' '}
+                <a
+                  href="https://github.com/superdurable/dex/tree/main/examples"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Dex examples
+                </a>
+                .
+              </p>
             </div>
           )}
           {loading && <div className="table-loading">Loading flows…</div>}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -716,6 +716,16 @@ pre {
   margin-bottom: 0;
 }
 
+.empty-state p + p {
+  margin-top: 8px;
+}
+
+.empty-state a {
+  color: var(--brand);
+  font-weight: 650;
+  text-decoration: underline;
+}
+
 .breadcrumbs {
   display: flex;
   gap: 7px;


### PR DESCRIPTION
## Summary
- Replace Temporal-facing `dexcli dev` flags with a smaller surface: `--sqlite-db-filename`, `--server-log-folder`, `--external-temporal-address`, and `--external-temporal-namespace`.
- Auto-assign local Temporal bind ports instead of exposing `--temporal-port` / `--temporal-ui-port`, and keep Dex Server plus workflow-engine logs in one folder printed as `Server log folder` on readiness.
- Update CLI docs, example scripts, and SDK test scripts to match the new flags.

## Test plan
- [ ] `make -C cli test`
- [ ] `make -C cli build && ./cli/dexcli dev -h`
- [ ] `./cli/dexcli dev` and confirm the ready banner prints Dex Web, Dex Server, Local DB, Blob store, and Server log folder (no Temporal wording)
- [ ] `./cli/dexcli dev --server-log-folder ./dex-logs` and confirm `dex-server.log` is written there; local stacks also write `temporal-engine-server.log` in the same folder
- [ ] Confirm `--sqlite-db-filename` is rejected with `--external-temporal-address`, and `--external-temporal-namespace` requires `--external-temporal-address`


Made with [Cursor](https://cursor.com)