### PR TITLE
Forbid Cursor co-author trailers on git commits

### DIFF
--- a/.cursor/rules/git-commit.mdc
+++ b/.cursor/rules/git-commit.mdc
@@ -1,0 +1,18 @@
+---
+description: Never add Cursor as a git commit co-author
+alwaysApply: true
+---
+
+# Git Commits — No Cursor Co-Author
+
+Never add Cursor (or any Cursor agent identity) as a git commit co-author.
+
+Do not include any of these trailers in commit messages:
+
+- `Co-authored-by: Cursor <...>`
+- `Co-authored-by: Cursor Agent <...>`
+- `Co-authored-by: cursoragent@cursor.com`
+- any other `Co-authored-by` line that names Cursor, Cursor Agent, or cursoragent
+
+Write the commit as the user only. Do not add `Made-with: Cursor` or similar
+Cursor attribution trailers either.


### PR DESCRIPTION
## Summary
- Add an always-on Cursor agent rule that forbids Cursor (or Cursor Agent) `Co-authored-by` trailers on git commits.
- Also forbid Cursor attribution trailers such as `Made-with: Cursor`.

## Test plan
- [ ] Confirm `.cursor/rules/git-commit.mdc` is always applied.
- [ ] On the next agent commit, verify the message has no Cursor `Co-authored-by` trailer.


Made with [Cursor](https://cursor.com)