### PR TITLE
Improve Step documentation

### DIFF
--- a/docs/content/primitives/step/basic.mdx
+++ b/docs/content/primitives/step/basic.mdx
@@ -476,7 +476,7 @@ When WaitFor method retries are exhausted:
 - **FailFlow** — Fail the flow. This is the default.
 - **PROCEED** — Continue to invoke Execute.
 
-With **PROCEED**, the same Step's **Execute** receives the durable input unchanged. **waitForMethodFailed()** returns true. **getRecoveryError()** has the error_type and detail from the final failed WaitFor attempt. It has no stack trace.
+With **PROCEED**, the same Step's **Execute** receives the durable input unchanged. **waitForMethodFailed()** returns true. **getRecoveryError()** has the error_type and detail from the final failed WaitFor attempt.
 
 Without a Worker response, error_type comes from Temporal or Cadence. For a Worker error, it has the Worker error_type and detail. The stack trace stays in history / last failure info.
 
@@ -683,9 +683,7 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 See the [failure recovery](/design-patterns/recovery) pattern and [money-transfer](/use-cases/money-transfer) use case.
 
-The recovery Step receives the failed Step's durable input unchanged. **getRecoveryError()** has the error_type and detail from the final failed Execute attempt. It survives queueing and **continue-as-new**.
-
-If the recovery Step's WaitFor also fails and proceeds, its Execute receives the newer WaitFor failure, not the original Execute failure.
+The recovery Step receives the failed Step's durable input unchanged. **getRecoveryError()** has the error_type and detail from the final failed Execute attempt.
 
 ### Step Failed events and last failure info
 

--- a/docs/content/primitives/step/basic.mdx
+++ b/docs/content/primitives/step/basic.mdx
@@ -478,8 +478,6 @@ When WaitFor method retries are exhausted:
 
 With **PROCEED**, the same Step's **Execute** receives the durable input unchanged. **waitForMethodFailed()** returns true. **getRecoveryError()** has the error_type and detail from the final failed WaitFor attempt.
 
-Without a Worker response, error_type comes from Temporal or Cadence. For a Worker error, it has the Worker error_type and detail. The stack trace stays in history / last failure info.
-
 <SdkTabs
   examples={{
     go: 'examples/go/primitives/proceed-on-wait-failure/workflow.go',

--- a/docs/content/primitives/step/basic.mdx
+++ b/docs/content/primitives/step/basic.mdx
@@ -378,7 +378,7 @@ Most of the times, you need to customize failing handling -- timeout, retry and 
 * **Retry policy** — re-invokes the **same** method on the **same** Step execution until attempts are exhausted.
 - **Failure policy** — decide what happens **after** retries end. Default is to fail the Flow. But WaitFor can run Execute anyway, or Execute can go to a recovery Step.
 
-Configure WaitFor and Execute by implementing the step method to return a StepOptions.
+Configure by implementing the step method to return a StepOptions.
 
 <SdkTabs
   examples={{
@@ -471,10 +471,14 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 ### WaitFor failure policy
 
-When WaitFor retries are exhausted:
+When WaitFor method retries are exhausted:
 
-- **PROCEED** — Execute runs in the **same workflow run**. Continue-as-new cannot occur between the failed WaitFor and that Execute.
-- **Fail the Flow** — default when not configured to proceed.
+- **FailFlow** — Fail the flow. This is the default.
+- **PROCEED** — Continue to invoke Execute.
+
+With **PROCEED**, the same Step's **Execute** receives the durable input unchanged. **waitForMethodFailed()** returns true. **getRecoveryError()** has the error_type and detail from the final failed WaitFor attempt. It has no stack trace.
+
+Without a Worker response, error_type comes from Temporal or Cadence. For a Worker error, it has the Worker error_type and detail. The stack trace stays in history / last failure info.
 
 <SdkTabs
   examples={{
@@ -605,7 +609,7 @@ fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<St
 
 ### Execute failure policy
 
-When Execute retries are exhausted, onExecuteFailureProceedTo / ExecuteFailure.proceedTo(...) queues a **recovery Step** with the same typed input. Recovery Steps are ordinary Steps — compensations are just more Steps.
+When Execute method retries are exhausted, onExecuteFailureProceedTo / ExecuteFailure.proceedTo(...) proceed to a **recovery Step** with the same input.
 
 <SdkTabs
   examples={{
@@ -679,18 +683,9 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 See the [failure recovery](/design-patterns/recovery) pattern and [money-transfer](/use-cases/money-transfer) use case.
 
-### What recovery WaitFor / Execute can read
+The recovery Step receives the failed Step's durable input unchanged. **getRecoveryError()** has the error_type and detail from the final failed Execute attempt. It survives queueing and **continue-as-new**.
 
-| Available | Semantics |
-| --- | --- |
-| **Step input** | The failed Step's durable input travels with the recovery movement unchanged. |
-| **RecoveryErrorInfo** | error_type + detail for the **final** failed attempt. No stack trace — by design. |
-| **waitForMethodFailed()** | On the WaitFor-proceed path, Execute on the **same** Step knows WaitFor failed. Pair with getRecoveryError(). |
-| **Precedence** | If the recovery Step's WaitFor also fails and proceeds, its Execute receives the **newer WaitFor failure**, not the original Execute failure. |
-| **Backend failures** | Timeouts without a Worker response use the Temporal or Cadence backend failure type. |
-| **Worker errors** | Structured detail and error_type; stack trace stays in history / last failure info, not in RecoveryErrorInfo. |
-
-Recovery error survives queueing and **continue-as-new** on recovery Step movements.
+If the recovery Step's WaitFor also fails and proceeds, its Execute receives the newer WaitFor failure, not the original Execute failure.
 
 ### Step Failed events and last failure info
 

--- a/docs/content/primitives/step/waiting-condition.mdx
+++ b/docs/content/primitives/step/waiting-condition.mdx
@@ -6,11 +6,179 @@ slug: /primitives/step/waiting-condition
 
 # Waiting
 
-WaitFor returns a **Wait** built from durable **Conditions** — [Timer](/primitives/timer), [Channel](/primitives/channel), [SubFlow](/primitives/subflow), and combinations of them. This page covers OR-of-AND waits and reading Condition results after the Wait completes.
+This page covers more advanced features for **WaitFor** than the basic features.
 
-## anyCombinationOf — OR of AND groups {#anycombinationof}
 
-anyCombinationOf expresses an OR of AND groups. Build each inner group as an all_of combination. **Every** Condition in the combination needs a non-empty **condition ID** so Dex can track which branch satisfied the Wait.
+
+## ConditionResults {#condition-results}
+
+After WaitFor completes, Execute can read what satisfied the Wait. For a [Channel](/primitives/channel), use GetConditionResults / results / condition_results to read published messages. For a [SubFlow](/primitives/subflow), use SubFlowResult / getConditionResults / condition_result to decode the child Flow output.
+
+### Channel results
+
+<SdkTabs
+examples={{
+python: 'examples/python/dex_examples/primitives/channel/channel_flow.py',
+go: 'examples/go/primitives/channel/workflow.go',
+java: 'examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java',
+typescript: 'examples/typescript/src/primitives/channel/channel-flow.ts',
+rust: 'examples/rust/src/primitives/channel/flow.rs',
+}}>
+<SdkSnippet lang="python">
+
+```python
+def execute(self, context: Context, input: int) -> StepDecision:
+    approvals = self.approval.results(context)
+    if approvals:
+        return graceful_complete(approvals[0])
+    return go_to(self, input)
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="go">
+
+```go
+func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, error) {
+	results, err := Approval.GetConditionResults(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) > 0 {
+		return dex.GracefulComplete(results[0]), nil
+	}
+	return dex.GoTo(channelWaitStep{}, input), nil
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="java">
+
+```java
+public StepDecision execute(final Context context, final Integer input) {
+    final List<String> approvals = approval.getConditionResults(context);
+    if (!approvals.isEmpty()) {
+        return StepDecision.gracefulComplete(approvals.get(0));
+    }
+    return StepDecision.goTo(waitForApproval, input);
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="typescript">
+
+```typescript
+public execute(context: Context, input: number): StepDecision {
+  const approvals = approval.results(context);
+  if (approvals.length > 0) {
+    return gracefulComplete(approvals[0]!);
+  }
+  return goTo(channelWaitStep, input);
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="rust">
+
+```rust
+fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
+    let approvals = approval().condition_results(context)?;
+    if let Some(value) = approvals.first() {
+        return Ok(StepDecision::graceful_complete(value.clone()));
+    }
+    Ok(StepDecision::go_to(&ChannelWait, input))
+}
+```
+
+</SdkSnippet>
+</SdkTabs>
+
+### SubFlow results
+
+<SdkTabs
+examples={{
+python: 'examples/python/dex_examples/primitives/subflow/subflow_flow.py',
+go: 'examples/go/primitives/subflow/workflow.go',
+java: 'examples/java/src/main/java/io/superdurable/dex/primitives/subflow/SubFlowParentFlow.java',
+typescript: 'examples/typescript/src/primitives/subflow/subflow-flow.ts',
+rust: 'examples/rust/src/primitives/subflow/flow.rs',
+}}>
+<SdkSnippet lang="python">
+
+```python
+def execute(self, context: Context, input: int) -> StepDecision:
+    del input
+    result = SubFlow.get_condition_results(context)
+    output = result.single_output(int)
+    return graceful_complete(f"{SubFlow.get_flow_id(context)}|{output}")
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="go">
+
+```go
+func (subFlowParentStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
+	result, err := dex.SubFlowResult(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var output int
+	if err := result.DecodeSingleOutput(&output); err != nil {
+		return nil, err
+	}
+	flowID, err := dex.SubFlowID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return dex.GracefulComplete(fmt.Sprintf("%s|%d", flowID, output)), nil
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="java">
+
+```java
+public StepDecision execute(final Context context, final Integer input) {
+    final Integer output =
+            SubFlow.getConditionResults(context).getSingleOutput(Integer.class);
+    return StepDecision.gracefulComplete(SubFlow.getFlowId(context) + "|" + output);
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="typescript">
+
+```typescript
+public execute(context: Context, _input: number): StepDecision {
+  const result = SubFlow.getConditionResults(context);
+  const output = result.singleOutput(doubleCodec);
+  const flowId = SubFlow.getFlowId(context);
+  return gracefulComplete(`${flowId}|${output}`);
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="rust">
+
+```rust
+fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
+    let result = SubFlow::condition_result(context)?;
+    let output: i32 = result
+        .single_output()
+        .map_err(HandlerError::from_error)?;
+    let flow_id = SubFlow::flow_id_at(context, 0)?;
+    Ok(StepDecision::graceful_complete(format!("{flow_id}|{output}")))
+}
+```
+
+</SdkSnippet>
+</SdkTabs>
+
+## anyCombinationOf {#anycombinationof}
+
+anyCombinationOf expresses an OR of AND groups. Build each inner group as an all_of combination.
+
+Note:
+**Every** Condition in the combination requires a unique **condition ID**.
 
 <SdkTabs
   examples={{
@@ -90,173 +258,11 @@ Ok(Wait::any_combination_of([
 </SdkTabs>
 
 
-## ConditionResults {#condition-results}
-
-After WaitFor completes, Execute can read what satisfied the Wait. For a [Channel](/primitives/channel), use GetConditionResults / results / condition_results to read published messages. For a [SubFlow](/primitives/subflow), use SubFlowResult / getConditionResults / condition_result to decode the child Flow output.
-
-### Channel results
-
-<SdkTabs
-  examples={{
-    python: 'examples/python/dex_examples/primitives/channel/channel_flow.py',
-    go: 'examples/go/primitives/channel/workflow.go',
-    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java',
-    typescript: 'examples/typescript/src/primitives/channel/channel-flow.ts',
-    rust: 'examples/rust/src/primitives/channel/flow.rs',
-  }}>
-<SdkSnippet lang="python">
-
-```python
-def execute(self, context: Context, input: int) -> StepDecision:
-    approvals = self.approval.results(context)
-    if approvals:
-        return graceful_complete(approvals[0])
-    return go_to(self, input)
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="go">
-
-```go
-func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, error) {
-	results, err := Approval.GetConditionResults(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if len(results) > 0 {
-		return dex.GracefulComplete(results[0]), nil
-	}
-	return dex.GoTo(channelWaitStep{}, input), nil
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="java">
-
-```java
-public StepDecision execute(final Context context, final Integer input) {
-    final List<String> approvals = approval.getConditionResults(context);
-    if (!approvals.isEmpty()) {
-        return StepDecision.gracefulComplete(approvals.get(0));
-    }
-    return StepDecision.goTo(waitForApproval, input);
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="typescript">
-
-```typescript
-public execute(context: Context, input: number): StepDecision {
-  const approvals = approval.results(context);
-  if (approvals.length > 0) {
-    return gracefulComplete(approvals[0]!);
-  }
-  return goTo(channelWaitStep, input);
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="rust">
-
-```rust
-fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-    let approvals = approval().condition_results(context)?;
-    if let Some(value) = approvals.first() {
-        return Ok(StepDecision::graceful_complete(value.clone()));
-    }
-    Ok(StepDecision::go_to(&ChannelWait, input))
-}
-```
-
-</SdkSnippet>
-</SdkTabs>
-
-### SubFlow results
-
-<SdkTabs
-  examples={{
-    python: 'examples/python/dex_examples/primitives/subflow/subflow_flow.py',
-    go: 'examples/go/primitives/subflow/workflow.go',
-    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/subflow/SubFlowParentFlow.java',
-    typescript: 'examples/typescript/src/primitives/subflow/subflow-flow.ts',
-    rust: 'examples/rust/src/primitives/subflow/flow.rs',
-  }}>
-<SdkSnippet lang="python">
-
-```python
-def execute(self, context: Context, input: int) -> StepDecision:
-    del input
-    result = SubFlow.get_condition_results(context)
-    output = result.single_output(int)
-    return graceful_complete(f"{SubFlow.get_flow_id(context)}|{output}")
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="go">
-
-```go
-func (subFlowParentStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
-	result, err := dex.SubFlowResult(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var output int
-	if err := result.DecodeSingleOutput(&output); err != nil {
-		return nil, err
-	}
-	flowID, err := dex.SubFlowID(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return dex.GracefulComplete(fmt.Sprintf("%s|%d", flowID, output)), nil
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="java">
-
-```java
-public StepDecision execute(final Context context, final Integer input) {
-    final Integer output =
-            SubFlow.getConditionResults(context).getSingleOutput(Integer.class);
-    return StepDecision.gracefulComplete(SubFlow.getFlowId(context) + "|" + output);
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="typescript">
-
-```typescript
-public execute(context: Context, _input: number): StepDecision {
-  const result = SubFlow.getConditionResults(context);
-  const output = result.singleOutput(doubleCodec);
-  const flowId = SubFlow.getFlowId(context);
-  return gracefulComplete(`${flowId}|${output}`);
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="rust">
-
-```rust
-fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
-    let result = SubFlow::condition_result(context)?;
-    let output: i32 = result
-        .single_output()
-        .map_err(HandlerError::from_error)?;
-    let flow_id = SubFlow::flow_id_at(context, 0)?;
-    Ok(StepDecision::graceful_complete(format!("{flow_id}|{output}")))
-}
-```
-
-</SdkSnippet>
-</SdkTabs>
-
 ## Step execution local {#step-execution-local}
 
-**SetStepExecutionLocal** stores a value on this **StepExecution** so **Execute** can read it with **GetStepExecutionLocal**. Use it when **WaitFor** computes something **Execute** needs and you do not want a Flow-level **Attribute**.
+**SetStepExecutionLocal** stores a value on this **StepExecution** so **Execute** can read it with **GetStepExecutionLocal**. Use it when **WaitFor** computes something **Execute** needs but a Flow-level **Attribute** is overkill.
 
+Note:
 Step input is already passed to both methods. Do not copy input into a local.
 
 <SdkTabs
@@ -354,7 +360,8 @@ fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<S
 
 ## Skip immediately {#skip-immediately}
 
-Return **SkipWaitImmediately** when **Execute** should run without waiting on durable conditions. Omitting **WaitFor** has the same effect; explicit skip is rarely needed.
+A special Wait is **SkipWaitImmediately**. It won't wait for any condition.
+This is sometimes needed when you build a dynamic WaitFor method that in certain branch you don't want to wait for anything.
 
 <SdkTabs
   examples={{

--- a/docs/content/primitives/step/waiting-condition.mdx
+++ b/docs/content/primitives/step/waiting-condition.mdx
@@ -42,9 +42,7 @@ class ChannelWaitStep(Step[int]):
         if context.has_timer_fired():
             return graceful_complete("approval timed out")
         approvals = self.approval.results(context)
-        if approvals:
-            return graceful_complete(approvals[0])
-        return go_to(self, input)
+        return graceful_complete(approvals[0])
 ```
 
 </SdkSnippet>
@@ -64,7 +62,7 @@ func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 	), nil
 }
 
-func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, error) {
+func (channelWaitStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
 	if ctx.HasTimerFired() {
 		return dex.GracefulComplete("approval timed out"), nil
 	}
@@ -72,10 +70,7 @@ func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, e
 	if err != nil {
 		return nil, err
 	}
-	if len(results) > 0 {
-		return dex.GracefulComplete(results[0]), nil
-	}
-	return dex.GoTo(channelWaitStep{}, input), nil
+	return dex.GracefulComplete(results[0]), nil
 }
 ```
 
@@ -102,10 +97,7 @@ final class ChannelWaitStep implements Step<Integer> {
             return StepDecision.gracefulComplete("approval timed out");
         }
         final List<String> approvals = approval.getConditionResults(context);
-        if (!approvals.isEmpty()) {
-            return StepDecision.gracefulComplete(approvals.get(0));
-        }
-        return StepDecision.goTo(waitForApproval, input);
+        return StepDecision.gracefulComplete(approvals.get(0));
     }
 }
 ```
@@ -130,15 +122,12 @@ class ChannelWait implements Step<number> {
     );
   }
 
-  public execute(context: Context, input: number): StepDecision {
+  public execute(context: Context, _input: number): StepDecision {
     if (context.hasTimerFired()) {
       return gracefulComplete("approval timed out");
     }
     const approvals = approval.results(context);
-    if (approvals.length > 0) {
-      return gracefulComplete(approvals[0]!);
-    }
-    return goTo(channelWaitStep, input);
+    return gracefulComplete(approvals[0]!);
   }
 }
 
@@ -166,17 +155,14 @@ impl Step for ChannelWait {
         ]))
     }
 
-    fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
+    fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
         if context.has_any_timer_fired() {
             return Ok(StepDecision::graceful_complete(
                 "approval timed out".to_owned(),
             ));
         }
         let approvals = approval().condition_results(context)?;
-        if let Some(value) = approvals.first() {
-            return Ok(StepDecision::graceful_complete(value.clone()));
-        }
-        Ok(StepDecision::go_to(&ChannelWait, input))
+        Ok(StepDecision::graceful_complete(approvals[0].clone()))
     }
 }
 ```

--- a/docs/content/primitives/step/waiting-condition.mdx
+++ b/docs/content/primitives/step/waiting-condition.mdx
@@ -27,18 +27,47 @@ rust: 'examples/rust/src/primitives/channel/flow.rs',
 <SdkSnippet lang="python">
 
 ```python
-def execute(self, context: Context, input: int) -> StepDecision:
-    approvals = self.approval.results(context)
-    if approvals:
-        return graceful_complete(approvals[0])
-    return go_to(self, input)
+class ChannelWaitStep(Step[int]):
+    def __init__(self, approval: Channel[str]) -> None:
+        self.approval = approval
+
+    def wait_for(self, context: Context, input: int) -> Wait:
+        del context
+        return Wait.any_of(
+            self.approval.for_one(),
+            Timer.by_duration(timedelta(seconds=input)),
+        )
+
+    def execute(self, context: Context, input: int) -> StepDecision:
+        if context.has_timer_fired():
+            return graceful_complete("approval timed out")
+        approvals = self.approval.results(context)
+        if approvals:
+            return graceful_complete(approvals[0])
+        return go_to(self, input)
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="go">
 
 ```go
+var Approval = dex.DefineChannel[string]("Approval")
+
+type channelWaitStep struct {
+	dex.StepDefaults
+}
+
+func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
+	return dex.AnyOf(
+		Approval.ForOne(),
+		dex.Timer(time.Duration(input)*time.Second),
+	), nil
+}
+
 func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, error) {
+	if ctx.HasTimerFired() {
+		return dex.GracefulComplete("approval timed out"), nil
+	}
 	results, err := Approval.GetConditionResults(ctx)
 	if err != nil {
 		return nil, err
@@ -54,12 +83,30 @@ func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, e
   <SdkSnippet lang="java">
 
 ```java
-public StepDecision execute(final Context context, final Integer input) {
-    final List<String> approvals = approval.getConditionResults(context);
-    if (!approvals.isEmpty()) {
-        return StepDecision.gracefulComplete(approvals.get(0));
+final class ChannelWaitStep implements Step<Integer> {
+    @Override
+    public Class<Integer> getInputType() {
+        return Integer.class;
     }
-    return StepDecision.goTo(waitForApproval, input);
+
+    @Override
+    public Wait waitFor(final Context context, final Integer input) {
+        return Wait.anyOf(
+                approval.forOne(),
+                Timer.byDuration(Duration.ofSeconds(input)));
+    }
+
+    @Override
+    public StepDecision execute(final Context context, final Integer input) {
+        if (context.hasTimerFired()) {
+            return StepDecision.gracefulComplete("approval timed out");
+        }
+        final List<String> approvals = approval.getConditionResults(context);
+        if (!approvals.isEmpty()) {
+            return StepDecision.gracefulComplete(approvals.get(0));
+        }
+        return StepDecision.goTo(waitForApproval, input);
+    }
 }
 ```
 
@@ -67,25 +114,70 @@ public StepDecision execute(final Context context, final Integer input) {
   <SdkSnippet lang="typescript">
 
 ```typescript
-public execute(context: Context, input: number): StepDecision {
-  const approvals = approval.results(context);
-  if (approvals.length > 0) {
-    return gracefulComplete(approvals[0]!);
+const approval = new Channel("Approval", stringCodec);
+
+class ChannelWait implements Step<number> {
+  public readonly inputCodec = doubleCodec;
+
+  public getStepType(): string {
+    return "ChannelWait";
   }
-  return goTo(channelWaitStep, input);
+
+  public waitFor(_context: Context, input: number): Wait {
+    return Wait.anyOf(
+      approval.forOne(),
+      Timer.byDuration(input * 1000),
+    );
+  }
+
+  public execute(context: Context, input: number): StepDecision {
+    if (context.hasTimerFired()) {
+      return gracefulComplete("approval timed out");
+    }
+    const approvals = approval.results(context);
+    if (approvals.length > 0) {
+      return gracefulComplete(approvals[0]!);
+    }
+    return goTo(channelWaitStep, input);
+  }
 }
+
+const channelWaitStep = new ChannelWait();
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="rust">
 
 ```rust
-fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-    let approvals = approval().condition_results(context)?;
-    if let Some(value) = approvals.first() {
-        return Ok(StepDecision::graceful_complete(value.clone()));
+fn approval() -> Channel<String> {
+    Channel::new("Approval")
+}
+
+#[derive(Default)]
+struct ChannelWait;
+
+impl Step for ChannelWait {
+    type Input = i32;
+
+    fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
+        Ok(Wait::any_of([
+            approval().for_one(),
+            Timer::by_duration(Duration::from_secs(input.max(0) as u64)),
+        ]))
     }
-    Ok(StepDecision::go_to(&ChannelWait, input))
+
+    fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
+        if context.has_any_timer_fired() {
+            return Ok(StepDecision::graceful_complete(
+                "approval timed out".to_owned(),
+            ));
+        }
+        let approvals = approval().condition_results(context)?;
+        if let Some(value) = approvals.first() {
+            return Ok(StepDecision::graceful_complete(value.clone()));
+        }
+        Ok(StepDecision::go_to(&ChannelWait, input))
+    }
 }
 ```
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
@@ -289,12 +289,13 @@ Execute 返回 **StepDecision**——指向一个或多个后续 Step 的 moveme
 
 ## StepOptions {#stepoptions}
 
-**Retry policy** 与 **failure policy** 回答不同问题：
+大多数时候，需要自定义 failure handling —— timeout、retry 与 failure policy。还有 heartbeat、durability 等更高级的 [Step options](/primitives/step/step-options)。
 
-- **Retry policy** — Dex 在**同一** Step execution 上重复调用**同一**方法，直到 attempt 耗尽。
-- **Failure policy** — retry 结束**之后**发生什么：失败 Flow、仍运行 Execute，或路由到 recovery Step。
+* Timeout 自定义一次方法（WaitFor/Execute）调用 attempt 的 timeout。
+* **Retry policy** — 在**同一** Step execution 上重复调用**同一**方法，直到 attempt 耗尽。
+- **Failure policy** — 决定 retry 结束**之后**发生什么。默认失败 Flow，但 WaitFor 仍可运行 Execute，Execute 也可以前往 recovery Step。
 
-在 StepOptions 上独立配置 WaitFor 与 Execute。
+通过在 Step 方法中实现返回 StepOptions 来配置。
 
 <SdkTabs
   examples={{
@@ -387,10 +388,14 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 ### WaitFor failure policy
 
-WaitFor retry 耗尽时：
+WaitFor method retry 耗尽时：
 
-- **PROCEED** — Execute 在**同一 workflow run** 中运行。失败的 WaitFor 与该 Execute 之间不能 continue-as-new。
-- **失败 Flow** — 未配置 proceed 时的默认行为。
+- **FailFlow** — 失败 Flow。这是默认行为。
+- **PROCEED** — 继续调用 Execute。
+
+使用 **PROCEED** 时，同一 Step 的 **Execute** 收到不变的 durable input。**waitForMethodFailed()** 返回 true。**getRecoveryError()** 包含最后一次失败 WaitFor attempt 的 error_type 和 detail，不含 stack trace。
+
+没有 Worker 响应时，error_type 来自 Temporal 或 Cadence。对于 Worker error，它包含 Worker 的 error_type 和 detail。stack trace 留在 history / last failure info。
 
 <SdkTabs
   examples={{
@@ -521,7 +526,7 @@ fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<St
 
 ### Execute failure policy
 
-Execute retry 耗尽时，onExecuteFailureProceedTo / ExecuteFailure.proceedTo(...) 将**recovery Step** 入队，typed input 不变。Recovery Step 是普通 Step——补偿只是更多 Step。
+Execute method retry 耗尽时，onExecuteFailureProceedTo / ExecuteFailure.proceedTo(...) 前往带有相同 input 的 **recovery Step**。
 
 <SdkTabs
   examples={{
@@ -595,18 +600,9 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 见 [failure recovery](/design-patterns/recovery) 模式与 [money-transfer](/use-cases/money-transfer) 用例。
 
-### Recovery WaitFor / Execute 可读内容
+recovery Step 收到失败 Step 不变的 durable input。**getRecoveryError()** 包含最后一次失败 Execute attempt 的 error_type 和 detail。它会经过入队和 **continue-as-new** 保留。
 
-| 可用 | 语义 |
-| --- | --- |
-| **Step input** | 失败 Step 的 durable input 随 recovery movement 原样传递。 |
-| **RecoveryErrorInfo** | **最终**失败 attempt 的 error_type + detail。设计上不含 stack trace。 |
-| **waitForMethodFailed()** | WaitFor-proceed 路径上，**同一** Step 的 Execute 可知 WaitFor 失败。配合 getRecoveryError()。 |
-| **优先级** | 若 recovery Step 的 WaitFor 也失败并 proceed，其 Execute 收到**较新的 WaitFor 失败**，而非原 Execute 失败。 |
-| **Backend 失败** | 无 Worker 响应的 timeout 使用 Temporal 或 Cadence backend failure type。 |
-| **Worker 错误** | 结构化 detail 与 error_type；stack trace 留在 history / last failure info，不在 RecoveryErrorInfo。 |
-
-Recovery error 在 recovery Step movement 的入队与 **continue-as-new** 后仍保留。
+如果 recovery Step 的 WaitFor 也失败并 proceed，它的 Execute 收到较新的 WaitFor failure，而不是原 Execute failure。
 
 ### Step Failed 事件与 last failure info
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
@@ -395,8 +395,6 @@ WaitFor method retry 耗尽时：
 
 使用 **PROCEED** 时，同一 Step 的 **Execute** 收到不变的 durable input。**waitForMethodFailed()** 返回 true。**getRecoveryError()** 包含最后一次失败 WaitFor attempt 的 error_type 和 detail。
 
-没有 Worker 响应时，error_type 来自 Temporal 或 Cadence。对于 Worker error，它包含 Worker 的 error_type 和 detail。stack trace 留在 history / last failure info。
-
 <SdkTabs
   examples={{
     go: 'examples/go/primitives/proceed-on-wait-failure/workflow.go',

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
@@ -393,7 +393,7 @@ WaitFor method retry 耗尽时：
 - **FailFlow** — 失败 Flow。这是默认行为。
 - **PROCEED** — 继续调用 Execute。
 
-使用 **PROCEED** 时，同一 Step 的 **Execute** 收到不变的 durable input。**waitForMethodFailed()** 返回 true。**getRecoveryError()** 包含最后一次失败 WaitFor attempt 的 error_type 和 detail，不含 stack trace。
+使用 **PROCEED** 时，同一 Step 的 **Execute** 收到不变的 durable input。**waitForMethodFailed()** 返回 true。**getRecoveryError()** 包含最后一次失败 WaitFor attempt 的 error_type 和 detail。
 
 没有 Worker 响应时，error_type 来自 Temporal 或 Cadence。对于 Worker error，它包含 Worker 的 error_type 和 detail。stack trace 留在 history / last failure info。
 
@@ -600,9 +600,7 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 见 [failure recovery](/design-patterns/recovery) 模式与 [money-transfer](/use-cases/money-transfer) 用例。
 
-recovery Step 收到失败 Step 不变的 durable input。**getRecoveryError()** 包含最后一次失败 Execute attempt 的 error_type 和 detail。它会经过入队和 **continue-as-new** 保留。
-
-如果 recovery Step 的 WaitFor 也失败并 proceed，它的 Execute 收到较新的 WaitFor failure，而不是原 Execute failure。
+recovery Step 收到失败 Step 不变的 durable input。**getRecoveryError()** 包含最后一次失败 Execute attempt 的 error_type 和 detail。
 
 ### Step Failed 事件与 last failure info
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/waiting-condition.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/waiting-condition.mdx
@@ -6,88 +6,7 @@ slug: /primitives/step/waiting-condition
 
 # 等待
 
-WaitFor 返回由 durable **Condition** 构成的 **Wait**——[Timer](/primitives/timer)、[Channel](/primitives/channel)、[SubFlow](/primitives/subflow) 及其组合。本页介绍 OR-of-AND 等待，以及 Wait 完成后读取 Condition 结果。
-
-## anyCombinationOf — AND 组的 OR {#anycombinationof}
-
-anyCombinationOf 表示 AND 组的 OR。每组内用 all_of 组合构建。**每个** Condition 都需要非空 **condition ID**，以便 Dex 追踪哪条分支满足了 Wait。
-
-<SdkTabs
-  examples={{
-    python: 'examples/python/dex_examples/primitives/wait_types/wait_types_flow.py',
-    go: 'examples/go/primitives/wait-types/workflow.go',
-    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/waittypes/WaitTypesFlow.java',
-    typescript: 'examples/typescript/src/primitives/wait-types/wait-types-flow.ts',
-    rust: 'examples/rust/src/primitives/wait_types/flow.rs',
-  }}>
-<SdkSnippet lang="python">
-
-```python
-return Wait.any_combination_of(
-    ConditionCombination.of(
-        channel_a.for_one(condition_id="signal-a"),
-        Timer.by_duration(timeout, condition_id="timeout"),
-    ),
-    ConditionCombination.of(
-        channel_b.for_one(condition_id="signal-b"),
-    ),
-)
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="go">
-
-```go
-return dex.AnyComboOf(
-	dex.Combo(
-		SignalA.ForOne(dex.WithConditionID("signal-a")),
-		dex.Timer(timeout, dex.WithConditionID("timeout")),
-	),
-	dex.Combo(
-		SignalB.ForOne(dex.WithConditionID("signal-b")),
-	),
-), nil
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="java">
-
-```java
-return Wait.anyCombinationOf(
-        ConditionCombination.of(
-                channelA.forOne("signal-a"),
-                Timer.byDuration(timeout, "timeout")),
-        ConditionCombination.of(channelB.forOne("signal-b")));
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="typescript">
-
-```typescript
-return Wait.anyCombinationOf(
-  ConditionCombination.of(
-    channelA.forOne("signal-a"),
-    Timer.byDuration(timeoutMs, "timeout"),
-  ),
-  ConditionCombination.of(channelB.forOne("signal-b")),
-);
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="rust">
-
-```rust
-Ok(Wait::any_combination_of([
-    ConditionCombination::all_of([
-        signal_a_channel().for_one().with_id("signal-a"),
-        Timer::by_duration(timeout).with_id("timeout"),
-    ]),
-    ConditionCombination::all_of([signal_b_channel().for_one().with_id("signal-b")]),
-]))
-```
-
-</SdkSnippet>
-</SdkTabs>
+本页介绍比基础功能更高级的 **WaitFor** 功能。
 
 
 ## ConditionResults {#condition-results}
@@ -107,18 +26,47 @@ WaitFor 完成后，Execute 可读取满足 Wait 的内容。对 [Channel](/prim
 <SdkSnippet lang="python">
 
 ```python
-def execute(self, context: Context, input: int) -> StepDecision:
-    approvals = self.approval.results(context)
-    if approvals:
-        return graceful_complete(approvals[0])
-    return go_to(self, input)
+class ChannelWaitStep(Step[int]):
+    def __init__(self, approval: Channel[str]) -> None:
+        self.approval = approval
+
+    def wait_for(self, context: Context, input: int) -> Wait:
+        del context
+        return Wait.any_of(
+            self.approval.for_one(),
+            Timer.by_duration(timedelta(seconds=input)),
+        )
+
+    def execute(self, context: Context, input: int) -> StepDecision:
+        if context.has_timer_fired():
+            return graceful_complete("approval timed out")
+        approvals = self.approval.results(context)
+        if approvals:
+            return graceful_complete(approvals[0])
+        return go_to(self, input)
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="go">
 
 ```go
+var Approval = dex.DefineChannel[string]("Approval")
+
+type channelWaitStep struct {
+	dex.StepDefaults
+}
+
+func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
+	return dex.AnyOf(
+		Approval.ForOne(),
+		dex.Timer(time.Duration(input)*time.Second),
+	), nil
+}
+
 func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, error) {
+	if ctx.HasTimerFired() {
+		return dex.GracefulComplete("approval timed out"), nil
+	}
 	results, err := Approval.GetConditionResults(ctx)
 	if err != nil {
 		return nil, err
@@ -134,12 +82,30 @@ func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, e
   <SdkSnippet lang="java">
 
 ```java
-public StepDecision execute(final Context context, final Integer input) {
-    final List<String> approvals = approval.getConditionResults(context);
-    if (!approvals.isEmpty()) {
-        return StepDecision.gracefulComplete(approvals.get(0));
+final class ChannelWaitStep implements Step<Integer> {
+    @Override
+    public Class<Integer> getInputType() {
+        return Integer.class;
     }
-    return StepDecision.goTo(waitForApproval, input);
+
+    @Override
+    public Wait waitFor(final Context context, final Integer input) {
+        return Wait.anyOf(
+                approval.forOne(),
+                Timer.byDuration(Duration.ofSeconds(input)));
+    }
+
+    @Override
+    public StepDecision execute(final Context context, final Integer input) {
+        if (context.hasTimerFired()) {
+            return StepDecision.gracefulComplete("approval timed out");
+        }
+        final List<String> approvals = approval.getConditionResults(context);
+        if (!approvals.isEmpty()) {
+            return StepDecision.gracefulComplete(approvals.get(0));
+        }
+        return StepDecision.goTo(waitForApproval, input);
+    }
 }
 ```
 
@@ -147,25 +113,70 @@ public StepDecision execute(final Context context, final Integer input) {
   <SdkSnippet lang="typescript">
 
 ```typescript
-public execute(context: Context, input: number): StepDecision {
-  const approvals = approval.results(context);
-  if (approvals.length > 0) {
-    return gracefulComplete(approvals[0]!);
+const approval = new Channel("Approval", stringCodec);
+
+class ChannelWait implements Step<number> {
+  public readonly inputCodec = doubleCodec;
+
+  public getStepType(): string {
+    return "ChannelWait";
   }
-  return goTo(channelWaitStep, input);
+
+  public waitFor(_context: Context, input: number): Wait {
+    return Wait.anyOf(
+      approval.forOne(),
+      Timer.byDuration(input * 1000),
+    );
+  }
+
+  public execute(context: Context, input: number): StepDecision {
+    if (context.hasTimerFired()) {
+      return gracefulComplete("approval timed out");
+    }
+    const approvals = approval.results(context);
+    if (approvals.length > 0) {
+      return gracefulComplete(approvals[0]!);
+    }
+    return goTo(channelWaitStep, input);
+  }
 }
+
+const channelWaitStep = new ChannelWait();
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="rust">
 
 ```rust
-fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-    let approvals = approval().condition_results(context)?;
-    if let Some(value) = approvals.first() {
-        return Ok(StepDecision::graceful_complete(value.clone()));
+fn approval() -> Channel<String> {
+    Channel::new("Approval")
+}
+
+#[derive(Default)]
+struct ChannelWait;
+
+impl Step for ChannelWait {
+    type Input = i32;
+
+    fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
+        Ok(Wait::any_of([
+            approval().for_one(),
+            Timer::by_duration(Duration::from_secs(input.max(0) as u64)),
+        ]))
     }
-    Ok(StepDecision::go_to(&ChannelWait, input))
+
+    fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
+        if context.has_any_timer_fired() {
+            return Ok(StepDecision::graceful_complete(
+                "approval timed out".to_owned(),
+            ));
+        }
+        let approvals = approval().condition_results(context)?;
+        if let Some(value) = approvals.first() {
+            return Ok(StepDecision::graceful_complete(value.clone()));
+        }
+        Ok(StepDecision::go_to(&ChannelWait, input))
+    }
 }
 ```
 
@@ -253,10 +264,95 @@ fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<S
 </SdkSnippet>
 </SdkTabs>
 
+## anyCombinationOf {#anycombinationof}
+
+anyCombinationOf 表示 AND 组的 OR。每组内用 all_of 组合构建。
+
+注意：
+组合中的**每个** Condition 都需要唯一的 **condition ID**。
+
+<SdkTabs
+  examples={{
+    python: 'examples/python/dex_examples/primitives/wait_types/wait_types_flow.py',
+    go: 'examples/go/primitives/wait-types/workflow.go',
+    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/waittypes/WaitTypesFlow.java',
+    typescript: 'examples/typescript/src/primitives/wait-types/wait-types-flow.ts',
+    rust: 'examples/rust/src/primitives/wait_types/flow.rs',
+  }}>
+<SdkSnippet lang="python">
+
+```python
+return Wait.any_combination_of(
+    ConditionCombination.of(
+        channel_a.for_one(condition_id="signal-a"),
+        Timer.by_duration(timeout, condition_id="timeout"),
+    ),
+    ConditionCombination.of(
+        channel_b.for_one(condition_id="signal-b"),
+    ),
+)
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="go">
+
+```go
+return dex.AnyComboOf(
+	dex.Combo(
+		SignalA.ForOne(dex.WithConditionID("signal-a")),
+		dex.Timer(timeout, dex.WithConditionID("timeout")),
+	),
+	dex.Combo(
+		SignalB.ForOne(dex.WithConditionID("signal-b")),
+	),
+), nil
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="java">
+
+```java
+return Wait.anyCombinationOf(
+        ConditionCombination.of(
+                channelA.forOne("signal-a"),
+                Timer.byDuration(timeout, "timeout")),
+        ConditionCombination.of(channelB.forOne("signal-b")));
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="typescript">
+
+```typescript
+return Wait.anyCombinationOf(
+  ConditionCombination.of(
+    channelA.forOne("signal-a"),
+    Timer.byDuration(timeoutMs, "timeout"),
+  ),
+  ConditionCombination.of(channelB.forOne("signal-b")),
+);
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="rust">
+
+```rust
+Ok(Wait::any_combination_of([
+    ConditionCombination::all_of([
+        signal_a_channel().for_one().with_id("signal-a"),
+        Timer::by_duration(timeout).with_id("timeout"),
+    ]),
+    ConditionCombination::all_of([signal_b_channel().for_one().with_id("signal-b")]),
+]))
+```
+
+</SdkSnippet>
+</SdkTabs>
+
 ## Step execution local {#step-execution-local}
 
 **SetStepExecutionLocal** 把值存在当前 **StepExecution** 上，供 **Execute** 用 **GetStepExecutionLocal** 读取。适用于 **WaitFor** 算出了 **Execute** 需要的数据，又不想为此定义 Flow 级 **Attribute**。
 
+注意：
 Step input 本身会传给两个方法，不要把 input 再拷进 local。
 
 <SdkTabs
@@ -354,7 +450,7 @@ fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<S
 
 ## Skip immediately {#skip-immediately}
 
-当 **Execute** 需要立即运行、不等待 durable condition 时，返回 **SkipWaitImmediately**。省略 **WaitFor** 效果相同；显式 skip 很少用到。
+一种特殊的 Wait 是 **SkipWaitImmediately**。它不等待任何 condition。当构建 dynamic **WaitFor** 方法时，某些分支不需要等待，可以使用它。
 
 <SdkTabs
   examples={{

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/waiting-condition.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/waiting-condition.mdx
@@ -41,9 +41,7 @@ class ChannelWaitStep(Step[int]):
         if context.has_timer_fired():
             return graceful_complete("approval timed out")
         approvals = self.approval.results(context)
-        if approvals:
-            return graceful_complete(approvals[0])
-        return go_to(self, input)
+        return graceful_complete(approvals[0])
 ```
 
 </SdkSnippet>
@@ -63,7 +61,7 @@ func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 	), nil
 }
 
-func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, error) {
+func (channelWaitStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
 	if ctx.HasTimerFired() {
 		return dex.GracefulComplete("approval timed out"), nil
 	}
@@ -71,10 +69,7 @@ func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, e
 	if err != nil {
 		return nil, err
 	}
-	if len(results) > 0 {
-		return dex.GracefulComplete(results[0]), nil
-	}
-	return dex.GoTo(channelWaitStep{}, input), nil
+	return dex.GracefulComplete(results[0]), nil
 }
 ```
 
@@ -101,10 +96,7 @@ final class ChannelWaitStep implements Step<Integer> {
             return StepDecision.gracefulComplete("approval timed out");
         }
         final List<String> approvals = approval.getConditionResults(context);
-        if (!approvals.isEmpty()) {
-            return StepDecision.gracefulComplete(approvals.get(0));
-        }
-        return StepDecision.goTo(waitForApproval, input);
+        return StepDecision.gracefulComplete(approvals.get(0));
     }
 }
 ```
@@ -129,15 +121,12 @@ class ChannelWait implements Step<number> {
     );
   }
 
-  public execute(context: Context, input: number): StepDecision {
+  public execute(context: Context, _input: number): StepDecision {
     if (context.hasTimerFired()) {
       return gracefulComplete("approval timed out");
     }
     const approvals = approval.results(context);
-    if (approvals.length > 0) {
-      return gracefulComplete(approvals[0]!);
-    }
-    return goTo(channelWaitStep, input);
+    return gracefulComplete(approvals[0]!);
   }
 }
 
@@ -165,17 +154,14 @@ impl Step for ChannelWait {
         ]))
     }
 
-    fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
+    fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
         if context.has_any_timer_fired() {
             return Ok(StepDecision::graceful_complete(
                 "approval timed out".to_owned(),
             ));
         }
         let approvals = approval().condition_results(context)?;
-        if let Some(value) = approvals.first() {
-            return Ok(StepDecision::graceful_complete(value.clone()));
-        }
-        Ok(StepDecision::go_to(&ChannelWait, input))
+        Ok(StepDecision::graceful_complete(approvals[0].clone()))
     }
 }
 ```

--- a/examples/go/primitives/channel/workflow.go
+++ b/examples/go/primitives/channel/workflow.go
@@ -55,7 +55,7 @@ func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 	), nil
 }
 
-func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, error) {
+func (channelWaitStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
 	if ctx.HasTimerFired() {
 		return dex.GracefulComplete("approval timed out"), nil
 	}
@@ -63,10 +63,7 @@ func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, e
 	if err != nil {
 		return nil, err
 	}
-	if len(results) > 0 {
-		return dex.GracefulComplete(results[0]), nil
-	}
-	return dex.GoTo(channelWaitStep{}, input), nil
+	return dex.GracefulComplete(results[0]), nil
 }
 
 func (*ChannelFlow) Approve(ctx dex.Context, _ dex.None) (*dex.RPCResult[dex.None], error) {

--- a/examples/go/primitives/channel/workflow.go
+++ b/examples/go/primitives/channel/workflow.go
@@ -56,6 +56,9 @@ func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 }
 
 func (channelWaitStep) Execute(ctx dex.Context, input int) (*dex.StepDecision, error) {
+	if ctx.HasTimerFired() {
+		return dex.GracefulComplete("approval timed out"), nil
+	}
 	results, err := Approval.GetConditionResults(ctx)
 	if err != nil {
 		return nil, err

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java
@@ -70,10 +70,7 @@ public class ChannelFlow implements Flow<Integer> {
                 return StepDecision.gracefulComplete("approval timed out");
             }
             final List<String> approvals = approval.getConditionResults(context);
-            if (!approvals.isEmpty()) {
-                return StepDecision.gracefulComplete(approvals.get(0));
-            }
-            return StepDecision.goTo(waitForApproval, input);
+            return StepDecision.gracefulComplete(approvals.get(0));
         }
     }
 }

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java
@@ -66,6 +66,9 @@ public class ChannelFlow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
+            if (context.hasTimerFired()) {
+                return StepDecision.gracefulComplete("approval timed out");
+            }
             final List<String> approvals = approval.getConditionResults(context);
             if (!approvals.isEmpty()) {
                 return StepDecision.gracefulComplete(approvals.get(0));

--- a/examples/python/dex_examples/primitives/channel/channel_flow.py
+++ b/examples/python/dex_examples/primitives/channel/channel_flow.py
@@ -45,6 +45,8 @@ class ChannelWaitStep(Step[int]):
         )
 
     def execute(self, context: Context, input: int) -> StepDecision:
+        if context.has_timer_fired():
+            return graceful_complete("approval timed out")
         approvals = self.approval.results(context)
         if approvals:
             return graceful_complete(approvals[0])

--- a/examples/python/dex_examples/primitives/channel/channel_flow.py
+++ b/examples/python/dex_examples/primitives/channel/channel_flow.py
@@ -48,9 +48,7 @@ class ChannelWaitStep(Step[int]):
         if context.has_timer_fired():
             return graceful_complete("approval timed out")
         approvals = self.approval.results(context)
-        if approvals:
-            return graceful_complete(approvals[0])
-        return go_to(self, input)
+        return graceful_complete(approvals[0])
 
 
 class ChannelFlow(Flow[int]):

--- a/examples/rust/src/primitives/channel/flow.rs
+++ b/examples/rust/src/primitives/channel/flow.rs
@@ -66,6 +66,11 @@ impl Step for ChannelWait {
     }
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
+        if context.has_any_timer_fired() {
+            return Ok(StepDecision::graceful_complete(
+                "approval timed out".to_owned(),
+            ));
+        }
         let approvals = approval().condition_results(context)?;
         if let Some(value) = approvals.first() {
             return Ok(StepDecision::graceful_complete(value.clone()));

--- a/examples/rust/src/primitives/channel/flow.rs
+++ b/examples/rust/src/primitives/channel/flow.rs
@@ -65,16 +65,13 @@ impl Step for ChannelWait {
         ]))
     }
 
-    fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
+    fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
         if context.has_any_timer_fired() {
             return Ok(StepDecision::graceful_complete(
                 "approval timed out".to_owned(),
             ));
         }
         let approvals = approval().condition_results(context)?;
-        if let Some(value) = approvals.first() {
-            return Ok(StepDecision::graceful_complete(value.clone()));
-        }
-        Ok(StepDecision::go_to(&ChannelWait, input))
+        Ok(StepDecision::graceful_complete(approvals[0].clone()))
     }
 }

--- a/examples/typescript/src/primitives/channel/channel-flow.ts
+++ b/examples/typescript/src/primitives/channel/channel-flow.ts
@@ -47,15 +47,12 @@ class ChannelWait implements Step<number> {
     );
   }
 
-  public execute(context: Context, input: number): StepDecision {
+  public execute(context: Context, _input: number): StepDecision {
     if (context.hasTimerFired()) {
       return gracefulComplete("approval timed out");
     }
     const approvals = approval.results(context);
-    if (approvals.length > 0) {
-      return gracefulComplete(approvals[0]!);
-    }
-    return goTo(channelWaitStep, input);
+    return gracefulComplete(approvals[0]!);
   }
 }
 

--- a/examples/typescript/src/primitives/channel/channel-flow.ts
+++ b/examples/typescript/src/primitives/channel/channel-flow.ts
@@ -48,6 +48,9 @@ class ChannelWait implements Step<number> {
   }
 
   public execute(context: Context, input: number): StepDecision {
+    if (context.hasTimerFired()) {
+      return gracefulComplete("approval timed out");
+    }
     const approvals = approval.results(context);
     if (approvals.length > 0) {
       return gracefulComplete(approvals[0]!);


### PR DESCRIPTION
## Summary

- Update Step and waiting-condition documentation in English and Simplified Chinese.
- Expand the five-language Channel ConditionResults snippets to show a Step implementation, WaitFor, AnyOf with a Timer, and the Timer result path.
- Simplify Step failure-policy and Channel examples to remove unreachable branches.

## Rationale and user impact

The Step docs now make the failure-policy behavior and completed Wait results easier to read. Every application snippet remains backed by a runnable example in the matching SDK.

## Validation

- `make docs-prose-check`
- `npm -C docs run check`
- `make -C examples/go bins`
- `make -C examples/go unitTests`
- `uv run pytest tests/unit/test_basic_sample.py` (from `examples/python`)
- `npm run typecheck` (from `examples/typescript`)
- `make -C examples/rust fmt-check`
- `make -C examples/rust clippy`
- `make -C examples/rust test`
- `make copyright-check`

The local Java compile passed. Its full test suite requires a running Dex Server and could not connect locally; GitHub CI will run the integration environment.
