### PR TITLE
Default omitted TypeScript Step and RPC codecs to JSON

### DIFF
--- a/docs/content/references/typescript-sdk.mdx
+++ b/docs/content/references/typescript-sdk.mdx
@@ -21,9 +21,10 @@ async execute(_context: Context, childId: string): Promise<StepDecision> {
 ```
 
 `waitForFlow` returns a read-only collection of hydrated Step completions. A
-Flow with one output can use `singleOutput(codec)`. For multiple outputs, match
-`stepType` or `stepExecutionId` and call `completion.decode(codec)`. Do not use
-array position as a parallel-branch contract.
+Flow with one JSON output can use `singleOutput()`. Scalar outputs still pass
+`stringCodec` or `doubleCodec`. For multiple outputs, match `stepType` or
+`stepExecutionId` and call `completion.decode()`. Do not use array position as a
+parallel-branch contract.
 
 Synchronous handlers remain valid. Do **not** block the event loop (`Atomics.wait`, `spawnSync`). Prefer short `waitForFlow` timeouts plus Step retry over one unbounded poll.
 
@@ -34,9 +35,9 @@ Examples under `examples/typescript` use a shared `getClient()` holder set at pr
 | Concern | TypeScript |
 | --- | --- |
 | Timers | `Timer.byDuration(ms)` (milliseconds) |
-| Codecs | Explicit `inputCodec` / `stringCodec` / `jsonCodec` on Steps and RPCs |
+| Codecs | Omit for JSON objects; pass `stringCodec` / `doubleCodec` / … for scalars |
 | Names | Always implement `getFlowType()` / `getStepType()` |
 | Client | Promise-based: `await client.startFlow(...)` |
-| RPC | `@rpc({ name, inputCodec, outputCodec })` → `return { output }` |
+| RPC | `@rpc()` for JSON, or `@rpc({ name, inputCodec, outputCodec })` → `return { output }` |
 
 See also the [sdk-typescript README](https://github.com/superdurable/dex/blob/main/sdk-typescript/README.md) and [parent–child](/design-patterns/parent-child) / [scalable parallel](/design-patterns/scalable-parallel) patterns.

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -13,28 +13,28 @@ The Client uses `@grpc/grpc-js` directly. Rust is only the implementation
 boundary for the shared BlobCache; TypeScript callbacks and network transport
 stay in Node.
 
-Step input codecs and RPC input/output codecs remain explicit because
-TypeScript erases generic types at runtime. They are serialization metadata,
-not builder arguments.
+Omitted Step input codecs and RPC input/output codecs use JSON
+(`JSON.stringify` / `JSON.parse`, no structural validation). Scalar wire kinds
+still need `stringCodec`, `booleanCodec`, `int64Codec`, `doubleCodec`, or
+`bytesCodec`. A `@rpc()` method with only `Context` and a `void` return stays a
+procedure.
 
 ```typescript
-class ApproveOrder implements Step<string> {
-  readonly inputCodec = stringCodec;
-
+class ApproveOrder implements Step<{ orderId: string }> {
   getStepType(): string {
     return "ApproveOrder";
   }
 
-  waitFor(_context: Context, _orderId: string): Wait {
+  waitFor(_context: Context, _order: { orderId: string }): Wait {
     return Wait.until(Timer.byDuration(1_000));
   }
 
-  execute(_context: Context, orderId: string): StepDecision {
-    return gracefulComplete(orderId);
+  execute(_context: Context, order: { orderId: string }): StepDecision {
+    return gracefulComplete(order);
   }
 }
 
-class Orders implements Flow<string> {
+class Orders implements Flow<{ orderId: string }> {
   readonly approve = new ApproveOrder();
 
   getFlowType(): string {

--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -82,7 +82,7 @@ import { Attribute, AttributeMap, IndexType } from "./persistence.js";
 import type { RPCResult } from "./rpc.js";
 import type { RetryPolicy, StepOptions } from "./step.js";
 import { requireName } from "./validation.js";
-import { decodeUnknown, decodeValue, encodeValue, ValueHydrator } from "./value-mapper.js";
+import { codecOrJson, decodeUnknown, decodeValue, encodeValue, ValueHydrator } from "./value-mapper.js";
 import { ChannelMap, type Channel } from "./wait.js";
 
 const defaultServerAddress = "localhost:8801";
@@ -177,7 +177,7 @@ export class Client {
       }
     } else {
       request.startStepType = registered.startStep.name;
-      request.stepInput = encodeValue(registered.startStep.step.inputCodec, input);
+      request.stepInput = encodeValue(codecOrJson(registered.startStep.step.inputCodec), input);
       request.stepOptions = mapStepOptions(
         registered.startStep.step.getStepOptions?.(),
         registered.startStep.step.waitFor === undefined,
@@ -271,7 +271,7 @@ export class Client {
     runId = "",
   ): Promise<unknown> {
     const rpc = registeredRPC(this.registry, rpcMethod);
-    const hasInput = rpc.options.inputCodec !== undefined;
+    const hasInput = rpc.hasInput;
     const response = await unary<InvokeRPCResponse>(
       { operation: "invokeRPC", flowId, requirement: "active" },
       (callback) =>
@@ -281,7 +281,7 @@ export class Client {
           runId: hasInput ? runId : (inputOrRunId as string | undefined) ?? "",
           rpcName: rpc.name,
           input: hasInput
-            ? encodeValue(rpc.options.inputCodec!, inputOrRunId)
+            ? encodeValue(codecOrJson(rpc.options.inputCodec), inputOrRunId)
             : undefined,
           timeoutSeconds: seconds(rpc.options.timeoutMs),
           lockAttributeKeys: (rpc.options.lockAttributes ?? []).map((lock) =>
@@ -292,10 +292,13 @@ export class Client {
         callback,
       ),
     );
-    if (rpc.options.outputCodec === undefined) {
+    if (rpc.options.outputCodec === undefined && response.output?.kind === undefined) {
       return undefined;
     }
-    return decodeValue(rpc.options.outputCodec, await this.hydrator.hydrate(response.output));
+    return decodeValue(
+      codecOrJson(rpc.options.outputCodec),
+      await this.hydrator.hydrate(response.output),
+    );
   }
 
   /**

--- a/sdk-typescript/src/codec.ts
+++ b/sdk-typescript/src/codec.ts
@@ -166,26 +166,40 @@ export function optionalCodec<T>(codec: Codec<T>): Codec<T | undefined> {
 }
 
 /**
- * Creates a deterministic JSON codec with application conversion hooks.
+ * Creates a JSON-wire codec.
  *
- * JSON.stringify semantics apply; `undefined`, cycles, and unsupported bigint values
- * fail during encoding. The decoder receives parsed, untrusted JSON data.
+ * Call `jsonCodec()` with no arguments to encode with `JSON.stringify` and decode
+ * with `JSON.parse` without structural validation. That identity codec is the
+ * default when a Step or RPC omits an explicit codec. Pass `decode` when the
+ * parsed JSON must be validated or converted, such as rebuilding a `Date`.
+ * JSON.stringify semantics apply; `undefined`, cycles, and unsupported bigint
+ * values fail during encoding.
  *
+ * @example
+ * ```ts
+ * const order = jsonCodec<Order>();
+ * const created = jsonCodec<Date>({
+ *   typeName: "Date",
+ *   decode: (value) => new Date(String(value)),
+ *   encode: (value) => value.toISOString(),
+ * });
+ * ```
  * @typeParam T - Application value type.
- * @param options - Stable name plus JSON conversion hooks.
+ * @param options - Optional type name and JSON conversion hooks.
  * @returns A JSON-wire codec for `T`.
  * @throws {@link TypeError} when encoding produces `undefined`.
  */
 export function jsonCodec<T>(options: {
-  /** Stable type name used in mapping errors. */
-  readonly typeName: string;
-  /** Validates and converts parsed JSON-compatible data. */
-  readonly decode: (value: unknown) => T;
+  /** Stable type name used in mapping errors; defaults to `json`. */
+  readonly typeName?: string;
+  /** Validates and converts parsed JSON-compatible data; identity by default. */
+  readonly decode?: (value: unknown) => T;
   /** Converts an application value to JSON-compatible data; identity by default. */
   readonly encode?: (value: T) => unknown;
-}): Codec<T> {
+} = {}): Codec<T> {
+  const decodeJson = options.decode ?? ((value: unknown) => value as T);
   return {
-    typeName: options.typeName,
+    typeName: options.typeName ?? "json",
     wireKind: "json",
     encode: (value) => {
       const data = JSON.stringify(options.encode?.(value) ?? value);
@@ -194,7 +208,7 @@ export function jsonCodec<T>(options: {
       }
       return { kind: "json", data };
     },
-    decode: (value) => options.decode(JSON.parse(requireKind(value, "json").data) as unknown),
+    decode: (value) => decodeJson(JSON.parse(requireKind(value, "json").data) as unknown),
   };
 }
 

--- a/sdk-typescript/src/flow-result.ts
+++ b/sdk-typescript/src/flow-result.ts
@@ -16,7 +16,7 @@ import {
 } from "./gen/dex.js";
 import { FlowErrorType, type FlowErrorType as FlowErrorTypeValue } from "./errors.js";
 import type { FlowStatus } from "./options.js";
-import { decodeValue } from "./value-mapper.js";
+import { codecOrJson, decodeValue } from "./value-mapper.js";
 
 /** Contains one output-bearing Step completion returned by {@link Client.waitForFlow}. */
 export interface StepCompletion {
@@ -27,10 +27,11 @@ export interface StepCompletion {
   /**
    * Decodes this already hydrated Step output.
    * @typeParam Output - Expected application output type.
-   * @param codec - Codec for the expected output type.
+   * @param codec - Codec for the expected output type. Omit this for JSON objects.
+   *   Scalar wire kinds still need an explicit codec.
    * @returns The decoded Step output.
    */
-  decode<Output>(codec: Codec<Output>): Output;
+  decode<Output>(codec?: Codec<Output>): Output;
 }
 
 /** Describes an observed Flow status and its output-bearing completions. */
@@ -50,11 +51,12 @@ export interface FlowResult {
   /**
    * Decodes the output when exactly one completion exists.
    * @typeParam Output - Expected application output type.
-   * @param codec - Codec for the expected output type.
+   * @param codec - Codec for the expected output type. Omit this for JSON objects.
+   *   Scalar wire kinds still need an explicit codec.
    * @returns The only decoded Step output.
    * @throws {@link TypeError} when nonterminal or when zero or multiple outputs exist.
    */
-  singleOutput<Output>(codec: Codec<Output>): Output;
+  singleOutput<Output>(codec?: Codec<Output>): Output;
 }
 
 /** @internal */
@@ -70,8 +72,8 @@ export function createStepCompletions(
     return Object.freeze({
       stepType: record.completedStepType,
       stepExecutionId: record.completedStepExecutionId,
-      decode<Output>(codec: Codec<Output>): Output {
-        return decodeValue(codec, value);
+      decode<Output>(codec?: Codec<Output>): Output {
+        return decodeValue(codecOrJson(codec), value);
       },
     });
   }));
@@ -91,7 +93,7 @@ export function createFlowResult(
     errorMessage,
     isTerminal,
     completions,
-    singleOutput<Output>(codec: Codec<Output>): Output {
+    singleOutput<Output>(codec?: Codec<Output>): Output {
       if (!isTerminal) {
         throw new TypeError("Flow result is not terminal");
       }

--- a/sdk-typescript/src/rpc.ts
+++ b/sdk-typescript/src/rpc.ts
@@ -44,9 +44,15 @@ export type RPC<Input, Output> = (
 export interface RPCOptions<Input = unknown, Output = unknown> {
   /** Protocol RPC name; uses the decorated method name when omitted. */
   readonly name?: string;
-  /** Required input codec for handlers that accept an input. */
+  /**
+   * Input codec. Omit this for JSON objects, or when the handler has no input.
+   * Scalar wire kinds still need an explicit codec.
+   */
   readonly inputCodec?: Codec<Input>;
-  /** Required output codec for handlers returning RPCResult. */
+  /**
+   * Output codec. Omit this for JSON objects, or when the handler returns void.
+   * Scalar wire kinds still need an explicit codec.
+   */
   readonly outputCodec?: Codec<Output>;
   /** Non-negative handler timeout in milliseconds. */
   readonly timeoutMs?: number;
@@ -58,99 +64,42 @@ export interface RegisteredRPC {
   readonly method: Function;
   readonly name: string;
   readonly options: RPCOptions<any, any>;
+  readonly hasInput: boolean;
 }
 
 const rpcOptions = new WeakMap<Function, RPCOptions<any, any>>();
 
 /**
- * Decorates an RPC with both typed input and output.
+ * Decorates a Flow method as an RPC handler.
  * @typeParam Input - Handler input type.
  * @typeParam Output - Handler output type.
- * @param options - Required input/output codecs and optional RPC settings.
+ * @param options - Optional codecs and RPC settings. Omitted codecs use JSON.
  * @returns A stage-3 method decorator validated during Registry construction.
  */
-export function rpc<Input, Output>(options: RPCOptions<Input, Output> & {
-  /** Required codec for the handler input. */
-  readonly inputCodec: Codec<Input>;
-  /** Required codec for the RPCResult output. */
-  readonly outputCodec: Codec<Output>;
-}): <This>(
-  method: (
-    this: This,
-    context: Context,
-    input: Input,
-  ) => RPCResult<Output> | Promise<RPCResult<Output>>,
-  context: ClassMethodDecoratorContext<
-    This,
-    (
-      this: This,
-      context: Context,
-      input: Input,
-    ) => RPCResult<Output> | Promise<RPCResult<Output>>
-  >,
-) => void;
-
-/**
- * Decorates an input-free RPC with typed output.
- * @typeParam Output - Handler output type.
- * @param options - Required output codec and optional RPC settings.
- * @returns A stage-3 method decorator validated during Registry construction.
- */
-export function rpc<Output>(options: RPCOptions<never, Output> & {
-  /** Input codecs are forbidden for an input-free handler. */
-  readonly inputCodec?: never;
-  /** Required codec for the RPCResult output. */
-  readonly outputCodec: Codec<Output>;
-}): <This>(
-  method: (this: This, context: Context) => RPCResult<Output> | Promise<RPCResult<Output>>,
-  context: ClassMethodDecoratorContext<
-    This,
-    (this: This, context: Context) => RPCResult<Output> | Promise<RPCResult<Output>>
-  >,
-) => void;
-
-/**
- * Decorates a typed-input RPC with no output.
- * @typeParam Input - Handler input type.
- * @param options - Required input codec and optional RPC settings.
- * @returns A stage-3 method decorator validated during Registry construction.
- */
-export function rpc<Input>(options: RPCOptions<Input, never> & {
-  /** Required codec for the handler input. */
-  readonly inputCodec: Codec<Input>;
-  /** Output codecs are forbidden for a void handler. */
-  readonly outputCodec?: never;
-}): <This>(
-  method: (this: This, context: Context, input: Input) => void | Promise<void>,
-  context: ClassMethodDecoratorContext<
-    This,
-    (this: This, context: Context, input: Input) => void | Promise<void>
-  >,
-) => void;
-
-/**
- * Decorates an input-free, output-free RPC.
- * @param options - Optional name, timeout, and Attribute locks.
- * @returns A stage-3 method decorator validated during Registry construction.
- */
-export function rpc(options?: RPCOptions<never, never> & {
-  /** Input codecs are forbidden for an input-free handler. */
-  readonly inputCodec?: never;
-  /** Output codecs are forbidden for a void handler. */
-  readonly outputCodec?: never;
-}): <This>(
-  method: (this: This, context: Context) => void | Promise<void>,
-  context: ClassMethodDecoratorContext<This, (this: This, context: Context) => void | Promise<void>>,
+export function rpc<Input = unknown, Output = unknown>(
+  options?: RPCOptions<Input, Output>,
+): <This>(
+  method: (this: This, context: Context, ...args: any[]) => unknown,
+  context: ClassMethodDecoratorContext<This, (this: This, context: Context, ...args: any[]) => unknown>,
 ) => void;
 
 /**
  * Creates a typed RPC method decorator.
  *
- * Registry construction validates handler shape, codecs, unique names, and locks.
+ * Registry construction validates handler shape, unique names, and locks.
  * The handler receives Context and optional input, then returns RPCResult or void.
+ * Omitted input and output codecs use JSON. Scalar wire kinds still need an
+ * explicit codec. A method with only a Context parameter and a void return is a
+ * procedure. Default-parameter methods report `Function.length` without those
+ * parameters, so pass `inputCodec` when a trailing input uses a default.
  *
  * @example
  * ```ts
+ * @rpc()
+ * describe(_context: Context, order: Order): RPCResult<Order> {
+ *   return { output: order };
+ * }
+ *
  * @rpc({ inputCodec: stringCodec, outputCodec: booleanCodec, timeoutMs: 10_000 })
  * async cancel(context: Context, reason: string): Promise<RPCResult<boolean>> {
  *   return { output: true };
@@ -198,6 +147,7 @@ export function registeredRPCs(flow: Flow<unknown>): readonly RegisteredRPC[] {
         method,
         name: options.name ?? name,
         options,
+        hasInput: method.length >= 2 || options.inputCodec !== undefined,
       });
     }
     prototype = Object.getPrototypeOf(prototype) as object | null;

--- a/sdk-typescript/src/step.ts
+++ b/sdk-typescript/src/step.ts
@@ -86,8 +86,7 @@ export interface StepOptions {
  *
  * @example
  * ```ts
- * const confirm: Step<string> = {
- *   inputCodec: stringCodec,
+ * const confirm: Step<{ id: string }> = {
  *   getStepType: () => "Confirm",
  *   waitFor: () => Wait.until(Timer.byDuration(1_000)),
  *   execute: (_context, input) => forceComplete(input),
@@ -96,8 +95,14 @@ export interface StepOptions {
  * @typeParam Input - Value passed by an incoming Step movement.
  */
 export interface Step<Input> {
-  /** Codec used for every incoming input value. */
-  readonly inputCodec: Codec<Input>;
+  /**
+   * Codec used for every incoming input value.
+   *
+   * Omit this for JSON objects. Scalar wire kinds still need {@link stringCodec},
+   * {@link booleanCodec}, {@link int64Codec}, {@link doubleCodec}, or
+   * {@link bytesCodec}.
+   */
+  readonly inputCodec?: Codec<Input>;
   /**
    * Returns the protocol Step type.
    * @returns A non-empty Step type unique within the containing Flow.

--- a/sdk-typescript/src/value-mapper.ts
+++ b/sdk-typescript/src/value-mapper.ts
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import type { BlobCache } from "./blob-cache.js";
-import type { Codec, Value as CodecValue } from "./codec.js";
+import { jsonCodec, type Codec, type Value as CodecValue } from "./codec.js";
 import { ValueMappingError } from "./errors.js";
 import { NullValue } from "./gen/google/protobuf/struct.js";
 import {
@@ -15,6 +15,13 @@ import {
   type FlowServiceClient,
   type LoadBlobsResponse,
 } from "./gen/dex.js";
+
+const jsonValueCodec = jsonCodec<unknown>();
+
+/** Returns `codec`, or the identity JSON codec when the caller omitted one. */
+export function codecOrJson<T>(codec?: Codec<T>): Codec<T> {
+  return codec ?? (jsonValueCodec as Codec<T>);
+}
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();

--- a/sdk-typescript/src/worker-dispatcher.ts
+++ b/sdk-typescript/src/worker-dispatcher.ts
@@ -65,6 +65,7 @@ import type {
   StepOptions,
 } from "./step.js";
 import {
+  codecOrJson,
   decodeValue,
   encodeUnknown,
   encodeValue,
@@ -98,7 +99,10 @@ export class WorkerDispatcher {
       {},
       cancellationSignal,
     );
-    const input = decodeValue(step.step.inputCodec, requireValue(request.stepInput, "Step input"));
+    const input = decodeValue(
+      codecOrJson(step.step.inputCodec),
+      requireValue(request.stepInput, "Step input"),
+    );
     if (step.step.waitFor === undefined) {
       throw new TypeError(`Step ${step.name} does not implement waitFor`);
     }
@@ -137,7 +141,10 @@ export class WorkerDispatcher {
       {},
       cancellationSignal,
     );
-    const input = decodeValue(step.step.inputCodec, requireValue(request.stepInput, "Step input"));
+    const input = decodeValue(
+      codecOrJson(step.step.inputCodec),
+      requireValue(request.stepInput, "Step input"),
+    );
     const decision = await step.step.execute(context, input);
     try {
       return InvokeExecuteMethodResponse.create({
@@ -210,9 +217,9 @@ export class WorkerDispatcher {
       const result = rpcResult(rpc, returned);
       return InvokeWorkerRPCResponse.create({
         output:
-          rpc.options.outputCodec === undefined
+          result === undefined
             ? encodeUnknown(undefined)
-            : encodeValue(rpc.options.outputCodec, result?.output),
+            : encodeValue(codecOrJson(rpc.options.outputCodec), result.output),
         stepDecision: rpcDecision(flow, result),
         upsertAttributes: [...context.getAttributeWrites()],
         recordEvents: [...context.getEvents()],
@@ -296,13 +303,13 @@ function invokeRPC(
   context: InvocationContext,
   input: Value | undefined,
 ): unknown {
-  if (rpc.options.inputCodec === undefined) {
+  if (!rpc.hasInput) {
     return rpc.method.call(flow.flow, context);
   }
   return rpc.method.call(
     flow.flow,
     context,
-    decodeValue(rpc.options.inputCodec, requireValue(input, "RPC input")),
+    decodeValue(codecOrJson(rpc.options.inputCodec), requireValue(input, "RPC input")),
   );
 }
 
@@ -310,14 +317,18 @@ function rpcResult(
   rpc: RegisteredRPC,
   returned: unknown,
 ): { output: unknown; nextSteps?: readonly StepMovement<unknown>[] } | undefined {
-  if (rpc.options.outputCodec === undefined) {
-    if (returned !== undefined) {
-      throw new TypeError(`procedure RPC ${rpc.name} must not return a value`);
+  if (returned === undefined) {
+    if (rpc.options.outputCodec !== undefined) {
+      throw new TypeError(`function RPC ${rpc.name} must return RPCResult`);
     }
     return undefined;
   }
   if (typeof returned !== "object" || returned === null || !("output" in returned)) {
-    throw new TypeError(`function RPC ${rpc.name} must return RPCResult`);
+    throw new TypeError(
+      rpc.options.outputCodec === undefined && !rpc.hasInput
+        ? `procedure RPC ${rpc.name} must not return a value`
+        : `function RPC ${rpc.name} must return RPCResult`,
+    );
   }
   return returned as { output: unknown; nextSteps?: readonly StepMovement<unknown>[] };
 }
@@ -487,7 +498,7 @@ function mapMovement(flow: RegisteredFlow, movement: StepMovement<unknown>): Pro
   }
   return ProtoStepMovement.create({
     stepType: target.name,
-    stepInput: encodeValue(target.step.inputCodec, movement.input),
+    stepInput: encodeValue(codecOrJson(target.step.inputCodec), movement.input),
     stepOptions: mapStepOptions(
       flow,
       movement.options ?? target.step.getStepOptions?.(),
@@ -644,7 +655,7 @@ class ConditionMapper {
           conditionId: id,
           subFlowType: target.name,
           startStepType: start.name,
-          stepInput: encodeValue(start.step.inputCodec, condition.subFlowInput),
+          stepInput: encodeValue(codecOrJson(start.step.inputCodec), condition.subFlowInput),
           stepOptions: mapStepOptions(
             target,
             start.step.getStepOptions?.(),

--- a/sdk-typescript/test/contracts.test.ts
+++ b/sdk-typescript/test/contracts.test.ts
@@ -48,8 +48,9 @@ import {
   Context as ProtoContext,
   InvokeExecuteMethodRequest,
   InvokeWaitForMethodRequest,
+  InvokeWorkerRPCRequest,
 } from "../src/gen/dex.js";
-import { encodeValue, type ValueHydrator } from "../src/value-mapper.js";
+import { codecOrJson, encodeValue, type ValueHydrator } from "../src/value-mapper.js";
 import { WorkerDispatcher } from "../src/worker-dispatcher.js";
 import { registeredFlowByName } from "../src/flow.js";
 import { InvocationContext } from "../src/invocation-context.js";
@@ -195,6 +196,86 @@ test("canonical codecs enforce wire kinds and int64 range", () => {
   assert.equal(int64Codec.decode(int64Codec.encode(42n)), 42n);
   assert.throws(() => int64Codec.encode(2n ** 63n), RangeError);
   assert.throws(() => int64Codec.decode(stringCodec.encode("42")), TypeError);
+});
+
+test("omitted codecs use identity JSON rather than scalar wire kinds", () => {
+  const identity = jsonCodec<{ orderId: string }>();
+  const order = { orderId: "order-1" };
+  assert.deepEqual(identity.decode(identity.encode(order)), order);
+  const jsonString = encodeValue(codecOrJson(), "hello");
+  assert.equal(jsonString.kind?.$case, "objValue");
+  assert.equal(jsonString.kind?.$case === "objValue" ? jsonString.kind.value.encoding : "", "json");
+  const scalarString = encodeValue(stringCodec, "hello");
+  assert.equal(scalarString.kind?.$case, "stringValue");
+});
+
+test("object Step and RPC omit codecs and still encode JSON", async () => {
+  class JsonStep implements Step<OrderInput> {
+    public getStepType(): string {
+      return "JsonStep";
+    }
+
+    public execute(_context: Context, input: OrderInput): StepDecision {
+      return gracefulComplete(input);
+    }
+  }
+
+  class JsonFlow implements Flow<OrderInput> {
+    public readonly start = new JsonStep();
+
+    public getFlowType(): string {
+      return "JsonFlow";
+    }
+
+    public getSteps(): StepList<OrderInput> {
+      return StepList.startStep(this.start);
+    }
+
+    @rpc()
+    public describe(_context: Context, input: OrderInput): RPCResult<OrderInput> {
+      return { output: input };
+    }
+
+    @rpc()
+    public ping(_context: Context): void {}
+  }
+
+  const flow = new JsonFlow();
+  const hydrator = {
+    hydrateAll: async (values: readonly unknown[]) => values,
+  } as unknown as ValueHydrator;
+  const dispatcher = new WorkerDispatcher(new Registry([flow]), hydrator);
+  const executed = await dispatcher.invokeExecute(
+    InvokeExecuteMethodRequest.create({
+      context: ProtoContext.create(),
+      flowType: flow.getFlowType(),
+      stepType: flow.start.getStepType(),
+      stepInput: encodeValue(codecOrJson(), { orderId: "order-1" }),
+      attributes: [],
+      stepExeLocals: [],
+    }),
+  );
+  const closeInput = executed.stepDecision?.closeDecision?.closeInput;
+  assert.equal(closeInput?.kind?.$case, "objValue");
+  const described = await dispatcher.invokeRPC(
+    InvokeWorkerRPCRequest.create({
+      context: ProtoContext.create(),
+      flowType: flow.getFlowType(),
+      rpcName: "describe",
+      input: encodeValue(codecOrJson(), { orderId: "order-1" }),
+      attributes: [],
+    }),
+  );
+  assert.equal(described.output?.kind?.$case, "objValue");
+  const pinged = await dispatcher.invokeRPC(
+    InvokeWorkerRPCRequest.create({
+      context: ProtoContext.create(),
+      flowType: flow.getFlowType(),
+      rpcName: "ping",
+      attributes: [],
+    }),
+  );
+  assert.equal(pinged.output?.kind?.$case, "objValue");
 });
 
 test("fluent wait factories validate channel bounds", () => {

--- a/sdk-typescript/test/integ/json-omit.integration.test.ts
+++ b/sdk-typescript/test/integ/json-omit.integration.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { flowId, withEnvironment } from "./environment.js";
+import { JsonOmitRpcFlow, JsonOmitStepFlow, type JsonOrder } from "./json_omit_codec_flow.js";
+
+test("object Step input omits codec and completes with JSON", async () => {
+  const flow = new JsonOmitStepFlow();
+  await withEnvironment([flow], async ({ client }) => {
+    const id = flowId("json-omit-step");
+    await client.startFlow(flow, id, { orderId: "order-1" });
+    const result = await client.waitForFlow(id, 30_000);
+    assert.deepEqual(result.singleOutput<JsonOrder>(), { orderId: "order-1" });
+  });
+});
+
+test("object RPC omits codecs and round-trips JSON", async () => {
+  const flow = new JsonOmitRpcFlow();
+  await withEnvironment([flow], async ({ client }) => {
+    const id = flowId("json-omit-rpc");
+    await client.startFlow(flow, id, undefined);
+    const output = await client.invokeRPC(flow.describe, id, { orderId: "order-2" });
+    assert.deepEqual(output, { orderId: "order-2" });
+    await client.stopFlow(id);
+  });
+});

--- a/sdk-typescript/test/integ/json_omit_codec_flow.ts
+++ b/sdk-typescript/test/integ/json_omit_codec_flow.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+import {
+  StepList,
+  gracefulComplete,
+  rpc,
+  type Context,
+  type Flow,
+  type RPCResult,
+  type Step,
+  type StepDecision,
+} from "../../src/index.js";
+
+export interface JsonOrder {
+  readonly orderId: string;
+}
+
+class CompleteJsonOrder implements Step<JsonOrder> {
+  public getStepType(): string {
+    return "CompleteJsonOrder";
+  }
+
+  public execute(_context: Context, input: JsonOrder): StepDecision {
+    return gracefulComplete(input);
+  }
+}
+
+export class JsonOmitStepFlow implements Flow<JsonOrder> {
+  public readonly start = new CompleteJsonOrder();
+
+  public getFlowType(): string {
+    return "JsonOmitStepFlow";
+  }
+
+  public getSteps() {
+    return StepList.startStep(this.start);
+  }
+}
+
+export class JsonOmitRpcFlow implements Flow {
+  public getFlowType(): string {
+    return "JsonOmitRpcFlow";
+  }
+
+  public getSteps() {
+    return StepList.empty();
+  }
+
+  @rpc()
+  public describe(_context: Context, order: JsonOrder): RPCResult<JsonOrder> {
+    return { output: order };
+  }
+}


### PR DESCRIPTION
## Summary
- Omitted Step `inputCodec` and RPC `inputCodec`/`outputCodec` now encode as JSON (`JSON.stringify` / `JSON.parse`), so object payloads no longer need a hand-written `jsonCodec`.
- Scalar wire kinds still require `stringCodec`, `booleanCodec`, `int64Codec`, `doubleCodec`, or `bytesCodec`. `@rpc()` procedures stay distinct by method arity and a void return.
- `decode()` / `singleOutput()` also default to JSON. Attribute and Channel constructors still take an explicit codec. Examples under `examples/typescript/` are unchanged.

## Test plan
- [x] `cd sdk-typescript && npm test`
- [x] `cd sdk-typescript && npm run docs:check`
- [ ] `cd sdk-typescript && npm run test:integration` (new `json-omit` cases; needs `dexcli dev`)


Made with [Cursor](https://cursor.com)