### PR TITLE
Rewrite root README intro from durable execution docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Learn more: [What is Durable Execution?](https://docs.superdurable.io/intro/what
 ## Quick start
 
 See [Quick start](https://docs.superdurable.io/quick-start) on docs.superdurable.io.
+
+If Dex is useful to you, please [star us on GitHub](https://github.com/superdurable/dex) to follow releases.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,13 @@
-# Dex - Durable Execution, Re-defined.
+# Dex - Durable Execution(D-EX), Dead Simple. More Power.
 
-**Dead Simple. More Power.**
+**Durable Execution** is an abstraction of the design patterns every reliable backend needs: multi-step orchestration, durable timers, retries, human-in-the-loop coordination, and production observability. Traditional databases and storage only persist data with passive read/write APIs—they do not give you atomic step transitions, worker dispatch, or failure handling out of the box. Engineers end up rebuilding the same queue-and-poll infrastructure on every project.
 
-Traditional databases persist only data. Durable Execution persists both data and actions. On top of that, Super Durable synchronizes persisted data with your existing databases and data storage—unifying your persistence architecture.
+**Dex** is a Durable Execution platform built on a small set of [durable primitives](https://docs.superdurable.io/primitives)—Steps, Attributes, Channels, Timers, and RPCs. You write a Flow in ordinary code, run Workers that host it, and use the Client to start and interact with Flow instances. Dex Server dispatches Step and RPC work to your Workers. Step transitions are atomic; waits and timers survive restarts; retries and compensation are declared on the Step. Unlike replay-based workflow engines, Dex does not split your logic into deterministic workflow code and separate activities—Worker handlers are ordinary code, and Attribute data lives in a blob store you can sync to databases you already run.
+
+Learn more: [What is Durable Execution?](https://docs.superdurable.io/intro/what-is-durable-execution) · [Why Dex?](https://docs.superdurable.io/intro/what-is-dex)
 
 <img width="676" height="607" alt="arch" src="https://github.com/user-attachments/assets/720e38a8-b151-4251-aa8a-5b62ae64a7f4" />
 
-
 ## Quick start
 
-```bash
-brew install superdurable/tap/dexcli
-dexcli dev
-```
-
-This starts the complete local Dex environment, including its internal
-workflow backend, and opens Dex Web at [http://127.0.0.1:8802](http://127.0.0.1:8802).
-If 8802 is already taken, `dexcli dev` prints the port it selected instead.
-
-See [cli/README.md](cli/README.md) for Dex endpoints and persistence options.
-
-Operate Dex without a browser using the same installed binary:
-
-```bash
-dexcli flow search
-dexcli flow inspect <flow-id>
-dexcli api list
-```
-
-Product documentation: [https://docs.superdurable.io](https://docs.superdurable.io)
-(source in [`docs/`](docs/)).
-
-## Releases
-
-Versions are per-component. Tag with a prefix (for example `server-v1.0.0`, `sdk-go/v1.2.3`, `blob-cache-go/v0.1.0`). Details: [CONTRIBUTING.md — Releases](CONTRIBUTING.md#releases-monorepo-tags).
-
-## Licensing
-
-Super Durable changes to the product, SDKs, protocol, CLI, and web components
-use the [Super Durable Source License 1.0](LICENSE). Production use is free up
-to US$10 million in consolidated annual revenue; after first exceeding the
-threshold, continued production use requires a subscription within 90 days.
-Competitive Dex products and hosted replacements always require a commercial
-license.
-
-Applications may bundle SDK and protocol components subject to the
-developer/operator revenue rule. End users that only run the application do
-not need a separate subscription. Legacy code retains its original license;
-`docs/` and `examples/` are excluded from the relicensing. See
-[LICENSING.md](LICENSING.md) and [LEGACY_NOTICES.md](LEGACY_NOTICES.md).
+See [Quick start](https://docs.superdurable.io/quick-start) on docs.superdurable.io.


### PR DESCRIPTION
## Summary
- Update the README tagline to "Dex - Durable Execution(D-EX), Dead Simple. More Power."
- Rewrite the intro from the What is Durable Execution and Why Dex docs, with links to those pages
- Point Quick start to https://docs.superdurable.io/quick-start
- Remove Releases and Licensing sections

## Test plan
- [ ] Review README rendering on GitHub


Made with [Cursor](https://cursor.com)