### PR TITLE
Rewrite root README intro and rename docs GitHub link to Star Us

### DIFF
--- a/docs/src/components/GitHubStarNavbarItem.tsx
+++ b/docs/src/components/GitHubStarNavbarItem.tsx
@@ -58,7 +58,7 @@ export default function GitHubStarNavbarItem({
       rel="noreferrer"
       onClick={onClick}
       aria-label={`Star superdurable/dex on GitHub. ${stars} stars`}>
-      <span>GitHub</span>
+      <span>Star Us</span>
       <span className="github-star-stat" aria-hidden="true">
         <span>★</span>
         <span>Star</span>


### PR DESCRIPTION
## Summary
- Rewrite the root README intro around durable execution and add a GitHub star reminder.
- Rename the docs navbar GitHub link label to **Star Us** to match the portal header.
- Includes merged docs reference reorganization, order-processing Quick Start, and Step graph refinements already on this branch.

## Test plan
- [ ] Review root `README.md` intro and star reminder copy
- [ ] Open docs site and confirm navbar shows **Star Us** with the star count badge
- [ ] Confirm the link still opens `https://github.com/superdurable/dex`


Made with [Cursor](https://cursor.com)