### PR TITLE
Rewrite Step Decision and Options documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,12 +11,8 @@ npm install
 npm start
 ```
 
-`npm start` only serves English. The language switcher needs both locales, so use a production build:
-
-```bash
-npm run build
-npm run serve
-```
+`npm start` builds and serves both English and Simplified Chinese. Do not run
+`docusaurus start` for review: it only serves English.
 
 Published pages live under [`content/`](content/). Site config:
 `docusaurus.config.ts`, `sidebars.ts`, `src/`.

--- a/docs/content/primitives/step/basic.mdx
+++ b/docs/content/primitives/step/basic.mdx
@@ -374,7 +374,7 @@ See more advanced [Step decision](/primitives/step/step-decision) for **DeadEnd*
 
 Most of the times, you need to customize failing handling -- timeout, retry and failure policy.  There are more advanced [Step options](/primitives/step/step-options) like heartbeat, durability etc.
 
-* Timeout customize the timeout of a single attempt of the method(WaitFor/Execute) invocation.
+* **Timeout** customize the timeout of a single attempt of the method(WaitFor/Execute) invocation.
 * **Retry policy** — re-invokes the **same** method on the **same** Step execution until attempts are exhausted.
 - **Failure policy** — decide what happens **after** retries end. Default is to fail the Flow. But WaitFor can run Execute anyway, or Execute can go to a recovery Step.
 

--- a/docs/content/primitives/step/step-decision.mdx
+++ b/docs/content/primitives/step/step-decision.mdx
@@ -88,6 +88,8 @@ Ok(StepDecision::go_to_many([
 
 **GracefulComplete** and **ForceComplete** can return an output. **ForceFail** returns a failure reason. The Flow result returns each output with the Step type and Step execution ID. When multiple Steps complete gracefully, all their outputs return together.
 
+A Flow can have no active Steps and still keep running. **DeadEnd** stops this branch without making a decision that triggers the Flow to complete.
+
 Use **GracefulComplete** when you want the remaining active Steps and branches to finish gracefully. Use **DeadEnd** when you do not want this branch to make a decision that triggers the Flow to complete. Use **ForceComplete** or **ForceFail** when you want to make an immediate decision.
 
 <SdkTabs

--- a/docs/content/primitives/step/step-decision.mdx
+++ b/docs/content/primitives/step/step-decision.mdx
@@ -261,14 +261,14 @@ fn execute(&self, _context: &mut Context, _successful: bool) -> HandlerResult<St
 </SdkSnippet>
 </SdkTabs>
 
-## Cancellation on StepDecision {#cancellation-on-stepdecision}
+## Cancellation {#cancellation-on-stepdecision}
 
-Return the winner's next movement **and** cancel losing Steps in the same decision.
+Return a **StepDecision** that can cancel other active Steps.
 
-- **CancelSteps** selects every queued or active execution of the selected Step types in this Flow.
-- **CancelSiblingSteps** selects only executions scheduled by the same Step execution as the current Step. Use it when separate fan-outs must not cancel each other's work.
+There are two types of cancellation:
 
-Dex resolves the selection after the current **Execute** succeeds. Finished, already canceled, and missing executions do nothing. Steps started by this decision are not selected. If both selectors name the same Step type, **CancelSteps** takes precedence.
+- **CancelSteps** selects active Steps by Step type.
+- **CancelSiblingSteps** selects active Steps that were triggered by the same parent Step execution.
 
 <SdkTabs
   examples={{

--- a/docs/content/primitives/step/step-decision.mdx
+++ b/docs/content/primitives/step/step-decision.mdx
@@ -6,11 +6,11 @@ slug: /primitives/step/step-decision
 
 # Step decision
 
-A **StepDecision** moves the Flow to one or more next Steps, closes the Flow, cancels other Steps, or atomically completes when Channels are empty.
+This page covers more advanced features for StepDecision than the basic features.
 
 ## GoToMulti {#gotomulti}
 
-Return multiple movements in one decision to fan out parallel work. The default step-decision sample starts three carrier Steps and a winner Step in the same call.
+Return multiple next Steps in one decision to fan out parallel work. The default step-decision sample starts three carrier Steps and a winner Step in the same call.
 
 <SdkTabs
   examples={{

--- a/docs/content/primitives/step/step-decision.mdx
+++ b/docs/content/primitives/step/step-decision.mdx
@@ -6,13 +6,11 @@ slug: /primitives/step/step-decision
 
 # Step decision
 
-This page covers the advanced **StepDecision** features. See [Basic Step](/primitives/step/basic) for the common path.
+This page covers the advanced **StepDecision** features. See the [basic page](/primitives/step/basic) for the basic features.
 
 ## Multiple next Steps {#gotomulti}
 
-**GoTo** starts one next Step. **GoToMulti** starts every movement in the decision. Use it to fan out work that can run in parallel. Each movement has its own input and can use its own Step options.
-
-The default step-decision sample starts two carrier Steps and a winner Step together.
+**GoTo** starts one next Step. **GoToMulti** starts multiple next Steps. Use it to fan out work that can run in parallel. Each Step movement has its own input and can also have its own Step options.
 
 <SdkTabs
   examples={{

--- a/docs/content/primitives/step/step-decision.mdx
+++ b/docs/content/primitives/step/step-decision.mdx
@@ -328,11 +328,11 @@ Ok(StepDecision::go_to(&RecordQuoteStep, quote)
 </SdkSnippet>
 </SdkTabs>
 
-## forceCompleteIfChannelsEmpty {#forcecompleteifchannelsempty}
+## ForceCompleteIfChannelsEmpty {#forcecompleteifchannelsempty}
 
-Use **ForceCompleteIfChannelsEmpty** when a Step drains one or more Channels. Dex checks every listed Channel as one decision. If they are all empty, the Flow completes with the supplied output. Otherwise Dex runs the fallback movements and the drain continues.
+**ForceCompleteIfChannelsEmpty** atomically checks if Channels are empty. If they are, it completes the Flow. Otherwise, it goes to other Steps.
 
-The guarded Channels must have a single consumer. See [drain signal channels](/design-patterns/drain-signal-channels) for the full runnable Flow.
+Use it when you want to drain the Channels and complete the Flow, so that the Flow can stay short. See [drain signal channels](/design-patterns/drain-signal-channels) for the full example.
 
 <SdkTabs
   examples={{

--- a/docs/content/primitives/step/step-decision.mdx
+++ b/docs/content/primitives/step/step-decision.mdx
@@ -81,14 +81,14 @@ Ok(StepDecision::go_to_many([
 
 | Decision | What it does |
 | --- | --- |
-| **GracefulComplete** | Stops this branch. The Flow completes after every active and queued Step has finished. |
-| **DeadEnd** | Stops this branch and leaves the Flow open. |
-| **ForceComplete** | Completes the Flow immediately without waiting for other Steps. |
-| **ForceFail** | Fails the Flow immediately without waiting for other Steps. |
+| **GracefulComplete** | Stops this branch and triggers the Flow to prepare for completion. When all branches and Steps are stopped, the Flow completes. |
+| **DeadEnd** | Stops this branch only. |
+| **ForceComplete** | Completes the Flow immediately. |
+| **ForceFail** | Fails the Flow immediately. |
 
-**GracefulComplete** and **ForceComplete** can return an output. The Flow result records that output with the Step type and Step execution ID. When parallel branches complete gracefully, identify each result by that identity, not its order in the result list.
+**GracefulComplete** and **ForceComplete** can return an output. **ForceFail** returns a failure reason. The Flow result returns each output with the Step type and Step execution ID. When multiple Steps complete gracefully, all their outputs return together.
 
-Use **GracefulComplete** when the remaining branches can finish normally. Use **DeadEnd** only when an RPC, Channel, or other external work will resume the Flow. **ForceComplete** and **ForceFail** are useful when one branch decides the result for the whole Flow, such as a timeout race.
+Use **GracefulComplete** when you want the remaining active Steps and branches to finish gracefully. Use **DeadEnd** when you do not want this branch to make a decision that triggers the Flow to complete. Use **ForceComplete** or **ForceFail** when you want to make an immediate decision.
 
 <SdkTabs
   examples={{

--- a/docs/content/primitives/step/step-decision.mdx
+++ b/docs/content/primitives/step/step-decision.mdx
@@ -6,11 +6,13 @@ slug: /primitives/step/step-decision
 
 # Step decision
 
-This page covers more advanced features for StepDecision than the basic features.
+This page covers the advanced **StepDecision** features. See [Basic Step](/primitives/step/basic) for the common path.
 
-## GoToMulti {#gotomulti}
+## Multiple next Steps {#gotomulti}
 
-Return multiple next Steps in one decision to fan out parallel work. The default step-decision sample starts three carrier Steps and a winner Step in the same call.
+**GoTo** starts one next Step. **GoToMulti** starts every movement in the decision. Use it to fan out work that can run in parallel. Each movement has its own input and can use its own Step options.
+
+The default step-decision sample starts two carrier Steps and a winner Step together.
 
 <SdkTabs
   examples={{
@@ -79,14 +81,16 @@ Ok(StepDecision::go_to_many([
 
 ## Close decisions {#close-decisions}
 
-| Decision | Flow stays open? | Output |
-| --- | --- | --- |
-| GracefulComplete(output) | No — closes after other active Steps finish | Optional Flow output |
-| DeadEnd() | Yes — branch stops; resume via RPC, Channel, or external work | None |
-| ForceFail(reason) | No — fails the Flow immediately | Failure reason |
-| ForceComplete(output) | No — completes the Flow immediately | Optional Flow output |
+| Decision | What it does |
+| --- | --- |
+| **GracefulComplete** | Stops this branch. The Flow completes after every active and queued Step has finished. |
+| **DeadEnd** | Stops this branch and leaves the Flow open. |
+| **ForceComplete** | Completes the Flow immediately without waiting for other Steps. |
+| **ForceFail** | Fails the Flow immediately without waiting for other Steps. |
 
-Use **GracefulComplete** when this branch owns the final result. Use **DeadEnd** only when something outside the graph will resume the Flow later. **ForceFail** and **ForceComplete** override sibling Steps — useful for timeout races.
+**GracefulComplete** and **ForceComplete** can return an output. The Flow result records that output with the Step type and Step execution ID. When parallel branches complete gracefully, identify each result by that identity, not its order in the result list.
+
+Use **GracefulComplete** when the remaining branches can finish normally. Use **DeadEnd** only when an RPC, Channel, or other external work will resume the Flow. **ForceComplete** and **ForceFail** are useful when one branch decides the result for the whole Flow, such as a timeout race.
 
 <SdkTabs
   examples={{
@@ -257,85 +261,14 @@ fn execute(&self, _context: &mut Context, _successful: bool) -> HandlerResult<St
 </SdkSnippet>
 </SdkTabs>
 
-
-## Step output and FlowResults {#step-output-and-flowresults}
-
-GracefulComplete(output) sets the Flow output when this branch closes the Flow. When a Step waits on a [SubFlow](/primitives/subflow), read the child output in Execute via SubFlowResult / getConditionResults / condition_result (see [Waiting — SubFlow results](/primitives/step/waiting-condition#condition-results)).
-
-<SdkTabs
-  examples={{
-    python: 'examples/python/dex_examples/primitives/subflow/subflow_flow.py',
-    go: 'examples/go/primitives/subflow/workflow.go',
-    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/subflow/SubFlowParentFlow.java',
-    typescript: 'examples/typescript/src/primitives/subflow/subflow-flow.ts',
-    rust: 'examples/rust/src/primitives/subflow/flow.rs',
-  }}>
-<SdkSnippet lang="python">
-
-```python
-def execute(self, context: Context, input: int) -> StepDecision:
-    del input
-    result = SubFlow.get_condition_results(context)
-    output = result.single_output(int)
-    return graceful_complete(f"{SubFlow.get_flow_id(context)}|{output}")
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="go">
-
-```go
-func (subFlowParentStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
-	result, err := dex.SubFlowResult(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var output int
-	if err := result.DecodeSingleOutput(&output); err != nil {
-		return nil, err
-	}
-	return dex.GracefulComplete(fmt.Sprintf("%s|%d", flowID, output)), nil
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="java">
-
-```java
-public StepDecision execute(final Context context, final Integer input) {
-    final Integer output =
-            SubFlow.getConditionResults(context).getSingleOutput(Integer.class);
-    return StepDecision.gracefulComplete(SubFlow.getFlowId(context) + "|" + output);
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="typescript">
-
-```typescript
-public execute(context: Context, _input: number): StepDecision {
-  const result = SubFlow.getConditionResults(context);
-  const output = result.singleOutput(doubleCodec);
-  return gracefulComplete(`${SubFlow.getFlowId(context)}|${output}`);
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="rust">
-
-```rust
-fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
-    let result = SubFlow::condition_result(context)?;
-    let output: i32 = result.single_output()?;
-    Ok(StepDecision::graceful_complete(format!("{flow_id}|{output}")))
-}
-```
-
-</SdkSnippet>
-</SdkTabs>
-
 ## Cancellation on StepDecision {#cancellation-on-stepdecision}
 
-Return the winner's next movement **and** cancel losing Step types in the same decision. Cancel all executions of a Step type, or only same-source sibling executions.
+Return the winner's next movement **and** cancel losing Steps in the same decision.
+
+- **CancelSteps** selects every queued or active execution of the selected Step types in this Flow.
+- **CancelSiblingSteps** selects only executions scheduled by the same Step execution as the current Step. Use it when separate fan-outs must not cancel each other's work.
+
+Dex resolves the selection after the current **Execute** succeeds. Finished, already canceled, and missing executions do nothing. Steps started by this decision are not selected. If both selectors name the same Step type, **CancelSteps** takes precedence.
 
 <SdkTabs
   examples={{
@@ -395,11 +328,11 @@ Ok(StepDecision::go_to(&RecordQuoteStep, quote)
 </SdkSnippet>
 </SdkTabs>
 
-An RPC can cancel Steps from the handler result as well. See [RPC](/primitives/rpc).
-
 ## forceCompleteIfChannelsEmpty {#forcecompleteifchannelsempty}
 
-This special decision atomically checks whether **all listed Channels are empty**. If so, Dex completes the Flow (with optional output). Otherwise it performs the movement list instead. Channels must follow single-consumer semantics.
+Use **ForceCompleteIfChannelsEmpty** when a Step drains one or more Channels. Dex checks every listed Channel as one decision. If they are all empty, the Flow completes with the supplied output. Otherwise Dex runs the fallback movements and the drain continues.
+
+The guarded Channels must have a single consumer. See [drain signal channels](/design-patterns/drain-signal-channels) for the full runnable Flow.
 
 <SdkTabs
   examples={{
@@ -464,5 +397,3 @@ Ok(StepDecision::force_complete_if_channels_empty(
 
 </SdkSnippet>
 </SdkTabs>
-
-See the [drain signal channels](/design-patterns/drain-signal-channels) pattern for a full runnable Flow.

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -8,12 +8,6 @@ slug: /primitives/step/step-options
 
 This page covers the advanced **StepOptions** features to deeply customize your Step type. See the [Basic Step](/primitives/step/basic#stepoptions) page for the basic features.
 
-## Method timeout and retry
-
-**WaitForMethodTimeout** and **ExecuteMethodTimeout** limit one invocation of the matching method. They do not limit how long the Step waits on a Channel, Timer, or SubFlow condition.
-
-When the method returns an error or times out, Dex applies **WaitForRetry** or **ExecuteRetry**. A retry invokes the same method again on the same Step execution. After retries exhaust, the failure policy decides whether the Flow fails, **Execute** proceeds, or a recovery Step starts. See [Basic Step](/primitives/step/basic#stepoptions).
-
 ## Custom retry
 
 Usually **RetryPolicy** decides the next retry interval. Use custom retry when the service you called tells you when to try again, for example a rate-limit response with a retry-after value.

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -162,7 +162,9 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 ## Heartbeat {#heartbeat}
 
-**HeartbeatTimeout** helps Dex notice that a regular Activity worker has stopped. Dex heartbeats while **WaitFor** or **Execute** is running. If the heartbeat stops, Dex can retry without waiting for the full method timeout.
+**HeartbeatTimeout** lets a Step with a long method timeout fail and schedule the next attempt earlier. Set a heartbeat timeout to use it. For example, an **Execute** method timeout of 60 seconds and a **HeartbeatTimeout** of 10 seconds lets Dex retry the Step in about 10 seconds instead of waiting for the full 60 seconds.
+
+It also lets Dex cancel a Step earlier. A Step that is being canceled does not have to wait for the full timeout, fail, or complete first.
 
 For example, an **ExecuteMethodTimeout** of 60 seconds and a **HeartbeatTimeout** of 10 seconds lets a dead worker retry in about 10 seconds instead of a minute. Use a positive whole-second timeout. An unset timeout disables heartbeats.
 

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -304,11 +304,11 @@ Heartbeat makes cancellation reach a regular handler earlier. It does not make a
 
 ## Attribute locks
 
-Concurrent Steps and RPC invocations can read and write the same Attribute. This can lead to race conditions. To avoid this, use Edge View locks. Dex Server ensures only one Step execution or RPC handling can acquire the lock at a time.
+Concurrent Steps and RPC invocations can read and write the same Attribute. This can lead to race conditions. To avoid this, use Attribute locks. Dex Server ensures only one Step execution or RPC handling can acquire the lock at a time.
 
 **WaitFor** and **Execute** have separate lock sets. Set them by returning **StepOptions**.
 
-See [Edge View locking](/primitives/attribute#locking) for more details.
+See [Attribute locking](/primitives/attribute#locking) for more details.
 
 ## Override StepOptions for one Step execution {#stepoptions-override-per-stepexecution}
 

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -162,13 +162,12 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 ## Heartbeat {#heartbeat}
 
-**HeartbeatTimeout** lets a Step with a long method timeout fail and schedule the next attempt earlier. Set a heartbeat timeout to use it. For example, an **Execute** method timeout of 60 seconds and a **HeartbeatTimeout** of 10 seconds lets Dex retry the Step in about 10 seconds instead of waiting for the full 60 seconds.
+**Heartbeat** lets a Step with a long method timeout fail and schedule the next attempt earlier, or being canceled earlier.
 
-It also lets Dex cancel a Step earlier. A Step that is being canceled does not have to wait for the full timeout, fail, or complete first.
+Set a **HeartbeatTimeout** to use it.
 
-For example, an **ExecuteMethodTimeout** of 60 seconds and a **HeartbeatTimeout** of 10 seconds lets a dead worker retry in about 10 seconds instead of a minute. Use a positive whole-second timeout. An unset timeout disables heartbeats.
 
-Local Activities do not heartbeat. If an **ASYNC** method falls back to a regular Activity, the same heartbeat timeout applies there.
+For example, an **Execute** method timeout of 60 seconds and a **HeartbeatTimeout** of 10 seconds lets Dex retry the Step in about 10 seconds instead of waiting for the full 60 seconds. Similarly, a Step that is being canceled does not have to wait for the full timeout, fail, or complete first.
 
 <SdkTabs
   examples={{

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -310,7 +310,7 @@ Concurrent Steps and RPC invocations can read and write the same Attribute. This
 
 See [Attribute locking](/primitives/attribute#locking) for more details.
 
-## Override StepOptions for one Step execution {#stepoptions-override-per-stepexecution}
+## Provide StepOptions Dynamically {#stepoptions-override-per-stepexecution}
 
 The **StepOptions** returned by a Step apply every time that Step runs. A **StepMovement** can carry options for one execution instead.
 

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -312,9 +312,9 @@ See [Attribute locking](/primitives/attribute#locking) for more details.
 
 ## Provide StepOptions Dynamically {#stepoptions-override-per-stepexecution}
 
-The **StepOptions** returned by a Step apply every time that Step runs. A **StepMovement** can carry options for one execution instead.
+The **StepOptions** returned by a Step implementation apply to every Step execution by default. Sometimes it is useful to override them dynamically for a certain Step execution.
 
-This is useful when the same Step is used in more than one path. Here the registered Step fails after one **WaitFor** attempt. The movement gives just this execution two attempts and lets it proceed to **Execute** after failure.
+To do this, provide the **StepOptions** override, then use a **StepDecision** to go to the next Step.
 
 <SdkTabs
   examples={{

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -8,11 +8,9 @@ slug: /primitives/step/step-options
 
 This page covers the advanced **StepOptions** features to deeply customize your Step type. See the [Basic Step](/primitives/step/basic#stepoptions) page for the basic features.
 
-## Custom retry
+## Retry After
 
-Usually **RetryPolicy** decides the next retry interval. Use custom retry when the service you called tells you when to try again, for example a rate-limit response with a retry-after value.
-
-Custom retry only changes the next interval. It does not reset the retry policy, attempt count, or method timeout.
+Use **RetryAfter** if you want to deeply customize the retry behavior. It overrides the retry schedule of the **RetryPolicy**.
 
 <SdkTabs
   examples={{
@@ -77,8 +75,6 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 
 </SdkSnippet>
 </SdkTabs>
-
-Custom retry is supported by Temporal. Cadence rejects it because its backend does not support a per-attempt retry interval.
 
 ## Durability {#durability}
 

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -84,7 +84,7 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 
 A Step should usually be idempotent, so **ASYNC** durability is generally safe to use. It is the default for most Steps.
 
-Steps with a recovery failure policy default to **SYNC** durability. The business may assume that once a Flow enters the following **Execute** method or recovery Step, it does not go back to the previous method. **SYNC** persists the previous completion first.
+Steps with a recovery failure policy default to **SYNC** durability. The business may assume that once a Flow enters the following Execute method or recovery Step, it does not go back to the previous method.
 
 Set the default durability with **FlowConfig**. This default does not apply to a method with a recovery failure policy. To override the durability for that method, set it in the Step's **StepOptions**.
 

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -78,11 +78,15 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 
 ## Durability {#durability}
 
-**SYNC** is the default. Dex runs the method as a regular Activity and records the result before the Flow continues.
+**SYNC** durability records the Step completion in Dex Server and persists it to storage synchronously.
 
-**ASYNC** first runs the method as a local Activity. It removes a backend round trip for short work. If the local Activity does not finish in Dex's local window, it falls back to a regular Activity. The local attempt and the fallback share the same retry budget.
+**ASYNC** durability does this asynchronously. Every few seconds, Dex Server flushes accumulated Step completions and persists them. It provides much higher throughput because it removes a lot of overhead from the backend database and server.
 
-Set a Flow-wide default with **FlowConfig**. Set **WaitForDurability** or **ExecuteDurability** when one method needs a different choice.
+A Step should usually be idempotent, so **ASYNC** durability is generally safe to use. It is the default for most Steps.
+
+Steps with a recovery failure policy default to **SYNC** durability. The business may assume that once a Flow enters the following **Execute** method or recovery Step, it does not go back to the previous method. **SYNC** persists the previous completion first.
+
+Set the default durability with **FlowConfig**. This default does not apply to a method with a recovery failure policy. To override the durability for that method, set it in the Step's **StepOptions**.
 
 <SdkTabs
   examples={{
@@ -155,10 +159,6 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 </SdkSnippet>
 </SdkTabs>
-
-An **ASYNC** method keeps the current Workflow Task busy while its local Activity runs. This can delay a sibling Step from registering a Timer, or delay processing a Timer that already fired. Use **SYNC** when that timing matters.
-
-When a method has a failure recovery policy, Dex uses **SYNC** unless the method explicitly selects a durability. This protects the recorded failure before **Execute** or the recovery Step starts.
 
 ## Heartbeat {#heartbeat}
 

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -314,7 +314,7 @@ See [Attribute locking](/primitives/attribute#locking) for more details.
 
 The **StepOptions** returned by a Step implementation apply to every Step execution by default. Sometimes it is useful to override them dynamically for a certain Step execution.
 
-To do this, provide the **StepOptions** override, then use a **StepDecision** to go to the next Step.
+Provide the **StepOptions** override when a **StepDecision** goes to the next Steps.
 
 <SdkTabs
   examples={{

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -6,11 +6,21 @@ slug: /primitives/step/step-options
 
 # Step options
 
-Configure WaitFor and Execute independently on StepOptions: method timeouts, retry policies, failure policies when retries are exhausted, durability, heartbeat, and StepOptions override per StepExecution.
+**StepOptions** customizes one Step. **WaitFor** and **Execute** each have their own timeout, retry, failure policy, durability, and Attribute locks.
+
+The common timeout, retry, and failure policy are covered in [Basic Step](/primitives/step/basic#stepoptions). This page covers the rest.
+
+## Method timeout and retry
+
+**WaitForMethodTimeout** and **ExecuteMethodTimeout** limit one invocation of the matching method. They do not limit how long the Step waits on a Channel, Timer, or SubFlow condition.
+
+When the method returns an error or times out, Dex applies **WaitForRetry** or **ExecuteRetry**. A retry invokes the same method again on the same Step execution. After retries exhaust, the failure policy decides whether the Flow fails, **Execute** proceeds, or a recovery Step starts. See [Basic Step](/primitives/step/basic#stepoptions).
 
 ## Custom retry
 
-**Not** a failure policy — handlers can request the **next retry interval** while preserving the current attempt failure.
+Usually **RetryPolicy** decides the next retry interval. Use custom retry when the service you called tells you when to try again, for example a rate-limit response with a retry-after value.
+
+Custom retry only changes the next interval. It does not reset the retry policy, attempt count, or method timeout.
 
 <SdkTabs
   examples={{
@@ -25,7 +35,7 @@ Configure WaitFor and Execute independently on StepOptions: method timeouts, ret
 ```java
 throw RetryAfterException.after(
         Duration.ofSeconds(7),
-        new RuntimeException("retry later"));
+        new IllegalStateException("not ready on attempt " + context.getAttempt()));
 ```
 
 </SdkSnippet>
@@ -76,18 +86,15 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 </SdkSnippet>
 </SdkTabs>
 
-- **Temporal** applies the delay to the next Activity retry without changing retry limits or method timeouts.
-- **Cadence** rejects dynamic intervals with INVALID_USER_FLOW_CODE.
-- On Temporal, the **current attempt failure** (not RetryAfterException itself) is the reported Worker error and appears in lastFailureInfo.
-
-When the Worker SDK attaches stack_trace on WorkerErrorResponse, Dex Web shows it under **Last failure** as originalWorkerErrorStackTrace. Go apps that want an origin stack wrap the cause with **dex.ErrorWithStack** (nest it under **RetryAfter** when using custom retry). Rust **HandlerError** constructors capture a construction-site stack automatically.
-
+Custom retry is supported by Temporal. Cadence rejects it because its backend does not support a per-attempt retry interval.
 
 ## Durability {#durability}
 
-Each Step method can override persistence durability: **SYNC** waits for Dex to acknowledge staged writes before the handler returns; **ASYNC** permits persistence after the handler accepts the result.
+**SYNC** is the default. Dex runs the method as a regular Activity and records the result before the Flow continues.
 
-When unset, Dex uses the Flow default from FlowConfig, then the server default.
+**ASYNC** first runs the method as a local Activity. It removes a backend round trip for short work. If the local Activity does not finish in Dex's local window, it falls back to a regular Activity. The local attempt and the fallback share the same retry budget.
+
+Set a Flow-wide default with **FlowConfig**. Set **WaitForDurability** or **ExecuteDurability** when one method needs a different choice.
 
 <SdkTabs
   examples={{
@@ -161,30 +168,17 @@ fn options(&self) -> StepOptions<Self::Input> {
 </SdkSnippet>
 </SdkTabs>
 
+An **ASYNC** method keeps the current Workflow Task busy while its local Activity runs. This can delay a sibling Step from registering a Timer, or delay processing a Timer that already fired. Use **SYNC** when that timing matters.
 
-### Local-activity window
-
-An **ASYNC** Step first runs as a local activity. Dex keeps the current Workflow Task open until the local stage returns or hits the local optimization timeout (about seven seconds). While that task is occupied, sibling Steps may start their durable timers later than they would with SYNC.
-
-If the local activity returns successfully first, Dex processes that result before any timer that fired during the local stage.
-
-Methods with a configured **failure-policy recovery path** default to SYNC. FlowConfig cannot override that default to ASYNC; set an explicit method-level override only when replaying the failed method after recovery begins is acceptable.
-
-:::note Timers and ASYNC Steps
-
-ASYNC Execute does not block Timer Conditions that are already registered elsewhere in the Flow from firing on schedule. Prefer a **Timer** when you need a durable deadline independent of long-running ASYNC work. Prefer **ASYNC Execute** when the handler can finish quickly in the local stage or when slightly deferred timer processing is acceptable. See [Timer](/primitives/timer).
-
-:::
+When a method has a failure recovery policy, Dex uses **SYNC** unless the method explicitly selects a durability. This protects the recorded failure before **Execute** or the recovery Step starts.
 
 ## Heartbeat {#heartbeat}
 
-heartbeat_timeout / HeartbeatTimeout enables cooperative cancellation for regular WaitFor and Execute activities. Dex calls the backend heartbeat API about once per second while the activity is active.
+**HeartbeatTimeout** helps Dex notice that a regular Activity worker has stopped. Dex heartbeats while **WaitFor** or **Execute** is running. If the heartbeat stops, Dex can retry without waiting for the full method timeout.
 
-Configure a positive whole-second value on StepOptions. Zero or unset disables heartbeats. Local activities ignore the option; ASYNC fallback to regular execution uses it.
+For example, an **ExecuteMethodTimeout** of 60 seconds and a **HeartbeatTimeout** of 10 seconds lets a dead worker retry in about 10 seconds instead of a minute. Use a positive whole-second timeout. An unset timeout disables heartbeats.
 
-Without a heartbeat, Dex may not detect a crashed worker until the full **method timeout** elapses. With a short heartbeat (for example 10s) and a long execute timeout (for example 60s), a crash can schedule the next retry in roughly one heartbeat interval instead of waiting the full minute.
-
-Cancellation reaches the handler through the heartbeat channel and Context cancellation. Without heartbeats, a handler may run until its natural return or full method timeout.
+Local Activities do not heartbeat. If an **ASYNC** method falls back to a regular Activity, the same heartbeat timeout applies there.
 
 <SdkTabs
   examples={{
@@ -222,20 +216,29 @@ func (step heartbeatStep) Execute(ctx dex.Context, batches int) (*dex.StepDecisi
   <SdkSnippet lang="java">
 
 ```java
-private final StepOptions options = StepOptions.newBuilder()
-        .executeTimeout(Duration.ofSeconds(60))
-        .heartbeatTimeout(Duration.ofSeconds(10))
-        .build();
+@Override
+public StepDecision execute(final Context context, final Integer batches) {
+    for (int batch = 0; batch < batches; batch++) {
+        if (context.isCancellationRequested()) {
+            return StepDecision.deadEnd();
+        }
+        try {
+            Thread.sleep(Duration.ofSeconds(2).toMillis());
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            return StepDecision.deadEnd();
+        }
+    }
+    return StepDecision.gracefulComplete("processed");
+}
 
 @Override
-public StepDecision execute(Context context, Job job) {
-    while (hasNextBatch(job)) {
-        if (Thread.interrupted()) {
-            break;
-        }
-        processBatch(job);
-    }
-    return StepDecision.deadEnd();
+public StepOptions getStepOptions() {
+    return StepOptions.newBuilder()
+            .executeMethodTimeout(Duration.ofSeconds(60))
+            .heartbeatTimeout(Duration.ofSeconds(10))
+            .executeRetry(RetryPolicy.newBuilder().maximumAttempts(3).build())
+            .build();
 }
 ```
 
@@ -243,14 +246,19 @@ public StepDecision execute(Context context, Job job) {
   <SdkSnippet lang="python">
 
 ```python
-options = StepOptions(heartbeat_timeout=timedelta(seconds=10))
+def get_step_options(self) -> StepOptions:
+    return StepOptions(
+        execute_method_timeout=timedelta(seconds=60),
+        heartbeat_timeout=timedelta(seconds=10),
+        execute_retry=RetryPolicy(maximum_attempts=3),
+    )
 
-def execute(self, context: Context, job: Job) -> StepDecision:
-    while has_next_batch(job):
+async def execute(self, context: Context, batches: int) -> StepDecision:
+    for _batch in range(batches):
         if context.is_cancellation_requested():
-            break
-        process_batch(job)
-    return dead_end()
+            return dead_end()
+        await asyncio.sleep(2)
+    return graceful_complete("processed")
 ```
 
 </SdkSnippet>
@@ -261,7 +269,9 @@ public getStepOptions(): StepOptions {
   return {
     executeMethodTimeoutMs: 60_000,
     heartbeatTimeoutMs: 10_000,
-    executeRetry: { maximumAttempts: 3 },
+    executeRetry: {
+      maximumAttempts: 3,
+    },
   };
 }
 
@@ -301,14 +311,21 @@ fn execute(&self, context: &mut Context, batches: Self::Input) -> HandlerResult<
 </SdkSnippet>
 </SdkTabs>
 
+Heartbeat makes cancellation reach a regular handler earlier. It does not make an external API call atomic. Use idempotency or compensation when the API needs it.
 
-Heartbeats make cancellation reach a regular activity promptly; they do not make external API calls atomic. Combine timeouts, idempotency, or compensation where needed.
+## Attribute locks
 
-## StepOptions override per StepExecution {#stepoptions-override-per-stepexecution}
+Concurrent Steps and RPCs can read the same Attribute. When a handler reads and writes shared state, declare **WaitForLockAttributes** or **ExecuteLockAttributes**. Dex waits for the listed Attribute or AttributeMap instances, then holds those locks for that method invocation.
 
-Registered StepOptions apply to every execution of a Step type. Sometimes one **movement** needs different retry or failure behavior — for example, a fan-out child that should proceed on WaitFor failure while siblings fail the Flow.
+**WaitFor** and **Execute** have separate lock sets. The locks are released when that method returns; they do not stay held while the Step waits on a condition. The Attribute definitions must belong to the Flow persistence schema.
 
-Pass override options on **StepMovement** / goToMulti / WithStepOptions so only that scheduled execution uses the override.
+See [Attribute locking](/primitives/attribute#locking) for the same lock used by RPCs.
+
+## Override StepOptions for one Step execution {#stepoptions-override-per-stepexecution}
+
+The **StepOptions** returned by a Step apply every time that Step runs. A **StepMovement** can carry options for one execution instead.
+
+This is useful when the same Step is used in more than one path. Here the registered Step fails after one **WaitFor** attempt. The movement gives just this execution two attempts and lets it proceed to **Execute** after failure.
 
 <SdkTabs
   examples={{
@@ -378,7 +395,4 @@ Ok(StepDecision::go_to_many([StepMovement::to_with_options(
 </SdkSnippet>
 </SdkTabs>
 
-The target Step's registered options still apply for fields you do not override. Recovery movements can carry their own override as well.
-
-
-When a movement override selects a failure-policy recovery path, durability defaults described in [Durability](#durability) apply to that method.
+Give a per-execution override every option this execution needs. That keeps its behavior clear, even when the registered Step options change later.

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -6,9 +6,7 @@ slug: /primitives/step/step-options
 
 # Step options
 
-**StepOptions** customizes one Step. **WaitFor** and **Execute** each have their own timeout, retry, failure policy, durability, and Attribute locks.
-
-The common timeout, retry, and failure policy are covered in [Basic Step](/primitives/step/basic#stepoptions). This page covers the rest.
+This page covers the advanced **StepOptions** features to deeply customize your Step type. See the [Basic Step](/primitives/step/basic#stepoptions) page for the basic features.
 
 ## Method timeout and retry
 

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -304,11 +304,11 @@ Heartbeat makes cancellation reach a regular handler earlier. It does not make a
 
 ## Attribute locks
 
-Concurrent Steps and RPCs can read the same Attribute. When a handler reads and writes shared state, declare **WaitForLockAttributes** or **ExecuteLockAttributes**. Dex waits for the listed Attribute or AttributeMap instances, then holds those locks for that method invocation.
+Concurrent Steps and RPC invocations can read and write the same Attribute. This can lead to race conditions. To avoid this, use Edge View locks. Dex Server ensures only one Step execution or RPC handling can acquire the lock at a time.
 
-**WaitFor** and **Execute** have separate lock sets. The locks are released when that method returns; they do not stay held while the Step waits on a condition. The Attribute definitions must belong to the Flow persistence schema.
+**WaitFor** and **Execute** have separate lock sets. Set them by returning **StepOptions**.
 
-See [Attribute locking](/primitives/attribute#locking) for the same lock used by RPCs.
+See [Edge View locking](/primitives/attribute#locking) for more details.
 
 ## Override StepOptions for one Step execution {#stepoptions-override-per-stepexecution}
 

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -383,5 +383,3 @@ Ok(StepDecision::go_to_many([StepMovement::to_with_options(
 
 </SdkSnippet>
 </SdkTabs>
-
-Give a per-execution override every option this execution needs. That keeps its behavior clear, even when the registered Step options change later.

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/basic.mdx
@@ -1,6 +1,6 @@
 ---
 title: Flow 基础
-sidebar_label: 基础
+sidebar_label: Basics
 slug: /primitives/flow/basic
 ---
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
@@ -1,6 +1,6 @@
 ---
 title: Step 基础功能
-sidebar_label: 基础
+sidebar_label: Basics
 slug: /primitives/step/basic
 ---
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
@@ -291,7 +291,7 @@ Execute 返回 **StepDecision**——指向一个或多个后续 Step 的 moveme
 
 大多数时候，需要自定义 failure handling —— timeout、retry 与 failure policy。还有 heartbeat、durability 等更高级的 [Step options](/primitives/step/step-options)。
 
-* Timeout 自定义一次方法（WaitFor/Execute）调用 attempt 的 timeout。
+* **Timeout** 自定义一次方法（WaitFor/Execute）调用 attempt 的 timeout。
 * **Retry policy** — 在**同一** Step execution 上重复调用**同一**方法，直到 attempt 耗尽。
 - **Failure policy** — 决定 retry 结束**之后**发生什么。默认失败 Flow，但 WaitFor 仍可运行 Execute，Execute 也可以前往 recovery Step。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
@@ -6,13 +6,11 @@ slug: /primitives/step/step-decision
 
 # Step decision
 
-本页介绍 **StepDecision** 的进阶功能。常见用法见[基础 Step](/primitives/step/basic)。
+本页介绍 **StepDecision** 的进阶功能。基础功能见[基础页面](/primitives/step/basic)。
 
 ## 多个后续 Step {#gotomulti}
 
-**GoTo** 启动一个后续 Step。**GoToMulti** 启动决策中的每个 movement。用它 fan-out 可并行的工作。每个 movement 有各自的输入，也可使用各自的 Step options。
-
-默认 step-decision 示例会同时启动两个 carrier Step 和一个 winner Step。
+**GoTo** 启动一个后续 Step。**GoToMulti** 启动多个后续 Step。用它 fan-out 可并行的工作。每个 Step movement 有各自的输入，也可以有各自的 Step options。
 
 <SdkTabs
   examples={{

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
@@ -328,11 +328,11 @@ Ok(StepDecision::go_to(&RecordQuoteStep, quote)
 </SdkSnippet>
 </SdkTabs>
 
-## forceCompleteIfChannelsEmpty {#forcecompleteifchannelsempty}
+## ForceCompleteIfChannelsEmpty {#forcecompleteifchannelsempty}
 
-某个 Step 要 drain 一个或多个 Channel 时，使用 **ForceCompleteIfChannelsEmpty**。Dex 将所有列出的 Channel 当作一次决策来检查。它们都为空时，Flow 以提供的 output 完成；否则 Dex 执行 fallback movement，继续 drain。
+**ForceCompleteIfChannelsEmpty** 原子检查 Channel 是否为空。若为空，它完成 Flow。否则，它转到其他 Step。
 
-被检查的 Channel 必须只有一个 consumer。完整可运行 Flow 见 [drain signal channels](/design-patterns/drain-signal-channels)。
+当你想 drain Channel 并完成 Flow，从而让 Flow 保持短小，使用它。完整例子见 [drain signal channels](/design-patterns/drain-signal-channels)。
 
 <SdkTabs
   examples={{

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
@@ -88,6 +88,8 @@ Ok(StepDecision::go_to_many([
 
 **GracefulComplete** 和 **ForceComplete** 可以返回 output。**ForceFail** 返回 failure reason。Flow result 会连同 Step type 和 Step execution ID 一起返回每个 output。多个 Step graceful complete 时，它们的所有 output 会一起返回。
 
+Flow 可以没有任何 active Step，但仍继续运行。**DeadEnd** 停止当前分支，不做出会触发 Flow 完成的决策。
+
 希望剩余 active Step 和分支 graceful finish 时，使用 **GracefulComplete**。不希望当前分支做出会触发 Flow 完成的决策时，使用 **DeadEnd**。希望立即做出决定时，使用 **ForceComplete** 或 **ForceFail**。
 
 <SdkTabs

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
@@ -261,14 +261,14 @@ fn execute(&self, _context: &mut Context, _successful: bool) -> HandlerResult<St
 </SdkSnippet>
 </SdkTabs>
 
-## Cancellation on StepDecision {#cancellation-on-stepdecision}
+## Cancellation {#cancellation-on-stepdecision}
 
-在同一次决策中返回胜者的下一 movement **并**取消失败的 Step。
+返回一个可以取消其他 active Step 的 **StepDecision**。
 
-- **CancelSteps** 选择当前 Flow 中所选 Step type 的全部 queued 或 active execution。
-- **CancelSiblingSteps** 只选择和当前 Step 由同一个 Step execution 调度的 execution。不同 fan-out 之间不应相互取消时使用它。
+有两种 cancellation：
 
-当前 **Execute** 成功后，Dex 才解析这次选择。已结束、已取消或不存在的 execution 不产生任何效果。当前决策新启动的 Step 不会被选择。如果两个 selector 包含同一个 Step type，**CancelSteps** 优先。
+- **CancelSteps** 按 Step type 选择 active Step。
+- **CancelSiblingSteps** 选择由同一个 parent Step execution 触发的 active Step。
 
 <SdkTabs
   examples={{

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
@@ -81,14 +81,14 @@ Ok(StepDecision::go_to_many([
 
 | 决策 | 行为 |
 | --- | --- |
-| **GracefulComplete** | 停止当前分支。所有 active 和 queued Step 都结束后，Flow 才完成。 |
-| **DeadEnd** | 停止当前分支，并保持 Flow 打开。 |
-| **ForceComplete** | 不等待其他 Step，立即完成 Flow。 |
-| **ForceFail** | 不等待其他 Step，立即让 Flow 失败。 |
+| **GracefulComplete** | 停止当前分支，并触发 Flow 为完成做准备。所有分支和 Step 都停止后，Flow 完成。 |
+| **DeadEnd** | 只停止当前分支。 |
+| **ForceComplete** | 立即完成 Flow。 |
+| **ForceFail** | 立即让 Flow 失败。 |
 
-**GracefulComplete** 和 **ForceComplete** 可以返回 output。Flow result 会连同 Step type 和 Step execution ID 一起记录该 output。多个并行分支 graceful complete 时，应按这个 identity 识别每个结果，不要依赖结果列表中的顺序。
+**GracefulComplete** 和 **ForceComplete** 可以返回 output。**ForceFail** 返回 failure reason。Flow result 会连同 Step type 和 Step execution ID 一起返回每个 output。多个 Step graceful complete 时，它们的所有 output 会一起返回。
 
-剩余分支可以正常结束时，用 **GracefulComplete**。只在 RPC、Channel 或其他外部工作会恢复 Flow 时使用 **DeadEnd**。当某个分支决定整个 Flow 的结果时，例如 timeout 竞态，使用 **ForceComplete** 或 **ForceFail**。
+希望剩余 active Step 和分支 graceful finish 时，使用 **GracefulComplete**。不希望当前分支做出会触发 Flow 完成的决策时，使用 **DeadEnd**。希望立即做出决定时，使用 **ForceComplete** 或 **ForceFail**。
 
 <SdkTabs
   examples={{

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
@@ -6,11 +6,13 @@ slug: /primitives/step/step-decision
 
 # Step decision
 
-**StepDecision** 可将 Flow 移到一个或多个后续 Step、关闭 Flow、取消其他 Step，或在 Channel 为空时原子地完成 Flow。
+本页介绍 **StepDecision** 的进阶功能。常见用法见[基础 Step](/primitives/step/basic)。
 
-## GoToMulti {#gotomulti}
+## 多个后续 Step {#gotomulti}
 
-一次决策返回多个 movement 以并行 fan-out。默认 step-decision 示例在同一次调用中启动三个 carrier Step 与一个 winner Step。
+**GoTo** 启动一个后续 Step。**GoToMulti** 启动决策中的每个 movement。用它 fan-out 可并行的工作。每个 movement 有各自的输入，也可使用各自的 Step options。
+
+默认 step-decision 示例会同时启动两个 carrier Step 和一个 winner Step。
 
 <SdkTabs
   examples={{
@@ -79,14 +81,16 @@ Ok(StepDecision::go_to_many([
 
 ## 关闭决策 {#close-decisions}
 
-| 决策 | Flow 保持打开？ | 输出 |
-| --- | --- | --- |
-| GracefulComplete(output) | 否——其他活跃 Step 结束后关闭 | 可选 Flow 输出 |
-| DeadEnd() | 是——分支停止；通过 RPC、Channel 或外部工作恢复 | 无 |
-| ForceFail(reason) | 否——立即失败 Flow | 失败原因 |
-| ForceComplete(output) | 否——立即完成 Flow | 可选 Flow output |
+| 决策 | 行为 |
+| --- | --- |
+| **GracefulComplete** | 停止当前分支。所有 active 和 queued Step 都结束后，Flow 才完成。 |
+| **DeadEnd** | 停止当前分支，并保持 Flow 打开。 |
+| **ForceComplete** | 不等待其他 Step，立即完成 Flow。 |
+| **ForceFail** | 不等待其他 Step，立即让 Flow 失败。 |
 
-本分支拥有最终结果时用 **GracefulComplete**。仅当图外会有东西稍后恢复 Flow 时用 **DeadEnd**。**ForceFail** 与 **ForceComplete** 覆盖 sibling Step——适用于 timeout 竞态。
+**GracefulComplete** 和 **ForceComplete** 可以返回 output。Flow result 会连同 Step type 和 Step execution ID 一起记录该 output。多个并行分支 graceful complete 时，应按这个 identity 识别每个结果，不要依赖结果列表中的顺序。
+
+剩余分支可以正常结束时，用 **GracefulComplete**。只在 RPC、Channel 或其他外部工作会恢复 Flow 时使用 **DeadEnd**。当某个分支决定整个 Flow 的结果时，例如 timeout 竞态，使用 **ForceComplete** 或 **ForceFail**。
 
 <SdkTabs
   examples={{
@@ -257,85 +261,14 @@ fn execute(&self, _context: &mut Context, _successful: bool) -> HandlerResult<St
 </SdkSnippet>
 </SdkTabs>
 
-
-## Step 输出与 FlowResults {#step-output-and-flowresults}
-
-本分支关闭 Flow 时，GracefulComplete(output) 设置 Flow 输出。Step 等待 [SubFlow](/primitives/subflow) 时，在 Execute 中通过 SubFlowResult / getConditionResults / condition_result 读取子输出（见 [等待 — SubFlow 结果](/primitives/step/waiting-condition#condition-results)）。
-
-<SdkTabs
-  examples={{
-    python: 'examples/python/dex_examples/primitives/subflow/subflow_flow.py',
-    go: 'examples/go/primitives/subflow/workflow.go',
-    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/subflow/SubFlowParentFlow.java',
-    typescript: 'examples/typescript/src/primitives/subflow/subflow-flow.ts',
-    rust: 'examples/rust/src/primitives/subflow/flow.rs',
-  }}>
-<SdkSnippet lang="python">
-
-```python
-def execute(self, context: Context, input: int) -> StepDecision:
-    del input
-    result = SubFlow.get_condition_results(context)
-    output = result.single_output(int)
-    return graceful_complete(f"{SubFlow.get_flow_id(context)}|{output}")
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="go">
-
-```go
-func (subFlowParentStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
-	result, err := dex.SubFlowResult(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var output int
-	if err := result.DecodeSingleOutput(&output); err != nil {
-		return nil, err
-	}
-	return dex.GracefulComplete(fmt.Sprintf("%s|%d", flowID, output)), nil
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="java">
-
-```java
-public StepDecision execute(final Context context, final Integer input) {
-    final Integer output =
-            SubFlow.getConditionResults(context).getSingleOutput(Integer.class);
-    return StepDecision.gracefulComplete(SubFlow.getFlowId(context) + "|" + output);
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="typescript">
-
-```typescript
-public execute(context: Context, _input: number): StepDecision {
-  const result = SubFlow.getConditionResults(context);
-  const output = result.singleOutput(doubleCodec);
-  return gracefulComplete(`${SubFlow.getFlowId(context)}|${output}`);
-}
-```
-
-</SdkSnippet>
-  <SdkSnippet lang="rust">
-
-```rust
-fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
-    let result = SubFlow::condition_result(context)?;
-    let output: i32 = result.single_output()?;
-    Ok(StepDecision::graceful_complete(format!("{flow_id}|{output}")))
-}
-```
-
-</SdkSnippet>
-</SdkTabs>
-
 ## Cancellation on StepDecision {#cancellation-on-stepdecision}
 
-在同一次决策中返回胜者的下一 movement **并**取消失败的 Step 类型。可取消某 Step 类型的全部 execution，或仅取消同源 sibling execution。
+在同一次决策中返回胜者的下一 movement **并**取消失败的 Step。
+
+- **CancelSteps** 选择当前 Flow 中所选 Step type 的全部 queued 或 active execution。
+- **CancelSiblingSteps** 只选择和当前 Step 由同一个 Step execution 调度的 execution。不同 fan-out 之间不应相互取消时使用它。
+
+当前 **Execute** 成功后，Dex 才解析这次选择。已结束、已取消或不存在的 execution 不产生任何效果。当前决策新启动的 Step 不会被选择。如果两个 selector 包含同一个 Step type，**CancelSteps** 优先。
 
 <SdkTabs
   examples={{
@@ -395,11 +328,11 @@ Ok(StepDecision::go_to(&RecordQuoteStep, quote)
 </SdkSnippet>
 </SdkTabs>
 
-RPC 也可从 handler 结果取消 Step。见 [RPC](/primitives/rpc)。
-
 ## forceCompleteIfChannelsEmpty {#forcecompleteifchannelsempty}
 
-该特殊决策原子检查**所列 Channel 是否均为空**。若是，Dex 完成 Flow（可选 output）；否则执行 movement 列表。Channel 须遵循单消费者语义。
+某个 Step 要 drain 一个或多个 Channel 时，使用 **ForceCompleteIfChannelsEmpty**。Dex 将所有列出的 Channel 当作一次决策来检查。它们都为空时，Flow 以提供的 output 完成；否则 Dex 执行 fallback movement，继续 drain。
+
+被检查的 Channel 必须只有一个 consumer。完整可运行 Flow 见 [drain signal channels](/design-patterns/drain-signal-channels)。
 
 <SdkTabs
   examples={{
@@ -464,5 +397,3 @@ Ok(StepDecision::force_complete_if_channels_empty(
 
 </SdkSnippet>
 </SdkTabs>
-
-完整可运行 Flow 见 [drain signal channels](/design-patterns/drain-signal-channels) 模式。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -309,7 +309,7 @@ Heartbeat 能让取消更早到达普通 handler。它不会让外部 API 调用
 
 更多细节见 [Attribute locking](/primitives/attribute#locking)。
 
-## Override StepOptions for one Step execution {#stepoptions-override-per-stepexecution}
+## 动态提供 StepOptions {#stepoptions-override-per-stepexecution}
 
 Step 返回的 **StepOptions** 适用于它的每次 execution。**StepMovement** 也可以为某一次 execution 携带 options。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -84,7 +84,7 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 
 Step 通常应当是 idempotent，所以一般可以安全使用 **ASYNC** durability。它是大多数 Step 的默认值。
 
-使用 recovery failure policy 的 Step 默认使用 **SYNC** durability。业务可能假设 Flow 进入后续的 **Execute** 方法或 recovery Step 后，不会再回到前一个方法。**SYNC** 会先持久化前一个 completion。
+使用 recovery failure policy 的 Step 默认使用 **SYNC** durability。业务可能假设 Flow 进入后续的 Execute 方法或 recovery Step 后，不会再回到前一个方法。
 
 用 **FlowConfig** 设置默认 durability。这个默认值不适用于使用 recovery failure policy 的方法。如需 override 这些方法的 durability，在该 Step 的 **StepOptions** 中设置。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -303,11 +303,11 @@ Heartbeat 能让取消更早到达普通 handler。它不会让外部 API 调用
 
 ## Attribute locks
 
-并发的 Step 和 RPC 可以读取同一个 Attribute。一个 handler 要读写共享状态时，声明 **WaitForLockAttributes** 或 **ExecuteLockAttributes**。Dex 会等待列出的 Attribute 或 AttributeMap instance，然后在这个方法 invocation 期间持有这些 lock。
+并发 Step 和 RPC invocation 可以读取和写入同一个 Attribute。这可能导致 race condition。要避免它，使用 Edge View lock。Dex Server 会确保同一时间只有一个 Step execution 或 RPC handling 能 acquire 这个 lock。
 
-**WaitFor** 与 **Execute** 有独立的 lock set。方法返回时 lock 会释放；Step 等待 condition 时不会一直持有。Attribute definition 必须属于 Flow 的 persistence schema。
+**WaitFor** 与 **Execute** 有独立的 lock set。通过返回 **StepOptions** 设置它们。
 
-RPC 使用同一把 lock，见 [Attribute locking](/primitives/attribute#locking)。
+更多细节见 [Edge View locking](/primitives/attribute#locking)。
 
 ## Override StepOptions for one Step execution {#stepoptions-override-per-stepexecution}
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -162,13 +162,11 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 ## Heartbeat {#heartbeat}
 
-**HeartbeatTimeout** 让拥有较长 method timeout 的 Step 更早失败并安排下一次 attempt。设置 heartbeat timeout 即可使用它。例如，**Execute** method timeout 为 60 秒，**HeartbeatTimeout** 为 10 秒时，Dex 大约 10 秒后就能 retry 这个 Step，而不必等完整的 60 秒。
+**Heartbeat** 让拥有较长 method timeout 的 Step 更早失败并安排下一次 attempt，或更早被 cancel。
 
-它也让 Dex 更早 cancel Step。正在被 cancel 的 Step 不必等到完整 timeout、失败或完成后才被 cancel。
+设置 **HeartbeatTimeout** 即可使用它。
 
-例如，**ExecuteMethodTimeout** 为 60 秒、**HeartbeatTimeout** 为 10 秒时，worker 挂掉后大约 10 秒就能 retry，而不是等一分钟。使用正整数秒 timeout。未设置时关闭 heartbeat。
-
-Local Activity 不会 heartbeat。**ASYNC** 方法 fallback 到普通 Activity 时，使用同一个 heartbeat timeout。
+例如，**Execute** method timeout 为 60 秒，**HeartbeatTimeout** 为 10 秒时，Dex 大约 10 秒后就能 retry 这个 Step，而不必等完整的 60 秒。类似地，正在被 cancel 的 Step 不必等到完整 timeout、失败或完成后才被 cancel。
 
 <SdkTabs
   examples={{

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -313,7 +313,7 @@ Heartbeat 能让取消更早到达普通 handler。它不会让外部 API 调用
 
 Step implementation 返回的 **StepOptions** 默认适用于每一次 Step execution。有时为某一次 Step execution 动态 override 它们会很有用。
 
-要这样做，提供 **StepOptions** override，然后用 **StepDecision** 进入下一个 Step。
+让 **StepDecision** 进入下一个 Steps 时，提供 **StepOptions** override。
 
 <SdkTabs
   examples={{

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -78,11 +78,15 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 
 ## Durability {#durability}
 
-**SYNC** 是默认值。Dex 将方法作为普通 Activity 运行，并在 Flow 继续前记录结果。
+**SYNC** durability 会将 Step completion 同步记录到 Dex Server，并持久化到 storage。
 
-**ASYNC** 会先把方法作为 local Activity 运行。它能省掉短任务的一次 backend round trip。如果 local Activity 没有在 Dex 的 local window 内完成，就会 fallback 到普通 Activity。local attempt 与 fallback 共用同一个 retry budget。
+**ASYNC** durability 会异步完成这件事。每隔几秒，Dex Server 会 flush 累积的 Step completion 并持久化。它减少了 backend database 和 server 的大量开销，因此吞吐量高得多。
 
-用 **FlowConfig** 设置 Flow 级默认值。某一个方法需要不同选择时，设置 **WaitForDurability** 或 **ExecuteDurability**。
+Step 通常应当是 idempotent，所以一般可以安全使用 **ASYNC** durability。它是大多数 Step 的默认值。
+
+使用 recovery failure policy 的 Step 默认使用 **SYNC** durability。业务可能假设 Flow 进入后续的 **Execute** 方法或 recovery Step 后，不会再回到前一个方法。**SYNC** 会先持久化前一个 completion。
+
+用 **FlowConfig** 设置默认 durability。这个默认值不适用于使用 recovery failure policy 的方法。如需 override 这些方法的 durability，在该 Step 的 **StepOptions** 中设置。
 
 <SdkTabs
   examples={{
@@ -155,10 +159,6 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 </SdkSnippet>
 </SdkTabs>
-
-**ASYNC** 方法的 local Activity 运行期间会占用当前 Workflow Task。这可能让 sibling Step 更晚注册 Timer，或更晚处理已经触发的 Timer。Timer 的时机重要时，用 **SYNC**。
-
-一个方法配置了 failure recovery policy 时，除非该方法明确选择 durability，Dex 会使用 **SYNC**。这样能在 **Execute** 或 recovery Step 开始前保护记录下来的 failure。
 
 ## Heartbeat {#heartbeat}
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -8,11 +8,9 @@ slug: /primitives/step/step-options
 
 本页介绍用于深度定制你的 Step type 的 **StepOptions** 进阶功能。基础功能见 [Basic Step](/primitives/step/basic#stepoptions) 页面。
 
-## Custom retry
+## Retry After
 
-通常由 **RetryPolicy** 决定下一次 retry 的间隔。被调用的服务告诉你何时再试时，可以用 custom retry，例如 rate limit 响应带有 retry-after 值。
-
-Custom retry 只改变下一次间隔。它不会重置 retry policy、attempt count 或 method timeout。
+如果要深度定制 retry behavior，使用 **RetryAfter**。它覆盖 **RetryPolicy** 的 retry schedule。
 
 <SdkTabs
   examples={{
@@ -77,8 +75,6 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 
 </SdkSnippet>
 </SdkTabs>
-
-Temporal 支持 custom retry。Cadence 不支持每次 attempt 的 retry 间隔，因此会拒绝它。
 
 ## Durability {#durability}
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -311,9 +311,9 @@ Heartbeat 能让取消更早到达普通 handler。它不会让外部 API 调用
 
 ## 动态提供 StepOptions {#stepoptions-override-per-stepexecution}
 
-Step 返回的 **StepOptions** 适用于它的每次 execution。**StepMovement** 也可以为某一次 execution 携带 options。
+Step implementation 返回的 **StepOptions** 默认适用于每一次 Step execution。有时为某一次 Step execution 动态 override 它们会很有用。
 
-同一个 Step 处在不同 path 时很有用。这里，已注册的 Step 在一次 **WaitFor** attempt 后失败。movement 让这一次 execution 尝试两次，并在失败后继续 **Execute**。
+要这样做，提供 **StepOptions** override，然后用 **StepDecision** 进入下一个 Step。
 
 <SdkTabs
   examples={{

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -6,9 +6,7 @@ slug: /primitives/step/step-options
 
 # Step options
 
-**StepOptions** 用来定制一个 Step。**WaitFor** 与 **Execute** 各自有 timeout、retry、failure policy、durability 和 Attribute lock。
-
-常用的 timeout、retry 和 failure policy 在 [Basic Step](/primitives/step/basic#stepoptions) 里。这一页介绍其他选项。
+本页介绍用于深度定制你的 Step type 的 **StepOptions** 进阶功能。基础功能见 [Basic Step](/primitives/step/basic#stepoptions) 页面。
 
 ## Method timeout and retry
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -6,11 +6,21 @@ slug: /primitives/step/step-options
 
 # Step options
 
-在 StepOptions 上独立配置 WaitFor 与 Execute：方法 timeout、retry policy、retry 耗尽后的 failure policy、durability、heartbeat 与按 StepExecution 覆盖 StepOptions。
+**StepOptions** 用来定制一个 Step。**WaitFor** 与 **Execute** 各自有 timeout、retry、failure policy、durability 和 Attribute lock。
+
+常用的 timeout、retry 和 failure policy 在 [Basic Step](/primitives/step/basic#stepoptions) 里。这一页介绍其他选项。
+
+## Method timeout and retry
+
+**WaitForMethodTimeout** 和 **ExecuteMethodTimeout** 限制对应方法的一次 invocation。它们不限制 Step 等待 Channel、Timer 或 SubFlow condition 的时间。
+
+方法返回 error 或 timeout 时，Dex 会使用 **WaitForRetry** 或 **ExecuteRetry**。retry 会再次调用同一个 Step execution 的同一个方法。retry 耗尽后，由 failure policy 决定 Flow 是否失败、是否继续 **Execute**，或是否启动 recovery Step。见 [Basic Step](/primitives/step/basic#stepoptions)。
 
 ## Custom retry
 
-**不是** failure policy——handler 可在保留当前 attempt 失败的同时请求**下一次 retry 间隔**。
+通常由 **RetryPolicy** 决定下一次 retry 的间隔。被调用的服务告诉你何时再试时，可以用 custom retry，例如 rate limit 响应带有 retry-after 值。
+
+Custom retry 只改变下一次间隔。它不会重置 retry policy、attempt count 或 method timeout。
 
 <SdkTabs
   examples={{
@@ -25,7 +35,7 @@ slug: /primitives/step/step-options
 ```java
 throw RetryAfterException.after(
         Duration.ofSeconds(7),
-        new RuntimeException("retry later"));
+        new IllegalStateException("not ready on attempt " + context.getAttempt()));
 ```
 
 </SdkSnippet>
@@ -76,18 +86,15 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 </SdkSnippet>
 </SdkTabs>
 
-- **Temporal** 将延迟用于下一次 Activity retry，不改变 retry 上限或 method timeout。
-- **Cadence** 以 INVALID_USER_FLOW_CODE 拒绝动态间隔。
-- 在 Temporal 上，**当前 attempt 失败**（而非 RetryAfterException 本身）是上报的 Worker 错误，出现在 lastFailureInfo。
-
-Worker SDK 在 WorkerErrorResponse 上附加 stack_trace 时，Dex Web 在 **Last failure** 下以 originalWorkerErrorStackTrace 显示。Go 应用若要上报 origin stack，用 **dex.ErrorWithStack** 包装 cause（配合 custom retry 时嵌在 **RetryAfter** 里）。Rust 的 **HandlerError** 构造函数会自动捕获 construction-site stack。
-
+Temporal 支持 custom retry。Cadence 不支持每次 attempt 的 retry 间隔，因此会拒绝它。
 
 ## Durability {#durability}
 
-每个 Step 方法可覆盖持久化 durability：**SYNC** 在 handler 返回前等待 Dex 确认 staged write；**ASYNC** 允许 handler 接受结果后再持久化。
+**SYNC** 是默认值。Dex 将方法作为普通 Activity 运行，并在 Flow 继续前记录结果。
 
-未设置时，Dex 使用 FlowConfig 的 Flow 默认，再使用 server 默认。
+**ASYNC** 会先把方法作为 local Activity 运行。它能省掉短任务的一次 backend round trip。如果 local Activity 没有在 Dex 的 local window 内完成，就会 fallback 到普通 Activity。local attempt 与 fallback 共用同一个 retry budget。
+
+用 **FlowConfig** 设置 Flow 级默认值。某一个方法需要不同选择时，设置 **WaitForDurability** 或 **ExecuteDurability**。
 
 <SdkTabs
   examples={{
@@ -161,30 +168,17 @@ fn options(&self) -> StepOptions<Self::Input> {
 </SdkSnippet>
 </SdkTabs>
 
+**ASYNC** 方法的 local Activity 运行期间会占用当前 Workflow Task。这可能让 sibling Step 更晚注册 Timer，或更晚处理已经触发的 Timer。Timer 的时机重要时，用 **SYNC**。
 
-### Local-activity 窗口
-
-**ASYNC** Step 先作为 local activity 运行。Dex 保持当前 Workflow Task 打开，直到 local 阶段返回或达到 local 优化 timeout（约七秒）。该 task 被占用时，sibling Step 的 durable timer 可能比 SYNC 更晚启动。
-
-若 local activity 先成功返回，Dex 在处理 local 阶段内触发的 timer 之前先处理该结果。
-
-配置了 **failure policy recovery 路径**的方法默认为 SYNC。FlowConfig 不能将该默认覆盖为 ASYNC；仅当 recovery 开始后重放失败方法可接受时，才设置显式 method 级覆盖。
-
-:::note Timers and ASYNC Steps
-
-ASYNC Execute 不会阻止 Flow 其他处已注册的 Timer Condition 按时触发。需要与长时 ASYNC 工作无关的 durable deadline 时，优先 **Timer**。handler 可在 local 阶段快速完成或可接受略延迟的 timer 处理时，优先 **ASYNC Execute**。见 [Timer](/primitives/timer)。
-
-:::
+一个方法配置了 failure recovery policy 时，除非该方法明确选择 durability，Dex 会使用 **SYNC**。这样能在 **Execute** 或 recovery Step 开始前保护记录下来的 failure。
 
 ## Heartbeat {#heartbeat}
 
-heartbeat_timeout / HeartbeatTimeout 为常规 WaitFor 与 Execute activity 启用协作式取消。activity 活跃期间 Dex 约每秒调用一次 backend heartbeat API。
+**HeartbeatTimeout** 帮助 Dex 发现执行普通 Activity 的 worker 已经停止。**WaitFor** 或 **Execute** 运行期间，Dex 会 heartbeat。heartbeat 停止后，Dex 不必等到完整 method timeout 才 retry。
 
-在 StepOptions 上配置正整数秒。零或未设置则禁用 heartbeat。Local activity 忽略该选项；ASYNC 回退到常规 execution 时使用。
+例如，**ExecuteMethodTimeout** 为 60 秒、**HeartbeatTimeout** 为 10 秒时，worker 挂掉后大约 10 秒就能 retry，而不是等一分钟。使用正整数秒 timeout。未设置时关闭 heartbeat。
 
-无 heartbeat 时，Dex 可能要等到完整 **method timeout** 才检测到 worker crash。短 heartbeat（如 10s）加长 execute timeout（如 60s）时，crash 可在约一个 heartbeat 间隔内调度下一次 retry，而不必等满一分钟。
-
-取消通过 heartbeat channel 与 Context 取消到达 handler。无 heartbeat 时，handler 可能运行到自然返回或完整 method timeout。
+Local Activity 不会 heartbeat。**ASYNC** 方法 fallback 到普通 Activity 时，使用同一个 heartbeat timeout。
 
 <SdkTabs
   examples={{
@@ -222,20 +216,29 @@ func (step heartbeatStep) Execute(ctx dex.Context, batches int) (*dex.StepDecisi
   <SdkSnippet lang="java">
 
 ```java
-private final StepOptions options = StepOptions.newBuilder()
-        .executeTimeout(Duration.ofSeconds(60))
-        .heartbeatTimeout(Duration.ofSeconds(10))
-        .build();
+@Override
+public StepDecision execute(final Context context, final Integer batches) {
+    for (int batch = 0; batch < batches; batch++) {
+        if (context.isCancellationRequested()) {
+            return StepDecision.deadEnd();
+        }
+        try {
+            Thread.sleep(Duration.ofSeconds(2).toMillis());
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            return StepDecision.deadEnd();
+        }
+    }
+    return StepDecision.gracefulComplete("processed");
+}
 
 @Override
-public StepDecision execute(Context context, Job job) {
-    while (hasNextBatch(job)) {
-        if (Thread.interrupted()) {
-            break;
-        }
-        processBatch(job);
-    }
-    return StepDecision.deadEnd();
+public StepOptions getStepOptions() {
+    return StepOptions.newBuilder()
+            .executeMethodTimeout(Duration.ofSeconds(60))
+            .heartbeatTimeout(Duration.ofSeconds(10))
+            .executeRetry(RetryPolicy.newBuilder().maximumAttempts(3).build())
+            .build();
 }
 ```
 
@@ -243,14 +246,19 @@ public StepDecision execute(Context context, Job job) {
   <SdkSnippet lang="python">
 
 ```python
-options = StepOptions(heartbeat_timeout=timedelta(seconds=10))
+def get_step_options(self) -> StepOptions:
+    return StepOptions(
+        execute_method_timeout=timedelta(seconds=60),
+        heartbeat_timeout=timedelta(seconds=10),
+        execute_retry=RetryPolicy(maximum_attempts=3),
+    )
 
-def execute(self, context: Context, job: Job) -> StepDecision:
-    while has_next_batch(job):
+async def execute(self, context: Context, batches: int) -> StepDecision:
+    for _batch in range(batches):
         if context.is_cancellation_requested():
-            break
-        process_batch(job)
-    return dead_end()
+            return dead_end()
+        await asyncio.sleep(2)
+    return graceful_complete("processed")
 ```
 
 </SdkSnippet>
@@ -261,7 +269,9 @@ public getStepOptions(): StepOptions {
   return {
     executeMethodTimeoutMs: 60_000,
     heartbeatTimeoutMs: 10_000,
-    executeRetry: { maximumAttempts: 3 },
+    executeRetry: {
+      maximumAttempts: 3,
+    },
   };
 }
 
@@ -301,14 +311,21 @@ fn execute(&self, context: &mut Context, batches: Self::Input) -> HandlerResult<
 </SdkSnippet>
 </SdkTabs>
 
+Heartbeat 能让取消更早到达普通 handler。它不会让外部 API 调用原子化。API 需要时，使用幂等或补偿。
 
-Heartbeat 使取消能尽快到达常规 activity；不能使外部 API 调用原子化。按需组合 timeout、幂等或补偿。
+## Attribute locks
 
-## 按 StepExecution 覆盖 StepOptions {#stepoptions-override-per-stepexecution}
+并发的 Step 和 RPC 可以读取同一个 Attribute。一个 handler 要读写共享状态时，声明 **WaitForLockAttributes** 或 **ExecuteLockAttributes**。Dex 会等待列出的 Attribute 或 AttributeMap instance，然后在这个方法 invocation 期间持有这些 lock。
 
-已注册的 StepOptions 适用于 Step 类型的每次 execution。有时某个 **movement** 需要不同的 retry 或 failure 行为——例如 fan-out 子 Step 在 WaitFor 失败时应 proceed，而 sibling 失败 Flow。
+**WaitFor** 与 **Execute** 有独立的 lock set。方法返回时 lock 会释放；Step 等待 condition 时不会一直持有。Attribute definition 必须属于 Flow 的 persistence schema。
 
-在 **StepMovement** / goToMulti / WithStepOptions 上传递 override，使仅该次调度的 execution 使用覆盖。
+RPC 使用同一把 lock，见 [Attribute locking](/primitives/attribute#locking)。
+
+## Override StepOptions for one Step execution {#stepoptions-override-per-stepexecution}
+
+Step 返回的 **StepOptions** 适用于它的每次 execution。**StepMovement** 也可以为某一次 execution 携带 options。
+
+同一个 Step 处在不同 path 时很有用。这里，已注册的 Step 在一次 **WaitFor** attempt 后失败。movement 让这一次 execution 尝试两次，并在失败后继续 **Execute**。
 
 <SdkTabs
   examples={{
@@ -378,7 +395,4 @@ Ok(StepDecision::go_to_many([StepMovement::to_with_options(
 </SdkSnippet>
 </SdkTabs>
 
-目标 Step 已注册 options 仍适用于未覆盖字段。Recovery movement 也可携带自己的 override。
-
-
-movement override 选择 failure policy recovery 路径时，[Durability](#durability) 中的 durability 默认适用于该方法。
+为每次 execution 的 override 提供它需要的所有 option。这样即使已注册 Step 的 options 后来改变，这次 execution 的行为也很清楚。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -382,5 +382,3 @@ Ok(StepDecision::go_to_many([StepMovement::to_with_options(
 
 </SdkSnippet>
 </SdkTabs>
-
-为每次 execution 的 override 提供它需要的所有 option。这样即使已注册 Step 的 options 后来改变，这次 execution 的行为也很清楚。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -8,12 +8,6 @@ slug: /primitives/step/step-options
 
 本页介绍用于深度定制你的 Step type 的 **StepOptions** 进阶功能。基础功能见 [Basic Step](/primitives/step/basic#stepoptions) 页面。
 
-## Method timeout and retry
-
-**WaitForMethodTimeout** 和 **ExecuteMethodTimeout** 限制对应方法的一次 invocation。它们不限制 Step 等待 Channel、Timer 或 SubFlow condition 的时间。
-
-方法返回 error 或 timeout 时，Dex 会使用 **WaitForRetry** 或 **ExecuteRetry**。retry 会再次调用同一个 Step execution 的同一个方法。retry 耗尽后，由 failure policy 决定 Flow 是否失败、是否继续 **Execute**，或是否启动 recovery Step。见 [Basic Step](/primitives/step/basic#stepoptions)。
-
 ## Custom retry
 
 通常由 **RetryPolicy** 决定下一次 retry 的间隔。被调用的服务告诉你何时再试时，可以用 custom retry，例如 rate limit 响应带有 retry-after 值。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -303,11 +303,11 @@ Heartbeat 能让取消更早到达普通 handler。它不会让外部 API 调用
 
 ## Attribute locks
 
-并发 Step 和 RPC invocation 可以读取和写入同一个 Attribute。这可能导致 race condition。要避免它，使用 Edge View lock。Dex Server 会确保同一时间只有一个 Step execution 或 RPC handling 能 acquire 这个 lock。
+并发 Step 和 RPC invocation 可以读取和写入同一个 Attribute。这可能导致 race condition。要避免它，使用 Attribute lock。Dex Server 会确保同一时间只有一个 Step execution 或 RPC handling 能 acquire 这个 lock。
 
 **WaitFor** 与 **Execute** 有独立的 lock set。通过返回 **StepOptions** 设置它们。
 
-更多细节见 [Edge View locking](/primitives/attribute#locking)。
+更多细节见 [Attribute locking](/primitives/attribute#locking)。
 
 ## Override StepOptions for one Step execution {#stepoptions-override-per-stepexecution}
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -162,7 +162,9 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 ## Heartbeat {#heartbeat}
 
-**HeartbeatTimeout** 帮助 Dex 发现执行普通 Activity 的 worker 已经停止。**WaitFor** 或 **Execute** 运行期间，Dex 会 heartbeat。heartbeat 停止后，Dex 不必等到完整 method timeout 才 retry。
+**HeartbeatTimeout** 让拥有较长 method timeout 的 Step 更早失败并安排下一次 attempt。设置 heartbeat timeout 即可使用它。例如，**Execute** method timeout 为 60 秒，**HeartbeatTimeout** 为 10 秒时，Dex 大约 10 秒后就能 retry 这个 Step，而不必等完整的 60 秒。
+
+它也让 Dex 更早 cancel Step。正在被 cancel 的 Step 不必等到完整 timeout、失败或完成后才被 cancel。
 
 例如，**ExecuteMethodTimeout** 为 60 秒、**HeartbeatTimeout** 为 10 秒时，worker 挂掉后大约 10 秒就能 retry，而不是等一分钟。使用正整数秒 timeout。未设置时关闭 heartbeat。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/waiting-condition.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/waiting-condition.mdx
@@ -1,6 +1,6 @@
 ---
 title: 等待
-sidebar_label: 等待
+sidebar_label: Waiting
 slug: /primitives/step/waiting-condition
 ---
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "npm run build && npm run serve",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
## Summary

- Rewrite the Step Decision page around multiple next Steps, Flow-closing decisions, cancellation, and Channel draining.
- Rewrite Step Options around method timeout and retry, custom retry, durability, heartbeat, Attribute locks, and per-execution overrides.
- Keep the Simplified Chinese pages and all five SDK snippets in sync with runnable examples.

## Rationale

The old pages mixed basic and advanced behavior, and the Step Options page omitted Attribute lock behavior. The new structure keeps Basic Step focused on the common failure policy and gives the advanced options their own explanations.

## User impact

Readers can choose the right close decision, understand cancellation scope, distinguish method timeout from durable waiting, and configure Step durability, heartbeats, locks, and per-execution behavior.

## Validation

- `make docs-prose-check`
- `npm -C docs run check`
