### PR TITLE
Place SubFlow nodes beside their parent in the Step graph

### DIFF
--- a/web/app/flows/CurrentRunRedirect.tsx
+++ b/web/app/flows/CurrentRunRedirect.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { readResponseJSON } from '@/lib/http';
 import type { FlowSummary } from '@/lib/types';
 
 export function CurrentRunRedirect({ flowId }: { flowId: string }) {
@@ -20,8 +21,7 @@ export function CurrentRunRedirect({ flowId }: { flowId: string }) {
       signal: controller.signal,
     })
       .then(async (response) => {
-        const data = await response.json() as FlowSummary & { error?: string };
-        if (!response.ok) throw new Error(data.error || 'Flow lookup failed');
+        const data = await readResponseJSON<FlowSummary>(response);
         navigate(`/flows/${encodeURIComponent(flowId)}/${encodeURIComponent(data.runId)}`, {
           replace: true,
         });

--- a/web/app/flows/FlowSearchPage.tsx
+++ b/web/app/flows/FlowSearchPage.tsx
@@ -15,6 +15,7 @@ import {
   type BasicFilter,
   type QueryOperator,
 } from '@/lib/query';
+import { readResponseJSON } from '@/lib/http';
 import type { FlowExecution, SearchFlowsResult } from '@/lib/types';
 import { StatusBadge } from '../components/StatusBadge';
 import { usePreferences } from '../providers';
@@ -131,8 +132,7 @@ export function FlowSearchPage() {
           nextPageToken: requestedToken,
         }),
       });
-      const data = await response.json() as SearchFlowsResult & { error?: string };
-      if (!response.ok) throw new Error(data.error || 'Search failed');
+      const data = await readResponseJSON<SearchFlowsResult>(response);
       setFlows(data.flows);
       setNextPageToken(data.nextPageToken);
       setPage(requestedPage);

--- a/web/app/flows/RunDetailsPage.tsx
+++ b/web/app/flows/RunDetailsPage.tsx
@@ -15,6 +15,7 @@ import type {
 } from 'react';
 import { formatDate, formatDuration } from '@/lib/format';
 import { hydrateBlobs } from '@/lib/blobs';
+import { readResponseJSON } from '@/lib/http';
 import { VALUE_BLOB_UNAVAILABLE } from '@/lib/unavailable';
 import type {
   FlowHistoryEvent,
@@ -73,12 +74,6 @@ function selectedEventConnectorTone(event: FlowHistoryEvent): SelectedEventConne
   if (event.type.startsWith('StepWaitFor')) return 'wait-for';
   if (event.type.startsWith('StepExecute')) return 'execute';
   return 'default';
-}
-
-async function responseJSON<T>(response: Response): Promise<T> {
-  const data = await response.json() as T & { error?: string };
-  if (!response.ok) throw new Error(data.error || `Request failed (${response.status})`);
-  return data;
 }
 
 export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: string }) {
@@ -168,7 +163,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
       return;
     }
     try {
-      const rawState = await responseJSON<FlowState>(await fetch(stateURL, { cache: 'no-store' }));
+      const rawState = await readResponseJSON<FlowState>(await fetch(stateURL, { cache: 'no-store' }));
       setState(rawState);
       const hydrated = await hydrateBlobs(rawState, blobCache.current);
       setState(hydrated.value);
@@ -195,7 +190,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
   }, [addDataWarning]);
 
   const loadSummary = useCallback(async () => {
-    const value = await responseJSON<FlowSummary>(await fetch(summaryURL, { cache: 'no-store' }));
+    const value = await readResponseJSON<FlowSummary>(await fetch(summaryURL, { cache: 'no-store' }));
     setSummary(value);
     return value;
   }, [summaryURL]);
@@ -212,7 +207,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
       estimatePageSize: '200',
     });
     if (token) params.set('nextPageToken', token);
-    const page = await responseJSON<HistoryPage>(
+    const page = await readResponseJSON<HistoryPage>(
       await fetch(`/api/flows/history?${params}`, { cache: 'no-store' }),
     );
     setHistory((current) => {
@@ -285,7 +280,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
           setWaitCycle((current) => current + 1);
           return;
         }
-        await responseJSON(response);
+        await readResponseJSON(response);
         const latestSummary = await loadSummary();
         await Promise.all([
           loadHistoryPage('', nextInternalEventId, true),

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -436,13 +436,15 @@ export function StepGraph({
     <div className="graph-view">
       <div className="view-toolbar">
         <div>
-          <p className="eyebrow">Business topology</p>
           <h2>Step graph</h2>
         </div>
         <div className="graph-legend">
-          {['Active', 'Waiting', 'Pending', 'Completed', 'Failed', 'Canceled'].map((status) => (
-            <span key={status}><i className={`legend-${status.toLowerCase()}`} />{status}</span>
-          ))}
+          <span><i className="legend-source" />Source</span>
+          <span><i className="legend-active" />Active</span>
+          <span><i className="legend-waiting" />Waiting</span>
+          <span><i className="legend-pending" />Pending</span>
+          <span><i className="legend-failed" />Failed</span>
+          <span><i className="legend-canceled" />Canceled</span>
           <span><i className="legend-subflow" />SubFlow</span>
         </div>
       </div>

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -13,11 +13,15 @@ import { Link } from 'react-router-dom';
 import {
   Background,
   Controls,
+  Handle,
   MarkerType,
   MiniMap,
+  Position,
   ReactFlow,
   type Edge,
   type Node,
+  type NodeProps,
+  type NodeTypes,
   type ReactFlowInstance,
 } from '@xyflow/react';
 import { buildStepGraph, stepGraphSelection } from '@/lib/graph';
@@ -32,6 +36,7 @@ import {
 interface StepNodeData extends Record<string, unknown> {
   label: React.ReactNode;
   model: StepGraphNode;
+  hasSubFlowChildren?: boolean;
 }
 
 type MethodStatus = 'Started' | 'Waiting' | 'Running' | 'Pending' | 'Completed' | 'Failed' | 'Canceled' | 'Not started';
@@ -232,12 +237,67 @@ function SubFlowNodeLabel({ flow }: { flow: StepGraphNode }) {
   );
 }
 
+function GraphNode({ data }: NodeProps<Node<StepNodeData>>) {
+  const { model } = data;
+  return (
+    <div className="graph-node-root">
+      {model.kind === 'step' && (
+        <Handle id="topology" position={Position.Top} type="target" />
+      )}
+      <div className="graph-node-body">{data.label}</div>
+      {(model.kind === 'source' || model.kind === 'step') && (
+        <Handle id="topology" position={Position.Bottom} type="source" />
+      )}
+      {model.kind === 'step' && data.hasSubFlowChildren === true && (
+        <Handle
+          className="graph-subflow-handle"
+          id="subflow"
+          position={Position.Right}
+          type="source"
+        />
+      )}
+      {model.kind === 'subflow' && (
+        <Handle
+          className="graph-subflow-handle"
+          id="subflow"
+          position={Position.Left}
+          type="target"
+        />
+      )}
+    </div>
+  );
+}
+
+const graphNodeTypes: NodeTypes = { graph: GraphNode };
+
 function graphNodeDimensions(node: StepGraphNode): { height: number; width: number } {
   if (node.kind !== 'step') return { height: 90, width: 220 };
   return {
     height: node.execute && !node.waitFor && !node.pendingWaitFor ? 126 : 158,
     width: 300,
   };
+}
+
+function nodeHandles(
+  node: StepGraphNode,
+  dimensions: { height: number; width: number },
+  hasSubFlowChildren: boolean,
+): Node['handles'] {
+  const box = { x: 0, y: 0, width: dimensions.width, height: dimensions.height };
+  if (node.kind === 'subflow') {
+    return [{ ...box, id: 'subflow', type: 'target', position: Position.Left }];
+  }
+  if (node.kind === 'source') {
+    return [{ ...box, id: 'topology', type: 'source', position: Position.Bottom }];
+  }
+  const handles: NonNullable<Node['handles']> = [
+    { ...box, id: 'topology', type: 'target', position: Position.Top },
+    { ...box, id: 'topology', type: 'source', position: Position.Bottom },
+  ];
+  if (hasSubFlowChildren) {
+    handles.push({ ...box, id: 'subflow', type: 'source', position: Position.Right });
+  }
+  return handles;
 }
 
 export function StepGraph({
@@ -265,24 +325,46 @@ export function StepGraph({
     () => stepGraphSelection(graph.nodes, graph.edges, selectedEvent),
     [graph.edges, graph.nodes, selectedEvent],
   );
+  const nodeByID = useMemo(
+    () => new Map(graph.nodes.map((node) => [node.id, node])),
+    [graph.nodes],
+  );
+  const subFlowParentIDs = useMemo(
+    () => new Set(
+      graph.nodes
+        .filter((node) => node.kind === 'subflow')
+        .map((node) => node.parentStepId),
+    ),
+    [graph.nodes],
+  );
   const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => {
     const isIncoming = selection.incomingEdgeIDs.has(edge.id);
     const isOutgoing = selection.outgoingEdgeIDs.has(edge.id);
+    const isSubFlow = nodeByID.get(edge.target)?.kind === 'subflow';
     const color = isIncoming ? previousStepColor : isOutgoing ? nextStepColor : graphEdgeColor;
     return {
       ...edge,
-      className: isIncoming ? 'graph-edge-incoming' : isOutgoing ? 'graph-edge-outgoing' : undefined,
+      className: isSubFlow
+        ? 'graph-edge-subflow'
+        : isIncoming ? 'graph-edge-incoming' : isOutgoing ? 'graph-edge-outgoing' : undefined,
       type: 'smoothstep',
+      sourceHandle: isSubFlow ? 'subflow' : 'topology',
+      targetHandle: isSubFlow ? 'subflow' : 'topology',
       markerEnd: { type: MarkerType.ArrowClosed, width: 18, height: 18, color },
-      style: { stroke: color, strokeWidth: isIncoming || isOutgoing ? 3 : 1.5 },
+      style: {
+        stroke: color,
+        strokeWidth: isIncoming || isOutgoing ? 3 : 1.5,
+        strokeDasharray: isSubFlow ? '6 4' : undefined,
+      },
       zIndex: isIncoming || isOutgoing ? 2 : 0,
     };
-  }), [graph.edges, selection]);
+  }), [graph.edges, nodeByID, selection]);
   const nodes = useMemo(() => {
     const raw: Array<Node<StepNodeData>> = graph.nodes.map((node) => {
       const dimensions = graphNodeDimensions(node);
       return {
         id: node.id,
+        type: 'graph',
         position: { x: 0, y: 0 },
         className: [
           'step-flow-node',
@@ -295,8 +377,10 @@ export function StepGraph({
         width: dimensions.width,
         height: dimensions.height,
         style: dimensions,
+        handles: nodeHandles(node, dimensions, subFlowParentIDs.has(node.id)),
         data: {
           model: node,
+          hasSubFlowChildren: subFlowParentIDs.has(node.id),
           label: node.kind === 'step' ? (
             <StepNodeLabel node={node} onSelect={onSelectEvent} />
           ) : node.kind === 'subflow' ? (
@@ -324,7 +408,7 @@ export function StepGraph({
       };
     });
     return layoutGraph(raw, edges);
-  }, [edges, graph.nodes, onSelectEvent, selection]);
+  }, [edges, flowId, graph.nodes, onSelectEvent, selection, subFlowParentIDs]);
   const bounds = useMemo(() => graphBounds(nodes), [nodes]);
   const initialZoom = defaultGraphZoom(bounds.width, canvasWidth);
 
@@ -370,9 +454,11 @@ export function StepGraph({
         <ReactFlow
           nodes={nodes}
           edges={edges}
+          nodeTypes={graphNodeTypes}
           minZoom={minimumGraphZoom}
           maxZoom={2}
           elementsSelectable={false}
+          nodesConnectable={false}
           nodesDraggable={false}
           preventScrolling={false}
           zoomOnScroll={false}

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -440,9 +440,8 @@ export function StepGraph({
         </div>
         <div className="graph-legend">
           <span><i className="legend-source" />Source</span>
-          <span><i className="legend-active" />Active</span>
+          <span><i className="legend-active" />Active / Pending</span>
           <span><i className="legend-waiting" />Waiting</span>
-          <span><i className="legend-pending" />Pending</span>
           <span><i className="legend-failed" />Failed</span>
           <span><i className="legend-canceled" />Canceled</span>
           <span><i className="legend-subflow" />SubFlow</span>

--- a/web/app/flows/details/StopFlowDialog.tsx
+++ b/web/app/flows/details/StopFlowDialog.tsx
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import { useState } from 'react';
+import { readResponseJSON } from '@/lib/http';
 import type { FlowSummary } from '@/lib/types';
 
 const stopTypes = [
@@ -50,8 +51,7 @@ export function StopFlowDialog({
           reason,
         }),
       });
-      const data = await response.json() as { error?: string };
-      if (!response.ok) throw new Error(data.error || 'Stop failed');
+      await readResponseJSON(response);
       onStopped();
       onClose();
     } catch (stopError) {

--- a/web/app/flows/details/TimeTravelDialog.tsx
+++ b/web/app/flows/details/TimeTravelDialog.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { readResponseJSON } from '@/lib/http';
 import {
   eventTimeTravelTarget,
   TIME_TRAVEL_STEP_METHOD,
@@ -87,8 +88,7 @@ export function TimeTravelDialog({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
-      const data = await response.json() as { runId?: string; error?: string };
-      if (!response.ok) throw new Error(data.error || 'Time travel failed');
+      const data = await readResponseJSON<{ runId?: string }>(response);
       navigate(`/flows/${encodeURIComponent(summary.flowId)}/${encodeURIComponent(data.runId || '')}`);
       onClose();
     } catch (timeTravelError) {

--- a/web/app/flows/details/graphLayout.test.ts
+++ b/web/app/flows/details/graphLayout.test.ts
@@ -24,6 +24,21 @@ function testNode(id: string): Node<Record<string, unknown>> {
   };
 }
 
+function layoutNode(
+  id: string,
+  kind: string,
+  width: number,
+  height: number,
+  parentStepId?: string,
+): Node<Record<string, unknown>> {
+  return {
+    id,
+    data: { model: { kind, parentStepId } },
+    position: { x: 0, y: 0 },
+    style: { height, width },
+  };
+}
+
 describe('step graph layout', () => {
   it('keeps a 90-execution fan-out and fan-in flow vertically readable', () => {
     const nodes: Array<Node<Record<string, unknown>>> = [testNode('start')];
@@ -70,6 +85,33 @@ describe('step graph layout', () => {
     expect(parallelRows.size).toBe(1);
     expect(defaultGraphZoom(bounds.width, 1_200)).toBe(minimumGraphZoom);
     expect(defaultGraphZoom(bounds.width, 1_800)).toBeGreaterThan(minimumGraphZoom);
+  });
+
+  it('places SubFlow nodes beside their parent instead of in the next Step rank', () => {
+    const nodes: Array<Node<Record<string, unknown>>> = [
+      layoutNode('__start__', 'source', 220, 90),
+      layoutNode('Parent-1', 'step', 300, 158),
+      layoutNode('Next-1', 'step', 300, 158),
+      layoutNode('__subflow:Parent-1:0', 'subflow', 220, 90, 'Parent-1'),
+    ];
+    const edges: Edge[] = [
+      { id: '__start__->Parent-1', source: '__start__', target: 'Parent-1' },
+      { id: 'Parent-1->Next-1', source: 'Parent-1', target: 'Next-1' },
+      { id: 'Parent-1->__subflow:Parent-1:0', source: 'Parent-1', target: '__subflow:Parent-1:0' },
+    ];
+
+    const layouted = layoutGraph(nodes, edges);
+    const start = layouted.find((node) => node.id === '__start__');
+    const parent = layouted.find((node) => node.id === 'Parent-1');
+    const next = layouted.find((node) => node.id === 'Next-1');
+    const subFlow = layouted.find((node) => node.id === '__subflow:Parent-1:0');
+
+    expect(parent?.position.y).toBeGreaterThan(start?.position.y ?? 0);
+    expect(next?.position.y).toBeGreaterThan((parent?.position.y ?? 0) + 150);
+    expect(subFlow?.position.x).toBeGreaterThan((parent?.position.x ?? 0) + 300);
+    expect(subFlow?.position.y).toBeGreaterThanOrEqual(parent?.position.y ?? 0);
+    expect((subFlow?.position.y ?? 0) + 90).toBeLessThanOrEqual((parent?.position.y ?? 0) + 158);
+    expect(subFlow?.position.y).toBeLessThan(next?.position.y ?? 0);
   });
 
   it('keeps uneven fan-out branches together', () => {

--- a/web/app/flows/details/graphLayout.ts
+++ b/web/app/flows/details/graphLayout.ts
@@ -66,6 +66,22 @@ export function layoutGraph<NodeData extends Record<string, unknown>>(
   edges: Edge[],
 ): Array<Node<NodeData>> {
   if (nodes.length === 0) return [];
+  const topologyNodes = nodes.filter((node) => !isSubFlowNode(node));
+  const subFlowNodes = nodes.filter(isSubFlowNode);
+  const topologyIDs = new Set(topologyNodes.map((node) => node.id));
+  const topologyEdges = edges.filter((edge) => (
+    topologyIDs.has(edge.source) && topologyIDs.has(edge.target)
+  ));
+  const positions = layoutTopology(topologyNodes, topologyEdges);
+  // SubFlow conditions are not next Steps; keep them off the topology ranks.
+  placeSubFlowNodes(subFlowNodes, topologyNodes, positions);
+  return nodes.map((node) => ({ ...node, position: positions.get(node.id) ?? node.position }));
+}
+
+function layoutTopology<NodeData extends Record<string, unknown>>(
+  nodes: Array<Node<NodeData>>,
+  edges: Edge[],
+): Map<string, { x: number; y: number }> {
   const graph = new dagre.graphlib.Graph();
   graph.setDefaultEdgeLabel(() => ({}));
   graph.setGraph({ rankdir: 'TB', ranksep: verticalGap, nodesep: horizontalGap });
@@ -115,8 +131,52 @@ export function layoutGraph<NodeData extends Record<string, unknown>>(
     }
     rowTop += rowHeight + verticalGap;
   }
+  return positions;
+}
 
-  return nodes.map((node) => ({ ...node, position: positions.get(node.id) ?? node.position }));
+function placeSubFlowNodes<NodeData extends Record<string, unknown>>(
+  subFlowNodes: Array<Node<NodeData>>,
+  topologyNodes: Array<Node<NodeData>>,
+  positions: Map<string, { x: number; y: number }>,
+): void {
+  const topologyByID = new Map(topologyNodes.map((node) => [node.id, node]));
+  const childrenByParent = new Map<string, Array<Node<NodeData>>>();
+  for (const node of subFlowNodes) {
+    const parentID = parentStepID(node);
+    if (!parentID || !positions.has(parentID)) continue;
+    childrenByParent.set(parentID, [...(childrenByParent.get(parentID) ?? []), node]);
+  }
+  for (const [parentID, children] of childrenByParent) {
+    const parent = topologyByID.get(parentID);
+    const parentPosition = positions.get(parentID);
+    if (!parent || !parentPosition) continue;
+    const stackHeight = children.reduce((height, child) => height + nodeHeight(child), 0)
+      + horizontalGap * Math.max(0, children.length - 1);
+    let nodeTop = parentPosition.y + Math.max(0, (nodeHeight(parent) - stackHeight) / 2);
+    const nodeLeft = parentPosition.x + nodeWidth(parent) + horizontalGap;
+    for (const child of children) {
+      positions.set(child.id, { x: nodeLeft, y: nodeTop });
+      nodeTop += nodeHeight(child) + horizontalGap;
+    }
+  }
+}
+
+function isSubFlowNode<NodeData extends Record<string, unknown>>(node: Node<NodeData>): boolean {
+  return nodeKind(node) === 'subflow';
+}
+
+function parentStepID<NodeData extends Record<string, unknown>>(node: Node<NodeData>): string {
+  const model = node.data.model;
+  if (!model || typeof model !== 'object') return '';
+  const value = (model as { parentStepId?: unknown }).parentStepId;
+  return typeof value === 'string' ? value : '';
+}
+
+function nodeKind<NodeData extends Record<string, unknown>>(node: Node<NodeData>): string {
+  const model = node.data.model;
+  if (!model || typeof model !== 'object') return '';
+  const value = (model as { kind?: unknown }).kind;
+  return typeof value === 'string' ? value : '';
 }
 
 export function defaultGraphZoom(contentWidth: number, viewportWidth: number): number {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2065,8 +2065,9 @@ pre {
   background: #8c6fc4;
 }
 
-.legend-completed {
-  background: #4e81a9;
+.legend-source {
+  border: 1px solid #856bb7;
+  background: #f5f1fb;
 }
 
 .legend-failed {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2163,7 +2163,7 @@ pre {
 .react-flow__node.step-flow-node {
   width: 220px;
   padding: 0;
-  overflow: hidden;
+  overflow: visible;
   border: 1px solid #bfcac7;
   border-radius: 10px;
   color: var(--ink);
@@ -2175,6 +2175,29 @@ pre {
 .react-flow__node.step-flow-node.selected {
   border-color: var(--brand);
   box-shadow: 0 0 0 3px rgba(111, 160, 54, 0.14);
+}
+
+.graph-node-root {
+  width: 100%;
+  height: 100%;
+}
+
+.graph-node-body {
+  height: 100%;
+  overflow: hidden;
+  border-radius: 10px;
+}
+
+.react-flow__node.step-flow-node .react-flow__handle {
+  width: 8px;
+  height: 8px;
+  border: none;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.react-flow__edge.graph-edge-subflow .react-flow__edge-path {
+  stroke-dasharray: 6 4;
 }
 
 .react-flow__node.node-active {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2061,10 +2061,6 @@ pre {
   background: #d39732;
 }
 
-.legend-pending {
-  background: #8c6fc4;
-}
-
 .legend-source {
   border: 1px solid #856bb7;
   background: #f5f1fb;
@@ -2201,16 +2197,13 @@ pre {
   stroke-dasharray: 6 4;
 }
 
-.react-flow__node.node-active {
+.react-flow__node.node-active,
+.react-flow__node.node-pending {
   border-color: var(--brand-bright);
 }
 
 .react-flow__node.node-waiting {
   border-color: #d39732;
-}
-
-.react-flow__node.node-pending {
-  border-color: #8c6fc4;
 }
 
 .react-flow__node.node-failed {

--- a/web/lib/blobs.ts
+++ b/web/lib/blobs.ts
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
+import { readResponseJSON } from './http';
 import { VALUE_BLOB_UNAVAILABLE } from './unavailable';
 
 export type BlobKind = 'string' | 'object';
@@ -73,8 +74,7 @@ export async function hydrateBlobs<T>(
       cache: 'no-store',
       signal,
     });
-    const result = await response.json() as { error?: string; values?: Record<string, unknown> };
-    if (!response.ok) throw new Error(result.error || `LoadBlobs failed (${response.status})`);
+    const result = await readResponseJSON<{ values?: Record<string, unknown> }>(response);
     for (const [key, resolved] of Object.entries(result.values ?? {})) {
       cache.set(key, resolved);
     }

--- a/web/lib/http.test.ts
+++ b/web/lib/http.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+import { describe, expect, it } from 'vitest';
+import { readResponseJSON } from './http';
+
+describe('readResponseJSON', () => {
+  it('returns parsed JSON for a successful response', async () => {
+    const response = jsonResponse({ flowId: 'order-1' }, 200);
+    await expect(readResponseJSON<{ flowId: string }>(response)).resolves.toEqual({
+      flowId: 'order-1',
+    });
+  });
+
+  it('uses the API error field when the response is not ok', async () => {
+    const response = jsonResponse({ error: 'Flow not found' }, 404);
+    await expect(readResponseJSON(response)).rejects.toThrow('Flow not found');
+  });
+
+  it('explains an empty body instead of a JSON parse failure', async () => {
+    const response = new Response('', {
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: { 'content-type': 'text/plain' },
+    });
+    Object.defineProperty(response, 'url', {
+      value: 'http://127.0.0.1:5173/api/flows/summary?flowId=order-1',
+    });
+
+    await expect(readResponseJSON(response)).rejects.toThrow(
+      'Dex API returned an empty response (HTTP 500) for /api/flows/summary?flowId=order-1. The Dex server may be unreachable.',
+    );
+  });
+
+  it('explains a non-JSON body and includes a short snippet', async () => {
+    const response = new Response('Error: connect ECONNREFUSED 127.0.0.1:8802', {
+      status: 500,
+    });
+    Object.defineProperty(response, 'url', {
+      value: 'http://127.0.0.1:5173/api/flows/search',
+    });
+
+    await expect(readResponseJSON(response)).rejects.toThrow(
+      'Dex API returned a non-JSON response (HTTP 500) for /api/flows/search: Error: connect ECONNREFUSED 127.0.0.1:8802',
+    );
+  });
+});
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/web/lib/http.ts
+++ b/web/lib/http.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+export async function readResponseJSON<T>(response: Response): Promise<T> {
+  const data = await parseResponseJSON<T & { error?: string }>(response);
+  if (!response.ok) {
+    throw new Error(data.error?.trim() || failedRequestMessage(response));
+  }
+  return data;
+}
+
+async function parseResponseJSON<T>(response: Response): Promise<T> {
+  const body = await response.text();
+  if (!body.trim()) {
+    throw new Error(emptyResponseMessage(response));
+  }
+  try {
+    return JSON.parse(body) as T;
+  } catch {
+    throw new Error(nonJSONResponseMessage(response, body));
+  }
+}
+
+function emptyResponseMessage(response: Response): string {
+  return `${responseDescription(response, 'an empty response')}. The Dex server may be unreachable.`;
+}
+
+function nonJSONResponseMessage(response: Response, body: string): string {
+  const snippet = bodySnippet(body);
+  const description = responseDescription(response, 'a non-JSON response');
+  return snippet ? `${description}: ${snippet}` : `${description}.`;
+}
+
+function failedRequestMessage(response: Response): string {
+  return responseDescription(response, 'an error');
+}
+
+function responseDescription(response: Response, kind: string): string {
+  const path = requestPath(response);
+  const status = `HTTP ${response.status}`;
+  return path
+    ? `Dex API returned ${kind} (${status}) for ${path}`
+    : `Dex API returned ${kind} (${status})`;
+}
+
+function requestPath(response: Response): string {
+  if (!response.url) return '';
+  try {
+    const url = new URL(response.url, 'http://127.0.0.1');
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return '';
+  }
+}
+
+function bodySnippet(body: string): string {
+  const trimmed = body.replace(/\s+/g, ' ').trim();
+  if (!trimmed || trimmed.startsWith('<')) return '';
+  return trimmed.length > 160 ? `${trimmed.slice(0, 157)}...` : trimmed;
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': 'http://127.0.0.1:8902',
-      '/healthz': 'http://127.0.0.1:8902',
+      '/api': process.env.DEX_WEB_PROXY ?? 'http://127.0.0.1:8902',
+      '/healthz': process.env.DEX_WEB_PROXY ?? 'http://127.0.0.1:8902',
     },
   },
   build: {


### PR DESCRIPTION
## Summary
- Place SubFlow condition nodes beside their parent Step instead of in the next topology rank, so they no longer occupy the old Flow closed slot.
- Restore Step graph edges after custom handles by giving each node explicit topology/subflow connection points.
- Replace empty Dex API JSON parse failures with a message that the server may be unreachable.

## Rationale
SubFlow is a WaitFor condition, not a next Step. Drawing it as a downstream successor made completed parent-child examples look like the SubFlow and Flow closed nodes had collided.

## User impact
Step graph shows SubFlow to the right of the waiting Step, with a dashed attachment edge. Failed API calls show the request path and HTTP status instead of `Unexpected end of JSON input`.

## Test plan
- [x] `cd web && npm test`
- [ ] Open a completed SubFlow parent run in Dex Web and confirm the child sits beside `SubFlowParentStep`, not below it
- [ ] Confirm `Flow start → Step` arrows still render on the child run
- [ ] With Dex stopped, confirm the run page error mentions an empty API response / unreachable server
