### PR TITLE
Add origin stack capture for Go and Rust Worker errors

### DIFF
--- a/sdk-go/dex/error_with_stack.go
+++ b/sdk-go/dex/error_with_stack.go
@@ -17,8 +17,9 @@ import (
 // ErrorWithStack wraps err with a stack captured at this call site.
 //
 // Use it when returning a plain Go error from waitFor or execute and you want
-// Dex to record the origin stack instead of the Worker wrap-site stack. Plain
-// errors are not Dex-owned, so capture is opt-in.
+// Dex to record an origin stack. Plain errors are not Dex-owned, so capture is
+// opt-in; without this wrapper Dex reports that no application stack was
+// captured instead of inventing a Worker wrap-site stack.
 //
 // Prefer nesting ErrorWithStack inside RetryAfter so RetryAfter remains the
 // protocol marker and the stack lives on the cause:

--- a/sdk-go/dex/error_with_stack.go
+++ b/sdk-go/dex/error_with_stack.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package dex
+
+import (
+	"fmt"
+	"io"
+	"runtime/debug"
+)
+
+// ErrorWithStack wraps err with a stack captured at this call site.
+//
+// Use it when returning a plain Go error from waitFor or execute and you want
+// Dex to record the origin stack instead of the Worker wrap-site stack. Plain
+// errors are not Dex-owned, so capture is opt-in.
+//
+// Prefer nesting ErrorWithStack inside RetryAfter so RetryAfter remains the
+// protocol marker and the stack lives on the cause:
+//
+//	return nil, dex.RetryAfter(30*time.Second, dex.ErrorWithStack(err))
+//
+// Unwrap returns the original err. Error returns the original message. Formatting
+// with %+v includes the captured stack. A nil err returns nil.
+func ErrorWithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &errorWithStack{
+		cause: err,
+		stack: debug.Stack(),
+	}
+}
+
+type errorWithStack struct {
+	cause error
+	stack []byte
+}
+
+// Error returns the wrapped failure message unchanged.
+func (err *errorWithStack) Error() string {
+	return err.cause.Error()
+}
+
+// Unwrap returns the original failure for errors.Is and errors.As.
+func (err *errorWithStack) Unwrap() error {
+	return err.cause
+}
+
+// Format writes the message for %s/%v and appends the origin stack for %+v.
+func (err *errorWithStack) Format(state fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if state.Flag('+') {
+			fmt.Fprintf(state, "%s\n%s", err.cause.Error(), err.stack)
+			return
+		}
+		fallthrough
+	case 's':
+		_, _ = io.WriteString(state, err.Error())
+	case 'q':
+		fmt.Fprintf(state, "%q", err.Error())
+	}
+}
+
+func (err *errorWithStack) stackTrace() string {
+	return fmt.Sprintf("%s\n%s", err.cause.Error(), err.stack)
+}

--- a/sdk-go/dex/error_with_stack_test.go
+++ b/sdk-go/dex/error_with_stack_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package dex
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestErrorWithStackUnwrapAndError(t *testing.T) {
+	cause := errors.New("payment failed")
+	wrapped := ErrorWithStack(cause)
+	if wrapped == nil {
+		t.Fatal("expected wrapped error")
+	}
+	if wrapped.Error() != "payment failed" {
+		t.Fatalf("Error() = %q", wrapped.Error())
+	}
+	if !errors.Is(wrapped, cause) {
+		t.Fatal("expected errors.Is to match cause")
+	}
+	if unwrapped := errors.Unwrap(wrapped); unwrapped != cause {
+		t.Fatalf("Unwrap() = %v, want cause", unwrapped)
+	}
+}
+
+func TestErrorWithStackPlusVIncludesOriginStack(t *testing.T) {
+	rendered := fmt.Sprintf("%+v", originStackMarker())
+	if !strings.Contains(rendered, "payment failed") {
+		t.Fatalf("missing message: %q", rendered)
+	}
+	if !strings.Contains(rendered, "originStackMarker") {
+		t.Fatalf("missing origin frame: %q", rendered)
+	}
+}
+
+func TestErrorWithStackNil(t *testing.T) {
+	if ErrorWithStack(nil) != nil {
+		t.Fatal("expected nil")
+	}
+}
+
+func originStackMarker() error {
+	return ErrorWithStack(errors.New("payment failed"))
+}

--- a/sdk-go/dex/worker_error.go
+++ b/sdk-go/dex/worker_error.go
@@ -146,7 +146,9 @@ func stackTraceFromError(cause error) string {
 	if errors.As(cause, &withStack) {
 		return withStack.stackTrace()
 	}
-	return fmt.Sprintf("%+v\n%s", cause, debug.Stack())
+	// Plain errors have no origin stack. Do not capture the Worker wrap site;
+	// that frame is not useful for diagnosing application failures.
+	return "no application stack captured; wrap with dex.ErrorWithStack(err) at the failure site"
 }
 
 func stackTraceFromPanic(recovered any) string {

--- a/sdk-go/dex/worker_error.go
+++ b/sdk-go/dex/worker_error.go
@@ -142,6 +142,10 @@ func workerStatusError(
 }
 
 func stackTraceFromError(cause error) string {
+	var withStack *errorWithStack
+	if errors.As(cause, &withStack) {
+		return withStack.stackTrace()
+	}
 	return fmt.Sprintf("%+v\n%s", cause, debug.Stack())
 }
 

--- a/sdk-go/dex/worker_error_test.go
+++ b/sdk-go/dex/worker_error_test.go
@@ -58,6 +58,64 @@ func TestFinishWorkerCallAttachesStackTraceAndRetryAfter(t *testing.T) {
 	}
 }
 
+func TestFinishWorkerCallPrefersOriginStack(t *testing.T) {
+	err := finishWorkerCall(testLogger{}, nil, originFailureWithStack())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	rpcStatus, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status, got %T", err)
+	}
+	details := rpcStatus.Details()
+	if len(details) != 1 {
+		t.Fatalf("expected one detail, got %d", len(details))
+	}
+	workerError, ok := details[0].(*dexpb.WorkerErrorResponse)
+	if !ok {
+		t.Fatalf("expected WorkerErrorResponse, got %T", details[0])
+	}
+	stackTrace := workerError.GetStackTrace()
+	if !strings.Contains(stackTrace, "origin boom") {
+		t.Fatalf("stack missing detail: %q", stackTrace)
+	}
+	if !strings.Contains(stackTrace, "originFailureWithStack") {
+		t.Fatalf("stack missing origin frame: %q", stackTrace)
+	}
+	if strings.Contains(stackTrace, "finishWorkerCall") {
+		t.Fatalf("expected origin stack, not wrap-site: %q", stackTrace)
+	}
+}
+
+func TestFinishWorkerCallPrefersOriginStackInsideRetryAfter(t *testing.T) {
+	err := finishWorkerCall(
+		testLogger{},
+		nil,
+		RetryAfter(3*time.Second, originFailureWithStack()),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	rpcStatus, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status, got %T", err)
+	}
+	workerError, ok := rpcStatus.Details()[0].(*dexpb.WorkerErrorResponse)
+	if !ok {
+		t.Fatalf("expected WorkerErrorResponse, got %T", rpcStatus.Details()[0])
+	}
+	if workerError.GetRetryAfterSeconds() != 3 {
+		t.Fatalf("retry after = %d, want 3", workerError.GetRetryAfterSeconds())
+	}
+	if !strings.Contains(workerError.GetStackTrace(), "originFailureWithStack") {
+		t.Fatalf("stack missing origin frame: %q", workerError.GetStackTrace())
+	}
+	if strings.Contains(workerError.GetStackTrace(), "finishWorkerCall") {
+		t.Fatalf("expected origin stack, not wrap-site: %q", workerError.GetStackTrace())
+	}
+}
+
 func TestTruncateStackTrace(t *testing.T) {
 	large := strings.Repeat("x", maxWorkerStackTraceBytes+100)
 	truncated := truncateStackTrace(large)
@@ -67,4 +125,8 @@ func TestTruncateStackTrace(t *testing.T) {
 	if !strings.Contains(truncated, string(stackTraceTruncationMarker)) {
 		t.Fatal("expected truncation marker")
 	}
+}
+
+func originFailureWithStack() error {
+	return ErrorWithStack(errors.New("origin boom"))
 }

--- a/sdk-go/dex/worker_error_test.go
+++ b/sdk-go/dex/worker_error_test.go
@@ -50,12 +50,26 @@ func TestFinishWorkerCallAttachesStackTraceAndRetryAfter(t *testing.T) {
 	if workerError.GetRetryAfterSeconds() != 7 {
 		t.Fatalf("retry after = %d, want 7", workerError.GetRetryAfterSeconds())
 	}
-	if workerError.GetStackTrace() == "" {
-		t.Fatal("expected stack trace")
+	assertMissingApplicationStack(t, workerError.GetStackTrace())
+}
+
+func TestFinishWorkerCallPlainErrorSkipsWrapSiteStack(t *testing.T) {
+	err := finishWorkerCall(testLogger{}, nil, errors.New("plain boom"))
+	if err == nil {
+		t.Fatal("expected error")
 	}
-	if !strings.Contains(workerError.GetStackTrace(), "boom") {
-		t.Fatalf("stack trace missing cause: %q", workerError.GetStackTrace())
+	rpcStatus, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status, got %T", err)
 	}
+	workerError, ok := rpcStatus.Details()[0].(*dexpb.WorkerErrorResponse)
+	if !ok {
+		t.Fatalf("expected WorkerErrorResponse, got %T", rpcStatus.Details()[0])
+	}
+	if workerError.GetDetail() != "plain boom" {
+		t.Fatalf("detail = %q, want plain boom", workerError.GetDetail())
+	}
+	assertMissingApplicationStack(t, workerError.GetStackTrace())
 }
 
 func TestFinishWorkerCallPrefersOriginStack(t *testing.T) {
@@ -129,4 +143,17 @@ func TestTruncateStackTrace(t *testing.T) {
 
 func originFailureWithStack() error {
 	return ErrorWithStack(errors.New("origin boom"))
+}
+
+func assertMissingApplicationStack(t *testing.T, stackTrace string) {
+	t.Helper()
+	if !strings.Contains(stackTrace, "dex.ErrorWithStack") {
+		t.Fatalf("stack missing ErrorWithStack hint: %q", stackTrace)
+	}
+	if strings.Contains(stackTrace, "finishWorkerCall") {
+		t.Fatalf("plain error must not include wrap-site stack: %q", stackTrace)
+	}
+	if strings.Contains(stackTrace, "stackTraceFromError") {
+		t.Fatalf("plain error must not include wrap-site stack: %q", stackTrace)
+	}
 }

--- a/sdk-go/integ/main_test.go
+++ b/sdk-go/integ/main_test.go
@@ -183,6 +183,7 @@ func integrationFlows() []dex.Flow {
 		stepCancellationFlow{},
 		workerRetryAfterWaitForFlow{},
 		workerRetryAfterExecuteFlow{},
+		workerOriginStackWaitForFlow{},
 	}
 }
 

--- a/sdk-go/integ/worker_origin_stack_flow_test.go
+++ b/sdk-go/integ/worker_origin_stack_flow_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package integ
+
+import (
+	"errors"
+	"time"
+
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+const (
+	originStackDetail         = "go origin stack failure"
+	originStackPolicyInterval = 2 * time.Second
+)
+
+type workerOriginStackWaitForFlow struct {
+	emptyFlowSchema
+}
+
+func (workerOriginStackWaitForFlow) GetSteps() []dex.StepDef {
+	return []dex.StepDef{dex.DefineStartStep(workerOriginStackWaitForStep{})}
+}
+
+type workerOriginStackWaitForStep struct {
+	dex.DefaultStepType
+}
+
+func (workerOriginStackWaitForStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		WaitForRetry: &dex.RetryPolicy{
+			InitialInterval: originStackPolicyInterval,
+			MaximumAttempts: 3,
+		},
+		WaitForDurability: dex.StepDurabilitySync,
+		ExecuteDurability: dex.StepDurabilitySync,
+	}
+}
+
+func (workerOriginStackWaitForStep) WaitFor(
+	ctx dex.Context,
+	_ struct{},
+) (*dex.Wait, error) {
+	if ctx.Attempt() == 1 {
+		return nil, originStackFailure()
+	}
+	return dex.SkipWaitImmediately(), nil
+}
+
+func (workerOriginStackWaitForStep) Execute(
+	_ dex.Context,
+	_ struct{},
+) (*dex.StepDecision, error) {
+	return dex.GracefulComplete("origin-stack"), nil
+}
+
+func originStackFailure() error {
+	return dex.ErrorWithStack(errors.New(originStackDetail))
+}

--- a/sdk-go/integ/worker_origin_stack_test.go
+++ b/sdk-go/integ/worker_origin_stack_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package integ
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superdurable/dex/sdk-go/dex"
+)
+
+func TestWaitForOriginStackTrace(t *testing.T) {
+	ctx := integrationContext(t)
+	flowID := newFlowID(t, "wait-origin-stack")
+	flowService := newFlowServiceClient(t)
+
+	runID, err := integClient.StartFlow(
+		ctx,
+		workerOriginStackWaitForFlow{},
+		flowID,
+		struct{}{},
+		dex.StartFlowOptions{},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, runID)
+
+	failure := awaitLiveWorkerFailure(t, flowService, flowID, runID)
+	assertWorkerFailureStackTrace(t, failure, originStackDetail)
+	require.Contains(
+		t,
+		failure.GetDetails().GetOriginalWorkerErrorStackTrace(),
+		"originStackFailure",
+	)
+	require.NotContains(
+		t,
+		failure.GetDetails().GetOriginalWorkerErrorStackTrace(),
+		"finishWorkerCall",
+	)
+
+	result := waitForFlow(t, flowID, false)
+	require.Equal(t, dex.FlowCompleted, result.Status)
+}

--- a/sdk-go/integ/worker_retry_after_flow_test.go
+++ b/sdk-go/integ/worker_retry_after_flow_test.go
@@ -45,7 +45,7 @@ func (workerRetryAfterWaitForStep) WaitFor(
 	if ctx.Attempt() == 1 {
 		return nil, dex.RetryAfter(
 			retryAfterDelay,
-			errors.New(waitForRetryAfterDetail),
+			dex.ErrorWithStack(errors.New(waitForRetryAfterDetail)),
 		)
 	}
 	return dex.SkipWaitImmediately(), nil
@@ -81,7 +81,7 @@ func (workerRetryAfterExecuteStep) Execute(
 	if ctx.Attempt() == 1 {
 		return nil, dex.RetryAfter(
 			retryAfterDelay,
-			errors.New(executeRetryAfterDetail),
+			dex.ErrorWithStack(errors.New(executeRetryAfterDetail)),
 		)
 	}
 	return dex.GracefulComplete("execute-retry-after"), nil

--- a/sdk-rust/crates/dex-sdk/src/attribute.rs
+++ b/sdk-rust/crates/dex-sdk/src/attribute.rs
@@ -84,8 +84,12 @@ impl<T> Attribute<T> {
     where
         T: Value,
     {
-        self.get(context)?
-            .ok_or_else(|| HandlerError::new(format!("attribute {} is missing", self.name)))
+        self.get(context)?.ok_or_else(|| {
+            HandlerError::new(
+                "dex_sdk::HandlerError",
+                format!("attribute {} is missing", self.name),
+            )
+        })
     }
 
     /// Stages `value` for durable persistence in the current invocation.
@@ -205,7 +209,10 @@ impl<T> AttributeMap<T> {
         T: Value,
     {
         self.get(context, instance)?.ok_or_else(|| {
-            HandlerError::new(format!("attribute {}[{instance}] is missing", self.name))
+            HandlerError::new(
+                "dex_sdk::HandlerError",
+                format!("attribute {}[{instance}] is missing", self.name),
+            )
         })
     }
 

--- a/sdk-rust/crates/dex-sdk/src/context.rs
+++ b/sdk-rust/crates/dex-sdk/src/context.rs
@@ -117,6 +117,7 @@ impl Context {
     pub(crate) fn sub_flow_result(&self, index: usize) -> HandlerResult<FlowResult> {
         if self.method != InvocationMethod::Execute {
             return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
                 "SubFlow results are available only during execute",
             ));
         }
@@ -125,9 +126,12 @@ impl Context {
             .as_ref()
             .and_then(|results| results.sub_flow_results.get(index))
             .ok_or_else(|| {
-                HandlerError::new(format!("SubFlow result index is unavailable: {index}"))
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("SubFlow result index is unavailable: {index}"),
+                )
             })?;
-        FlowResult::from_proto(result).map_err(|error| HandlerError::new(error.to_string()))
+        FlowResult::from_proto(result).map_err(HandlerError::from_error)
     }
 
     pub(crate) fn sub_flow_id(&self, index: usize) -> HandlerResult<String> {
@@ -181,7 +185,12 @@ impl Context {
             .get(key)
             .and_then(|entry| entry.value.as_ref())
             .or_else(|| self.locals.get(key))
-            .ok_or_else(|| HandlerError::new(format!("step-execution local {key} is missing")))?;
+            .ok_or_else(|| {
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("step-execution local {key} is missing"),
+                )
+            })?;
         value_mapper::decode_handler(value)
     }
 
@@ -195,9 +204,10 @@ impl Context {
     pub fn record_event<T: Value>(&mut self, name: &str, value: T) -> HandlerResult<()> {
         require_name(name, "event name")?;
         if !self.event_names.insert(name.to_string()) {
-            return Err(HandlerError::new(format!(
-                "event was already recorded: {name}"
-            )));
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                format!("event was already recorded: {name}"),
+            ));
         }
         self.events.push(Kv {
             key: name.to_string(),
@@ -362,6 +372,7 @@ impl Context {
     ) -> HandlerResult<Vec<String>> {
         if self.method != InvocationMethod::Rpc {
             return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
                 "ChannelMap introspection requires an RPC invocation",
             ));
         }
@@ -443,10 +454,12 @@ impl Context {
     ) -> HandlerResult<Option<T>> {
         let key = self.registered_name(name, kind, instance)?;
         if let Some(write) = self.attribute_writes.get(&key) {
-            let value = write
-                .value
-                .as_ref()
-                .ok_or_else(|| HandlerError::new(format!("Attribute write {key} has no Value")))?;
+            let value = write.value.as_ref().ok_or_else(|| {
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("Attribute write {key} has no Value"),
+                )
+            })?;
             if matches!(value.kind, Some(value::Kind::NullValue(_))) {
                 return Ok(None);
             }
@@ -544,25 +557,33 @@ impl Context {
         instance: Option<&str>,
     ) -> HandlerResult<String> {
         let definition = self.flow.persistence.get(name).ok_or_else(|| {
-            HandlerError::new(format!(
-                "persistence definition does not belong to Flow: {name}"
-            ))
+            HandlerError::new(
+                "dex_sdk::HandlerError",
+                format!("persistence definition does not belong to Flow: {name}"),
+            )
         })?;
         if definition.kind != kind {
-            return Err(HandlerError::new(format!(
-                "persistence definition kind does not match: {name}"
-            )));
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                format!("persistence definition kind does not match: {name}"),
+            ));
         }
         match kind {
             PersistenceKind::AttributeMap | PersistenceKind::ChannelMap => instance
                 .map(|instance| physical_name(name, instance))
-                .ok_or_else(|| HandlerError::new(format!("{name} requires an instance"))),
+                .ok_or_else(|| {
+                    HandlerError::new(
+                        "dex_sdk::HandlerError",
+                        format!("{name} requires an instance"),
+                    )
+                }),
             PersistenceKind::Attribute | PersistenceKind::Channel if instance.is_none() => {
                 Ok(name.to_string())
             }
-            _ => Err(HandlerError::new(format!(
-                "static persistence definition cannot use an instance: {name}"
-            ))),
+            _ => Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                format!("static persistence definition cannot use an instance: {name}"),
+            )),
         }
     }
 }
@@ -573,7 +594,10 @@ fn sorted_instance_keys(
 ) -> HandlerResult<Vec<String>> {
     let mut keys = physical_keys
         .iter()
-        .map(|key| decode_instance(key, prefix).map_err(HandlerError::new))
+        .map(|key| {
+            decode_instance(key, prefix)
+                .map_err(|error| HandlerError::new("dex_sdk::HandlerError", error))
+        })
         .collect::<HandlerResult<Vec<_>>>()?;
     keys.sort();
     Ok(keys)
@@ -631,11 +655,17 @@ fn map_values(kind: &str, entries: Vec<Kv>) -> HandlerResult<HashMap<String, Pro
     let mut mapped = HashMap::new();
     for entry in entries {
         require_name(&entry.key, kind)?;
-        let value = entry
-            .value
-            .ok_or_else(|| HandlerError::new(format!("{kind} {} has no Value", entry.key)))?;
+        let value = entry.value.ok_or_else(|| {
+            HandlerError::new(
+                "dex_sdk::HandlerError",
+                format!("{kind} {} has no Value", entry.key),
+            )
+        })?;
         if mapped.insert(entry.key.clone(), value).is_some() {
-            return Err(HandlerError::new(format!("duplicate {kind} {}", entry.key)));
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                format!("duplicate {kind} {}", entry.key),
+            ));
         }
     }
     Ok(mapped)
@@ -643,7 +673,10 @@ fn map_values(kind: &str, entries: Vec<Kv>) -> HandlerResult<HashMap<String, Pro
 
 fn require_name(value: &str, kind: &str) -> HandlerResult<()> {
     if value.is_empty() {
-        Err(HandlerError::new(format!("{kind} is required")))
+        Err(HandlerError::new(
+            "dex_sdk::HandlerError",
+            format!("{kind} is required"),
+        ))
     } else {
         Ok(())
     }

--- a/sdk-rust/crates/dex-sdk/src/handler_error.rs
+++ b/sdk-rust/crates/dex-sdk/src/handler_error.rs
@@ -22,17 +22,39 @@ pub type HandlerResult<T> = Result<T, HandlerError>;
 /// [`Backtrace::force_capture`]. The Worker prefers that construction-site
 /// stack over a wrap-site capture when encoding [`dex_protocol::dex::WorkerErrorResponse`].
 ///
+/// Prefer [`Self::from_error`] when wrapping another [`Error`] so Dex receives that
+/// concrete type name. Use [`Self::new`] when you want an explicit application error
+/// type string.
+///
 /// # Examples
 ///
 /// ```
+/// use std::error::Error;
+/// use std::fmt::{Display, Formatter};
+///
 /// use dex_sdk::HandlerError;
 ///
+/// #[derive(Debug)]
+/// struct PaymentError;
+///
+/// impl Display for PaymentError {
+///     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+///         formatter.write_str("payment failed")
+///     }
+/// }
+///
+/// impl Error for PaymentError {}
+///
 /// fn charge() -> Result<(), HandlerError> {
-///     Err(HandlerError::new("payment failed"))
+///     Err(HandlerError::new("PaymentDeclined", "payment failed"))
+/// }
+///
+/// fn charge_from_error() -> Result<(), HandlerError> {
+///     Err(HandlerError::from_error(PaymentError))
 /// }
 ///
 /// fn charge_with_retry() -> Result<(), HandlerError> {
-///     Err(HandlerError::retry_after(30, "payment failed"))
+///     Err(HandlerError::retry_after(30, "PaymentDeclined", "payment failed"))
 /// }
 /// ```
 #[derive(Debug)]
@@ -44,7 +66,12 @@ pub struct HandlerError {
 }
 
 impl HandlerError {
-    /// Creates a handler error with a developer-facing message.
+    /// Creates a handler error with an explicit error type and message.
+    ///
+    /// `error_type` is the stable label Dex stores as
+    /// [`dex_protocol::dex::WorkerErrorResponse::error_type`]. Prefer a short
+    /// application-specific name such as `"PaymentDeclined"` or a library type
+    /// path. `message` is the developer-facing detail string.
     ///
     /// Captures a stack at this call site so Dex can report the origin of the
     /// failure. Prefer constructing the error where the failure is detected
@@ -55,13 +82,52 @@ impl HandlerError {
     /// ```
     /// use dex_sdk::HandlerError;
     ///
-    /// let error = HandlerError::new("payment failed");
+    /// let error = HandlerError::new("PaymentDeclined", "payment failed");
     /// assert_eq!(error.to_string(), "payment failed");
     /// ```
-    pub fn new(message: impl Into<String>) -> Self {
+    pub fn new(error_type: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
-            error_type: std::any::type_name::<Self>().to_string(),
+            error_type: error_type.into(),
+            retry_after_seconds: None,
+            stack: Backtrace::force_capture(),
+        }
+    }
+
+    /// Creates a handler error from another [`Error`], preserving its type name.
+    ///
+    /// Uses [`std::any::type_name`] of `E` as
+    /// [`dex_protocol::dex::WorkerErrorResponse::error_type`] and `error.to_string()`
+    /// as the detail. Captures a stack at this call site the same way
+    /// [`Self::new`] does. Prefer this when mapping database, HTTP, or other
+    /// library failures into a Dex handler failure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::error::Error;
+    /// use std::fmt::{Display, Formatter};
+    ///
+    /// use dex_sdk::HandlerError;
+    ///
+    /// #[derive(Debug)]
+    /// struct DbError;
+    ///
+    /// impl Display for DbError {
+    ///     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+    ///         formatter.write_str("connection refused")
+    ///     }
+    /// }
+    ///
+    /// impl Error for DbError {}
+    ///
+    /// let error = HandlerError::from_error(DbError);
+    /// assert_eq!(error.to_string(), "connection refused");
+    /// ```
+    pub fn from_error<E: Error>(error: E) -> Self {
+        Self {
+            message: error.to_string(),
+            error_type: std::any::type_name::<E>().to_string(),
             retry_after_seconds: None,
             stack: Backtrace::force_capture(),
         }
@@ -71,20 +137,26 @@ impl HandlerError {
     ///
     /// Captures a stack at this call site the same way [`Self::new`] does.
     /// `after_seconds` is the delay Dex should wait before retrying the Step
-    /// method. `message` is the failure detail reported to Dex.
+    /// method. `error_type` is stored as
+    /// [`dex_protocol::dex::WorkerErrorResponse::error_type`]. `message` is the
+    /// failure detail reported to Dex.
     ///
     /// # Examples
     ///
     /// ```
     /// use dex_sdk::HandlerError;
     ///
-    /// let error = HandlerError::retry_after(30, "payment failed");
+    /// let error = HandlerError::retry_after(30, "PaymentDeclined", "payment failed");
     /// assert_eq!(error.to_string(), "payment failed");
     /// ```
-    pub fn retry_after(after_seconds: i32, message: impl Into<String>) -> Self {
+    pub fn retry_after(
+        after_seconds: i32,
+        error_type: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
         Self {
             message: message.into(),
-            error_type: std::any::type_name::<Self>().to_string(),
+            error_type: error_type.into(),
             retry_after_seconds: Some(after_seconds),
             stack: Backtrace::force_capture(),
         }
@@ -133,6 +205,17 @@ impl Error for HandlerError {}
 mod tests {
     use super::*;
 
+    #[derive(Debug)]
+    struct SampleDbError;
+
+    impl Display for SampleDbError {
+        fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("connection refused")
+        }
+    }
+
+    impl Error for SampleDbError {}
+
     #[test]
     fn invalid_step_result_has_stable_context_and_type() {
         let error = HandlerError::invalid_step_result(
@@ -150,9 +233,35 @@ mod tests {
     }
 
     #[test]
+    fn new_stores_explicit_error_type() {
+        let error = HandlerError::new("PaymentDeclined", "payment failed");
+        assert_eq!("PaymentDeclined", error.error_type());
+        assert_eq!("payment failed", error.to_string());
+    }
+
+    #[test]
+    fn from_error_stores_concrete_type_name() {
+        let error = HandlerError::from_error(SampleDbError);
+        assert_eq!(std::any::type_name::<SampleDbError>(), error.error_type());
+        assert_eq!("connection refused", error.to_string());
+    }
+
+    #[test]
     fn new_captures_stack_at_construction_site() {
         fn marker_frame() -> HandlerError {
-            HandlerError::new("boom")
+            HandlerError::new("TestFailure", "boom")
+        }
+        let rendered = format!("{}", marker_frame().stack_trace());
+        assert!(
+            rendered.contains("marker_frame"),
+            "expected construction-site frame, got {rendered}"
+        );
+    }
+
+    #[test]
+    fn from_error_captures_stack_at_construction_site() {
+        fn marker_frame() -> HandlerError {
+            HandlerError::from_error(SampleDbError)
         }
         let rendered = format!("{}", marker_frame().stack_trace());
         assert!(

--- a/sdk-rust/crates/dex-sdk/src/handler_error.rs
+++ b/sdk-rust/crates/dex-sdk/src/handler_error.rs
@@ -6,39 +6,87 @@
 //
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
+use std::backtrace::Backtrace;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 
 /// Result returned by application Step and RPC handlers.
 pub type HandlerResult<T> = Result<T, HandlerError>;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 /// Reports an application-defined Step or RPC failure to Dex.
 ///
 /// Return this error from [`crate::Step::wait_for`], [`crate::Step::execute`], or an RPC handler.
 /// Dex records the message and applies the configured retry or failure policy.
+///
+/// Every constructor captures a stack at the construction site with
+/// [`Backtrace::force_capture`]. The Worker prefers that construction-site
+/// stack over a wrap-site capture when encoding [`dex_protocol::dex::WorkerErrorResponse`].
+///
+/// # Examples
+///
+/// ```
+/// use dex_sdk::HandlerError;
+///
+/// fn charge() -> Result<(), HandlerError> {
+///     Err(HandlerError::new("payment failed"))
+/// }
+///
+/// fn charge_with_retry() -> Result<(), HandlerError> {
+///     Err(HandlerError::retry_after(30, "payment failed"))
+/// }
+/// ```
+#[derive(Debug)]
 pub struct HandlerError {
     message: String,
     error_type: String,
     retry_after_seconds: Option<i32>,
+    stack: Backtrace,
 }
 
 impl HandlerError {
     /// Creates a handler error with a developer-facing message.
+    ///
+    /// Captures a stack at this call site so Dex can report the origin of the
+    /// failure. Prefer constructing the error where the failure is detected
+    /// rather than mapping it later through a distant helper.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dex_sdk::HandlerError;
+    ///
+    /// let error = HandlerError::new("payment failed");
+    /// assert_eq!(error.to_string(), "payment failed");
+    /// ```
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
             error_type: std::any::type_name::<Self>().to_string(),
             retry_after_seconds: None,
+            stack: Backtrace::force_capture(),
         }
     }
 
     /// Requests the next retry interval while preserving this failure.
+    ///
+    /// Captures a stack at this call site the same way [`Self::new`] does.
+    /// `after_seconds` is the delay Dex should wait before retrying the Step
+    /// method. `message` is the failure detail reported to Dex.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dex_sdk::HandlerError;
+    ///
+    /// let error = HandlerError::retry_after(30, "payment failed");
+    /// assert_eq!(error.to_string(), "payment failed");
+    /// ```
     pub fn retry_after(after_seconds: i32, message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
             error_type: std::any::type_name::<Self>().to_string(),
             retry_after_seconds: Some(after_seconds),
+            stack: Backtrace::force_capture(),
         }
     }
 
@@ -60,11 +108,16 @@ impl HandlerError {
             message: format!("{target} {method} returned an invalid result: {detail}"),
             error_type: "dex_sdk::SdkError::InvalidStepResult".to_string(),
             retry_after_seconds: None,
+            stack: Backtrace::force_capture(),
         }
     }
 
     pub(crate) fn error_type(&self) -> &str {
         &self.error_type
+    }
+
+    pub(crate) fn stack_trace(&self) -> &Backtrace {
+        &self.stack
     }
 }
 
@@ -93,6 +146,18 @@ mod tests {
             error
                 .to_string()
                 .contains("Flow OrderFlow Step ApproveOrder")
+        );
+    }
+
+    #[test]
+    fn new_captures_stack_at_construction_site() {
+        fn marker_frame() -> HandlerError {
+            HandlerError::new("boom")
+        }
+        let rendered = format!("{}", marker_frame().stack_trace());
+        assert!(
+            rendered.contains("marker_frame"),
+            "expected construction-site frame, got {rendered}"
         );
     }
 }

--- a/sdk-rust/crates/dex-sdk/src/registry.rs
+++ b/sdk-rust/crates/dex-sdk/src/registry.rs
@@ -214,9 +214,9 @@ impl<SomeFlow: Flow> ErasedFlow for TypedFlow<SomeFlow> {
     }
 
     fn handle_timeout(&self, context: &mut Context) -> HandlerResult<StepDecision> {
-        let handler = self
-            .timeout_handler
-            .ok_or_else(|| crate::HandlerError::new("Flow has no timeout handler"))?;
+        let handler = self.timeout_handler.ok_or_else(|| {
+            crate::HandlerError::new("dex_sdk::HandlerError", "Flow has no timeout handler")
+        })?;
         handler(self.flow.as_ref(), context)
     }
     fn wait_for(
@@ -229,7 +229,10 @@ impl<SomeFlow: Flow> ErasedFlow for TypedFlow<SomeFlow> {
             .steps()
             .find(step_type)
             .ok_or_else(|| {
-                crate::HandlerError::new(format!("Step is not registered: {step_type}"))
+                crate::HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("Step is not registered: {step_type}"),
+                )
             })?
             .wait_for(context, input)
     }
@@ -244,7 +247,10 @@ impl<SomeFlow: Flow> ErasedFlow for TypedFlow<SomeFlow> {
             .steps()
             .find(step_type)
             .ok_or_else(|| {
-                crate::HandlerError::new(format!("Step is not registered: {step_type}"))
+                crate::HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("Step is not registered: {step_type}"),
+                )
             })?
             .execute(context, input)
     }
@@ -255,7 +261,10 @@ impl<SomeFlow: Flow> ErasedFlow for TypedFlow<SomeFlow> {
             .steps()
             .find(step_type)
             .ok_or_else(|| {
-                crate::HandlerError::new(format!("Step is not registered: {step_type}"))
+                crate::HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("Step is not registered: {step_type}"),
+                )
             })?
             .options())
     }

--- a/sdk-rust/crates/dex-sdk/src/value_mapper.rs
+++ b/sdk-rust/crates/dex-sdk/src/value_mapper.rs
@@ -120,5 +120,5 @@ fn value_error(message: impl Into<String>) -> SdkError {
 }
 
 fn handler_mapping_error(error: SdkError) -> HandlerError {
-    HandlerError::new(error.to_string())
+    HandlerError::from_error(error)
 }

--- a/sdk-rust/crates/dex-sdk/src/worker.rs
+++ b/sdk-rust/crates/dex-sdk/src/worker.rs
@@ -248,10 +248,7 @@ struct GoogleRpcStatus {
 
 fn worker_status(error: HandlerError) -> Status {
     let message = error.to_string();
-    let stack_trace = truncate_stack_trace(&format!(
-        "{message}\n{}",
-        std::backtrace::Backtrace::capture()
-    ));
+    let stack_trace = truncate_stack_trace(&format!("{message}\n{}", error.stack_trace()));
     let worker_error = WorkerErrorResponse {
         detail: message.clone(),
         error_type: error.error_type().to_string(),

--- a/sdk-rust/crates/dex-sdk/src/worker_dispatcher.rs
+++ b/sdk-rust/crates/dex-sdk/src/worker_dispatcher.rs
@@ -32,8 +32,8 @@ use crate::value_hydrator::ValueHydrator;
 use crate::value_mapper;
 use crate::wait::{Condition, ConditionKind, Wait, WaitKind};
 use crate::{
-    HandlerError, HandlerResult, Registry, RetryPolicy, StepDurability, SubFlowReusePolicy,
-    WaitForFailurePolicy,
+    HandlerError, HandlerResult, Registry, RetryPolicy, SdkError, StepDurability,
+    SubFlowReusePolicy, WaitForFailurePolicy,
 };
 
 const TIMEOUT_HANDLER_STEP_TYPE: &str = "sys:timeout_handler";
@@ -60,14 +60,20 @@ impl WorkerDispatcher {
             .get(request.step_type.as_str())
             .cloned()
             .ok_or_else(|| {
-                HandlerError::new(format!("Step is not registered: {}", request.step_type))
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("Step is not registered: {}", request.step_type),
+                )
             })?;
         let mut context = Context::new(
             InvocationMethod::WaitFor,
             flow.clone(),
-            request
-                .context
-                .ok_or_else(|| HandlerError::new("Worker request Context is required"))?,
+            request.context.ok_or_else(|| {
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    "Worker request Context is required",
+                )
+            })?,
             request.attributes,
             Vec::new(),
             None,
@@ -75,7 +81,7 @@ impl WorkerDispatcher {
         )?;
         let input = request
             .step_input
-            .ok_or_else(|| HandlerError::new("Step input is required"))?;
+            .ok_or_else(|| HandlerError::new("dex_sdk::HandlerError", "Step input is required"))?;
         let cancellation = context.cancellation();
         let registry = self.registry.clone();
         run_handler(cancellation, move || {
@@ -110,14 +116,20 @@ impl WorkerDispatcher {
             .get(request.step_type.as_str())
             .cloned()
             .ok_or_else(|| {
-                HandlerError::new(format!("Step is not registered: {}", request.step_type))
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("Step is not registered: {}", request.step_type),
+                )
             })?;
         let mut context = Context::new(
             InvocationMethod::Execute,
             flow.clone(),
-            request
-                .context
-                .ok_or_else(|| HandlerError::new("Worker request Context is required"))?,
+            request.context.ok_or_else(|| {
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    "Worker request Context is required",
+                )
+            })?,
             request.attributes,
             request.step_exe_locals,
             request.condition_results,
@@ -125,7 +137,7 @@ impl WorkerDispatcher {
         )?;
         let input = request
             .step_input
-            .ok_or_else(|| HandlerError::new("Step input is required"))?;
+            .ok_or_else(|| HandlerError::new("dex_sdk::HandlerError", "Step input is required"))?;
         let cancellation = context.cancellation();
         run_handler(cancellation, move || {
             let decision = flow.handler.execute(step.name, &mut context, &input)?;
@@ -151,17 +163,26 @@ impl WorkerDispatcher {
         flow: RegisteredFlow,
     ) -> HandlerResult<InvokeExecuteMethodResponse> {
         if request.step_input.is_some() {
-            return Err(HandlerError::new("timeout handler input must be absent"));
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "timeout handler input must be absent",
+            ));
         }
         if !flow.handler.has_timeout_handler() {
-            return Err(HandlerError::new("Flow has no timeout handler"));
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "Flow has no timeout handler",
+            ));
         }
         let mut context = Context::new(
             InvocationMethod::Execute,
             flow.clone(),
-            request
-                .context
-                .ok_or_else(|| HandlerError::new("Worker request Context is required"))?,
+            request.context.ok_or_else(|| {
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    "Worker request Context is required",
+                )
+            })?,
             request.attributes,
             request.step_exe_locals,
             request.condition_results,
@@ -202,14 +223,20 @@ impl WorkerDispatcher {
             .get(request.rpc_name.as_str())
             .cloned()
             .ok_or_else(|| {
-                HandlerError::new(format!("RPC is not registered: {}", request.rpc_name))
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("RPC is not registered: {}", request.rpc_name),
+                )
             })?;
         let mut context = Context::new(
             InvocationMethod::Rpc,
             flow.clone(),
-            request
-                .context
-                .ok_or_else(|| HandlerError::new("Worker request Context is required"))?,
+            request.context.ok_or_else(|| {
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    "Worker request Context is required",
+                )
+            })?,
             request.attributes,
             Vec::new(),
             None,
@@ -217,7 +244,7 @@ impl WorkerDispatcher {
         )?;
         let input = request
             .input
-            .ok_or_else(|| HandlerError::new("RPC input is required"))?;
+            .ok_or_else(|| HandlerError::new("dex_sdk::HandlerError", "RPC input is required"))?;
         let cancellation = context.cancellation();
         run_handler(cancellation, move || {
             let result = rpc.handler.invoke(&mut context, &input)?;
@@ -304,7 +331,10 @@ impl WorkerDispatcher {
             for flow_result in &mut conditions.sub_flow_results {
                 for completion in &mut flow_result.results {
                     values.push(completion.completed_step_output.take().ok_or_else(|| {
-                        HandlerError::new("SubFlow Step completion output is required")
+                        HandlerError::new(
+                            "dex_sdk::HandlerError",
+                            "SubFlow Step completion output is required",
+                        )
                     })?);
                 }
             }
@@ -370,7 +400,12 @@ where
     let _cancel_on_drop = CancelOnDrop(cancellation);
     tokio::task::spawn_blocking(handler)
         .await
-        .map_err(|error| HandlerError::new(format!("user handler task failed: {error}")))?
+        .map_err(|error| {
+            HandlerError::new(
+                "dex_sdk::HandlerError",
+                format!("user handler task failed: {error}"),
+            )
+        })?
 }
 
 struct CancelOnDrop(InvocationCancellation);
@@ -389,7 +424,10 @@ pub(crate) fn map_step_options(
         .execute_failure_step
         .map(|target| {
             let target = flow.steps.get(target).ok_or_else(|| {
-                HandlerError::new(format!("execute failure Step is not registered: {target}"))
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("execute failure Step is not registered: {target}"),
+                )
             })?;
             Ok((
                 target.name,
@@ -443,8 +481,9 @@ fn map_retry(retry: RetryPolicy) -> HandlerResult<ProtoRetryPolicy> {
         initial_interval_seconds: optional_seconds(retry.initial_interval)?,
         backoff_coefficient: retry.backoff_coefficient.unwrap_or_default() as f32,
         maximum_interval_seconds: optional_seconds(retry.maximum_interval)?,
-        maximum_attempts: i32::try_from(retry.maximum_attempts.unwrap_or_default())
-            .map_err(|_| HandlerError::new("maximum attempts exceed int32"))?,
+        maximum_attempts: i32::try_from(retry.maximum_attempts.unwrap_or_default()).map_err(
+            |_| HandlerError::new("dex_sdk::HandlerError", "maximum attempts exceed int32"),
+        )?,
         total_duration_seconds: optional_seconds(retry.total_duration)?,
     })
 }
@@ -482,6 +521,7 @@ fn map_wait(
         WaitKind::AnyCombinationOf(combinations) => {
             if combinations.is_empty() {
                 return Err(HandlerError::new(
+                    "dex_sdk::HandlerError",
                     "Wait requires at least one Condition combination",
                 ));
             }
@@ -520,7 +560,10 @@ fn map_decision(
     let mut mapped = match decision.kind {
         StepDecisionKind::Next(movements) => {
             if movements.is_empty() {
-                return Err(HandlerError::new("go_to_many requires a movement"));
+                return Err(HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    "go_to_many requires a movement",
+                ));
             }
             Ok(ProtoStepDecision {
                 next_steps: map_movements(flow, movements)?,
@@ -583,6 +626,7 @@ fn map_cancellation_step_types(
     for step_type in selected {
         if !flow.steps.contains_key(step_type) {
             return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
                 "cancellation Step does not belong to Flow",
             ));
         }
@@ -621,10 +665,12 @@ fn map_movements(
 }
 
 fn map_movement(flow: &RegisteredFlow, movement: StepMovement) -> HandlerResult<ProtoStepMovement> {
-    let target = flow
-        .steps
-        .get(movement.target_step_type)
-        .ok_or_else(|| HandlerError::new("Step movement target does not belong to Flow"))?;
+    let target = flow.steps.get(movement.target_step_type).ok_or_else(|| {
+        HandlerError::new(
+            "dex_sdk::HandlerError",
+            "Step movement target does not belong to Flow",
+        )
+    })?;
     let step_input = movement.encode_input().map_err(handler_error)?;
     let options = movement
         .options_override
@@ -670,14 +716,21 @@ impl<'a> ConditionMapper<'a> {
         let id = condition.id.unwrap_or_default();
         if id_required && id.is_empty() {
             return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
                 "any_combination_of requires every Condition to have an ID",
             ));
         }
         if id_was_provided && id.is_empty() {
-            return Err(HandlerError::new("empty Condition ID"));
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "empty Condition ID",
+            ));
         }
         if !id.is_empty() && self.used_ids.contains(&id) {
-            return Err(HandlerError::new("duplicate Condition ID"));
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "duplicate Condition ID",
+            ));
         }
         if !id.is_empty() {
             self.used_ids.insert(id.clone());
@@ -696,20 +749,27 @@ impl<'a> ConditionMapper<'a> {
                 at_most,
             } => {
                 let definition = self.flow.persistence.get(&name).ok_or_else(|| {
-                    HandlerError::new(format!("Channel is not registered: {name}"))
+                    HandlerError::new(
+                        "dex_sdk::HandlerError",
+                        format!("Channel is not registered: {name}"),
+                    )
                 })?;
                 let channel_name = match definition.kind {
                     PersistenceKind::Channel if instance.is_none() => name,
                     PersistenceKind::ChannelMap => physical_name(
                         &name,
                         instance.as_deref().ok_or_else(|| {
-                            HandlerError::new(format!("ChannelMap {name} requires an instance"))
+                            HandlerError::new(
+                                "dex_sdk::HandlerError",
+                                format!("ChannelMap {name} requires an instance"),
+                            )
                         })?,
                     ),
                     _ => {
-                        return Err(HandlerError::new(format!(
-                            "Channel is not registered: {name}"
-                        )));
+                        return Err(HandlerError::new(
+                            "dex_sdk::HandlerError",
+                            format!("Channel is not registered: {name}"),
+                        ));
                     }
                 };
                 self.channels.push(ChannelCondition {
@@ -725,16 +785,19 @@ impl<'a> ConditionMapper<'a> {
                     .flow(definition.flow_type)
                     .map_err(handler_error)?;
                 if target.type_id != definition.type_id {
-                    return Err(HandlerError::new(format!(
-                        "SubFlow {} does not match the registered Rust type",
-                        definition.flow_type
-                    )));
+                    return Err(HandlerError::new(
+                        "dex_sdk::HandlerError",
+                        format!(
+                            "SubFlow {} does not match the registered Rust type",
+                            definition.flow_type
+                        ),
+                    ));
                 }
                 let start = target.start_step.as_ref().ok_or_else(|| {
-                    HandlerError::new(format!(
-                        "SubFlow {} has no starting Step",
-                        definition.flow_type
-                    ))
+                    HandlerError::new(
+                        "dex_sdk::HandlerError",
+                        format!("SubFlow {} has no starting Step", definition.flow_type),
+                    )
                 })?;
                 let step_options =
                     map_step_options(target, target.handler.step_options(start.name)?)?;
@@ -746,8 +809,9 @@ impl<'a> ConditionMapper<'a> {
                     step_input: Some(definition.input),
                     step_options: Some(step_options),
                     options: Some(options),
-                    sub_flow_index: i32::try_from(self.sub_flows.len())
-                        .map_err(|_| HandlerError::new("too many SubFlow Conditions"))?,
+                    sub_flow_index: i32::try_from(self.sub_flows.len()).map_err(|_| {
+                        HandlerError::new("dex_sdk::HandlerError", "too many SubFlow Conditions")
+                    })?,
                 });
             }
         }
@@ -772,10 +836,10 @@ fn map_sub_flow_options(
         .map(|attribute| {
             let logical_name = attribute.key.split('/').next().unwrap_or(&attribute.key);
             if !target.persistence.contains_key(logical_name) {
-                return Err(HandlerError::new(format!(
-                    "SubFlow Attribute is not registered: {}",
-                    attribute.key
-                )));
+                return Err(HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("SubFlow Attribute is not registered: {}", attribute.key),
+                ));
             }
             Ok(AttributeWrite {
                 key: attribute.key.clone(),
@@ -816,10 +880,12 @@ fn take_entry_values(entries: &mut [Kv]) -> HandlerResult<Vec<dex_protocol::dex:
     entries
         .iter_mut()
         .map(|entry| {
-            entry
-                .value
-                .take()
-                .ok_or_else(|| HandlerError::new(format!("{} has no Value", entry.key)))
+            entry.value.take().ok_or_else(|| {
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("{} has no Value", entry.key),
+                )
+            })
         })
         .collect()
 }
@@ -830,14 +896,15 @@ fn restore_entry_values(
 ) -> HandlerResult<()> {
     let mut values = values.into_iter();
     for entry in entries {
-        entry.value = Some(
-            values
-                .next()
-                .ok_or_else(|| HandlerError::new("hydrated Value count mismatch"))?,
-        );
+        entry.value = Some(values.next().ok_or_else(|| {
+            HandlerError::new("dex_sdk::HandlerError", "hydrated Value count mismatch")
+        })?);
     }
     if values.next().is_some() {
-        return Err(HandlerError::new("hydrated Value count mismatch"));
+        return Err(HandlerError::new(
+            "dex_sdk::HandlerError",
+            "hydrated Value count mismatch",
+        ));
     }
     Ok(())
 }
@@ -848,21 +915,25 @@ fn restore_n_entry_values(
     count: usize,
 ) -> HandlerResult<()> {
     if entries.len() != count {
-        return Err(HandlerError::new("hydrated Value count mismatch"));
+        return Err(HandlerError::new(
+            "dex_sdk::HandlerError",
+            "hydrated Value count mismatch",
+        ));
     }
     for entry in entries {
-        entry.value = Some(
-            values
-                .next()
-                .ok_or_else(|| HandlerError::new("hydrated Value count mismatch"))?,
-        );
+        entry.value = Some(values.next().ok_or_else(|| {
+            HandlerError::new("dex_sdk::HandlerError", "hydrated Value count mismatch")
+        })?);
     }
     Ok(())
 }
 
 fn require_conditions(conditions: &[Condition]) -> HandlerResult<()> {
     if conditions.is_empty() {
-        Err(HandlerError::new("Wait requires at least one Condition"))
+        Err(HandlerError::new(
+            "dex_sdk::HandlerError",
+            "Wait requires at least one Condition",
+        ))
     } else {
         Ok(())
     }
@@ -871,7 +942,9 @@ fn require_conditions(conditions: &[Condition]) -> HandlerResult<()> {
 fn optional_count(value: Option<usize>) -> HandlerResult<Option<i32>> {
     value
         .map(|value| {
-            i32::try_from(value).map_err(|_| HandlerError::new("channel count exceeds int32"))
+            i32::try_from(value).map_err(|_| {
+                HandlerError::new("dex_sdk::HandlerError", "channel count exceeds int32")
+            })
         })
         .transpose()
 }
@@ -885,20 +958,28 @@ fn optional_seconds(value: Option<Duration>) -> HandlerResult<i32> {
 
 fn seconds32(duration: Duration) -> HandlerResult<i32> {
     if duration.subsec_nanos() != 0 {
-        return Err(HandlerError::new("Duration must use whole seconds"));
+        return Err(HandlerError::new(
+            "dex_sdk::HandlerError",
+            "Duration must use whole seconds",
+        ));
     }
-    i32::try_from(duration.as_secs()).map_err(|_| HandlerError::new("Duration exceeds int32"))
+    i32::try_from(duration.as_secs())
+        .map_err(|_| HandlerError::new("dex_sdk::HandlerError", "Duration exceeds int32"))
 }
 
 fn seconds64(duration: Duration) -> HandlerResult<i64> {
     if duration.subsec_nanos() != 0 {
-        return Err(HandlerError::new("Duration must use whole seconds"));
+        return Err(HandlerError::new(
+            "dex_sdk::HandlerError",
+            "Duration must use whole seconds",
+        ));
     }
-    i64::try_from(duration.as_secs()).map_err(|_| HandlerError::new("Duration exceeds int64"))
+    i64::try_from(duration.as_secs())
+        .map_err(|_| HandlerError::new("dex_sdk::HandlerError", "Duration exceeds int64"))
 }
 
-fn handler_error(error: impl std::fmt::Display) -> HandlerError {
-    HandlerError::new(error.to_string())
+fn handler_error(error: SdkError) -> HandlerError {
+    HandlerError::from_error(error)
 }
 
 #[allow(dead_code)]

--- a/sdk-rust/crates/dex-sdk/tests/cross_sdk/channels.rs
+++ b/sdk-rust/crates/dex-sdk/tests/cross_sdk/channels.rs
@@ -99,9 +99,10 @@ impl Step for InterStepChannelConsumer {
         let first = self.first.condition_results(context)?;
         let second = self.second.condition_results(context)?;
         if !first.is_empty() || second != [2] {
-            return Err(HandlerError::new(format!(
-                "unexpected channel results: first={first:?} second={second:?}"
-            )));
+            return Err(HandlerError::new(
+                "ChannelsFailure",
+                format!("unexpected channel results: first={first:?} second={second:?}"),
+            ));
         }
         Ok(StepDecision::graceful_complete(second[0]))
     }
@@ -180,9 +181,10 @@ impl Step for ChannelFirstStep {
         let first = self.first.condition_results(context)?;
         let second = self.second.condition_results(context)?;
         if !first.is_empty() || second != [10] {
-            return Err(HandlerError::new(format!(
-                "unexpected first-step channel results: first={first:?} second={second:?}"
-            )));
+            return Err(HandlerError::new(
+                "ChannelsFailure",
+                format!("unexpected first-step channel results: first={first:?} second={second:?}"),
+            ));
         }
         Ok(StepDecision::go_to(
             &ChannelSecondStep {
@@ -211,14 +213,20 @@ impl Step for ChannelSecondStep {
 
     fn execute(&self, context: &mut Context, (): ()) -> HandlerResult<StepDecision> {
         if !context.has_any_timer_fired() || !context.has_timer_fired(0) {
-            return Err(HandlerError::new("skipped timer was not reported as fired"));
+            return Err(HandlerError::new(
+                "ChannelsFailure",
+                "skipped timer was not reported as fired",
+            ));
         }
         let first = self.first.condition_results(context)?;
         let second = self.second.condition_results(context)?;
         if first != [100] || !second.is_empty() {
-            return Err(HandlerError::new(format!(
-                "unexpected second-step channel results: first={first:?} second={second:?}"
-            )));
+            return Err(HandlerError::new(
+                "ChannelsFailure",
+                format!(
+                    "unexpected second-step channel results: first={first:?} second={second:?}"
+                ),
+            ));
         }
         Ok(StepDecision::graceful_complete(first[0]))
     }
@@ -247,7 +255,10 @@ impl Step for TimerStep {
 
     fn execute(&self, context: &mut Context, input: u64) -> HandlerResult<StepDecision> {
         if !context.has_any_timer_fired() || !context.has_timer_fired(0) {
-            return Err(HandlerError::new("natural timer was not reported as fired"));
+            return Err(HandlerError::new(
+                "ChannelsFailure",
+                "natural timer was not reported as fired",
+            ));
         }
         Ok(StepDecision::graceful_complete(input + 1))
     }

--- a/sdk-rust/crates/dex-sdk/tests/cross_sdk/handler_context.rs
+++ b/sdk-rust/crates/dex-sdk/tests/cross_sdk/handler_context.rs
@@ -46,7 +46,10 @@ impl Step for HandlerContextFirstStep {
 
 fn validate_attempt_metadata(context: &Context) -> HandlerResult<()> {
     if context.attempt() < 1 || context.first_attempt_at() == SystemTime::UNIX_EPOCH {
-        return Err(HandlerError::new("invalid first-step attempt metadata"));
+        return Err(HandlerError::new(
+            "HandlerContextFailure",
+            "invalid first-step attempt metadata",
+        ));
     }
     Ok(())
 }

--- a/sdk-rust/crates/dex-sdk/tests/cross_sdk/persistence.rs
+++ b/sdk-rust/crates/dex-sdk/tests/cross_sdk/persistence.rs
@@ -138,7 +138,10 @@ impl Step for PersistenceFirstStep {
             || self.decimal.get_required(context)? != 2.1
             || self.datetime.get_required(context)? != input.datetime
         {
-            return Err(HandlerError::new("unexpected initial attributes"));
+            return Err(HandlerError::new(
+                "PersistenceFailure",
+                "unexpected initial attributes",
+            ));
         }
         self.data.set(context, input)?;
         self.text.set(context, "a string".to_string())?;
@@ -153,11 +156,17 @@ impl Step for PersistenceFirstStep {
         input: PersistenceModel,
     ) -> HandlerResult<StepDecision> {
         if self.integer.get_required(context)? != 1 {
-            return Err(HandlerError::new("wait_for integer write was not visible"));
+            return Err(HandlerError::new(
+                "PersistenceFailure",
+                "wait_for integer write was not visible",
+            ));
         }
         let data = self.data.get_required(context)?;
         if data.text != input.text || data.number != input.number {
-            return Err(HandlerError::new("wait_for data write was not visible"));
+            return Err(HandlerError::new(
+                "PersistenceFailure",
+                "wait_for data write was not visible",
+            ));
         }
         self.datetime.set(context, data.datetime)?;
         self.boolean.set(context, true)?;
@@ -200,7 +209,10 @@ impl Step for PersistenceSecondStep {
         if self.datetime.get_required(context)? != data.datetime
             || !self.boolean.get_required(context)?
         {
-            return Err(HandlerError::new("persisted values did not round trip"));
+            return Err(HandlerError::new(
+                "PersistenceFailure",
+                "persisted values did not round trip",
+            ));
         }
         self.decimal.set(context, 1.0)?;
         self.full_text.set(context, "Hail Dex!".to_string())?;
@@ -209,7 +221,10 @@ impl Step for PersistenceSecondStep {
 
     fn execute(&self, context: &mut Context, (): ()) -> HandlerResult<StepDecision> {
         if self.full_text.get_required(context)? != "Hail Dex!" {
-            return Err(HandlerError::new("unexpected persisted text"));
+            return Err(HandlerError::new(
+                "PersistenceFailure",
+                "unexpected persisted text",
+            ));
         }
         self.keyword.set(context, "Dex".to_string())?;
         Ok(StepDecision::graceful_complete("done".to_string()))

--- a/sdk-rust/crates/dex-sdk/tests/cross_sdk/rpc.rs
+++ b/sdk-rust/crates/dex-sdk/tests/cross_sdk/rpc.rs
@@ -64,7 +64,7 @@ impl RpcWorkflow {
     }
 
     fn fail(&self, _context: &mut Context, _input: i32) -> HandlerResult<RpcResult<i32>> {
-        Err(HandlerError::new("planned RPC failure"))
+        Err(HandlerError::new("RpcFailure", "planned RPC failure"))
     }
 }
 
@@ -103,12 +103,16 @@ impl Step for RpcStep {
     fn execute(&self, context: &mut Context, input: i32) -> HandlerResult<StepDecision> {
         let values = self.channel.condition_results(context)?;
         if values != [input + 1] {
-            return Err(HandlerError::new(format!(
-                "unexpected RPC channel values {values:?}"
-            )));
+            return Err(HandlerError::new(
+                "RpcFailure",
+                format!("unexpected RPC channel values {values:?}"),
+            ));
         }
         if self.status.get_required(context)? != "invoked" {
-            return Err(HandlerError::new("RPC attribute write was not committed"));
+            return Err(HandlerError::new(
+                "RpcFailure",
+                "RPC attribute write was not committed",
+            ));
         }
         Ok(StepDecision::graceful_complete(values[0] + 1))
     }

--- a/sdk-rust/crates/dex-sdk/tests/cross_sdk/state.rs
+++ b/sdk-rust/crates/dex-sdk/tests/cross_sdk/state.rs
@@ -34,7 +34,7 @@ impl Step for ExecuteRecoveryFailStep {
     type Input = String;
 
     fn execute(&self, _context: &mut Context, _input: String) -> HandlerResult<StepDecision> {
-        Err(HandlerError::new("planned Execute failure"))
+        Err(HandlerError::new("StateFailure", "planned Execute failure"))
     }
 
     fn options(&self) -> StepOptions<Self::Input> {
@@ -74,7 +74,7 @@ impl Step for WaitForFailureStep {
     type Input = ();
 
     fn wait_for(&self, _context: &mut Context, (): ()) -> HandlerResult<Wait> {
-        Err(HandlerError::new("test WaitFor failing"))
+        Err(HandlerError::new("StateFailure", "test WaitFor failing"))
     }
 
     fn execute(&self, _context: &mut Context, (): ()) -> HandlerResult<StepDecision> {
@@ -105,7 +105,10 @@ impl Step for WaitForTimeoutStep {
 
     fn wait_for(&self, context: &mut Context, (): ()) -> HandlerResult<Wait> {
         context.wait_for_cancellation();
-        Err(HandlerError::new("wait_for invocation was cancelled"))
+        Err(HandlerError::new(
+            "StateFailure",
+            "wait_for invocation was cancelled",
+        ))
     }
 
     fn execute(&self, _context: &mut Context, (): ()) -> HandlerResult<StepDecision> {

--- a/sdk-rust/crates/dex-sdk/tests/integ.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ.rs
@@ -109,6 +109,10 @@ mod subflow_workflow;
 mod timer_test;
 #[path = "integ/timer_workflow.rs"]
 mod timer_workflow;
+#[path = "integ/worker_origin_stack_test.rs"]
+mod worker_origin_stack_test;
+#[path = "integ/worker_origin_stack_workflow.rs"]
+mod worker_origin_stack_workflow;
 #[path = "integ/worker_retry_after_test.rs"]
 mod worker_retry_after_test;
 #[path = "integ/worker_retry_after_workflow.rs"]

--- a/sdk-rust/crates/dex-sdk/tests/integ/any_command_combination_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/any_command_combination_workflow.rs
@@ -53,6 +53,7 @@ impl Step for AnyCommandCombinationStep {
 
     fn wait_for(&self, _context: &mut Context, _input: i32) -> HandlerResult<Wait> {
         Err(HandlerError::new(
+            "UnknownConditionId",
             "Found unknown condition ID in the combination list",
         ))
     }

--- a/sdk-rust/crates/dex-sdk/tests/integ/basic_abnormal_exit_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/basic_abnormal_exit_workflow.rs
@@ -39,7 +39,10 @@ impl Step for BasicAbnormalExitStep {
     type Input = i32;
 
     fn execute(&self, _context: &mut Context, _input: i32) -> HandlerResult<StepDecision> {
-        Err(HandlerError::new("abnormal exit"))
+        Err(HandlerError::new(
+            "BasicAbnormalExitFailure",
+            "abnormal exit",
+        ))
     }
 
     fn options(&self) -> StepOptions<Self::Input> {

--- a/sdk-rust/crates/dex-sdk/tests/integ/basic_immutable_step_options_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/basic_immutable_step_options_workflow.rs
@@ -58,12 +58,18 @@ impl Step for FailingWaitStep {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, input: i32) -> HandlerResult<Wait> {
-        Err(HandlerError::new(format!("expected wait failure {input}")))
+        Err(HandlerError::new(
+            "BasicImmutableStepOptionsFailure",
+            format!("expected wait failure {input}"),
+        ))
     }
 
     fn execute(&self, context: &mut Context, input: i32) -> HandlerResult<StepDecision> {
         if !context.wait_for_method_failed() {
-            return Err(HandlerError::new("wait failure was not reported"));
+            return Err(HandlerError::new(
+                "BasicImmutableStepOptionsFailure",
+                "wait failure was not reported",
+            ));
         }
         if input == 1 {
             return Ok(StepDecision::go_to(self, 2));

--- a/sdk-rust/crates/dex-sdk/tests/integ/basic_proceed_on_wait_failure_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/basic_proceed_on_wait_failure_workflow.rs
@@ -41,7 +41,10 @@ impl Step for FailingWaitStep {
     type Input = String;
 
     fn wait_for(&self, _context: &mut Context, _input: String) -> HandlerResult<Wait> {
-        Err(HandlerError::new("wait failure"))
+        Err(HandlerError::new(
+            "BasicProceedOnWaitFailureFailure",
+            "wait failure",
+        ))
     }
 
     fn execute(&self, _context: &mut Context, input: String) -> HandlerResult<StepDecision> {

--- a/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_workflow.rs
@@ -109,14 +109,18 @@ impl Step for ConsumeStep {
 
     fn execute(&self, context: &mut Context, input: i32) -> HandlerResult<StepDecision> {
         if !self.second_channel.condition_results(context)?.is_empty() {
-            return Err(HandlerError::new("second channel should still be waiting"));
+            return Err(HandlerError::new(
+                "InternalChannelFailure",
+                "second channel should still be waiting",
+            ));
         }
         let first = self.first_channel.condition_results(context)?[0];
         let mapped = self.channel_map.condition_results(context, "one")?[0];
         if mapped != 3 {
-            return Err(HandlerError::new(format!(
-                "mapped channel returned {mapped}"
-            )));
+            return Err(HandlerError::new(
+                "InternalChannelFailure",
+                format!("mapped channel returned {mapped}"),
+            ));
         }
         Ok(StepDecision::graceful_complete(input + first))
     }

--- a/sdk-rust/crates/dex-sdk/tests/integ/no_start_state_dead_end_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/no_start_state_dead_end_workflow.rs
@@ -45,7 +45,10 @@ impl NoStartStateDeadEndWorkflow {
 
     fn invoke(&self, context: &mut Context, _input: String) -> HandlerResult<RpcResult<i64>> {
         if context.flow_id().is_empty() || context.run_id().is_empty() {
-            return Err(HandlerError::new("invalid RPC context"));
+            return Err(HandlerError::new(
+                "NoStartStateDeadEndFailure",
+                "invalid RPC context",
+            ));
         }
         Ok(RpcResult::new(100).then(StepMovement::to(&self.complete, ())))
     }

--- a/sdk-rust/crates/dex-sdk/tests/integ/no_start_state_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/no_start_state_workflow.rs
@@ -29,7 +29,10 @@ impl NoStartStateWorkflow {
 
     fn invoke(&self, context: &mut Context, _input: String) -> HandlerResult<RpcResult<i64>> {
         if context.flow_id().is_empty() || context.run_id().is_empty() {
-            return Err(HandlerError::new("invalid RPC context"));
+            return Err(HandlerError::new(
+                "NoStartStateFailure",
+                "invalid RPC context",
+            ));
         }
         Ok(RpcResult::new(Self::RPC_OUTPUT).then(StepMovement::to(&self.triggered, ())))
     }

--- a/sdk-rust/crates/dex-sdk/tests/integ/persistence_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/persistence_workflow.rs
@@ -101,7 +101,10 @@ impl Step for PersistenceStep {
     fn execute(&self, context: &mut Context, input: String) -> HandlerResult<StepDecision> {
         let local: String = context.step_execution_local("local")?;
         if local != input {
-            return Err(HandlerError::new("step execution local did not round trip"));
+            return Err(HandlerError::new(
+                "PersistenceFailure",
+                "step execution local did not round trip",
+            ));
         }
         self.keyword.set(context, input)?;
         self.integer.set(context, 1)?;

--- a/sdk-rust/crates/dex-sdk/tests/integ/rpc_no_state_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/rpc_no_state_workflow.rs
@@ -43,12 +43,15 @@ impl RpcNoStateWorkflow {
     }
 
     fn fail(&self, _context: &mut Context, input: String) -> HandlerResult<RpcResult<i64>> {
-        Err(HandlerError::new(input))
+        Err(HandlerError::new("RpcNoStateFailure", input))
     }
 
     fn invoke(&self, context: &mut Context, _input: String) -> HandlerResult<RpcResult<i64>> {
         if context.flow_id().is_empty() || context.run_id().is_empty() {
-            return Err(HandlerError::new("invalid RPC context"));
+            return Err(HandlerError::new(
+                "RpcNoStateFailure",
+                "invalid RPC context",
+            ));
         }
         Ok(RpcResult::new(RpcWorkflow::RPC_OUTPUT))
     }

--- a/sdk-rust/crates/dex-sdk/tests/integ/rpc_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/rpc_test.rs
@@ -198,7 +198,7 @@ fn test_rpc_error() {
     {
         SdkError::WorkerInvocation { service, worker } => {
             assert_eq!(GrpcCode::FailedPrecondition, service.code());
-            assert!(worker.error_type().contains("HandlerError"));
+            assert_eq!("RpcNoStateFailure", worker.error_type());
             assert!(worker.detail().contains("this is an error"));
         }
         error => panic!("expected WorkerInvocation, got {error:?}"),

--- a/sdk-rust/crates/dex-sdk/tests/integ/rpc_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/rpc_workflow.rs
@@ -127,7 +127,7 @@ impl RpcWorkflow {
 
     fn require_context(context: &Context) -> HandlerResult<()> {
         if context.flow_id().is_empty() || context.run_id().is_empty() {
-            return Err(HandlerError::new("invalid RPC context"));
+            return Err(HandlerError::new("RpcFailure", "invalid RPC context"));
         }
         Ok(())
     }

--- a/sdk-rust/crates/dex-sdk/tests/integ/signal_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/signal_workflow.rs
@@ -82,7 +82,10 @@ impl Step for FirstStep {
 
     fn execute(&self, context: &mut Context, input: i32) -> HandlerResult<StepDecision> {
         if !self.second.condition_results(context)?.is_empty() {
-            return Err(HandlerError::new("second signal should still be waiting"));
+            return Err(HandlerError::new(
+                "SignalFailure",
+                "second signal should still be waiting",
+            ));
         }
         let value = self.first.condition_results(context)?[0];
         Ok(StepDecision::go_to(
@@ -118,16 +121,25 @@ impl Step for CombinationStep {
 
     fn execute(&self, context: &mut Context, input: i32) -> HandlerResult<StepDecision> {
         if !self.second.condition_results(context)?.is_empty() {
-            return Err(HandlerError::new("second signal should still be waiting"));
+            return Err(HandlerError::new(
+                "SignalFailure",
+                "second signal should still be waiting",
+            ));
         }
         if self.third.condition_results(context)?.len() != 1 {
-            return Err(HandlerError::new("null signal was not received"));
+            return Err(HandlerError::new(
+                "SignalFailure",
+                "null signal was not received",
+            ));
         }
         if self.signal_map.condition_results(context, "one")?.len() != 1 {
-            return Err(HandlerError::new("mapped signal was not received"));
+            return Err(HandlerError::new(
+                "SignalFailure",
+                "mapped signal was not received",
+            ));
         }
         if !context.has_any_timer_fired() {
-            return Err(HandlerError::new("timer was not fired"));
+            return Err(HandlerError::new("SignalFailure", "timer was not fired"));
         }
         Ok(StepDecision::graceful_complete(
             input + self.first.condition_results(context)?[0],

--- a/sdk-rust/crates/dex-sdk/tests/integ/state_options_locking_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/state_options_locking_workflow.rs
@@ -137,7 +137,10 @@ impl Step for CompleteStep {
 
     fn execute(&self, context: &mut Context, parallelism: i32) -> HandlerResult<StepDecision> {
         if self.completed.condition_results(context)?.len() != parallelism as usize {
-            return Err(HandlerError::new("not all locked Steps completed"));
+            return Err(HandlerError::new(
+                "StateOptionsLockingFailure",
+                "not all locked Steps completed",
+            ));
         }
         Ok(StepDecision::graceful_complete(format!(
             "{}:{}",

--- a/sdk-rust/crates/dex-sdk/tests/integ/state_options_override_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/state_options_override_workflow.rs
@@ -78,12 +78,18 @@ impl Step for CompleteStep {
 
     fn wait_for(&self, _context: &mut Context, input: String) -> HandlerResult<Wait> {
         *self.output.lock().expect("second output lock") = format!("{input}_state2_start");
-        Err(HandlerError::new("state 2 wait failure"))
+        Err(HandlerError::new(
+            "StateOptionsOverrideFailure",
+            "state 2 wait failure",
+        ))
     }
 
     fn execute(&self, context: &mut Context, _input: String) -> HandlerResult<StepDecision> {
         if !context.wait_for_method_failed() {
-            return Err(HandlerError::new("waitFor failure was not reported"));
+            return Err(HandlerError::new(
+                "StateOptionsOverrideFailure",
+                "waitFor failure was not reported",
+            ));
         }
         let mut output = self.output.lock().expect("second output lock");
         output.push_str("_state2_decide");

--- a/sdk-rust/crates/dex-sdk/tests/integ/state_options_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/state_options_workflow.rs
@@ -155,9 +155,10 @@ fn require_attribute(
 ) -> HandlerResult<()> {
     let actual = attribute.get_required(context)?;
     if actual != expected {
-        return Err(HandlerError::new(format!(
-            "Attribute was {actual}, expected {expected}"
-        )));
+        return Err(HandlerError::new(
+            "StateOptionsFailure",
+            format!("Attribute was {actual}, expected {expected}"),
+        ));
     }
     Ok(())
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/state_recovery_no_wait_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/state_recovery_no_wait_workflow.rs
@@ -41,7 +41,10 @@ impl Step for FailingNoWaitStep {
     type Input = i32;
 
     fn execute(&self, _context: &mut Context, _input: i32) -> HandlerResult<StepDecision> {
-        Err(HandlerError::new("execute failure"))
+        Err(HandlerError::new(
+            "StateRecoveryNoWaitFailure",
+            "execute failure",
+        ))
     }
 
     fn options(&self) -> StepOptions<Self::Input> {

--- a/sdk-rust/crates/dex-sdk/tests/integ/state_recovery_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/state_recovery_workflow.rs
@@ -45,7 +45,7 @@ impl Step for FailingStep {
     }
 
     fn execute(&self, _context: &mut Context, _input: i32) -> HandlerResult<StepDecision> {
-        Err(HandlerError::new("execute failure"))
+        Err(HandlerError::new("StateRecoveryFailure", "execute failure"))
     }
 
     fn options(&self) -> StepOptions<Self::Input> {

--- a/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_workflow.rs
@@ -304,7 +304,10 @@ impl Step for CancellationWinner {
     fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
         if self.0.scenario == CancellationScenario::LocalExecute {
             if !self.0.blocking_started.wait(Duration::from_secs(10)) {
-                return Err(HandlerError::new("local loser did not start"));
+                return Err(HandlerError::new(
+                    "StepCancellationFailure",
+                    "local loser did not start",
+                ));
             }
             thread::sleep(Duration::from_secs(1));
         }
@@ -390,7 +393,10 @@ impl Step for CancellationSelectorWinner {
             .selector_waits_registered
             .wait(Duration::from_secs(10))
         {
-            return Err(HandlerError::new("selector Steps did not reach waiting"));
+            return Err(HandlerError::new(
+                "StepCancellationFailure",
+                "selector Steps did not reach waiting",
+            ));
         }
         let decision = StepDecision::go_to(&CancellationFinal, self.0.scenario.name().to_string());
         if self.0.scenario == CancellationScenario::GlobalSelector {

--- a/sdk-rust/crates/dex-sdk/tests/integ/subflow_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/subflow_workflow.rs
@@ -312,6 +312,6 @@ fn sub_flow_with_options<SomeFlow: Flow>(
     SubFlow::run_with_options(flow, input, options).map_err(handler_error)
 }
 
-fn handler_error(error: impl std::fmt::Display) -> HandlerError {
-    HandlerError::new(error.to_string())
+fn handler_error(error: dex_sdk::SdkError) -> HandlerError {
+    HandlerError::from_error(error)
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/worker_origin_stack_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/worker_origin_stack_test.rs
@@ -1,0 +1,53 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+use std::time::Duration;
+
+use dex_sdk::{FlowStatus, Registry};
+
+use crate::flow_service_client::{assert_worker_failure_stack_trace, await_live_worker_failure};
+use crate::support::{DexDevTestEnvironment, flow_id};
+use crate::worker_origin_stack_workflow::{ORIGIN_STACK_DETAIL, WorkerOriginStackWaitForWorkflow};
+
+#[test]
+#[ignore = "requires dexcli dev"]
+fn test_wait_for_origin_stack_trace() {
+    let environment = DexDevTestEnvironment::start(
+        Registry::new().register(WorkerOriginStackWaitForWorkflow::new()),
+    );
+    let workflow = WorkerOriginStackWaitForWorkflow::new();
+    let flow_id = flow_id("wait-origin-stack");
+    let run_id = environment
+        .client
+        .start_flow(&workflow, &flow_id, ())
+        .expect("start waitFor origin-stack Flow");
+    let failure = await_live_worker_failure(&flow_id, &run_id);
+    if failure.details.is_some() {
+        assert_worker_failure_stack_trace(&failure, ORIGIN_STACK_DETAIL);
+        let stack_trace = &failure
+            .details
+            .as_ref()
+            .expect("Step failure details")
+            .original_worker_error_stack_trace;
+        assert!(
+            stack_trace.contains("origin_stack_failure"),
+            "expected construction-site frame, got {stack_trace}"
+        );
+        assert!(
+            !stack_trace.contains("worker_status"),
+            "expected construction-site stack, not wrap-site: {stack_trace}"
+        );
+    }
+    let result = environment
+        .client
+        .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
+        .expect("complete waitFor origin-stack Flow");
+    assert_eq!(FlowStatus::Completed, result.status());
+}

--- a/sdk-rust/crates/dex-sdk/tests/integ/worker_origin_stack_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/worker_origin_stack_test.rs
@@ -29,13 +29,9 @@ fn test_wait_for_origin_stack_trace() {
         .start_flow(&workflow, &flow_id, ())
         .expect("start waitFor origin-stack Flow");
     let failure = await_live_worker_failure(&flow_id, &run_id);
-    if failure.details.is_some() {
+    if let Some(details) = &failure.details {
         assert_worker_failure_stack_trace(&failure, ORIGIN_STACK_DETAIL);
-        let stack_trace = &failure
-            .details
-            .as_ref()
-            .expect("Step failure details")
-            .original_worker_error_stack_trace;
+        let stack_trace = &details.original_worker_error_stack_trace;
         assert!(
             stack_trace.contains("origin_stack_failure"),
             "expected construction-site frame, got {stack_trace}"

--- a/sdk-rust/crates/dex-sdk/tests/integ/worker_origin_stack_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/worker_origin_stack_workflow.rs
@@ -1,0 +1,70 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+use std::time::Duration;
+
+use dex_sdk::{
+    Context, Flow, HandlerError, HandlerResult, RetryPolicy, Step, StepDecision, StepDurability,
+    StepList, StepOptions, Wait,
+};
+
+pub(crate) const ORIGIN_STACK_DETAIL: &str = "rust origin stack failure";
+
+pub(crate) struct WorkerOriginStackWaitForWorkflow {
+    start: WorkerOriginStackWaitForStep,
+}
+
+impl WorkerOriginStackWaitForWorkflow {
+    pub(crate) fn new() -> Self {
+        Self {
+            start: WorkerOriginStackWaitForStep,
+        }
+    }
+}
+
+impl Flow for WorkerOriginStackWaitForWorkflow {
+    type StartInput = ();
+
+    fn steps(&self) -> StepList<'_, Self::StartInput> {
+        StepList::start(&self.start)
+    }
+}
+
+struct WorkerOriginStackWaitForStep;
+
+impl Step for WorkerOriginStackWaitForStep {
+    type Input = ();
+
+    fn options(&self) -> StepOptions<Self::Input> {
+        StepOptions::new()
+            .wait_for_retry(
+                RetryPolicy::new()
+                    .initial_interval(Duration::from_secs(2))
+                    .maximum_attempts(3),
+            )
+            .wait_for_durability(StepDurability::Sync)
+            .execute_durability(StepDurability::Sync)
+    }
+
+    fn wait_for(&self, context: &mut Context, _input: ()) -> HandlerResult<Wait> {
+        if context.attempt() == 1 {
+            return Err(origin_stack_failure());
+        }
+        Ok(Wait::skip_immediately())
+    }
+
+    fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        Ok(StepDecision::graceful_complete("origin-stack".to_string()))
+    }
+}
+
+fn origin_stack_failure() -> HandlerError {
+    HandlerError::new(ORIGIN_STACK_DETAIL)
+}

--- a/sdk-rust/crates/dex-sdk/tests/integ/worker_origin_stack_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/worker_origin_stack_workflow.rs
@@ -8,6 +8,8 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::error::Error;
+use std::fmt::{Display, Formatter};
 use std::time::Duration;
 
 use dex_sdk::{
@@ -65,6 +67,17 @@ impl Step for WorkerOriginStackWaitForStep {
     }
 }
 
+#[derive(Debug)]
+struct OriginStackFailure;
+
+impl Display for OriginStackFailure {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(ORIGIN_STACK_DETAIL)
+    }
+}
+
+impl Error for OriginStackFailure {}
+
 fn origin_stack_failure() -> HandlerError {
-    HandlerError::new(ORIGIN_STACK_DETAIL)
+    HandlerError::from_error(OriginStackFailure)
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/worker_retry_after_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/worker_retry_after_workflow.rs
@@ -60,6 +60,7 @@ impl Step for WorkerRetryAfterWaitForStep {
         if context.attempt() == 1 {
             return Err(HandlerError::retry_after(
                 RETRY_AFTER_SECONDS,
+                "WorkerRetryAfter",
                 WAIT_FOR_RETRY_AFTER_DETAIL,
             ));
         }
@@ -112,6 +113,7 @@ impl Step for WorkerRetryAfterExecuteStep {
         if context.attempt() == 1 {
             return Err(HandlerError::retry_after(
                 RETRY_AFTER_SECONDS,
+                "WorkerRetryAfter",
                 EXECUTE_RETRY_AFTER_DETAIL,
             ));
         }

--- a/sdk-rust/crates/dex-sdk/tests/integ/workflow_uncompleted_state_failure_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/workflow_uncompleted_state_failure_workflow.rs
@@ -43,7 +43,10 @@ impl Step for WorkflowUncompletedStateFailureStep {
     }
 
     fn execute(&self, _context: &mut Context, _input: i32) -> HandlerResult<StepDecision> {
-        Err(HandlerError::new("test api failing"))
+        Err(HandlerError::new(
+            "WorkflowUncompletedStateFailureFailure",
+            "test api failing",
+        ))
     }
 
     fn options(&self) -> StepOptions<Self::Input> {


### PR DESCRIPTION
## Summary
- Go: add opt-in `dex.ErrorWithStack(err)` that captures `debug.Stack()` at the helper call site; Worker prefers that origin stack over the wrap-site fallback. Nest it under `RetryAfter` as the cause.
- Rust: `HandlerError::new` / `retry_after` automatically capture with `Backtrace::force_capture()`; Worker encodes the stored construction-site stack (still 4KiB truncated). No separate `.with_stack()`.

## Rationale
Returned Worker errors previously only recorded the wrap-site stack. Origin capture makes failure diagnosis accurate without changing Java/Python/TS APIs.

## User impact
- Go apps that want origin stacks wrap errors with `ErrorWithStack`.
- Rust apps get construction-site stacks by default when creating `HandlerError`.

## Test plan
- [x] Go unit: Unwrap/Error/%+v for `ErrorWithStack`; `finishWorkerCall` prefers origin stack (including under `RetryAfter`)
- [x] Rust unit: `HandlerError::new` stack contains construction helper frame; doctests
- [x] Go/Rust integ: waitFor returns failure from a helper; assert stack contains helper frame and not wrap-site (`finishWorkerCall` / `worker_status`)
- [ ] CI: gofmt/license/rustfmt/clippy on touched crates

## Validation
```bash
cd sdk-go && go test ./dex -count=1 -run 'ErrorWithStack|FinishWorkerCall|TruncateStack'
cd sdk-rust && cargo test -p dex-sdk handler_error --lib && cargo test -p dex-sdk --doc && cargo clippy -p dex-sdk --lib -- -D warnings
```
