### PR TITLE
examples(ts): pin 0.1.11 and omit JSON codecs

### DIFF
--- a/docs/content/primitives/step.mdx
+++ b/docs/content/primitives/step.mdx
@@ -324,7 +324,7 @@ public RPCResult<QuoteStatus> acceptQuote(Context context, Quote quote) {
   <SdkSnippet lang="typescript">
 
 ```typescript
-@rpc({ name: "acceptQuote", inputCodec: quoteCodec, outputCodec: quoteStatusCodec })
+@rpc({ name: "acceptQuote" })
 acceptQuote(_context: Context, quote: Quote): RPCResult<QuoteStatus> {
   return {
     output: QuoteStatus.ACCEPTED,

--- a/docs/content/references/typescript-sdk.mdx
+++ b/docs/content/references/typescript-sdk.mdx
@@ -5,7 +5,7 @@ sidebar_label: TypeScript SDK
 
 # TypeScript SDK notes
 
-Package: `@superdurable/dex` (examples target **^0.1.3+**).
+Package: `@superdurable/dex` (examples target **0.1.11**).
 
 ## Async handlers
 

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,6 +1,6 @@
 # Dex TypeScript examples
 
-These examples target [`@superdurable/dex@0.1.10`](https://www.npmjs.com/package/@superdurable/dex).
+These examples target [`@superdurable/dex@0.1.11`](https://www.npmjs.com/package/@superdurable/dex).
 
 The sample process hosts one gRPC Worker (default `127.0.0.1:8803`) and an HTTP
 controller on port `8080`. Step `execute` / `waitFor` / RPC handlers may

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@superdurable/dex-examples-typescript",
       "version": "0.0.0",
       "dependencies": {
-        "@superdurable/dex": "0.1.10",
+        "@superdurable/dex": "0.1.11",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -125,9 +125,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@superdurable/dex": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.1.10.tgz",
-      "integrity": "sha512-P0AhInm49jKiILzDMqXdb5WiZyz2fv8UVXy+AlY3w/GAfADfKz9Ns0TFfA9UnfFBuyozAYUbOAoTVMtuQNhJjg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.1.11.tgz",
+      "integrity": "sha512-d98p4S3xUYG5txDNuASz/edEWWbFXlFSgzUeJIRce22EArfcuD0M5v8SH8es0E0ZHuHCZbRHgqJ1yakNyF4AOQ==",
       "license": "LicenseRef-Super-Durable-1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.13.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -16,7 +16,7 @@
     "smoke": "npm run build && node --test --experimental-test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/e2e/flow-smoke.test.js'"
   },
   "dependencies": {
-    "@superdurable/dex": "0.1.10",
+    "@superdurable/dex": "0.1.11",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/examples/typescript/src/patterns/cron/cron-schedule-flow.ts
+++ b/examples/typescript/src/patterns/cron/cron-schedule-flow.ts
@@ -17,7 +17,6 @@
 import {
   StepList,
   gracefulComplete,
-  voidCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -26,8 +25,6 @@ import {
 } from "@superdurable/dex";
 
 class CronScheduleStep implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public getStepType(): string {
     return "CronScheduleStep";
   }

--- a/examples/typescript/src/patterns/drain-channels/internal/drain-internal-channels-flow.ts
+++ b/examples/typescript/src/patterns/drain-channels/internal/drain-internal-channels-flow.ts
@@ -26,7 +26,6 @@ import {
   gracefulComplete,
   jsonCodec,
   stringCodec,
-  voidCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -68,8 +67,6 @@ class Init implements Step<string> {
 }
 
 class UpsertMongoRecord implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: DrainInternalChannelsFlow) {}
 
   public getStepType(): string {
@@ -150,8 +147,6 @@ class ProcessData implements Step<string> {
 }
 
 class Finalize implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: DrainInternalChannelsFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/patterns/interruptible/interruptible-execution-flow.ts
+++ b/examples/typescript/src/patterns/interruptible/interruptible-execution-flow.ts
@@ -23,10 +23,8 @@ import {
   goTo,
   goToMulti,
   gracefulComplete,
-  jsonCodec,
   rpc,
   stringCodec,
-  voidCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -34,18 +32,11 @@ import {
   type StepDecision,
 } from "@superdurable/dex";
 
-import {
-  workJobParametersInputCodec,
-  type WorkJobParametersInput,
-} from "./work-job-parameters-input.js";
+import { type WorkJobParametersInput } from "./work-job-parameters-input.js";
 
 export const DA_INTERRUPT_SIGNAL = "interruptSignal";
 
-const workJobInputCodec = jsonCodec<WorkJobParametersInput>(workJobParametersInputCodec);
-
 class Init implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: InterruptibleExecutionFlow) {}
 
   public getStepType(): string {
@@ -62,8 +53,6 @@ class Init implements Step<void> {
 }
 
 class WorkAExecution implements Step<WorkJobParametersInput> {
-  public readonly inputCodec = workJobInputCodec;
-
   public constructor(private readonly flow: InterruptibleExecutionFlow) {}
 
   public getStepType(): string {
@@ -98,8 +87,6 @@ class WorkAExecution implements Step<WorkJobParametersInput> {
 }
 
 class WorkNExecution implements Step<WorkJobParametersInput> {
-  public readonly inputCodec = workJobInputCodec;
-
   public constructor(private readonly flow: InterruptibleExecutionFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/patterns/interruptible/work-job-parameters-input.ts
+++ b/examples/typescript/src/patterns/interruptible/work-job-parameters-input.ts
@@ -18,14 +18,3 @@ export interface WorkJobParametersInput {
   jobUpperBound: number;
   progress: number;
 }
-
-export const workJobParametersInputCodec = {
-  typeName: "WorkJobParametersInput",
-  decode: (value: unknown): WorkJobParametersInput => {
-    const record = value as WorkJobParametersInput;
-    return {
-      jobUpperBound: Number(record.jobUpperBound),
-      progress: Number(record.progress),
-    };
-  },
-};

--- a/examples/typescript/src/patterns/intervention/manual-intervention-flow.ts
+++ b/examples/typescript/src/patterns/intervention/manual-intervention-flow.ts
@@ -38,8 +38,6 @@ export const SIGNAL_CHANNEL_COMMAND_SKIP = "signal_channel_command_skip";
 export const NUMBER_OF_RETRIES = "number_of_retries";
 
 class Init implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: ManualInterventionFlow) {}
 
   public getStepType(): string {
@@ -92,8 +90,6 @@ class GetData implements Step<boolean> {
 }
 
 class ErrorStep implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: ManualInterventionFlow) {}
 
   public getStepType(): string {
@@ -117,8 +113,6 @@ class ErrorStep implements Step<void> {
 }
 
 class Final implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: ManualInterventionFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/patterns/parallel/job-seeker.ts
+++ b/examples/typescript/src/patterns/parallel/job-seeker.ts
@@ -19,15 +19,3 @@ export interface JobSeeker {
   email: string;
   phoneNumber: string;
 }
-
-export const jobSeekerCodec = {
-  typeName: "JobSeeker",
-  decode: (value: unknown): JobSeeker => {
-    const record = value as JobSeeker;
-    return {
-      id: String(record.id),
-      email: String(record.email),
-      phoneNumber: String(record.phoneNumber),
-    };
-  },
-};

--- a/examples/typescript/src/patterns/parallel/parallel-states-with-await-flow.ts
+++ b/examples/typescript/src/patterns/parallel/parallel-states-with-await-flow.ts
@@ -23,7 +23,6 @@ import {
   doubleCodec,
   goToMulti,
   gracefulComplete,
-  jsonCodec,
   stringCodec,
   type Context,
   type Flow,
@@ -32,11 +31,10 @@ import {
   type StepDecision,
 } from "@superdurable/dex";
 
-import { jobSeekerCodec, type JobSeeker } from "./job-seeker.js";
+import { type JobSeeker } from "./job-seeker.js";
 
 export const NOTIFY_CHANNEL = "test_notify_channel";
 
-const jobSeekerInputCodec = jsonCodec<JobSeeker>(jobSeekerCodec);
 const countInputCodec = doubleCodec;
 
 class Starting implements Step<number> {
@@ -66,8 +64,6 @@ class Starting implements Step<number> {
 }
 
 class NotifyUser implements Step<JobSeeker> {
-  public readonly inputCodec = jobSeekerInputCodec;
-
   public constructor(private readonly flow: ParallelStatesWithAwaitFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/patterns/parallel/simple-parallel-states-flow.ts
+++ b/examples/typescript/src/patterns/parallel/simple-parallel-states-flow.ts
@@ -19,7 +19,6 @@ import {
   StepMovement,
   goToMulti,
   gracefulComplete,
-  jsonCodec,
   stringCodec,
   type Context,
   type Flow,
@@ -28,14 +27,11 @@ import {
   type StepDecision,
 } from "@superdurable/dex";
 
-import { jobSeekerCodec, type JobSeeker } from "./job-seeker.js";
+import { type JobSeeker } from "./job-seeker.js";
 
-const jobSeekerInputCodec = jsonCodec<JobSeeker>(jobSeekerCodec);
 const stringInputCodec = stringCodec;
 
 class Init implements Step<JobSeeker> {
-  public readonly inputCodec = jobSeekerInputCodec;
-
   public constructor(private readonly flow: SimpleParallelStatesFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/patterns/parent-child/parent-flow-v2.ts
+++ b/examples/typescript/src/patterns/parent-child/parent-flow-v2.ts
@@ -24,8 +24,6 @@ import {
   doubleCodec,
   goTo,
   goToMulti,
-  jsonCodec,
-  voidCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -37,16 +35,12 @@ import { getClient } from "../../client-holder.js";
 import { startOptions } from "../../config/env.js";
 import { isFlowAlreadyStarted } from "../../service-errors.js";
 import { childFlow, type ChildFlow } from "../scalable-parallel/child-flow.js";
-import {
-  waitForChildInputCodec,
-  type WaitForChildInput,
-} from "./wait-for-child-input.js";
+import { type WaitForChildInput } from "./wait-for-child-input.js";
 
 export const CONCURRENCY_PER_PARENT_WORKFLOW = 3;
 export const TASK_QUEUE = "task_queue";
 
 const countInputCodec = doubleCodec;
-const waitForChildInputCodecImpl = jsonCodec<WaitForChildInput>(waitForChildInputCodec);
 
 class Init implements Step<number> {
   public readonly inputCodec = countInputCodec;
@@ -71,8 +65,6 @@ class Init implements Step<number> {
 }
 
 class LoopForNextTask implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: ParentFlowV2) {}
 
   public getStepType(): string {
@@ -123,8 +115,6 @@ class StartChildWorkflow implements Step<number> {
 }
 
 class AwaitChildWorkflowCompletion implements Step<WaitForChildInput> {
-  public readonly inputCodec = waitForChildInputCodecImpl;
-
   public constructor(private readonly flow: ParentFlowV2) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/patterns/parent-child/wait-for-child-input.ts
+++ b/examples/typescript/src/patterns/parent-child/wait-for-child-input.ts
@@ -18,14 +18,3 @@ export interface WaitForChildInput {
   childWFId: string;
   timerSeconds: number;
 }
-
-export const waitForChildInputCodec = {
-  typeName: "WaitForChildInput",
-  decode: (value: unknown): WaitForChildInput => {
-    const record = value as WaitForChildInput;
-    return {
-      childWFId: String(record.childWFId),
-      timerSeconds: Number(record.timerSeconds),
-    };
-  },
-};

--- a/examples/typescript/src/patterns/polling/backoff-polling-flow.ts
+++ b/examples/typescript/src/patterns/polling/backoff-polling-flow.ts
@@ -19,7 +19,6 @@ import {
   goTo,
   gracefulComplete,
   stringCodec,
-  voidCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -34,8 +33,6 @@ import {
 } from "../shared/service-dependency.js";
 
 class ReadExternalDep implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(
     private readonly flow: BackoffPollingFlow,
     private readonly service: ServiceDependency,

--- a/examples/typescript/src/patterns/polling/simple-polling-flow.ts
+++ b/examples/typescript/src/patterns/polling/simple-polling-flow.ts
@@ -20,7 +20,6 @@ import {
   Wait,
   goTo,
   gracefulComplete,
-  voidCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -29,8 +28,6 @@ import {
 } from "@superdurable/dex";
 
 class SimplePolling implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: SimplePollingFlow) {}
 
   public getStepType(): string {
@@ -55,8 +52,6 @@ class SimplePolling implements Step<void> {
 }
 
 class SimplePollingComplete implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public getStepType(): string {
     return "SimplePollingComplete";
   }

--- a/examples/typescript/src/patterns/recovery/failure-recovery-flow.ts
+++ b/examples/typescript/src/patterns/recovery/failure-recovery-flow.ts
@@ -71,8 +71,6 @@ class PaymentProcessor {
 }
 
 class UpdateItemQuantity implements Step<FailureRecoveryWorkflowInput> {
-  public readonly inputCodec = workflowInputCodec;
-
   public constructor(
     private readonly flow: FailureRecoveryFlow,
     private readonly database: DatabaseConnection,
@@ -130,8 +128,6 @@ class ChargeForItems implements Step<number> {
 }
 
 class UpdateQuantityRecovery implements Step<FailureRecoveryWorkflowInput> {
-  public readonly inputCodec = workflowInputCodec;
-
   public constructor(private readonly database: DatabaseConnection) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/patterns/reminders/reminder-flow.ts
+++ b/examples/typescript/src/patterns/reminders/reminder-flow.ts
@@ -47,8 +47,6 @@ export const INTERNAL_CHANNEL_COMPLETE_PROCESS = "CompleteProcess";
 const REMINDER_WAIT_MS = 5_000;
 
 class Init implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: ReminderFlow) {}
 
   public getStepType(): string {
@@ -65,8 +63,6 @@ class Init implements Step<void> {
 }
 
 class ProcessTimeout implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(
     private readonly flow: ReminderFlow,
     private readonly service: ServiceDependency,
@@ -92,8 +88,6 @@ class ProcessTimeout implements Step<void> {
 }
 
 class Reminder implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(
     private readonly flow: ReminderFlow,
     private readonly service: ServiceDependency,

--- a/examples/typescript/src/patterns/resettable-timer/resettable-timer-flow.ts
+++ b/examples/typescript/src/patterns/resettable-timer/resettable-timer-flow.ts
@@ -23,7 +23,6 @@ import {
   gracefulComplete,
   rpc,
   stringCodec,
-  voidCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -35,8 +34,6 @@ export const RESET_TIMER_CHANNEL = "RESET_TIMER_CHANNEL";
 export const TIMER_DURATION_MS = 5 * 60 * 1000;
 
 class ResettableTimerStep implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: ResettableTimerFlow) {}
 
   public getStepType(): string {
@@ -59,8 +56,6 @@ class ResettableTimerStep implements Step<void> {
 }
 
 class TimerExpired implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public getStepType(): string {
     return "TimerExpired";
   }

--- a/examples/typescript/src/patterns/scalable-parallel/models/batch-enqueue-request.ts
+++ b/examples/typescript/src/patterns/scalable-parallel/models/batch-enqueue-request.ts
@@ -17,13 +17,3 @@
 export interface BatchEnqueueRequest {
   list: string[];
 }
-
-export const batchEnqueueRequestCodec = {
-  typeName: "BatchEnqueueRequest",
-  decode: (value: unknown): BatchEnqueueRequest => {
-    const record = value as BatchEnqueueRequest;
-    return {
-      list: Array.isArray(record.list) ? record.list.map(String) : [],
-    };
-  },
-};

--- a/examples/typescript/src/patterns/scalable-parallel/parent-flow.ts
+++ b/examples/typescript/src/patterns/scalable-parallel/parent-flow.ts
@@ -42,10 +42,7 @@ import {
 import { getClient } from "../../client-holder.js";
 import { HOUR_MS } from "../../config/env.js";
 import { isFlowAlreadyStarted } from "../../service-errors.js";
-import {
-  batchEnqueueRequestCodec,
-  type BatchEnqueueRequest,
-} from "./models/batch-enqueue-request.js";
+import { type BatchEnqueueRequest } from "./models/batch-enqueue-request.js";
 import { childFlow, type ChildFlow } from "./child-flow.js";
 
 export const NUM_PARENT_WORKFLOWS = 2;
@@ -55,7 +52,6 @@ export const TASK_QUEUE = "TaskQueue";
 export const CHILD_COMPLETE_CHANNEL_PREFIX = "ChildComplete_";
 export const DA_CURRENT_WAIT_CHILD_WFS = "CurrentWaitChildWfs";
 
-const batchInputCodec = jsonCodec<BatchEnqueueRequest>(batchEnqueueRequestCodec);
 const stringArrayCodec = jsonCodec<string[]>({
   typeName: "string[]",
   decode: (value: unknown) =>
@@ -63,8 +59,6 @@ const stringArrayCodec = jsonCodec<string[]>({
 });
 
 class Init implements Step<BatchEnqueueRequest> {
-  public readonly inputCodec = batchInputCodec;
-
   public constructor(private readonly flow: ParentFlow) {}
 
   public getStepType(): string {
@@ -80,8 +74,6 @@ class Init implements Step<BatchEnqueueRequest> {
 }
 
 class LoopForNextMessage implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(
     private readonly flow: ParentFlow,
     private readonly child: ChildFlow,
@@ -192,7 +184,7 @@ export class ParentFlow implements Flow<BatchEnqueueRequest> {
     };
   }
 
-  @rpc({ inputCodec: batchInputCodec, outputCodec: booleanCodec })
+  @rpc({ outputCodec: booleanCodec })
   public enqueue(context: Context, request: BatchEnqueueRequest): RPCResult<boolean> {
     if (this.taskQueue.size(context) + request.list.length > MAX_BUFFERED_TASKS) {
       return { output: false };

--- a/examples/typescript/src/patterns/timeout/flow-graceful-timeout.ts
+++ b/examples/typescript/src/patterns/timeout/flow-graceful-timeout.ts
@@ -23,7 +23,6 @@ import {
   forceComplete,
   forceFail,
   goToMulti,
-  voidCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -49,8 +48,6 @@ class Init implements Step<boolean> {
 }
 
 class Timeout implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public getStepType(): string {
     return "Timeout";
   }

--- a/examples/typescript/src/patterns/wait-for-state-completion/wait-for-state-completion-flow.ts
+++ b/examples/typescript/src/patterns/wait-for-state-completion/wait-for-state-completion-flow.ts
@@ -43,8 +43,6 @@ export const JOB_SEEKER_DATA = "job_seeker_data";
 const jobSeekerDataInputCodec = jsonCodec<JobSeekerData>(jobSeekerDataCodec);
 
 class PersistData implements Step<JobSeekerData> {
-  public readonly inputCodec = jobSeekerDataInputCodec;
-
   public constructor(private readonly flow: WaitForStateCompletionFlow) {}
 
   public getStepType(): string {
@@ -59,8 +57,6 @@ class PersistData implements Step<JobSeekerData> {
 }
 
 class UpdateExternalSystem implements Step<JobSeekerData> {
-  public readonly inputCodec = jobSeekerDataInputCodec;
-
   public constructor(private readonly flow: WaitForStateCompletionFlow) {}
 
   public getStepType(): string {
@@ -103,7 +99,7 @@ export class WaitForStateCompletionFlow implements Flow<JobSeekerData> {
     return { attributes: [this.jobSeekerData] };
   }
 
-  @rpc({ outputCodec: jobSeekerDataInputCodec })
+  @rpc()
   public getJobSeekerData(context: Context): RPCResult<JobSeekerData> {
     const data = this.jobSeekerData.get(context);
     if (data === undefined) {

--- a/examples/typescript/src/primitives/channel/channel-flow.ts
+++ b/examples/typescript/src/primitives/channel/channel-flow.ts
@@ -24,7 +24,6 @@ import {
   gracefulComplete,
   rpc,
   stringCodec,
-  voidCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -77,7 +76,7 @@ export class ChannelFlow implements Flow<number> {
     return { channels: [this.approval] };
   }
 
-  @rpc({ inputCodec: voidCodec })
+  @rpc()
   public approve(context: Context): void {
     this.approval.publish(context, "approved");
   }

--- a/examples/typescript/src/products/engagement/engagement-flow.ts
+++ b/examples/typescript/src/products/engagement/engagement-flow.ts
@@ -46,8 +46,6 @@ import {
 } from "../../shared/my-dependency-service.js";
 import {
   Status,
-  engagementDescriptionCodec,
-  engagementInputCodec,
   statusCodec,
   type EngagementDescription,
   type EngagementInput,
@@ -102,12 +100,12 @@ export class EngagementFlow implements Flow<EngagementInput> {
     };
   }
 
-  @rpc({ outputCodec: engagementDescriptionCodec })
+  @rpc()
   public describe(context: Context): RPCResult<EngagementDescription> {
     return { output: this.describeEngagement(context) };
   }
 
-  @rpc({ inputCodec: stringCodec, outputCodec: statusCodec })
+  @rpc({ inputCodec: stringCodec })
   public decline(context: Context, note: string): RPCResult<Status> {
     const status = this.engagementStatus.get(context);
     if (status !== Status.INITIATED) {
@@ -122,7 +120,7 @@ export class EngagementFlow implements Flow<EngagementInput> {
     };
   }
 
-  @rpc({ inputCodec: stringCodec, outputCodec: statusCodec })
+  @rpc({ inputCodec: stringCodec })
   public accept(context: Context, note: string): RPCResult<Status> {
     const status = this.engagementStatus.get(context);
     if (status !== Status.INITIATED && status !== Status.DECLINED) {
@@ -159,8 +157,6 @@ export class EngagementFlow implements Flow<EngagementInput> {
 }
 
 class Initialize implements Step<EngagementInput> {
-  public readonly inputCodec = engagementInputCodec;
-
   public constructor(private readonly flow: EngagementFlow) {}
 
   public getStepType(): string {
@@ -182,8 +178,6 @@ class Initialize implements Step<EngagementInput> {
 }
 
 class ProcessTimeout implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: EngagementFlow) {}
 
   public getStepType(): string {
@@ -211,8 +205,6 @@ class ProcessTimeout implements Step<void> {
 }
 
 class Reminder implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: EngagementFlow) {}
 
   public getStepType(): string {
@@ -243,8 +235,6 @@ class Reminder implements Step<void> {
 }
 
 class NotifyExternalSystem implements Step<Status> {
-  public readonly inputCodec = statusCodec;
-
   public constructor(private readonly flow: EngagementFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/products/engagement/models.ts
+++ b/examples/typescript/src/products/engagement/models.ts
@@ -45,35 +45,6 @@ export function decodeStatus(value: unknown): Status {
   throw new Error(`unknown status: ${status}`);
 }
 
-export function decodeEngagementInput(value: unknown): EngagementInput {
-  const record = value as EngagementInput;
-  return {
-    employerId: String(record.employerId),
-    jobSeekerId: String(record.jobSeekerId),
-    notes: String(record.notes ?? ""),
-  };
-}
-
-export function decodeEngagementDescription(value: unknown): EngagementDescription {
-  const record = value as EngagementDescription;
-  return {
-    employerId: String(record.employerId),
-    jobSeekerId: String(record.jobSeekerId),
-    notes: String(record.notes ?? ""),
-    currentStatus: decodeStatus(record.currentStatus),
-  };
-}
-
-export const engagementInputCodec = jsonCodec<EngagementInput>({
-  typeName: "EngagementInput",
-  decode: decodeEngagementInput,
-});
-
-export const engagementDescriptionCodec = jsonCodec<EngagementDescription>({
-  typeName: "EngagementDescription",
-  decode: decodeEngagementDescription,
-});
-
 export const statusCodec = jsonCodec<Status>({
   typeName: "Status",
   decode: decodeStatus,

--- a/examples/typescript/src/products/job-post/job-info.ts
+++ b/examples/typescript/src/products/job-post/job-info.ts
@@ -14,28 +14,12 @@
  * limitations under the License.
  */
 
-import { jsonCodec, optionalCodec, stringCodec } from "@superdurable/dex";
+import { optionalCodec, stringCodec } from "@superdurable/dex";
 
 export interface JobInfo {
   title: string;
   description: string;
   notes: string;
 }
-
-export function decodeJobInfo(value: unknown): JobInfo {
-  const record = value as JobInfo;
-  return {
-    title: String(record.title),
-    description: String(record.description),
-    notes: String(record.notes ?? ""),
-  };
-}
-
-export const jobInfoCodec = jsonCodec<JobInfo>({
-  typeName: "JobInfo",
-  decode: decodeJobInfo,
-});
-
-export const optionalJobInfoCodec = optionalCodec(jobInfoCodec);
 
 export const optionalStringCodec = optionalCodec(stringCodec);

--- a/examples/typescript/src/products/job-post/job-post-flow.ts
+++ b/examples/typescript/src/products/job-post/job-post-flow.ts
@@ -21,10 +21,8 @@ import {
   StepMovement,
   deadEnd,
   int64Codec,
-  optionalCodec,
   rpc,
   stringCodec,
-  voidCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -39,7 +37,7 @@ import {
   myDependencyService,
   type MyDependencyService,
 } from "../../shared/my-dependency-service.js";
-import { jobInfoCodec, optionalStringCodec, type JobInfo } from "./job-info.js";
+import { optionalStringCodec, type JobInfo } from "./job-info.js";
 
 export class JobPostFlow implements Flow {
   public readonly title = new Attribute("Title", stringCodec, {
@@ -71,17 +69,17 @@ export class JobPostFlow implements Flow {
     };
   }
 
-  @rpc({ outputCodec: jobInfoCodec })
+  @rpc()
   public get(context: Context): RPCResult<JobInfo> {
     return { output: this.readJobInfo(context) };
   }
 
-  @rpc({ name: "getWithStrongConsistency", outputCodec: jobInfoCodec })
+  @rpc({ name: "getWithStrongConsistency" })
   public getWithStrongConsistency(context: Context): RPCResult<JobInfo> {
     return this.get(context);
   }
 
-  @rpc({ inputCodec: jobInfoCodec, outputCodec: voidCodec })
+  @rpc()
   public update(context: Context, input: JobInfo): RPCResult<void> {
     this.title.set(context, input.title);
     this.jobDescription.set(context, input.description);
@@ -102,8 +100,6 @@ export class JobPostFlow implements Flow {
 }
 
 class ExternalUpdate implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   private readonly options: StepOptions = {
     executeRetry: {
       backoffCoefficient: 2,

--- a/examples/typescript/src/products/microservices/orchestration-flow.ts
+++ b/examples/typescript/src/products/microservices/orchestration-flow.ts
@@ -100,8 +100,6 @@ class CallAPI1 implements Step<string> {
 }
 
 class CallAPI2 implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: OrchestrationFlow) {}
 
   public getStepType(): string {
@@ -115,8 +113,6 @@ class CallAPI2 implements Step<void> {
 }
 
 class CallAPI3 implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: OrchestrationFlow) {}
 
   public getStepType(): string {
@@ -138,8 +134,6 @@ class CallAPI3 implements Step<void> {
 }
 
 class CallAPI4 implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: OrchestrationFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/products/money-transfer/money-transfer-flow.ts
+++ b/examples/typescript/src/products/money-transfer/money-transfer-flow.ts
@@ -20,7 +20,6 @@ import {
   forceFail,
   goTo,
   gracefulComplete,
-  jsonCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -34,12 +33,7 @@ import {
   myDependencyService,
   type MyDependencyService,
 } from "../../shared/my-dependency-service.js";
-import {
-  transferRequestCodec,
-  type TransferRequest,
-} from "./transfer-request.js";
-
-const inputCodec = jsonCodec<TransferRequest>(transferRequestCodec);
+import { type TransferRequest } from "./transfer-request.js";
 
 export class MoneyTransferFlow implements Flow<TransferRequest> {
   private readonly checkBalance = new CheckBalance(this);
@@ -104,8 +98,6 @@ export class MoneyTransferFlow implements Flow<TransferRequest> {
 }
 
 class CheckBalance implements Step<TransferRequest> {
-  public readonly inputCodec = inputCodec;
-
   public constructor(private readonly flow: MoneyTransferFlow) {}
 
   public getStepType(): string {
@@ -121,8 +113,6 @@ class CheckBalance implements Step<TransferRequest> {
 }
 
 class CreateDebitMemo implements Step<TransferRequest> {
-  public readonly inputCodec = inputCodec;
-
   public constructor(private readonly flow: MoneyTransferFlow) {}
 
   public getStepType(): string {
@@ -140,8 +130,6 @@ class CreateDebitMemo implements Step<TransferRequest> {
 }
 
 class Debit implements Step<TransferRequest> {
-  public readonly inputCodec = inputCodec;
-
   public constructor(private readonly flow: MoneyTransferFlow) {}
 
   public getStepType(): string {
@@ -159,8 +147,6 @@ class Debit implements Step<TransferRequest> {
 }
 
 class CreateCreditMemo implements Step<TransferRequest> {
-  public readonly inputCodec = inputCodec;
-
   public constructor(private readonly flow: MoneyTransferFlow) {}
 
   public getStepType(): string {
@@ -178,8 +164,6 @@ class CreateCreditMemo implements Step<TransferRequest> {
 }
 
 class Credit implements Step<TransferRequest> {
-  public readonly inputCodec = inputCodec;
-
   public constructor(private readonly flow: MoneyTransferFlow) {}
 
   public getStepType(): string {
@@ -199,8 +183,6 @@ class Credit implements Step<TransferRequest> {
 }
 
 class Compensate implements Step<TransferRequest> {
-  public readonly inputCodec = inputCodec;
-
   public constructor(private readonly flow: MoneyTransferFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/products/money-transfer/transfer-request.ts
+++ b/examples/typescript/src/products/money-transfer/transfer-request.ts
@@ -20,16 +20,3 @@ export interface TransferRequest {
   readonly amount: number;
   readonly notes: string;
 }
-
-export const transferRequestCodec = {
-  typeName: "TransferRequest",
-  decode: (value: unknown): TransferRequest => {
-    const record = value as TransferRequest;
-    return {
-      fromAccount: String(record.fromAccount),
-      toAccount: String(record.toAccount),
-      amount: Number(record.amount),
-      notes: String(record.notes ?? ""),
-    };
-  },
-};

--- a/examples/typescript/src/products/polling/polling-flow.ts
+++ b/examples/typescript/src/products/polling/polling-flow.ts
@@ -92,8 +92,6 @@ class Initialize implements Step<number> {
 }
 
 class WaitForTasks implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: PollingFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/products/shortlist-candidates/employer-opt-in-flow.ts
+++ b/examples/typescript/src/products/shortlist-candidates/employer-opt-in-flow.ts
@@ -24,7 +24,6 @@ import {
   forceComplete,
   rpc,
   stringCodec,
-  voidCodec,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -33,7 +32,7 @@ import {
   type StepDecision,
 } from "@superdurable/dex";
 
-import { employerOptInInputCodec, type EmployerOptInInput } from "./employer-opt-in-input.js";
+import { type EmployerOptInInput } from "./employer-opt-in-input.js";
 
 export class EmployerOptInFlow implements Flow<EmployerOptInInput> {
   public readonly employerId = new Attribute("EMPLOYER_OPT_IN_EmployerId", stringCodec, {
@@ -64,15 +63,13 @@ export class EmployerOptInFlow implements Flow<EmployerOptInInput> {
     return { output: this.optedIn.get(context) === true };
   }
 
-  @rpc({ outputCodec: voidCodec })
+  @rpc()
   public optOut(_context: Context): RPCResult<void> {
     return { output: undefined, nextSteps: [StepMovement.of(this.optOutStep, undefined)] };
   }
 }
 
 class OptIn implements Step<EmployerOptInInput> {
-  public readonly inputCodec = employerOptInInputCodec;
-
   public constructor(private readonly flow: EmployerOptInFlow) {}
 
   public getStepType(): string {
@@ -87,8 +84,6 @@ class OptIn implements Step<EmployerOptInInput> {
 }
 
 class OptOut implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: EmployerOptInFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/products/shortlist-candidates/employer-opt-in-input.ts
+++ b/examples/typescript/src/products/shortlist-candidates/employer-opt-in-input.ts
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-import { jsonCodec } from "@superdurable/dex";
-
 export interface EmployerOptInInput {
   employerId: string;
 }
-
-export function decodeEmployerOptInInput(value: unknown): EmployerOptInInput {
-  const record = value as EmployerOptInInput;
-  return { employerId: String(record.employerId) };
-}
-
-export const employerOptInInputCodec = jsonCodec<EmployerOptInInput>({
-  typeName: "EmployerOptInInput",
-  decode: decodeEmployerOptInInput,
-});

--- a/examples/typescript/src/products/shortlist-candidates/shortlist-flow.ts
+++ b/examples/typescript/src/products/shortlist-candidates/shortlist-flow.ts
@@ -41,7 +41,7 @@ import {
   type MyDependencyService,
 } from "../../shared/my-dependency-service.js";
 import { employerOptInFlow } from "./employer-opt-in-flow.js";
-import { shortlistInputCodec, type ShortlistInput } from "./shortlist-input.js";
+import { type ShortlistInput } from "./shortlist-input.js";
 import { isOptedIn } from "./workflow-ids.js";
 
 export const SA_KEY_EMPLOYER_ID = "SHORTLIST_EmployerId";
@@ -87,8 +87,6 @@ export class ShortlistFlow implements Flow<ShortlistInput> {
 }
 
 class Shortlist implements Step<ShortlistInput> {
-  public readonly inputCodec = shortlistInputCodec;
-
   public constructor(private readonly flow: ShortlistFlow) {}
 
   public getStepType(): string {
@@ -104,8 +102,6 @@ class Shortlist implements Step<ShortlistInput> {
 }
 
 class SendEmail implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: ShortlistFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/products/shortlist-candidates/shortlist-input.ts
+++ b/examples/typescript/src/products/shortlist-candidates/shortlist-input.ts
@@ -14,22 +14,7 @@
  * limitations under the License.
  */
 
-import { jsonCodec } from "@superdurable/dex";
-
 export interface ShortlistInput {
   employerId: string;
   candidateId: string;
 }
-
-export function decodeShortlistInput(value: unknown): ShortlistInput {
-  const record = value as ShortlistInput;
-  return {
-    employerId: String(record.employerId),
-    candidateId: String(record.candidateId),
-  };
-}
-
-export const shortlistInputCodec = jsonCodec<ShortlistInput>({
-  typeName: "ShortlistInput",
-  decode: decodeShortlistInput,
-});

--- a/examples/typescript/src/products/signup/user-signup-flow.ts
+++ b/examples/typescript/src/products/signup/user-signup-flow.ts
@@ -78,8 +78,6 @@ export class UserSignupFlow implements Flow<SignupForm> {
 }
 
 class Submit implements Step<SignupForm> {
-  public readonly inputCodec = signupFormCodec;
-
   public constructor(private readonly flow: UserSignupFlow) {}
 
   public getStepType(): string {
@@ -95,8 +93,6 @@ class Submit implements Step<SignupForm> {
 }
 
 class Verify implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: UserSignupFlow) {}
 
   public getStepType(): string {

--- a/examples/typescript/src/products/subscription/subscription-flow.ts
+++ b/examples/typescript/src/products/subscription/subscription-flow.ts
@@ -42,18 +42,13 @@ import {
   type MyDependencyService,
 } from "../../shared/my-dependency-service.js";
 import { SubscriptionBilling } from "./subscription-billing.js";
-import { decodeCustomer, decodeSubscription, type Customer, type Subscription } from "./models.js";
+import { decodeCustomer, type Customer, type Subscription } from "./models.js";
 
 const SUBSCRIPTION_OVER_KEY = "subscription-over";
 
 const customerCodec = jsonCodec<Customer>({
   typeName: "Customer",
   decode: decodeCustomer,
-});
-
-const subscriptionCodec = jsonCodec<Subscription>({
-  typeName: "Subscription",
-  decode: decodeSubscription,
 });
 
 export class SubscriptionFlow implements Flow<Customer> {
@@ -90,15 +85,13 @@ export class SubscriptionFlow implements Flow<Customer> {
     };
   }
 
-  @rpc({ outputCodec: subscriptionCodec })
+  @rpc()
   public describe(context: Context): RPCResult<Subscription> {
     return { output: this.customerDetails.get(context).subscription };
   }
 }
 
 class Initialize implements Step<Customer> {
-  public readonly inputCodec = customerCodec;
-
   public constructor(private readonly flow: SubscriptionFlow) {}
 
   public getStepType(): string {
@@ -116,8 +109,6 @@ class Initialize implements Step<Customer> {
 }
 
 class Trial implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: SubscriptionFlow) {}
 
   public getStepType(): string {
@@ -137,8 +128,6 @@ class Trial implements Step<void> {
 }
 
 class ChargeCurrentBill implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: SubscriptionFlow) {}
 
   public getStepType(): string {
@@ -170,8 +159,6 @@ class ChargeCurrentBill implements Step<void> {
 }
 
 class Cancel implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: SubscriptionFlow) {}
 
   public getStepType(): string {
@@ -190,8 +177,6 @@ class Cancel implements Step<void> {
 }
 
 class UpdateChargeAmount implements Step<void> {
-  public readonly inputCodec = voidCodec;
-
   public constructor(private readonly flow: SubscriptionFlow) {}
 
   public getStepType(): string {


### PR DESCRIPTION
## Summary
- Published TypeScript SDK `0.1.11` (`sdk-typescript/v0.1.11`) and pinned `examples/typescript` to `@superdurable/dex@0.1.11`.
- Omit Step `inputCodec` and RPC codecs for JSON objects and void payloads; keep scalar codecs and Attribute/Channel codecs (including Date conversion on entity-store RPCs).

## Test plan
- [x] `npm run typecheck` and example unit tests pass against `0.1.11`.
- [ ] TypeScript example CI resolves `@superdurable/dex@0.1.11` from npm.
- [ ] Example integration jobs against `dexcli dev` pass.


Made with [Cursor](https://cursor.com)