### PR TITLE
Show timeout handler Steps only for Handler policy

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": "sh .cursor/hooks/reject-cursor-coauthor.sh",
+        "failClosed": true
+      }
+    ],
+    "afterShellExecution": [
+      {
+        "command": "sh .cursor/hooks/reject-cursor-coauthor.sh"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/reject-cursor-coauthor.sh
+++ b/.cursor/hooks/reject-cursor-coauthor.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# Cursor hook: reject git commits that attribute Cursor as a co-author.
+payload=$(mktemp)
+trap 'rm -f "$payload"' EXIT
+cat > "$payload"
+python3 - "$payload" <<'PY'
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+
+FORBIDDEN_IN_MESSAGE = re.compile(
+    r"(?im)^\s*Co-authored-by:.*\bcursor\b"
+    r"|cursoragent@cursor\.com"
+    r"|^\s*Made-with:\s*Cursor\b"
+)
+GIT_COMMIT = re.compile(
+    r"(?:^|[;&|\n]\s*)git\b(?:\s+(?:-[^\s]+|-C\s+\S+))*\s+commit\b"
+)
+SKIP_HOOKS = re.compile(r"(?:^|\s)(--no-verify|-n)(?:\s|$)")
+
+
+def read_payload() -> dict:
+    try:
+        with open(sys.argv[1], encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def command_text(payload: dict) -> str:
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict) and isinstance(tool_input.get("command"), str):
+        return tool_input["command"]
+    command = payload.get("command")
+    return command if isinstance(command, str) else ""
+
+
+def is_after_event(payload: dict) -> bool:
+    event = str(payload.get("hook_event_name") or payload.get("event") or "")
+    return event.startswith("after") or event.startswith("post") or "exit_code" in payload
+
+
+def emit(payload: dict) -> None:
+    json.dump(payload, sys.stdout, separators=(",", ":"))
+    sys.stdout.write("\n")
+
+
+def head_message() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%B"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return ""
+    return result.stdout if result.returncode == 0 else ""
+
+
+def deny(message: str) -> None:
+    emit(
+        {
+            "permission": "deny",
+            "agent_message": message,
+            "user_message": message,
+        }
+    )
+
+
+def main() -> int:
+    payload = read_payload()
+    command = command_text(payload)
+    if not GIT_COMMIT.search(command):
+        emit({"permission": "allow"})
+        return 0
+
+    if is_after_event(payload):
+        if FORBIDDEN_IN_MESSAGE.search(head_message()):
+            message = (
+                "HEAD has a Cursor co-author trailer. Amend the message to "
+                "remove it before pushing. Do not use --no-verify."
+            )
+            emit(
+                {
+                    "permission": "allow",
+                    "agent_message": message,
+                    "additional_context": message,
+                }
+            )
+            return 0
+        emit({"permission": "allow"})
+        return 0
+
+    if SKIP_HOOKS.search(command):
+        deny("Do not skip git hooks. Re-run git commit without --no-verify or -n.")
+        return 0
+
+    emit({"permission": "allow"})
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+PY

--- a/.cursor/rules/git-commit.mdc
+++ b/.cursor/rules/git-commit.mdc
@@ -1,18 +1,41 @@
 ---
-description: Never add Cursor as a git commit co-author
+description: Never add Cursor as a git commit co-author; verify every commit message
 alwaysApply: true
 ---
 
-# Git Commits — No Cursor Co-Author
+# Git commits — human author only
 
-Never add Cursor (or any Cursor agent identity) as a git commit co-author.
+The commit Author, Committer, and message must be the human user only.
+Cursor, Cursor Agent, and `cursoragent@cursor.com` are never co-authors.
 
-Do not include any of these trailers in commit messages:
+This is mandatory. Cursor's commit wrapper, diff-tab "commit and create pull
+request", and `git commit --trailer` often inject the trailer below. Treat that
+as a bug to undo, not as something to keep.
+
+```
+Co-authored-by: Cursor <cursoragent@cursor.com>
+```
+
+## Forbidden
+
+Never write, keep, or push any of these:
 
 - `Co-authored-by: Cursor <...>`
 - `Co-authored-by: Cursor Agent <...>`
-- `Co-authored-by: cursoragent@cursor.com`
-- any other `Co-authored-by` line that names Cursor, Cursor Agent, or cursoragent
+- `Co-authored-by:` lines that mention Cursor, Cursor Agent, or cursoragent
+- `Made-with: Cursor` or other Cursor attribution trailers
+- `git commit --trailer ...Cursor...`
+- `git commit --no-verify` / `-n` to skip the hook that rejects those trailers
 
-Write the commit as the user only. Do not add `Made-with: Cursor` or similar
-Cursor attribution trailers either.
+Human `Co-authored-by` trailers for real people are fine.
+
+## Required after every `git commit`
+
+1. Run `git log -1 --format='%an %ae%n%B'`.
+2. If a forbidden trailer is present, amend **immediately** and remove only
+   that trailer. This amend is authorized even after a successful commit.
+3. Run the same `git log -1` check again. Do not push until it is clean.
+
+`.githooks/commit-msg` strips forbidden trailers if a wrapper injects them.
+Cursor `.cursor/hooks/reject-cursor-coauthor.sh` blocks `--no-verify` and warns
+if HEAD still has a Cursor trailer. Do not bypass either hook.

--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -15,6 +15,11 @@ End every agent turn that changes repository files with one commit on the
 current branch. Leave a clean working tree. Do not create empty commits for
 discussion-only turns.
 
+Never add Cursor as Author, Committer, or `Co-authored-by`. Cursor's commit
+wrapper often injects `Co-authored-by: Cursor <cursoragent@cursor.com>`; strip
+it before pushing. After every commit run `git log -1 --format=%B`. Do not use
+`--no-verify`. See `.cursor/rules/git-commit.mdc`.
+
 ## Compatibility
 
 - The project has not launched. Remove dead config fields immediately.

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Strip Cursor/agent attribution trailers. Agents must not skip this hook.
+set -e
+
+message_file=$1
+if [ ! -f "$message_file" ]; then
+  echo "commit-msg: missing commit message file" >&2
+  exit 1
+fi
+
+filtered=$(mktemp)
+trap 'rm -f "$filtered"' EXIT
+if ! grep -Eiv \
+  '^[[:space:]]*Co-authored-by:.*cursor|^[[:space:]]*Made-with:[[:space:]]*Cursor\b|cursoragent@cursor\.com' \
+  "$message_file" > "$filtered"; then
+  :
+fi
+cat "$filtered" > "$message_file"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,11 @@ End every agent turn that changes repository files with one commit on the
 current branch. Leave a clean working tree. Do not create empty commits for
 discussion-only turns.
 
+Never add Cursor as Author, Committer, or `Co-authored-by`. Cursor's commit
+wrapper often injects `Co-authored-by: Cursor <cursoragent@cursor.com>`; strip
+it before pushing. After every commit run `git log -1 --format=%B`. Do not use
+`--no-verify`. See `.cursor/rules/git-commit.mdc`.
+
 ### Regenerate the Entire Repository After Proto Changes
 
 Whenever any `.proto` file changes, run `make generated-code` from the repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,11 @@ End every agent turn that changes repository files with one commit on the
 current branch. Leave a clean working tree. Do not create empty commits for
 discussion-only turns.
 
+Never add Cursor as Author, Committer, or `Co-authored-by`. Cursor's commit
+wrapper often injects `Co-authored-by: Cursor <cursoragent@cursor.com>`; strip
+it before pushing. After every commit run `git log -1 --format=%B`. Do not use
+`--no-verify`. See `.cursor/rules/git-commit.mdc`.
+
 ## Compatibility
 
 - The project has not launched. Remove dead config fields immediately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,9 @@ Go SDK + samples use root [`go.work`](go.work). `blob-cache-go` remains outside 
 - Python 3.9+ and uv (for `sdk-python` / `examples/python`)
 - Docker (for integration tests / local Temporal+Cadence stacks)
 
+Install the commit-msg hook once per clone with `make githooks`. It rejects
+Cursor co-author trailers. Do not pass `--no-verify`.
+
 ## Go workspace
 
 Root [`go.work`](go.work) includes `sdk-go` and `examples/go` (local `replace` for the SDK).

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,13 @@ GENERATED_CODE_PATHS := \
 	sdk-python/dex/dexpb \
 	sdk-typescript/src/gen
 
-.PHONY: help ci-runner-check copyright copyright-check generated-code generated-code-check
+.PHONY: help ci-runner-check copyright copyright-check generated-code generated-code-check githooks
 
 help: ## Show targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-22s %s\n", $$1, $$2}'
+
+githooks: ## Install commit-msg hook that rejects Cursor co-author trailers
+	bash script/install-githooks
 
 ci-runner-check: ## Verify CI workflows route main pushes to self-hosted runners
 	bash .github/scripts/check-ci-runners.sh

--- a/script/install-githooks
+++ b/script/install-githooks
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Install the repo commit-msg hook into this clone's git hooks directory.
+set -e
+
+root=$(git rev-parse --show-toplevel)
+hook_dir=$(git rev-parse --git-path hooks)
+mkdir -p "$hook_dir"
+cp "$root/.githooks/commit-msg" "$hook_dir/commit-msg"
+chmod +x "$root/.githooks/commit-msg" "$hook_dir/commit-msg"
+echo "Installed $hook_dir/commit-msg"

--- a/web/app/flows/details/EventDetails.test.tsx
+++ b/web/app/flows/details/EventDetails.test.tsx
@@ -544,6 +544,27 @@ describe('flow start event details', () => {
 
     expect(markup).toContain('Flow timeout');
     expect(markup).toContain('1m');
+    expect(markup).not.toContain('Timeout policy');
+  });
+
+  it('renders the configured flow timeout policy', () => {
+    const event: FlowHistoryEvent = {
+      eventId: 1,
+      eventTime: '2026-08-05T23:44:29Z',
+      type: 'FlowStartedOrContinued',
+      payload: {
+        flowTimeout: '60s',
+        flowTimeoutPolicy: 2,
+        initialStart: { startStepType: 'charge' },
+      },
+    };
+
+    const markup = renderDetails(event);
+
+    expect(markup).toContain('Flow timeout');
+    expect(markup).toContain('1m');
+    expect(markup).toContain('Timeout policy');
+    expect(markup).toContain('Cancel');
   });
 
   it('links a minimal continued SubFlow state by generated Flow ID', () => {

--- a/web/app/flows/details/EventDetails.tsx
+++ b/web/app/flows/details/EventDetails.tsx
@@ -29,6 +29,7 @@ import {
   executeFailurePolicyLabel,
   flowErrorTypeLabel,
   flowStatusLabel,
+  flowTimeoutPolicyLabel,
   grpcStatusLabel,
   subFlowReusePolicyLabel,
   waitForFailurePolicyLabel,
@@ -509,6 +510,9 @@ function SubFlowRecord({
         ['Condition ID', value.conditionId],
         ['Reuse policy', subFlowReusePolicyLabel(options.reusePolicy)],
         ['Timeout', seconds(options.flowTimeoutSeconds)],
+        ['Timeout policy', Number(options.flowTimeoutSeconds) > 0
+          ? specifiedTimeoutPolicy(options.flowTimeoutPolicy)
+          : undefined],
         ['Start delay', seconds(options.flowStartDelaySeconds)],
         ['Retry initial interval', seconds(retry.initialIntervalSeconds)],
         ['Retry backoff coefficient', retry.backoffCoefficient],
@@ -894,13 +898,29 @@ function protobufDuration(value: unknown): string | undefined {
   return displayValue(value);
 }
 
+function flowTimeoutFields(payload: Data): Field[] {
+  const duration = protobufDuration(payload.flowTimeout);
+  if (!duration) {
+    return [['Flow timeout', 'No timeout']];
+  }
+  return [
+    ['Flow timeout', duration],
+    ['Timeout policy', specifiedTimeoutPolicy(payload.flowTimeoutPolicy)],
+  ];
+}
+
+function specifiedTimeoutPolicy(value: unknown): string | undefined {
+  const label = flowTimeoutPolicyLabel(value);
+  return label === 'Unspecified' ? undefined : label;
+}
+
 function InitialStartDetails({ payload, showHeading = true }: { payload: Data; showHeading?: boolean }) {
   const start = asData(payload.initialStart);
   return (
     <>
       <DetailSection title={showHeading ? 'Initial start' : undefined}>
         <Fields values={[
-          ['Flow timeout', protobufDuration(payload.flowTimeout) ?? 'No timeout'],
+          ...flowTimeoutFields(payload),
           ['Start step', start.startStepType],
         ]} />
         <ValueBlock label="Step input" value={start.stepInput} />
@@ -931,7 +951,7 @@ function ContinuedStartDetails({
       <DetailSection title={showHeading ? 'Continued run' : undefined}>
         <Fields values={[
           ['Previous run ID', continued.previousRunId],
-          ['Flow timeout', protobufDuration(payload.flowTimeout) ?? 'No timeout'],
+          ...flowTimeoutFields(payload),
         ]} />
       </DetailSection>
       {Array.isArray(continued.stepsToStart) && continued.stepsToStart.length > 0 && (

--- a/web/lib/graph.test.ts
+++ b/web/lib/graph.test.ts
@@ -440,4 +440,45 @@ describe('step graph', () => {
       flowId: 'SubFlow:parent-Parent-1-0',
     });
   });
+
+  it('hides the timeout handler Step unless the timeout policy is Handler', () => {
+    const timeoutHandler = {
+      stepExecutionId: 'sys:timeout_handler-1',
+      fromStepExecutionId: '__start__',
+      stepType: 'sys:timeout_handler',
+      phase: 'Waiting' as const,
+      stepExecutionLocals: [],
+      timers: [],
+    };
+
+    const failGraph = buildStepGraph([
+      event(1, 'FlowStartedOrContinued', {}, {
+        flowTimeout: '60s',
+        flowTimeoutPolicy: 1,
+        initialStart: { startStepType: 'charge' },
+      }),
+    ], [timeoutHandler]);
+    expect(failGraph.nodes.find((node) => node.stepType === 'sys:timeout_handler')).toBeUndefined();
+
+    const cancelGraph = buildStepGraph([
+      event(1, 'FlowStartedOrContinued', {}, {
+        flowTimeout: '60s',
+        flowTimeoutPolicy: 2,
+        initialStart: { startStepType: 'charge' },
+      }),
+    ], [timeoutHandler]);
+    expect(cancelGraph.nodes.find((node) => node.stepType === 'sys:timeout_handler')).toBeUndefined();
+
+    const handlerGraph = buildStepGraph([
+      event(1, 'FlowStartedOrContinued', {}, {
+        flowTimeout: '60s',
+        flowTimeoutPolicy: 3,
+        initialStart: { startStepType: 'charge' },
+      }),
+    ], [timeoutHandler]);
+    expect(handlerGraph.nodes.find((node) => node.stepType === 'sys:timeout_handler')).toMatchObject({
+      id: 'sys:timeout_handler-1',
+      status: 'Waiting',
+    });
+  });
 });

--- a/web/lib/graph.ts
+++ b/web/lib/graph.ts
@@ -12,10 +12,11 @@ import type {
   StepGraphEdge,
   StepGraphNode,
 } from './types';
-import { subFlowReusePolicyLabel, subFlowStatusName } from './semantic';
+import { isHandlerTimeoutPolicy, subFlowReusePolicyLabel, subFlowStatusName } from './semantic';
 import { generatedSubFlowID } from './subflows';
 
 export const START_NODE_ID = '__start__';
+export const FLOW_TIMEOUT_HANDLER_STEP_TYPE = 'sys:timeout_handler';
 
 const stepEventTypes = new Set([
   'StepWaitForCompleted',
@@ -117,6 +118,8 @@ export function buildStepGraph(
     }
   }
 
+  hideNonHandlerTimeoutNodes(nodes, events);
+
   const edges: StepGraphEdge[] = [];
   for (const node of nodes.values()) {
     if (node.kind === 'subflow') {
@@ -184,6 +187,19 @@ export function stepGraphSelection(
     incomingEdgeIDs,
     outgoingEdgeIDs,
   };
+}
+
+function hideNonHandlerTimeoutNodes(
+  nodes: Map<string, StepGraphNode>,
+  events: FlowHistoryEvent[],
+): void {
+  const started = events.find((event) => event.type === 'FlowStartedOrContinued');
+  if (isHandlerTimeoutPolicy(started?.payload.flowTimeoutPolicy)) return;
+  for (const [id, node] of nodes) {
+    if (node.stepType === FLOW_TIMEOUT_HANDLER_STEP_TYPE) {
+      nodes.delete(id);
+    }
+  }
 }
 
 function addStepEvent(

--- a/web/lib/semantic.ts
+++ b/web/lib/semantic.ts
@@ -119,6 +119,24 @@ export function flowErrorTypeLabel(value: unknown): string {
   });
 }
 
+export function flowTimeoutPolicyLabel(value: unknown): string {
+  return enumLabel(value, {
+    0: 'Unspecified',
+    1: 'Fail',
+    2: 'Cancel',
+    3: 'Handler',
+    FLOW_TIMEOUT_POLICY_UNSPECIFIED: 'Unspecified',
+    FLOW_TIMEOUT_POLICY_FAIL: 'Fail',
+    FLOW_TIMEOUT_POLICY_CANCEL: 'Cancel',
+    FLOW_TIMEOUT_POLICY_HANDLER: 'Handler',
+  });
+}
+
+export function isHandlerTimeoutPolicy(value: unknown): boolean {
+  const key = String(value ?? 0);
+  return key === '3' || key === 'FLOW_TIMEOUT_POLICY_HANDLER';
+}
+
 export function closeDecisionTypeLabel(value: unknown): string {
   return enumLabel(value, {
     0: 'Unspecified',


### PR DESCRIPTION
## Summary
- Dex Web now hides the internal `sys:timeout_handler` Step graph node unless the Flow timeout policy is Handler. Fail and Cancel still use that Step as a durable timer, but it is not application work.
- Start and SubFlow event details now show the resolved timeout policy (Fail, Cancel, Handler) next to the timeout duration.

## Rationale
Any positive timeout previously rendered `sys:timeout_handler` with Execute stuck on Not started. That is misleading for Fail/Cancel, which terminate inside the interpreter and never invoke Worker Execute.

## User impact
- Graph: timeout handler node appears only for Handler policy.
- Event details: Flow timeout / SubFlow timeout now include Timeout policy when a timeout is configured.
- Live Flow State still lists the system Step so SkipTimer diagnostics remain available.

## Test plan
- [x] `npm test` in `web/`
- [ ] Confirm a Fail or Cancel timeout run no longer shows `sys:timeout_handler` in the graph
- [ ] Confirm a Handler timeout run still shows the node
- [ ] Confirm start history shows Timeout policy next to Flow timeout


Made with [Cursor](https://cursor.com)