### PR TITLE
Route Temporal SDK logs to Dex server log

### DIFF
--- a/cli/internal/dev/supervisor_integ_test.go
+++ b/cli/internal/dev/supervisor_integ_test.go
@@ -150,8 +150,12 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 	if !strings.Contains(logText, cfg.sqliteDBDirectory()) {
 		t.Fatalf("workflow engine log missing DB directory: %s", logText)
 	}
-	if _, err := os.Stat(cfg.dexServerLogPath()); err != nil {
+	dexLog, err := os.ReadFile(cfg.dexServerLogPath())
+	if err != nil {
 		t.Fatalf("Dex server log file missing: %v", err)
+	}
+	if !bytes.Contains(dexLog, []byte("Started Worker")) {
+		t.Fatalf("Dex server log missing Temporal worker logs: %s", dexLog)
 	}
 	if cfg.SQLiteDBFilename == "" {
 		t.Fatal("missing Temporal database")

--- a/server/service/bootstrap/bootstrap.go
+++ b/server/service/bootstrap/bootstrap.go
@@ -31,6 +31,7 @@ import (
 	"github.com/superdurable/dex/service/common/log/tag"
 	"github.com/superdurable/dex/service/common/workerclient"
 	"github.com/superdurable/dex/service/indexsync"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
 
@@ -61,6 +62,7 @@ type Runtime struct {
 	attributeStore    *attributestore.Manager
 	blobStore         blobstore.BlobStore
 	logger            log.Logger
+	zapLogger         *zap.Logger
 	metricsCloser     io.Closer
 	serveError        chan error
 	indexSynchronizer *indexsync.Synchronizer
@@ -104,6 +106,7 @@ func New(cfg *config.Config, options *Options) (*Runtime, error) {
 		options:    options,
 		workerPool: workerPool,
 		logger:     logger,
+		zapLogger:  zapLogger,
 		serveError: make(chan error, 1),
 	}
 	attributeStore, err := attributestore.NewManager(context.Background(), &cfg.AttributeStore, logger)

--- a/server/service/bootstrap/temporal.go
+++ b/server/service/bootstrap/temporal.go
@@ -37,6 +37,7 @@ func (r *Runtime) createTemporalServices() (
 	clientOptions := client.Options{
 		HostPort:  temporalConfig.HostPort,
 		Namespace: temporalConfig.Namespace,
+		Logger:    newTemporalLogger(r.zapLogger),
 	}
 	metrics := client.MetricsNopHandler
 	if temporalConfig.Prometheus != nil {

--- a/server/service/bootstrap/temporal_logger.go
+++ b/server/service/bootstrap/temporal_logger.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package bootstrap
+
+import (
+	"fmt"
+
+	temporallog "go.temporal.io/sdk/log"
+	"go.uber.org/zap"
+)
+
+type temporalLogger struct {
+	zapLogger *zap.Logger
+}
+
+var _ temporallog.Logger = (*temporalLogger)(nil)
+var _ temporallog.WithLogger = (*temporalLogger)(nil)
+
+func newTemporalLogger(zapLogger *zap.Logger) *temporalLogger {
+	if zapLogger == nil {
+		panic("Temporal logger requires a Zap logger")
+	}
+	return &temporalLogger{zapLogger: zapLogger}
+}
+
+func (l *temporalLogger) Debug(message string, keyvals ...interface{}) {
+	l.zapLogger.Debug(message, temporalLogFields(keyvals)...)
+}
+
+func (l *temporalLogger) Info(message string, keyvals ...interface{}) {
+	l.zapLogger.Info(message, temporalLogFields(keyvals)...)
+}
+
+func (l *temporalLogger) Warn(message string, keyvals ...interface{}) {
+	l.zapLogger.Warn(message, temporalLogFields(keyvals)...)
+}
+
+func (l *temporalLogger) Error(message string, keyvals ...interface{}) {
+	l.zapLogger.Error(message, temporalLogFields(keyvals)...)
+}
+
+func (l *temporalLogger) With(keyvals ...interface{}) temporallog.Logger {
+	return newTemporalLogger(l.zapLogger.With(temporalLogFields(keyvals)...))
+}
+
+func temporalLogFields(keyvals []interface{}) []zap.Field {
+	fields := make([]zap.Field, 0, (len(keyvals)+1)/2)
+	for index := 0; index+1 < len(keyvals); index += 2 {
+		fields = append(fields, zap.Any(fmt.Sprint(keyvals[index]), keyvals[index+1]))
+	}
+	if len(keyvals)%2 == 1 {
+		fields = append(fields, zap.Any(fmt.Sprint(keyvals[len(keyvals)-1]), nil))
+	}
+	return fields
+}


### PR DESCRIPTION
## Summary

- Route Temporal SDK worker logs through Dex's configured Zap logger.
- Keep local Temporal engine logs separate while preserving worker context in dex-server.log.
- Verify dexcli dev writes the SDK worker startup record to the Dex server log.

## Rationale

The SDK's default logger writes to the Dex process terminal, bypassing the local server log folder.

## User impact

After restarting dexcli dev, Temporal worker logs are stored in the printed server log folder instead of the terminal.

## Validation

- make -C server unitTests 2>&1 | tee /tmp/test-dexcli-temporal-sdk-logger-server.log
- make -C cli test 2>&1 | tee /tmp/test-dexcli-temporal-sdk-logger-cli.log
- make -C cli integration-test 2>&1 | tee /tmp/test-dexcli-temporal-sdk-logger-integration.log
- make copyright-check 2>&1 | tee /tmp/test-dexcli-temporal-sdk-logger-copyright.log
