### PR TITLE
Drop redundant Rust Flow type-name overrides

### DIFF
--- a/examples/rust/src/patterns/cron/flow.rs
+++ b/examples/rust/src/patterns/cron/flow.rs
@@ -44,10 +44,6 @@ impl CronScheduleFlow {
 impl Flow for CronScheduleFlow {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "CronScheduleFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.run)
     }

--- a/examples/rust/src/patterns/drain_channels/flow.rs
+++ b/examples/rust/src/patterns/drain_channels/flow.rs
@@ -42,10 +42,6 @@ pub struct DrainInternalChannelsFlow {
 impl Flow for DrainInternalChannelsFlow {
     type StartInput = Vec<String>;
 
-    fn flow_type(&self) -> &'static str {
-        "DrainInternalChannelsFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.seed).and(&self.drain)
     }
@@ -109,10 +105,6 @@ impl DrainSignalChannelsFlow {
 
 impl Flow for DrainSignalChannelsFlow {
     type StartInput = ();
-
-    fn flow_type(&self) -> &'static str {
-        "DrainSignalChannelsFlow"
-    }
 
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.drain)

--- a/examples/rust/src/patterns/entity_store/flow.rs
+++ b/examples/rust/src/patterns/entity_store/flow.rs
@@ -102,10 +102,6 @@ impl UserProfileFlow {
 impl Flow for UserProfileFlow {
     type StartInput = ();
 
-    fn flow_type(&self) -> &'static str {
-        "UserProfileFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::empty()
     }

--- a/examples/rust/src/patterns/interruptible/flow.rs
+++ b/examples/rust/src/patterns/interruptible/flow.rs
@@ -44,10 +44,6 @@ impl InterruptibleExecutionFlow {
 impl Flow for InterruptibleExecutionFlow {
     type StartInput = ();
 
-    fn flow_type(&self) -> &'static str {
-        "InterruptibleExecutionFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.init)
             .and(&self.work_a_execution)

--- a/examples/rust/src/patterns/intervention/flow.rs
+++ b/examples/rust/src/patterns/intervention/flow.rs
@@ -50,10 +50,6 @@ impl ManualInterventionFlow {
 impl Flow for ManualInterventionFlow {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "ManualInterventionFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.risky_operation).and(&self.await_approval)
     }

--- a/examples/rust/src/patterns/parallel/flow.rs
+++ b/examples/rust/src/patterns/parallel/flow.rs
@@ -43,10 +43,6 @@ pub struct SimpleParallelStatesFlow {
 impl Flow for SimpleParallelStatesFlow {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "SimpleParallelStatesFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.fork)
             .and(&self.branch_one)
@@ -112,10 +108,6 @@ impl ParallelStatesWithAwaitFlow {
 
 impl Flow for ParallelStatesWithAwaitFlow {
     type StartInput = ();
-
-    fn flow_type(&self) -> &'static str {
-        "ParallelStatesWithAwaitFlow"
-    }
 
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.fork)

--- a/examples/rust/src/patterns/parent_child/flow.rs
+++ b/examples/rust/src/patterns/parent_child/flow.rs
@@ -50,10 +50,6 @@ impl ParentFlowV2 {
 impl Flow for ParentFlowV2 {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "ParentFlowV2"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.record_child).and(&self.await_child)
     }

--- a/examples/rust/src/patterns/polling/flow.rs
+++ b/examples/rust/src/patterns/polling/flow.rs
@@ -43,10 +43,6 @@ pub struct SimplePollingFlow {
 impl Flow for SimplePollingFlow {
     type StartInput = u32;
 
-    fn flow_type(&self) -> &'static str {
-        "SimplePollingFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.poll)
     }
@@ -82,10 +78,6 @@ pub struct BackoffPollingFlow {
 
 impl Flow for BackoffPollingFlow {
     type StartInput = u32;
-
-    fn flow_type(&self) -> &'static str {
-        "BackoffPollingFlow"
-    }
 
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.poll)

--- a/examples/rust/src/patterns/recovery/flow.rs
+++ b/examples/rust/src/patterns/recovery/flow.rs
@@ -42,10 +42,6 @@ pub struct FailureRecoveryFlow {
 impl Flow for FailureRecoveryFlow {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "FailureRecoveryFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.reserve).and(&self.compensate)
     }

--- a/examples/rust/src/patterns/reminders/flow.rs
+++ b/examples/rust/src/patterns/reminders/flow.rs
@@ -58,10 +58,6 @@ impl ReminderFlow {
 impl Flow for ReminderFlow {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "ReminderFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.start)
             .and(&self.remind)

--- a/examples/rust/src/patterns/resettable_timer/flow.rs
+++ b/examples/rust/src/patterns/resettable_timer/flow.rs
@@ -51,10 +51,6 @@ impl ResettableTimerFlow {
 impl Flow for ResettableTimerFlow {
     type StartInput = u64;
 
-    fn flow_type(&self) -> &'static str {
-        "ResettableTimerFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.wait)
     }

--- a/examples/rust/src/patterns/scalable_parallel/flow.rs
+++ b/examples/rust/src/patterns/scalable_parallel/flow.rs
@@ -41,10 +41,6 @@ pub struct ChildFlow {
 impl Flow for ChildFlow {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "ChildFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.process)
     }
@@ -89,10 +85,6 @@ impl ParentFlow {
 
 impl Flow for ParentFlow {
     type StartInput = usize;
-
-    fn flow_type(&self) -> &'static str {
-        "ParentFlow"
-    }
 
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.drain)
@@ -149,10 +141,6 @@ impl RequestReceiverFlow {
 
 impl Flow for RequestReceiverFlow {
     type StartInput = ();
-
-    fn flow_type(&self) -> &'static str {
-        "RequestReceiverFlow"
-    }
 
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.forward)

--- a/examples/rust/src/patterns/timeout/flow.rs
+++ b/examples/rust/src/patterns/timeout/flow.rs
@@ -44,10 +44,6 @@ pub struct FlowGracefulTimeout {
 impl Flow for FlowGracefulTimeout {
     type StartInput = bool;
 
-    fn flow_type(&self) -> &'static str {
-        "FlowGracefulTimeout"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.start)
             .and(&self.task)

--- a/examples/rust/src/patterns/wait_for_state_completion/flow.rs
+++ b/examples/rust/src/patterns/wait_for_state_completion/flow.rs
@@ -55,10 +55,6 @@ impl WaitForStateCompletionFlow {
 impl Flow for WaitForStateCompletionFlow {
     type StartInput = PersistRequest;
 
-    fn flow_type(&self) -> &'static str {
-        "WaitForStateCompletionFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.persist_data).and(&self.background_work)
     }

--- a/examples/rust/src/primitives/attribute/flow.rs
+++ b/examples/rust/src/primitives/attribute/flow.rs
@@ -28,10 +28,6 @@ pub struct AttributeFlow {
 impl Flow for AttributeFlow {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "AttributeFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.start)
     }

--- a/examples/rust/src/primitives/channel/flow.rs
+++ b/examples/rust/src/primitives/channel/flow.rs
@@ -39,10 +39,6 @@ impl ChannelFlow {
 impl Flow for ChannelFlow {
     type StartInput = i32;
 
-    fn flow_type(&self) -> &'static str {
-        "ChannelFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.wait)
     }

--- a/examples/rust/src/primitives/client_apis/flow.rs
+++ b/examples/rust/src/primitives/client_apis/flow.rs
@@ -31,10 +31,6 @@ pub struct ClientApisFlow {
 impl Flow for ClientApisFlow {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "ClientApisFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.index)
     }

--- a/examples/rust/src/primitives/rpc/flow.rs
+++ b/examples/rust/src/primitives/rpc/flow.rs
@@ -44,10 +44,6 @@ impl RpcFlow {
 impl Flow for RpcFlow {
     type StartInput = i32;
 
-    fn flow_type(&self) -> &'static str {
-        "RpcFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.wait).and(&self.complete)
     }

--- a/examples/rust/src/primitives/step/flow.rs
+++ b/examples/rust/src/primitives/step/flow.rs
@@ -23,10 +23,6 @@ pub struct StepFlow {
 impl Flow for StepFlow {
     type StartInput = i32;
 
-    fn flow_type(&self) -> &'static str {
-        "StepFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.first).and(&self.second)
     }

--- a/examples/rust/src/primitives/step/retry_flow.rs
+++ b/examples/rust/src/primitives/step/retry_flow.rs
@@ -27,10 +27,6 @@ pub struct RetryFlow {
 impl Flow for RetryFlow {
     type StartInput = i32;
 
-    fn flow_type(&self) -> &'static str {
-        "RetryFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.start)
     }

--- a/examples/rust/src/primitives/subflow/flow.rs
+++ b/examples/rust/src/primitives/subflow/flow.rs
@@ -27,10 +27,6 @@ pub struct SubFlowChildFlow {
 impl Flow for SubFlowChildFlow {
     type StartInput = i32;
 
-    fn flow_type(&self) -> &'static str {
-        "SubFlowChildFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.start)
     }
@@ -62,10 +58,6 @@ impl SubFlowParentFlow {
 
 impl Flow for SubFlowParentFlow {
     type StartInput = i32;
-
-    fn flow_type(&self) -> &'static str {
-        "SubFlowParentFlow"
-    }
 
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.start)

--- a/examples/rust/src/primitives/timer/flow.rs
+++ b/examples/rust/src/primitives/timer/flow.rs
@@ -24,10 +24,6 @@ pub struct TimerFlow {
 impl Flow for TimerFlow {
     type StartInput = i32;
 
-    fn flow_type(&self) -> &'static str {
-        "TimerFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.start)
     }

--- a/examples/rust/src/products/engagement/flow.rs
+++ b/examples/rust/src/products/engagement/flow.rs
@@ -99,10 +99,6 @@ impl EngagementFlow {
 impl Flow for EngagementFlow {
     type StartInput = EngagementRequest;
 
-    fn flow_type(&self) -> &'static str {
-        "EngagementFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.start)
             .and(&self.wait_for_decision)

--- a/examples/rust/src/products/job_post/flow.rs
+++ b/examples/rust/src/products/job_post/flow.rs
@@ -78,10 +78,6 @@ impl JobPostFlow {
 impl Flow for JobPostFlow {
     type StartInput = JobPost;
 
-    fn flow_type(&self) -> &'static str {
-        "JobPostFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.create)
     }

--- a/examples/rust/src/products/microservices/flow.rs
+++ b/examples/rust/src/products/microservices/flow.rs
@@ -61,10 +61,6 @@ impl OrchestrationFlow {
 impl Flow for OrchestrationFlow {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "OrchestrationFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.call_api_one)
             .and(&self.call_api_two)

--- a/examples/rust/src/products/money_transfer/flow.rs
+++ b/examples/rust/src/products/money_transfer/flow.rs
@@ -54,10 +54,6 @@ pub struct MoneyTransferFlow {
 impl Flow for MoneyTransferFlow {
     type StartInput = TransferRequest;
 
-    fn flow_type(&self) -> &'static str {
-        "MoneyTransferFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.check_balance)
             .and(&self.debit)

--- a/examples/rust/src/products/polling/flow.rs
+++ b/examples/rust/src/products/polling/flow.rs
@@ -58,10 +58,6 @@ impl PollingFlow {
 impl Flow for PollingFlow {
     type StartInput = u32;
 
-    fn flow_type(&self) -> &'static str {
-        "PollingFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.start)
             .and(&self.wait_for_task_a)

--- a/examples/rust/src/products/shortlist_candidates/flow.rs
+++ b/examples/rust/src/products/shortlist_candidates/flow.rs
@@ -68,10 +68,6 @@ impl EmployerOptInFlow {
 impl Flow for EmployerOptInFlow {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "EmployerOptInFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.opt_in).and(&self.await_opt_out)
     }
@@ -139,10 +135,6 @@ impl ShortlistFlow {
 
 impl Flow for ShortlistFlow {
     type StartInput = ShortlistRequest;
-
-    fn flow_type(&self) -> &'static str {
-        "ShortlistFlow"
-    }
 
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.schedule_contact)

--- a/examples/rust/src/products/signup/flow.rs
+++ b/examples/rust/src/products/signup/flow.rs
@@ -52,10 +52,6 @@ impl UserSignupFlow {
 impl Flow for UserSignupFlow {
     type StartInput = String;
 
-    fn flow_type(&self) -> &'static str {
-        "UserSignupFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.send_verification).and(&self.await_verification)
     }

--- a/examples/rust/src/products/subscription/flow.rs
+++ b/examples/rust/src/products/subscription/flow.rs
@@ -78,10 +78,6 @@ impl SubscriptionFlow {
 impl Flow for SubscriptionFlow {
     type StartInput = SubscriptionRequest;
 
-    fn flow_type(&self) -> &'static str {
-        "SubscriptionFlow"
-    }
-
     fn steps(&self) -> StepList<'_, Self::StartInput> {
         StepList::start(&self.welcome)
             .and(&self.billing)

--- a/sdk-rust/crates/dex-sdk/src/flow.rs
+++ b/sdk-rust/crates/dex-sdk/src/flow.rs
@@ -30,10 +30,6 @@ pub type FlowTimeoutHandler<SomeFlow> = fn(&SomeFlow, &mut Context) -> HandlerRe
 /// impl Flow for OrderFlow {
 ///     type StartInput = String;
 ///
-///     fn flow_type(&self) -> &'static str {
-///         "OrderFlow"
-///     }
-///
 ///     fn steps(&self) -> StepList<'_, Self::StartInput> {
 ///         StepList::empty()
 ///     }


### PR DESCRIPTION
## Summary
- Remove explicit `flow_type` impls from Rust examples. The SDK already defaults to the final type-name segment, and every example name already matched that default.
- Keep the customized `test-customized-flow-type` override in the SDK integ suite so an explicit protocol name is still covered.
- Drop the redundant `flow_type` from the `Flow` trait doctest.

## Test plan
- [x] `cd examples/rust && cargo test --locked --test catalog_integration`
- [x] `cd sdk-rust && cargo fmt --all`


Made with [Cursor](https://cursor.com)