### PR TITLE
Rewrite RPC documentation

### DIFF
--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -95,6 +95,14 @@ impl RpcFlow {
 </SdkSnippet>
 </SdkTabs>
 
+### Java and Kotlin
+
+**Client.newRpcStub** creates a subclass of the Flow. A Java Flow class and its RPC methods must not be final. Kotlin makes both final by default, so declare the Flow class and its RPC methods with **open**.
+
+### TypeScript codecs
+
+TypeScript uses JSON when **inputCodec** or **outputCodec** is omitted. Provide a codec when the input or output is not JSON, including scalar values such as strings, numbers, booleans, and bigints.
+
 ## Invoke an RPC
 
 Pass the registered RPC method, Flow ID, and typed input to the Client. The call waits until the Worker handler returns. On success, the Client decodes **RPCResult.output**.

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -3,11 +3,17 @@ title: RPC
 slug: /primitives/rpc
 ---
 
+import RpcRequestDiagram from '@site/src/components/primitives/rpc/RpcRequestDiagram';
+
 # RPC
 
-An **RPC** is an external entry point on an active Flow. An application calls it through the Client. Dex Server sends the call to the Flow's Worker, where the method can read or change durable Flow state.
+RPC stands for “Remote Procedure Call”. It allows external systems to interact with a Flow execution.
 
-Use a Step when the Flow moves itself. Use an RPC when an external user or service needs to approve an order, submit input, cancel work, or ask a running Flow for its state.
+A **Client** invokes an RPC. **Dex Server** sends it to a **Worker**. The **Worker** runs it, then returns the result through **Dex Server** to the **Client**.
+
+<RpcRequestDiagram />
+
+RPC can read and write durable state through Attributes, publish Channels, and trigger a brand-new Step to run.
 
 ## Define an RPC
 

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -13,13 +13,9 @@ A **Client** invokes an RPC. **Dex Server** sends it to a **Worker**. The **Work
 
 <RpcRequestDiagram />
 
-RPC can read and write durable state through Attributes, publish Channels, and trigger a brand-new Step to run.
-
 ## Define an RPC
 
-Add an RPC method to the Flow. It receives **Context** and zero or one typed input. It returns a typed **RPCResult**; procedure-style RPCs can return no output.
-
-This RPC stores the submitted message and publishes an internal Channel. The Flow's waiting Step can then continue.
+RPC can read and write durable state through Attributes, publish Channels, and trigger a brand-new Step to run.
 
 <SdkTabs
   examples={{

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -5,41 +5,46 @@ slug: /primitives/rpc
 
 # RPC
 
-An **RPC** is a Worker handler for external read/write against a running Flow. Callers read durable state, mutate it, publish Channels, cancel Steps, and optionally move the Flow — atomically from the caller’s point of view.
+An **RPC** is an external entry point on an active Flow. An application calls it through the Client. Dex Server sends the call to the Flow's Worker, where the method can read or change durable Flow state.
 
-## Why you need it
+Use a Step when the Flow moves itself. Use an RPC when an external user or service needs to approve an order, submit input, cancel work, or ask a running Flow for its state.
 
-External callers need a single request that can inspect and change a live Flow without a separate read API, write API, and “signal” endpoint.
+## Define an RPC
 
-## Declare and invoke
+Add an RPC method to the Flow. It receives **Context** and zero or one typed input. It returns a typed **RPCResult**; procedure-style RPCs can return no output.
 
-Declare **@rpc** / RPC methods on the Flow; invoke via client **InvokeRPC**.
+This RPC stores the submitted message and publishes an internal Channel. The Flow's waiting Step can then continue.
 
-Choose an SDK (preference is sticky in this browser; default Python).
-
-<SdkTabs>
+<SdkTabs
+  examples={{
+    python: 'examples/python/dex_examples/primitives/rpc',
+    go: 'examples/go/primitives/rpc',
+    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/rpc',
+    typescript: 'examples/typescript/src/primitives/rpc',
+    rust: 'examples/rust/src/primitives/rpc',
+  }}>
 <SdkSnippet lang="python">
 
 ```python
 @rpc
-def nudge(self, context, message: str) -> RPCResult:
-    status.set(context, "nudged")
-    unblock.publish(context, message)
-    return RPCResult(output="ok")
+def trigger(self, context: Context, input: str) -> RPCResult[str]:
+    self.data.set(context, input)
+    self.internal.publish(context, None)
+    return RPCResult(input)
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="go">
 
 ```go
-func (f *MyFlow) Nudge(ctx dex.Context, message string) (*dex.RPCResult[string], error) {
-	if err := status.Set(ctx, "nudged"); err != nil {
+func (*RpcFlow) Trigger(ctx dex.Context, input string) (*dex.RPCResult[string], error) {
+	if err := Data.Set(ctx, input); err != nil {
 		return nil, err
 	}
-	if err := unblock.Publish(ctx, message); err != nil {
+	if err := Internal.Publish(ctx, nil); err != nil {
 		return nil, err
 	}
-	return &dex.RPCResult[string]{Output: "ok"}, nil
+	return &dex.RPCResult[string]{Output: input}, nil
 }
 ```
 
@@ -47,11 +52,11 @@ func (f *MyFlow) Nudge(ctx dex.Context, message string) (*dex.RPCResult[string],
   <SdkSnippet lang="java">
 
 ```java
-@RPC(name = "nudge")
-public RPCResult<String> nudge(Context context, String message) {
-    status.set(context, "nudged");
-    unblock.publish(context, message);
-    return RPCResult.of("ok");
+@RPC
+public RPCResult<String> trigger(final Context context, final String input) {
+    data.set(context, input);
+    internal.publish(context, null);
+    return RPCResult.of(input);
 }
 ```
 
@@ -59,46 +64,134 @@ public RPCResult<String> nudge(Context context, String message) {
   <SdkSnippet lang="typescript">
 
 ```typescript
-@rpc({ name: "nudge", inputCodec: stringCodec, outputCodec: stringCodec })
-nudge(context: Context, message: string): RPCResult<string> {
-  this.status.set(context, "nudged");
-  this.unblock.publish(context, message);
-  return { output: "ok" };
+@rpc({ inputCodec: stringCodec, outputCodec: stringCodec })
+public trigger(context: Context, input: string): RPCResult<string> {
+  this.data.set(context, input);
+  internal.publish(context, undefined);
+  return { output: input };
 }
+```
 
-// Client (Promise-based):
-await client.invokeRPC(flow.nudge, flowId, "hello");
+</SdkSnippet>
+  <SdkSnippet lang="rust">
+
+```rust
+impl RpcFlow {
+    fn trigger(&self, context: &mut Context, input: String) -> HandlerResult<RpcResult<String>> {
+        data().set(context, input.clone())?;
+        internal().publish(context, ())?;
+        Ok(RpcResult::new(input))
+    }
+}
 ```
 
 </SdkSnippet>
 </SdkTabs>
 
-RPCs run through the server to the Worker (**InvokeRPC** → Worker **InvokeWorkerRPC**). They are not Step executions; they do not upsert Step locals.
+An RPC is not a Step. It does not run **WaitFor** or **Execute**, and it does not create a **StepExecution**. It can read and write declared Attributes, publish Channels, and return a result that cancels Step types or starts next Steps. Dex applies Attribute and Channel writes first, then cancellation, then next Steps.
 
-An RPC can also cancel Step executions and start next Steps. See [Step cancellation](/primitives/step/step-decision#cancellation-on-stepdecision). For serializing Attribute access from RPCs, see [Attribute locking](/primitives/attribute#locking) and [RPC locking](#rpc-locking).
+## Invoke an RPC
 
-## How Dex implements it
+Pass the registered RPC method, Flow ID, and typed input to the Client. The call waits until the Worker handler returns. On success, the Client decodes **RPCResult.output**.
 
-Non-locking RPCs use a query, Worker call, and optional result signal by default.
-Temporal can route all RPCs through one synchronous Workflow Update by setting
-**api.useTemporalSynchronousUpdateForAllRPCs: true**. Locking RPCs always use the
-Update and are unavailable on Cadence. Once terminal finalization begins, the
-Update validator rejects new RPCs. Large input and output values are stored in
-the configured Blob Store and hydrated when displayed or returned through an SDK.
-Keep the default signal path when Temporal Update concurrency is more important
-than validator rejection and atomic effect commits.
+<SdkTabs
+  examples={{
+    python: 'examples/python/dex_examples/primitives/rpc',
+    go: 'examples/go/primitives/rpc',
+    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/rpc',
+    typescript: 'examples/typescript/src/primitives/rpc',
+    rust: 'examples/rust/src/primitives/rpc',
+  }}>
+<SdkSnippet lang="python">
 
-Successful Updates always contain RPC input and output. Signal history includes
-them only when **api.includeRPCInputOutputIntoHistory** is enabled. Values above the
-Blob Store threshold are stored as references and hydrated by Dex clients, Dex
-Web, and dexcli.
+```python
+result = await app_state.client.invoke_rpc(
+    app_state.rpc.trigger,
+    required_query("workflowId"),
+    required_query("message"),
+)
+return result
+```
 
-## RPC locking
+</SdkSnippet>
+  <SdkSnippet lang="go">
 
-RPC atomicity means the Worker handler runs with requested Attribute locks so concurrent Steps/RPCs cannot interleave conflicting writes.
+```go
+var output string
+err := controller.client.InvokeRPC(
+	request.Request.Context(),
+	flowID,
+	controller.flow.Trigger,
+	message,
+	&output,
+	sdk.InvokeOptions{},
+)
+httputil.RespondString(request, output, err)
+```
 
-Lock only the Attributes you need. Over-locking reduces concurrency; under-locking races.
+</SdkSnippet>
+  <SdkSnippet lang="java">
+
+```java
+final RpcFlow stub = client.newRpcStub(RpcFlow.class, workflowId);
+return ResponseEntity.ok(client.invokeRPC(stub::trigger, message));
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="typescript">
+
+```typescript
+const result = await client.invokeRPC(rpcFlow.trigger, workflowId, message);
+response.send(result);
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="rust">
+
+```rust
+match run_blocking(move || client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)) {
+    Ok(result) => ok_text(result),
+    Err(error) => map_sdk_error(error).into_response(),
+}
+```
+
+</SdkSnippet>
+</SdkTabs>
+
+The target Flow must still be active. A missing or completed Flow is rejected. If the Worker handler fails or exceeds its timeout, the Client returns a Worker invocation error.
+
+An RPC call has a request ID. Retrying by calling the Client again is a new RPC call, so make any external business side effect idempotent when the caller may retry after a lost response.
+
+## Advanced
+
+### RPC timeout
+
+An RPC timeout limits one Worker handler invocation. It is not a Flow timeout and does not close the Flow. Set one when the caller needs a shorter bound than the Dex Server default.
+
+Python, Java, TypeScript, and Rust declare the timeout with the RPC handler. Go passes it in **InvokeOptions** for each Client invocation. When the application does not set a timeout, Dex Server uses its default.
+
+Timeout is not a retry policy. A timed-out handler returns an error to the caller. If the endpoint retries the Client call, it should use an idempotency key in its own business operation.
+
+### Attribute locks
+
+RPCs do not lock Attributes by default. A simple write, such as the example above, does not need a lock. A read-modify-write operation usually does.
+
+For example, an RPC that reads a balance, adds an amount, and writes the balance back must lock that Attribute. Otherwise a Step or another RPC can read the same old balance and overwrite the first result.
+
+Declare only the Attributes or AttributeMap instances the RPC changes as a read-modify-write unit. Python, Java, TypeScript, and Rust declare locks with the RPC handler. Go passes **InvokeOptions.LockAttributes** to **InvokeRPC**.
+
+Dex Server attempts to acquire all requested locks before the Worker handler runs. It does not wait for them. If one is already held, the call returns an RPC lock-conflict error; the caller can retry with its own backoff. Locks apply within one Flow and are released when the invocation finishes.
+
+Locking RPCs require Temporal. Cadence does not support them.
+
+### How Dex Server runs an RPC
+
+Dex Server resolves the active Run, loads the Flow state, and dispatches the handler to the Worker. The Worker returns the output together with Attribute writes, Channel messages, cancellation, and next-Step movements. Dex Server then records those Flow changes.
+
+For a normal RPC without locks, Dex Server uses a query, Worker call, and signal to apply Flow changes. A Temporal deployment can set **api.useTemporalSynchronousUpdateForAllRPCs** to run every RPC through a synchronous Update. Locking RPCs always use that Update path. Once terminal finalization begins, the Update path rejects new RPCs.
+
+You normally do not need to choose this path. Keep the default unless you operate Dex Server and need the Update path's validation and commit behavior for every RPC.
 
 ## Traditional workarounds
 
-Without Dex: separate read APIs, write APIs, and “signal” endpoints with careful locking — often inconsistent under concurrency.
+Without RPC, an application usually builds separate read APIs, write APIs, and signal endpoints around a Flow, then adds its own concurrency control. Those APIs can observe or change different versions of the Flow. An RPC keeps the external operation next to the Flow code and lets Dex Server deliver it to the right Worker.

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -105,8 +105,6 @@ TypeScript uses JSON when **inputCodec** or **outputCodec** is omitted. Provide 
 
 ## Invoke an RPC
 
-Pass the registered RPC method, Flow ID, and typed input to the Client. The call waits until the Worker handler returns. On success, the Client decodes **RPCResult.output**.
-
 <SdkTabs
   examples={{
     python: 'examples/python/dex_examples/primitives/rpc',
@@ -160,10 +158,6 @@ let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 
 </SdkSnippet>
 </SdkTabs>
-
-The target Flow must still be active. A missing or completed Flow is rejected. If the Worker handler fails or exceeds its timeout, the Client returns a Worker invocation error.
-
-An RPC call has a request ID. Retrying by calling the Client again is a new RPC call, so make any external business side effect idempotent when the caller may retry after a lost response.
 
 ## Advanced
 

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -13,7 +13,7 @@ A **Client** invokes an RPC. **Dex Server** sends it to a **Worker**. The **Work
 
 <RpcRequestDiagram />
 
-## Define an RPC
+## Define and Invoke an RPC
 
 RPC can read and write durable state through Attributes, publish Channels, and trigger a brand-new Step to run.
 
@@ -102,8 +102,6 @@ impl RpcFlow {
 ### TypeScript codecs
 
 TypeScript uses JSON when **inputCodec** or **outputCodec** is omitted. Provide a codec when the input or output is not JSON, including scalar values such as strings, numbers, booleans, and bigints.
-
-## Invoke an RPC
 
 <SdkTabs
   examples={{

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -31,8 +31,8 @@ RPC can read and write durable state through Attributes, publish Channels, and t
 @rpc
 def trigger(self, context: Context, input: str) -> RPCResult[str]:
     self.data.set(context, input)
-    self.internal.publish(context, None)
-    return RPCResult(input)
+    self.example_ch.publish(context, None)
+    return RPCResult(input, next_steps=(StepMovement.of(self.example_step, input),))
 ```
 
 </SdkSnippet>
@@ -43,10 +43,15 @@ func (*RpcFlow) Trigger(ctx dex.Context, input string) (*dex.RPCResult[string], 
 	if err := Data.Set(ctx, input); err != nil {
 		return nil, err
 	}
-	if err := Internal.Publish(ctx, nil); err != nil {
+	if err := ExampleCh.Publish(ctx, nil); err != nil {
 		return nil, err
 	}
-	return &dex.RPCResult[string]{Output: input}, nil
+	return &dex.RPCResult[string]{
+		Output: input,
+		NextSteps: []dex.StepMovement{
+			dex.MovementOf(exampleStep{}, input),
+		},
+	}, nil
 }
 ```
 
@@ -57,8 +62,8 @@ func (*RpcFlow) Trigger(ctx dex.Context, input string) (*dex.RPCResult[string], 
 @RPC
 public RPCResult<String> trigger(final Context context, final String input) {
     data.set(context, input);
-    internal.publish(context, null);
-    return RPCResult.of(input);
+    exampleCh.publish(context, null);
+    return RPCResult.of(input, StepMovement.of(exampleStep, input));
 }
 ```
 
@@ -69,8 +74,8 @@ public RPCResult<String> trigger(final Context context, final String input) {
 @rpc({ inputCodec: stringCodec, outputCodec: stringCodec })
 public trigger(context: Context, input: string): RPCResult<string> {
   this.data.set(context, input);
-  internal.publish(context, undefined);
-  return { output: input };
+  exampleCh.publish(context, undefined);
+  return { output: input, nextSteps: [StepMovement.of(this.exampleStep, input)] };
 }
 ```
 
@@ -81,16 +86,14 @@ public trigger(context: Context, input: string): RPCResult<string> {
 impl RpcFlow {
     fn trigger(&self, context: &mut Context, input: String) -> HandlerResult<RpcResult<String>> {
         data().set(context, input.clone())?;
-        internal().publish(context, ())?;
-        Ok(RpcResult::new(input))
+        example_ch().publish(context, ())?;
+        Ok(RpcResult::new(input.clone()).then(StepMovement::to(&self.example_step, input)))
     }
 }
 ```
 
 </SdkSnippet>
 </SdkTabs>
-
-An RPC is not a Step. It does not run **WaitFor** or **Execute**, and it does not create a **StepExecution**. It can read and write declared Attributes, publish Channels, and return a result that cancels Step types or starts next Steps. Dex applies Attribute and Channel writes first, then cancellation, then next Steps.
 
 ## Invoke an RPC
 

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -118,54 +118,44 @@ Pass the registered RPC method, Flow ID, and typed input to the Client. The call
 <SdkSnippet lang="python">
 
 ```python
-result = await app_state.client.invoke_rpc(
-    app_state.rpc.trigger,
-    required_query("workflowId"),
-    required_query("message"),
-)
-return result
+result = await client.invoke_rpc(flow.trigger, flow_id, message)
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="go">
 
 ```go
-var output string
-err := controller.client.InvokeRPC(
-	request.Request.Context(),
+var result string
+err := client.InvokeRPC(
+	ctx,
 	flowID,
-	controller.flow.Trigger,
+	flow.Trigger,
 	message,
-	&output,
+	&result,
 	sdk.InvokeOptions{},
 )
-httputil.RespondString(request, output, err)
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="java">
 
 ```java
-final RpcFlow stub = client.newRpcStub(RpcFlow.class, workflowId);
-return ResponseEntity.ok(client.invokeRPC(stub::trigger, message));
+final RpcFlow flow = client.newRpcStub(RpcFlow.class, flowId);
+final String result = client.invokeRPC(flow::trigger, message);
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="typescript">
 
 ```typescript
-const result = await client.invokeRPC(rpcFlow.trigger, workflowId, message);
-response.send(result);
+const result = await client.invokeRPC(flow.trigger, flowId, message);
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="rust">
 
 ```rust
-match run_blocking(move || client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)) {
-    Ok(result) => ok_text(result),
-    Err(error) => map_sdk_error(error).into_response(),
-}
+let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 ```
 
 </SdkSnippet>

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -103,6 +103,8 @@ impl RpcFlow {
 
 TypeScript uses JSON when **inputCodec** or **outputCodec** is omitted. Provide a codec when the input or output is not JSON, including scalar values such as strings, numbers, booleans, and bigints.
 
+Then invoke the RPC like below example:
+
 <SdkTabs
   examples={{
     python: 'examples/python/dex_examples/primitives/rpc',

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -9,7 +9,7 @@ import RpcRequestDiagram from '@site/src/components/primitives/rpc/RpcRequestDia
 
 RPC stands for “Remote Procedure Call”. It allows external systems to interact with a Flow execution.
 
-A **Client** invokes an RPC. **Dex Server** sends it to a **Worker**. The **Worker** runs it, then returns the result through **Dex Server** to the **Client**.
+A **Client** invokes an RPC. **Dex Server** sends it to a **Worker**. The **Worker** runs it, then returns the result to **Dex Server** to persist. **Dex Server** then returns the output to the **Client**.
 
 <RpcRequestDiagram />
 

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -161,20 +161,55 @@ let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 
 ## RPC timeout
 
-An RPC timeout limits one Worker handler invocation. It is not a Flow timeout and does not close the Flow. Set one when the caller needs a shorter bound than the Dex Server default.
+An RPC timeout limits one Worker handler invocation.
 
-Python, Java, TypeScript, and Rust declare the timeout with the RPC handler. Go passes it in **InvokeOptions** for each Client invocation. When the application does not set a timeout, Dex Server uses its default.
+Python, Java, TypeScript, and Rust declare the timeout with the RPC handler. Go passes it in **InvokeOptions** for each Client invocation. When the application does not set a timeout, Dex Server uses its default. The default maximum is 60 seconds.
 
-Timeout is not a retry policy. A timed-out handler returns an error to the caller. If the endpoint retries the Client call, it should use an idempotency key in its own business operation.
+<SdkTabs
+  examples={{
+    python: 'examples/python/dex_examples/primitives/rpc',
+    go: 'examples/go/primitives/rpc',
+    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/rpc',
+    typescript: 'examples/typescript/src/primitives/rpc',
+    rust: 'examples/rust/src/primitives/rpc',
+  }}>
+<SdkSnippet lang="python">
+
+```python
+@rpc(timeout=timedelta(seconds=30))
+```
+
+</SdkSnippet>
+<SdkSnippet lang="go">
+
+```go
+sdk.InvokeOptions{Timeout: 30 * time.Second}
+```
+
+</SdkSnippet>
+<SdkSnippet lang="java">
+
+```java
+@RPC(timeoutSeconds = 30)
+```
+
+</SdkSnippet>
+<SdkSnippet lang="typescript">
+
+```typescript
+@rpc({ inputCodec: stringCodec, outputCodec: stringCodec, timeoutMs: 30_000 })
+```
+
+</SdkSnippet>
+<SdkSnippet lang="rust">
+
+```rust
+RpcList::new().function(RPC_TRIGGER.timeout(Duration::from_secs(30)), Self::trigger)
+```
+
+</SdkSnippet>
+</SdkTabs>
 
 ## Attribute locks
 
-RPCs do not lock Attributes by default. A simple write, such as the example above, does not need a lock. A read-modify-write operation usually does.
-
-For example, an RPC that reads a balance, adds an amount, and writes the balance back must lock that Attribute. Otherwise a Step or another RPC can read the same old balance and overwrite the first result.
-
-Declare only the Attributes or AttributeMap instances the RPC changes as a read-modify-write unit. Python, Java, TypeScript, and Rust declare locks with the RPC handler. Go passes **InvokeOptions.LockAttributes** to **InvokeRPC**.
-
-Dex Server attempts to acquire all requested locks before the Worker handler runs. It does not wait for them. If one is already held, the call returns an RPC lock-conflict error; the caller can retry with its own backoff. Locks apply within one Flow and are released when the invocation finishes.
-
-Locking RPCs require Temporal. Cadence does not support them.
+See [Locking](/primitives/attribute#locking) for Attribute locks.

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -157,9 +157,7 @@ let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 </SdkSnippet>
 </SdkTabs>
 
-## Advanced
-
-### RPC timeout
+## RPC timeout
 
 An RPC timeout limits one Worker handler invocation. It is not a Flow timeout and does not close the Flow. Set one when the caller needs a shorter bound than the Dex Server default.
 
@@ -167,7 +165,7 @@ Python, Java, TypeScript, and Rust declare the timeout with the RPC handler. Go 
 
 Timeout is not a retry policy. A timed-out handler returns an error to the caller. If the endpoint retries the Client call, it should use an idempotency key in its own business operation.
 
-### Attribute locks
+## Attribute locks
 
 RPCs do not lock Attributes by default. A simple write, such as the example above, does not need a lock. A read-modify-write operation usually does.
 
@@ -178,15 +176,3 @@ Declare only the Attributes or AttributeMap instances the RPC changes as a read-
 Dex Server attempts to acquire all requested locks before the Worker handler runs. It does not wait for them. If one is already held, the call returns an RPC lock-conflict error; the caller can retry with its own backoff. Locks apply within one Flow and are released when the invocation finishes.
 
 Locking RPCs require Temporal. Cadence does not support them.
-
-### How Dex Server runs an RPC
-
-Dex Server resolves the active Run, loads the Flow state, and dispatches the handler to the Worker. The Worker returns the output together with Attribute writes, Channel messages, cancellation, and next-Step movements. Dex Server then records those Flow changes.
-
-For a normal RPC without locks, Dex Server uses a query, Worker call, and signal to apply Flow changes. A Temporal deployment can set **api.useTemporalSynchronousUpdateForAllRPCs** to run every RPC through a synchronous Update. Locking RPCs always use that Update path. Once terminal finalization begins, the Update path rejects new RPCs.
-
-You normally do not need to choose this path. Keep the default unless you operate Dex Server and need the Update path's validation and commit behavior for every RPC.
-
-## Traditional workarounds
-
-Without RPC, an application usually builds separate read APIs, write APIs, and signal endpoints around a Flow, then adds its own concurrency control. Those APIs can observe or change different versions of the Flow. An RPC keeps the external operation next to the Flow code and lets Dex Server deliver it to the right Worker.

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -95,6 +95,14 @@ impl RpcFlow {
 </SdkSnippet>
 </SdkTabs>
 
+### Java 和 Kotlin
+
+**Client.newRpcStub** 会创建 Flow 的子类。Java Flow class 和它的 RPC method 都不能是 final。Kotlin 默认将两者都设为 final，所以要将 Flow class 和它的 RPC method 声明为 **open**。
+
+### TypeScript codec
+
+TypeScript 未设置 **inputCodec** 或 **outputCodec** 时会使用 JSON。input 或 output 不是 JSON 时需要提供 codec，包括 string、number、boolean 和 bigint 等 scalar value。
+
 ## 调用 RPC
 
 向 Client 传入已注册的 RPC method、Flow ID 和 typed input。调用会等待 Worker handler 返回；成功后 Client 解码 **RPCResult.output**。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -161,20 +161,55 @@ let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 
 ## RPC timeout
 
-RPC timeout 限制一次 Worker handler invocation。它不是 Flow timeout，也不会关闭 Flow。调用方需要比 Dex Server default 更短的上限时再设置。
+RPC timeout 限制一次 Worker handler invocation。
 
-Python、Java、TypeScript 和 Rust 在 RPC handler 上声明 timeout。Go 在每次 Client 调用的 **InvokeOptions** 中传入。应用不设置 timeout 时，Dex Server 使用自己的 default。
+Python、Java、TypeScript 和 Rust 在 RPC handler 上声明 timeout。Go 在每次 Client 调用的 **InvokeOptions** 中传入。应用不设置 timeout 时，Dex Server 使用自己的 default。默认最大值为 60 秒。
 
-Timeout 不是 retry policy。handler timeout 后会向调用方返回 error。endpoint 如果要 retry Client 调用，应在自己的业务操作中使用 idempotency key。
+<SdkTabs
+  examples={{
+    python: 'examples/python/dex_examples/primitives/rpc',
+    go: 'examples/go/primitives/rpc',
+    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/rpc',
+    typescript: 'examples/typescript/src/primitives/rpc',
+    rust: 'examples/rust/src/primitives/rpc',
+  }}>
+<SdkSnippet lang="python">
+
+```python
+@rpc(timeout=timedelta(seconds=30))
+```
+
+</SdkSnippet>
+<SdkSnippet lang="go">
+
+```go
+sdk.InvokeOptions{Timeout: 30 * time.Second}
+```
+
+</SdkSnippet>
+<SdkSnippet lang="java">
+
+```java
+@RPC(timeoutSeconds = 30)
+```
+
+</SdkSnippet>
+<SdkSnippet lang="typescript">
+
+```typescript
+@rpc({ inputCodec: stringCodec, outputCodec: stringCodec, timeoutMs: 30_000 })
+```
+
+</SdkSnippet>
+<SdkSnippet lang="rust">
+
+```rust
+RpcList::new().function(RPC_TRIGGER.timeout(Duration::from_secs(30)), Self::trigger)
+```
+
+</SdkSnippet>
+</SdkTabs>
 
 ## Attribute locks
 
-RPC 默认不锁 Attribute。像上面的简单写入不需要锁。read-modify-write 通常需要。
-
-例如，一个 RPC 读取 balance、加上金额后写回 balance，就必须锁住这个 Attribute。否则 Step 或另一个 RPC 可能读取同一个旧 balance，然后覆盖前一个结果。
-
-只声明构成一个 read-modify-write 操作的 Attribute 或 AttributeMap instance。Python、Java、TypeScript 和 Rust 在 RPC handler 上声明 lock。Go 通过 **InvokeRPC** 的 **InvokeOptions.LockAttributes** 传入。
-
-Dex Server 会在 Worker handler 开始前尝试一次性获取所有声明的 lock，不会等待。任何一个 lock 已被占用时，调用返回 RPC lock-conflict error；调用方可以按自己的 backoff retry。lock 只在一个 Flow 内生效，并在 invocation 结束时释放。
-
-locking RPC 需要 Temporal。Cadence 不支持。
+Attribute lock 请参阅 [Locking](/primitives/attribute#locking)。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -1,0 +1,197 @@
+---
+title: RPC
+slug: /primitives/rpc
+---
+
+# RPC
+
+**RPC** 是 active Flow 的外部入口。应用通过 Client 调用它。Dex Server 将调用发给 Flow 的 Worker；这个方法可以读取或修改 durable Flow state。
+
+Flow 自己推进时用 Step。外部用户或服务需要批准订单、提交输入、取消工作，或查询运行中的 Flow state 时用 RPC。
+
+## 定义 RPC
+
+在 Flow 上添加一个 RPC 方法。它接收 **Context** 和零或一个 typed input，返回 typed **RPCResult**；procedure-style RPC 也可以不返回 output。
+
+下面的 RPC 保存提交的 message，并发布一个内部 Channel。正在等待的 Step 就可以继续。
+
+<SdkTabs
+  examples={{
+    python: 'examples/python/dex_examples/primitives/rpc',
+    go: 'examples/go/primitives/rpc',
+    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/rpc',
+    typescript: 'examples/typescript/src/primitives/rpc',
+    rust: 'examples/rust/src/primitives/rpc',
+  }}>
+<SdkSnippet lang="python">
+
+```python
+@rpc
+def trigger(self, context: Context, input: str) -> RPCResult[str]:
+    self.data.set(context, input)
+    self.internal.publish(context, None)
+    return RPCResult(input)
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="go">
+
+```go
+func (*RpcFlow) Trigger(ctx dex.Context, input string) (*dex.RPCResult[string], error) {
+	if err := Data.Set(ctx, input); err != nil {
+		return nil, err
+	}
+	if err := Internal.Publish(ctx, nil); err != nil {
+		return nil, err
+	}
+	return &dex.RPCResult[string]{Output: input}, nil
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="java">
+
+```java
+@RPC
+public RPCResult<String> trigger(final Context context, final String input) {
+    data.set(context, input);
+    internal.publish(context, null);
+    return RPCResult.of(input);
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="typescript">
+
+```typescript
+@rpc({ inputCodec: stringCodec, outputCodec: stringCodec })
+public trigger(context: Context, input: string): RPCResult<string> {
+  this.data.set(context, input);
+  internal.publish(context, undefined);
+  return { output: input };
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="rust">
+
+```rust
+impl RpcFlow {
+    fn trigger(&self, context: &mut Context, input: String) -> HandlerResult<RpcResult<String>> {
+        data().set(context, input.clone())?;
+        internal().publish(context, ())?;
+        Ok(RpcResult::new(input))
+    }
+}
+```
+
+</SdkSnippet>
+</SdkTabs>
+
+RPC 不是 Step。它不会执行 **WaitFor** 或 **Execute**，也不会创建 **StepExecution**。它可以读取和写入已声明的 Attribute、发布 Channel，并返回用于取消 Step type 或启动下一个 Step 的结果。Dex 会先应用 Attribute 和 Channel 写入，再取消 Step，最后调度下一个 Step。
+
+## 调用 RPC
+
+向 Client 传入已注册的 RPC method、Flow ID 和 typed input。调用会等待 Worker handler 返回；成功后 Client 解码 **RPCResult.output**。
+
+<SdkTabs
+  examples={{
+    python: 'examples/python/dex_examples/primitives/rpc',
+    go: 'examples/go/primitives/rpc',
+    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/rpc',
+    typescript: 'examples/typescript/src/primitives/rpc',
+    rust: 'examples/rust/src/primitives/rpc',
+  }}>
+<SdkSnippet lang="python">
+
+```python
+result = await app_state.client.invoke_rpc(
+    app_state.rpc.trigger,
+    required_query("workflowId"),
+    required_query("message"),
+)
+return result
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="go">
+
+```go
+var output string
+err := controller.client.InvokeRPC(
+	request.Request.Context(),
+	flowID,
+	controller.flow.Trigger,
+	message,
+	&output,
+	sdk.InvokeOptions{},
+)
+httputil.RespondString(request, output, err)
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="java">
+
+```java
+final RpcFlow stub = client.newRpcStub(RpcFlow.class, workflowId);
+return ResponseEntity.ok(client.invokeRPC(stub::trigger, message));
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="typescript">
+
+```typescript
+const result = await client.invokeRPC(rpcFlow.trigger, workflowId, message);
+response.send(result);
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="rust">
+
+```rust
+match run_blocking(move || client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)) {
+    Ok(result) => ok_text(result),
+    Err(error) => map_sdk_error(error).into_response(),
+}
+```
+
+</SdkSnippet>
+</SdkTabs>
+
+目标 Flow 必须仍然 active。不存在或已经完成的 Flow 会被拒绝。Worker handler 失败或超过 timeout 时，Client 会返回 Worker invocation error。
+
+每次 RPC 调用都有 request ID。再次调用 Client 来 retry 是一次新的 RPC 调用。因此如果调用方可能在丢失 response 后 retry，外部业务 side effect 要自己保证 idempotent。
+
+## Advanced
+
+### RPC timeout
+
+RPC timeout 限制一次 Worker handler invocation。它不是 Flow timeout，也不会关闭 Flow。调用方需要比 Dex Server default 更短的上限时再设置。
+
+Python、Java、TypeScript 和 Rust 在 RPC handler 上声明 timeout。Go 在每次 Client 调用的 **InvokeOptions** 中传入。应用不设置 timeout 时，Dex Server 使用自己的 default。
+
+Timeout 不是 retry policy。handler timeout 后会向调用方返回 error。endpoint 如果要 retry Client 调用，应在自己的业务操作中使用 idempotency key。
+
+### Attribute locks
+
+RPC 默认不锁 Attribute。像上面的简单写入不需要锁。read-modify-write 通常需要。
+
+例如，一个 RPC 读取 balance、加上金额后写回 balance，就必须锁住这个 Attribute。否则 Step 或另一个 RPC 可能读取同一个旧 balance，然后覆盖前一个结果。
+
+只声明构成一个 read-modify-write 操作的 Attribute 或 AttributeMap instance。Python、Java、TypeScript 和 Rust 在 RPC handler 上声明 lock。Go 通过 **InvokeRPC** 的 **InvokeOptions.LockAttributes** 传入。
+
+Dex Server 会在 Worker handler 开始前尝试一次性获取所有声明的 lock，不会等待。任何一个 lock 已被占用时，调用返回 RPC lock-conflict error；调用方可以按自己的 backoff retry。lock 只在一个 Flow 内生效，并在 invocation 结束时释放。
+
+locking RPC 需要 Temporal。Cadence 不支持。
+
+### Dex Server 如何执行 RPC
+
+Dex Server 先解析 active Run，加载 Flow state，再将 handler 发给 Worker。Worker 返回 output，以及 Attribute write、Channel message、cancellation 和 next-Step movement。Dex Server 再记录这些 Flow change。
+
+普通的无锁 RPC 默认通过 query、Worker call 和 signal 应用 Flow change。Temporal deployment 可以设置 **api.useTemporalSynchronousUpdateForAllRPCs**，让所有 RPC 都走 synchronous Update。locking RPC 总是走 Update path。terminal finalization 开始后，Update path 会拒绝新的 RPC。
+
+通常不需要选择这条 path。除非你在运营 Dex Server，并且每个 RPC 都需要 Update path 的 validation 和 commit behavior，否则保持 default。
+
+## Traditional workarounds
+
+没有 RPC 时，应用通常围绕 Flow 写单独的 read API、write API 和 signal endpoint，再自己处理并发控制。这些 API 很容易读到或修改 Flow 的不同版本。RPC 把外部操作放在 Flow code 旁边，并让 Dex Server 将它送到正确的 Worker。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -13,13 +13,9 @@ RPC 是 “Remote Procedure Call” 的缩写，允许外部系统与 Flow execu
 
 <RpcRequestDiagram />
 
-RPC 可以通过 Attribute 读取和写入 durable state、向 Channel publish，也可以 trigger 一个全新的 Step 来运行。
-
 ## 定义 RPC
 
-在 Flow 上添加一个 RPC 方法。它接收 **Context** 和零或一个 typed input，返回 typed **RPCResult**；procedure-style RPC 也可以不返回 output。
-
-下面的 RPC 保存提交的 message，并发布一个内部 Channel。正在等待的 Step 就可以继续。
+RPC 可以通过 Attribute 读取和写入 durable state、向 Channel publish，也可以 trigger 一个全新的 Step 来运行。
 
 <SdkTabs
   examples={{

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -103,6 +103,8 @@ impl RpcFlow {
 
 TypeScript 未设置 **inputCodec** 或 **outputCodec** 时会使用 JSON。input 或 output 不是 JSON 时需要提供 codec，包括 string、number、boolean 和 bigint 等 scalar value。
 
+然后像下面的例子一样调用 RPC：
+
 <SdkTabs
   examples={{
     python: 'examples/python/dex_examples/primitives/rpc',

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -9,7 +9,7 @@ import RpcRequestDiagram from '@site/src/components/primitives/rpc/RpcRequestDia
 
 RPC 是 “Remote Procedure Call” 的缩写，允许外部系统与 Flow execution 交互。
 
-**Client** 发起 RPC。**Dex Server** 将它发送给 **Worker**。**Worker** 执行后，再经 **Dex Server** 将结果返回给 **Client**。
+**Client** 发起 RPC。**Dex Server** 将它发送给 **Worker**。**Worker** 执行后，将结果返回给 **Dex Server** 持久化。**Dex Server** 再将输出返回给 **Client**。
 
 <RpcRequestDiagram />
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -31,8 +31,8 @@ RPC 可以通过 Attribute 读取和写入 durable state、向 Channel publish�
 @rpc
 def trigger(self, context: Context, input: str) -> RPCResult[str]:
     self.data.set(context, input)
-    self.internal.publish(context, None)
-    return RPCResult(input)
+    self.example_ch.publish(context, None)
+    return RPCResult(input, next_steps=(StepMovement.of(self.example_step, input),))
 ```
 
 </SdkSnippet>
@@ -43,10 +43,15 @@ func (*RpcFlow) Trigger(ctx dex.Context, input string) (*dex.RPCResult[string], 
 	if err := Data.Set(ctx, input); err != nil {
 		return nil, err
 	}
-	if err := Internal.Publish(ctx, nil); err != nil {
+	if err := ExampleCh.Publish(ctx, nil); err != nil {
 		return nil, err
 	}
-	return &dex.RPCResult[string]{Output: input}, nil
+	return &dex.RPCResult[string]{
+		Output: input,
+		NextSteps: []dex.StepMovement{
+			dex.MovementOf(exampleStep{}, input),
+		},
+	}, nil
 }
 ```
 
@@ -57,8 +62,8 @@ func (*RpcFlow) Trigger(ctx dex.Context, input string) (*dex.RPCResult[string], 
 @RPC
 public RPCResult<String> trigger(final Context context, final String input) {
     data.set(context, input);
-    internal.publish(context, null);
-    return RPCResult.of(input);
+    exampleCh.publish(context, null);
+    return RPCResult.of(input, StepMovement.of(exampleStep, input));
 }
 ```
 
@@ -69,8 +74,8 @@ public RPCResult<String> trigger(final Context context, final String input) {
 @rpc({ inputCodec: stringCodec, outputCodec: stringCodec })
 public trigger(context: Context, input: string): RPCResult<string> {
   this.data.set(context, input);
-  internal.publish(context, undefined);
-  return { output: input };
+  exampleCh.publish(context, undefined);
+  return { output: input, nextSteps: [StepMovement.of(this.exampleStep, input)] };
 }
 ```
 
@@ -81,16 +86,14 @@ public trigger(context: Context, input: string): RPCResult<string> {
 impl RpcFlow {
     fn trigger(&self, context: &mut Context, input: String) -> HandlerResult<RpcResult<String>> {
         data().set(context, input.clone())?;
-        internal().publish(context, ())?;
-        Ok(RpcResult::new(input))
+        example_ch().publish(context, ())?;
+        Ok(RpcResult::new(input.clone()).then(StepMovement::to(&self.example_step, input)))
     }
 }
 ```
 
 </SdkSnippet>
 </SdkTabs>
-
-RPC 不是 Step。它不会执行 **WaitFor** 或 **Execute**，也不会创建 **StepExecution**。它可以读取和写入已声明的 Attribute、发布 Channel，并返回用于取消 Step type 或启动下一个 Step 的结果。Dex 会先应用 Attribute 和 Channel 写入，再取消 Step，最后调度下一个 Step。
 
 ## 调用 RPC
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -3,11 +3,17 @@ title: RPC
 slug: /primitives/rpc
 ---
 
+import RpcRequestDiagram from '@site/src/components/primitives/rpc/RpcRequestDiagram';
+
 # RPC
 
-**RPC** 是 active Flow 的外部入口。应用通过 Client 调用它。Dex Server 将调用发给 Flow 的 Worker；这个方法可以读取或修改 durable Flow state。
+RPC 是 “Remote Procedure Call” 的缩写，允许外部系统与 Flow execution 交互。
 
-Flow 自己推进时用 Step。外部用户或服务需要批准订单、提交输入、取消工作，或查询运行中的 Flow state 时用 RPC。
+**Client** 发起 RPC。**Dex Server** 将它发送给 **Worker**。**Worker** 执行后，再经 **Dex Server** 将结果返回给 **Client**。
+
+<RpcRequestDiagram />
+
+RPC 可以通过 Attribute 读取和写入 durable state、向 Channel publish，也可以 trigger 一个全新的 Step 来运行。
 
 ## 定义 RPC
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -13,7 +13,7 @@ RPC 是 “Remote Procedure Call” 的缩写，允许外部系统与 Flow execu
 
 <RpcRequestDiagram />
 
-## 定义 RPC
+## 定义和调用 RPC
 
 RPC 可以通过 Attribute 读取和写入 durable state、向 Channel publish，也可以 trigger 一个全新的 Step 来运行。
 
@@ -102,8 +102,6 @@ impl RpcFlow {
 ### TypeScript codec
 
 TypeScript 未设置 **inputCodec** 或 **outputCodec** 时会使用 JSON。input 或 output 不是 JSON 时需要提供 codec，包括 string、number、boolean 和 bigint 等 scalar value。
-
-## 调用 RPC
 
 <SdkTabs
   examples={{

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -118,54 +118,44 @@ TypeScript 未设置 **inputCodec** 或 **outputCodec** 时会使用 JSON。inpu
 <SdkSnippet lang="python">
 
 ```python
-result = await app_state.client.invoke_rpc(
-    app_state.rpc.trigger,
-    required_query("workflowId"),
-    required_query("message"),
-)
-return result
+result = await client.invoke_rpc(flow.trigger, flow_id, message)
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="go">
 
 ```go
-var output string
-err := controller.client.InvokeRPC(
-	request.Request.Context(),
+var result string
+err := client.InvokeRPC(
+	ctx,
 	flowID,
-	controller.flow.Trigger,
+	flow.Trigger,
 	message,
-	&output,
+	&result,
 	sdk.InvokeOptions{},
 )
-httputil.RespondString(request, output, err)
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="java">
 
 ```java
-final RpcFlow stub = client.newRpcStub(RpcFlow.class, workflowId);
-return ResponseEntity.ok(client.invokeRPC(stub::trigger, message));
+final RpcFlow flow = client.newRpcStub(RpcFlow.class, flowId);
+final String result = client.invokeRPC(flow::trigger, message);
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="typescript">
 
 ```typescript
-const result = await client.invokeRPC(rpcFlow.trigger, workflowId, message);
-response.send(result);
+const result = await client.invokeRPC(flow.trigger, flowId, message);
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="rust">
 
 ```rust
-match run_blocking(move || client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)) {
-    Ok(result) => ok_text(result),
-    Err(error) => map_sdk_error(error).into_response(),
-}
+let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 ```
 
 </SdkSnippet>

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -105,8 +105,6 @@ TypeScript 未设置 **inputCodec** 或 **outputCodec** 时会使用 JSON。inpu
 
 ## 调用 RPC
 
-向 Client 传入已注册的 RPC method、Flow ID 和 typed input。调用会等待 Worker handler 返回；成功后 Client 解码 **RPCResult.output**。
-
 <SdkTabs
   examples={{
     python: 'examples/python/dex_examples/primitives/rpc',
@@ -160,10 +158,6 @@ let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 
 </SdkSnippet>
 </SdkTabs>
-
-目标 Flow 必须仍然 active。不存在或已经完成的 Flow 会被拒绝。Worker handler 失败或超过 timeout 时，Client 会返回 Worker invocation error。
-
-每次 RPC 调用都有 request ID。再次调用 Client 来 retry 是一次新的 RPC 调用。因此如果调用方可能在丢失 response 后 retry，外部业务 side effect 要自己保证 idempotent。
 
 ## Advanced
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -157,9 +157,7 @@ let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 </SdkSnippet>
 </SdkTabs>
 
-## Advanced
-
-### RPC timeout
+## RPC timeout
 
 RPC timeout 限制一次 Worker handler invocation。它不是 Flow timeout，也不会关闭 Flow。调用方需要比 Dex Server default 更短的上限时再设置。
 
@@ -167,7 +165,7 @@ Python、Java、TypeScript 和 Rust 在 RPC handler 上声明 timeout。Go 在�
 
 Timeout 不是 retry policy。handler timeout 后会向调用方返回 error。endpoint 如果要 retry Client 调用，应在自己的业务操作中使用 idempotency key。
 
-### Attribute locks
+## Attribute locks
 
 RPC 默认不锁 Attribute。像上面的简单写入不需要锁。read-modify-write 通常需要。
 
@@ -178,15 +176,3 @@ RPC 默认不锁 Attribute。像上面的简单写入不需要锁。read-modify-
 Dex Server 会在 Worker handler 开始前尝试一次性获取所有声明的 lock，不会等待。任何一个 lock 已被占用时，调用返回 RPC lock-conflict error；调用方可以按自己的 backoff retry。lock 只在一个 Flow 内生效，并在 invocation 结束时释放。
 
 locking RPC 需要 Temporal。Cadence 不支持。
-
-### Dex Server 如何执行 RPC
-
-Dex Server 先解析 active Run，加载 Flow state，再将 handler 发给 Worker。Worker 返回 output，以及 Attribute write、Channel message、cancellation 和 next-Step movement。Dex Server 再记录这些 Flow change。
-
-普通的无锁 RPC 默认通过 query、Worker call 和 signal 应用 Flow change。Temporal deployment 可以设置 **api.useTemporalSynchronousUpdateForAllRPCs**，让所有 RPC 都走 synchronous Update。locking RPC 总是走 Update path。terminal finalization 开始后，Update path 会拒绝新的 RPC。
-
-通常不需要选择这条 path。除非你在运营 Dex Server，并且每个 RPC 都需要 Update path 的 validation 和 commit behavior，否则保持 default。
-
-## Traditional workarounds
-
-没有 RPC 时，应用通常围绕 Flow 写单独的 read API、write API 和 signal endpoint，再自己处理并发控制。这些 API 很容易读到或修改 Flow 的不同版本。RPC 把外部操作放在 Flow code 旁边，并让 Dex Server 将它送到正确的 Worker。

--- a/docs/src/components/primitives/rpc/RpcRequestDiagram.tsx
+++ b/docs/src/components/primitives/rpc/RpcRequestDiagram.tsx
@@ -13,6 +13,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 type Copy = {
   label: string;
+  application: string;
   request: string;
   dispatch: string;
   result: string;
@@ -26,7 +27,8 @@ type Copy = {
 };
 
 const EN: Copy = {
-  label: 'RPC request travels from Client to Dex Server to Worker, then the result returns to Client',
+  label: 'An RPC travels between the Client and Worker in an Application through Dex Server',
+  application: 'Application',
   request: 'RPC request',
   dispatch: 'invoke RPC',
   result: 'RPC result',
@@ -40,7 +42,8 @@ const EN: Copy = {
 };
 
 const ZH: Copy = {
-  label: 'RPC 请求从 Client 经 Dex Server 到 Worker，结果再返回 Client',
+  label: 'RPC 在 Application 中的 Client 和 Worker 之间经 Dex Server 传递',
+  application: 'Application',
   request: 'RPC 请求',
   dispatch: '调用 RPC',
   result: 'RPC 结果',
@@ -54,40 +57,33 @@ const ZH: Copy = {
 };
 
 function Node({
-  kicker,
   title,
   detail,
   x,
+  y,
+  width,
+  height,
   fill = 'var(--surface-solid)',
   textFill = 'var(--text)',
   detailFill = 'var(--muted-strong)',
 }: {
-  kicker: string;
   title: string;
   detail: string;
   x: number;
+  y: number;
+  width: number;
+  height: number;
   fill?: string;
   textFill?: string;
   detailFill?: string;
 }): ReactNode {
   return (
     <g>
-      <rect x={x} y="80" width="205" height="120" rx="14" fill={fill} stroke="var(--line-strong)" />
-      <text
-        x={x + 102.5}
-        y="112"
-        fill={detailFill}
-        fontFamily="var(--ifm-font-family-monospace)"
-        fontSize="11"
-        fontWeight="650"
-        letterSpacing="1.4"
-        textAnchor="middle">
-        {kicker}
-      </text>
-      <text x={x + 102.5} y="146" fill={textFill} fontSize="19" fontWeight="700" textAnchor="middle">
+      <rect x={x} y={y} width={width} height={height} rx="14" fill={fill} stroke="var(--line-strong)" />
+      <text x={x + width / 2} y={y + height / 2 - 5} fill={textFill} fontSize="19" fontWeight="700" textAnchor="middle">
         {title}
       </text>
-      <text x={x + 102.5} y="174" fill={detailFill} fontSize="13" textAnchor="middle">
+      <text x={x + width / 2} y={y + height / 2 + 22} fill={detailFill} fontSize="13" textAnchor="middle">
         {detail}
       </text>
     </g>
@@ -136,7 +132,7 @@ export default function RpcRequestDiagram(): ReactNode {
   return (
     <div className="exec-diagram" role="img" aria-label={copy.label}>
       <svg
-        viewBox="0 0 880 260"
+        viewBox="0 0 880 310"
         preserveAspectRatio="xMidYMid meet"
         style={{display: 'block', height: 'auto', maxWidth: '100%', position: 'relative', width: '100%', zIndex: 1}}>
         <defs>
@@ -151,20 +147,50 @@ export default function RpcRequestDiagram(): ReactNode {
             <path d="M 0 0 L 9 4.5 L 0 9 Z" fill="var(--forest)" />
           </marker>
         </defs>
-        <Arrow from={225} to={337} y={112} label={copy.request} labelY={62} />
-        <Arrow from={542} to={654} y={112} label={copy.dispatch} labelY={62} />
-        <Arrow from={654} to={542} y={172} label={copy.result} labelY={226} />
-        <Arrow from={337} to={225} y={172} label={copy.response} labelY={226} />
-        <Node kicker="CLIENT" title={copy.client} detail={copy.clientDetail} x={20} />
-        <Node kicker="DEX SERVER" title={copy.server} detail={copy.serverDetail} fill="var(--lime-soft)" x={337} />
+        <rect
+          x="20"
+          y="25"
+          width="370"
+          height="260"
+          rx="18"
+          fill="var(--surface)"
+          stroke="var(--line-strong)"
+          strokeDasharray="7 6"
+        />
+        <text
+          x="48"
+          y="55"
+          fill="var(--forest)"
+          fontFamily="var(--ifm-font-family-monospace)"
+          fontSize="12"
+          fontWeight="650"
+          letterSpacing="1.4">
+          {copy.application.toUpperCase()}
+        </text>
+        <Arrow from={350} to={570} y={105} label={copy.request} labelY={91} />
+        <Arrow from={570} to={350} y={137} label={copy.response} labelY={162} />
+        <Arrow from={570} to={350} y={207} label={copy.dispatch} labelY={193} />
+        <Arrow from={350} to={570} y={239} label={copy.result} labelY={264} />
+        <Node title={copy.client} detail={copy.clientDetail} x={50} y={75} width={300} height={75} />
         <Node
-          kicker="WORKER"
           title={copy.worker}
           detail={copy.workerDetail}
+          x={50}
+          y={180}
+          width={300}
+          height={75}
           detailFill="#d7f6ab"
           fill="var(--forest)"
           textFill="#ffffff"
-          x={654}
+        />
+        <Node
+          title={copy.server}
+          detail={copy.serverDetail}
+          fill="var(--lime-soft)"
+          x={570}
+          y={100}
+          width={260}
+          height={145}
         />
       </svg>
     </div>

--- a/docs/src/components/primitives/rpc/RpcRequestDiagram.tsx
+++ b/docs/src/components/primitives/rpc/RpcRequestDiagram.tsx
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
  */
 
-import React, {type CSSProperties, type ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 type Copy = {
@@ -57,31 +57,76 @@ function Node({
   kicker,
   title,
   detail,
-  tone,
+  x,
+  fill = 'var(--surface-solid)',
+  textFill = 'var(--text)',
+  detailFill = 'var(--muted-strong)',
 }: {
   kicker: string;
   title: string;
   detail: string;
-  tone?: 'accent' | 'success';
+  x: number;
+  fill?: string;
+  textFill?: string;
+  detailFill?: string;
 }): ReactNode {
   return (
-    <div className={`exec-node exec-node-compact${tone ? ` exec-node-${tone}` : ''}`}>
-      <span className="exec-kicker">{kicker}</span>
-      <strong>{title}</strong>
-      <p>{detail}</p>
-    </div>
+    <g>
+      <rect x={x} y="80" width="205" height="120" rx="14" fill={fill} stroke="var(--line-strong)" />
+      <text
+        x={x + 102.5}
+        y="112"
+        fill={detailFill}
+        fontFamily="var(--ifm-font-family-monospace)"
+        fontSize="11"
+        fontWeight="650"
+        letterSpacing="1.4"
+        textAnchor="middle">
+        {kicker}
+      </text>
+      <text x={x + 102.5} y="146" fill={textFill} fontSize="19" fontWeight="700" textAnchor="middle">
+        {title}
+      </text>
+      <text x={x + 102.5} y="174" fill={detailFill} fontSize="13" textAnchor="middle">
+        {detail}
+      </text>
+    </g>
   );
 }
 
-function Arrow({label, up = false}: {label: string; up?: boolean}): ReactNode {
-  const arrowStyle: CSSProperties | undefined = up ? {transform: 'rotate(180deg)'} : undefined;
-  const labelStyle: CSSProperties | undefined = up
-    ? {transform: 'translateY(-50%) rotate(180deg)'}
-    : undefined;
+function Arrow({
+  from,
+  to,
+  y,
+  label,
+  labelY,
+}: {
+  from: number;
+  to: number;
+  y: number;
+  label: string;
+  labelY: number;
+}): ReactNode {
   return (
-    <div className="exec-arrow" style={arrowStyle}>
-      <span style={labelStyle}>{label}</span>
-    </div>
+    <g>
+      <path
+        d={`M ${from} ${y} H ${to}`}
+        fill="none"
+        markerEnd="url(#rpc-arrowhead)"
+        stroke="var(--forest)"
+        strokeLinecap="round"
+        strokeWidth="4"
+      />
+      <text
+        x={(from + to) / 2}
+        y={labelY}
+        fill="var(--muted-strong)"
+        fontSize="12"
+        fontWeight="650"
+        textAnchor="middle">
+        {label}
+      </text>
+    </g>
   );
 }
 
@@ -90,15 +135,38 @@ export default function RpcRequestDiagram(): ReactNode {
   const copy = i18n.currentLocale === 'zh-Hans' ? ZH : EN;
   return (
     <div className="exec-diagram" role="img" aria-label={copy.label}>
-      <Node kicker="CLIENT" title={copy.client} detail={copy.clientDetail} />
-      <Arrow label={copy.request} />
-      <Node kicker="DEX" title={copy.server} detail={copy.serverDetail} tone="accent" />
-      <Arrow label={copy.dispatch} />
-      <Node kicker="WORKER" title={copy.worker} detail={copy.workerDetail} tone="success" />
-      <Arrow label={copy.result} up />
-      <Node kicker="DEX" title={copy.server} detail={copy.serverDetail} tone="accent" />
-      <Arrow label={copy.response} up />
-      <Node kicker="CLIENT" title={copy.client} detail={copy.clientDetail} />
+      <svg
+        viewBox="0 0 880 260"
+        preserveAspectRatio="xMidYMid meet"
+        style={{display: 'block', height: 'auto', maxWidth: '100%', position: 'relative', width: '100%', zIndex: 1}}>
+        <defs>
+          <marker
+            id="rpc-arrowhead"
+            markerHeight="9"
+            markerWidth="9"
+            orient="auto"
+            refX="7.5"
+            refY="4.5"
+            viewBox="0 0 9 9">
+            <path d="M 0 0 L 9 4.5 L 0 9 Z" fill="var(--forest)" />
+          </marker>
+        </defs>
+        <Arrow from={225} to={337} y={112} label={copy.request} labelY={62} />
+        <Arrow from={542} to={654} y={112} label={copy.dispatch} labelY={62} />
+        <Arrow from={654} to={542} y={172} label={copy.result} labelY={226} />
+        <Arrow from={337} to={225} y={172} label={copy.response} labelY={226} />
+        <Node kicker="CLIENT" title={copy.client} detail={copy.clientDetail} x={20} />
+        <Node kicker="DEX SERVER" title={copy.server} detail={copy.serverDetail} fill="var(--lime-soft)" x={337} />
+        <Node
+          kicker="WORKER"
+          title={copy.worker}
+          detail={copy.workerDetail}
+          detailFill="#d7f6ab"
+          fill="var(--forest)"
+          textFill="#ffffff"
+          x={654}
+        />
+      </svg>
     </div>
   );
 }

--- a/docs/src/components/primitives/rpc/RpcRequestDiagram.tsx
+++ b/docs/src/components/primitives/rpc/RpcRequestDiagram.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Licensed under the Super Durable Source License 1.0.
+ * You may not use this file except in compliance with the License.
+ * See the LICENSE file in the repository root.
+ *
+ * SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+ */
+
+import React, {type CSSProperties, type ReactNode} from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+type Copy = {
+  label: string;
+  request: string;
+  dispatch: string;
+  result: string;
+  response: string;
+  client: string;
+  clientDetail: string;
+  server: string;
+  serverDetail: string;
+  worker: string;
+  workerDetail: string;
+};
+
+const EN: Copy = {
+  label: 'RPC request travels from Client to Dex Server to Worker, then the result returns to Client',
+  request: 'RPC request',
+  dispatch: 'invoke RPC',
+  result: 'RPC result',
+  response: 'return result',
+  client: 'Client',
+  clientDetail: 'Invokes an RPC',
+  server: 'Dex Server',
+  serverDetail: 'Routes the request and result',
+  worker: 'Worker',
+  workerDetail: 'Runs the RPC method',
+};
+
+const ZH: Copy = {
+  label: 'RPC 请求从 Client 经 Dex Server 到 Worker，结果再返回 Client',
+  request: 'RPC 请求',
+  dispatch: '调用 RPC',
+  result: 'RPC 结果',
+  response: '返回结果',
+  client: 'Client',
+  clientDetail: '发起 RPC',
+  server: 'Dex Server',
+  serverDetail: '路由请求和结果',
+  worker: 'Worker',
+  workerDetail: '执行 RPC method',
+};
+
+function Node({
+  kicker,
+  title,
+  detail,
+  tone,
+}: {
+  kicker: string;
+  title: string;
+  detail: string;
+  tone?: 'accent' | 'success';
+}): ReactNode {
+  return (
+    <div className={`exec-node exec-node-compact${tone ? ` exec-node-${tone}` : ''}`}>
+      <span className="exec-kicker">{kicker}</span>
+      <strong>{title}</strong>
+      <p>{detail}</p>
+    </div>
+  );
+}
+
+function Arrow({label, up = false}: {label: string; up?: boolean}): ReactNode {
+  const arrowStyle: CSSProperties | undefined = up ? {transform: 'rotate(180deg)'} : undefined;
+  const labelStyle: CSSProperties | undefined = up
+    ? {transform: 'translateY(-50%) rotate(180deg)'}
+    : undefined;
+  return (
+    <div className="exec-arrow" style={arrowStyle}>
+      <span style={labelStyle}>{label}</span>
+    </div>
+  );
+}
+
+export default function RpcRequestDiagram(): ReactNode {
+  const {i18n} = useDocusaurusContext();
+  const copy = i18n.currentLocale === 'zh-Hans' ? ZH : EN;
+  return (
+    <div className="exec-diagram" role="img" aria-label={copy.label}>
+      <Node kicker="CLIENT" title={copy.client} detail={copy.clientDetail} />
+      <Arrow label={copy.request} />
+      <Node kicker="DEX" title={copy.server} detail={copy.serverDetail} tone="accent" />
+      <Arrow label={copy.dispatch} />
+      <Node kicker="WORKER" title={copy.worker} detail={copy.workerDetail} tone="success" />
+      <Arrow label={copy.result} up />
+      <Node kicker="DEX" title={copy.server} detail={copy.serverDetail} tone="accent" />
+      <Arrow label={copy.response} up />
+      <Node kicker="CLIENT" title={copy.client} detail={copy.clientDetail} />
+    </div>
+  );
+}

--- a/docs/src/components/primitives/rpc/RpcRequestDiagram.tsx
+++ b/docs/src/components/primitives/rpc/RpcRequestDiagram.tsx
@@ -19,11 +19,8 @@ type Copy = {
   result: string;
   response: string;
   client: string;
-  clientDetail: string;
   server: string;
-  serverDetail: string;
   worker: string;
-  workerDetail: string;
 };
 
 const EN: Copy = {
@@ -34,11 +31,8 @@ const EN: Copy = {
   result: 'RPC result',
   response: 'return result',
   client: 'Client',
-  clientDetail: 'Invokes an RPC',
   server: 'Dex Server',
-  serverDetail: 'Routes the request and result',
   worker: 'Worker',
-  workerDetail: 'Runs the RPC method',
 };
 
 const ZH: Copy = {
@@ -49,42 +43,32 @@ const ZH: Copy = {
   result: 'RPC 结果',
   response: '返回结果',
   client: 'Client',
-  clientDetail: '发起 RPC',
   server: 'Dex Server',
-  serverDetail: '路由请求和结果',
   worker: 'Worker',
-  workerDetail: '执行 RPC method',
 };
 
 function Node({
   title,
-  detail,
   x,
   y,
   width,
   height,
   fill = 'var(--surface-solid)',
   textFill = 'var(--text)',
-  detailFill = 'var(--muted-strong)',
 }: {
   title: string;
-  detail: string;
   x: number;
   y: number;
   width: number;
   height: number;
   fill?: string;
   textFill?: string;
-  detailFill?: string;
 }): ReactNode {
   return (
     <g>
       <rect x={x} y={y} width={width} height={height} rx="14" fill={fill} stroke="var(--line-strong)" />
-      <text x={x + width / 2} y={y + height / 2 - 5} fill={textFill} fontSize="19" fontWeight="700" textAnchor="middle">
+      <text x={x + width / 2} y={y + height / 2 + 7} fill={textFill} fontSize="19" fontWeight="700" textAnchor="middle">
         {title}
-      </text>
-      <text x={x + width / 2} y={y + height / 2 + 22} fill={detailFill} fontSize="13" textAnchor="middle">
-        {detail}
       </text>
     </g>
   );
@@ -109,9 +93,9 @@ function Arrow({
         d={`M ${from} ${y} H ${to}`}
         fill="none"
         markerEnd="url(#rpc-arrowhead)"
-        stroke="var(--forest)"
+        stroke="var(--line-strong)"
         strokeLinecap="round"
-        strokeWidth="4"
+        strokeWidth="2.5"
       />
       <text
         x={(from + to) / 2}
@@ -138,13 +122,14 @@ export default function RpcRequestDiagram(): ReactNode {
         <defs>
           <marker
             id="rpc-arrowhead"
-            markerHeight="9"
-            markerWidth="9"
+            markerHeight="8"
+            markerUnits="userSpaceOnUse"
+            markerWidth="8"
             orient="auto"
-            refX="7.5"
-            refY="4.5"
-            viewBox="0 0 9 9">
-            <path d="M 0 0 L 9 4.5 L 0 9 Z" fill="var(--forest)" />
+            refX="7"
+            refY="4"
+            viewBox="0 0 8 8">
+            <path d="M 1 1 L 7 4 L 1 7" fill="none" stroke="var(--line-strong)" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" />
           </marker>
         </defs>
         <rect
@@ -171,21 +156,18 @@ export default function RpcRequestDiagram(): ReactNode {
         <Arrow from={570} to={350} y={137} label={copy.response} labelY={162} />
         <Arrow from={570} to={350} y={207} label={copy.dispatch} labelY={193} />
         <Arrow from={350} to={570} y={239} label={copy.result} labelY={264} />
-        <Node title={copy.client} detail={copy.clientDetail} x={50} y={75} width={300} height={75} />
+        <Node title={copy.client} x={50} y={75} width={300} height={75} />
         <Node
           title={copy.worker}
-          detail={copy.workerDetail}
           x={50}
           y={180}
           width={300}
           height={75}
-          detailFill="#d7f6ab"
-          fill="var(--forest)"
-          textFill="#ffffff"
+          fill="var(--lime-soft)"
+          textFill="var(--forest)"
         />
         <Node
           title={copy.server}
-          detail={copy.serverDetail}
           fill="var(--lime-soft)"
           x={570}
           y={100}

--- a/docs/src/components/primitives/rpc/RpcRequestDiagram.tsx
+++ b/docs/src/components/primitives/rpc/RpcRequestDiagram.tsx
@@ -26,10 +26,10 @@ type Copy = {
 const EN: Copy = {
   label: 'An RPC travels between the Client and Worker in an Application through Dex Server',
   application: 'Application',
-  request: 'RPC request',
-  dispatch: 'invoke RPC',
-  result: 'RPC result',
-  response: 'return result',
+  request: '1  Invoke RPC request',
+  dispatch: '2  Route request to Worker',
+  result: '3  Return result to Dex Server',
+  response: '4  Return output to Client',
   client: 'Client',
   server: 'Dex Server',
   worker: 'Worker',
@@ -38,10 +38,10 @@ const EN: Copy = {
 const ZH: Copy = {
   label: 'RPC 在 Application 中的 Client 和 Worker 之间经 Dex Server 传递',
   application: 'Application',
-  request: 'RPC 请求',
-  dispatch: '调用 RPC',
-  result: 'RPC 结果',
-  response: '返回结果',
+  request: '1  发起 RPC 请求',
+  dispatch: '2  将请求发送给 Worker',
+  result: '3  将结果返回给 Dex Server',
+  response: '4  将输出返回给 Client',
   client: 'Client',
   server: 'Dex Server',
   worker: 'Worker',
@@ -74,6 +74,25 @@ function Node({
   );
 }
 
+function DexServerNode({title}: {title: string}): ReactNode {
+  return (
+    <g>
+      <rect x="570" y="100" width="260" height="145" rx="14" fill="var(--lime-soft)" stroke="var(--line-strong)" />
+      <text x="700" y="148" fill="var(--text)" fontSize="19" fontWeight="700" textAnchor="middle">
+        {title}
+      </text>
+      <path
+        d="M 678 180 C 678 175 688 171 700 171 C 712 171 722 175 722 180 V 208 C 722 213 712 217 700 217 C 688 217 678 213 678 208 Z"
+        fill="var(--surface-solid)"
+        stroke="var(--forest)"
+        strokeWidth="2"
+      />
+      <ellipse cx="700" cy="180" rx="22" ry="9" fill="var(--surface-solid)" stroke="var(--forest)" strokeWidth="2" />
+      <path d="M 678 194 C 678 199 688 203 700 203 C 712 203 722 199 722 194" fill="none" stroke="var(--forest)" strokeWidth="2" />
+    </g>
+  );
+}
+
 function Arrow({
   from,
   to,
@@ -93,14 +112,14 @@ function Arrow({
         d={`M ${from} ${y} H ${to}`}
         fill="none"
         markerEnd="url(#rpc-arrowhead)"
-        stroke="var(--line-strong)"
+        stroke="var(--forest)"
         strokeLinecap="round"
-        strokeWidth="2.5"
+        strokeWidth="3"
       />
       <text
         x={(from + to) / 2}
         y={labelY}
-        fill="var(--muted-strong)"
+        fill="var(--forest)"
         fontSize="12"
         fontWeight="650"
         textAnchor="middle">
@@ -122,14 +141,14 @@ export default function RpcRequestDiagram(): ReactNode {
         <defs>
           <marker
             id="rpc-arrowhead"
-            markerHeight="8"
+            markerHeight="10"
             markerUnits="userSpaceOnUse"
-            markerWidth="8"
+            markerWidth="10"
             orient="auto"
-            refX="7"
-            refY="4"
-            viewBox="0 0 8 8">
-            <path d="M 1 1 L 7 4 L 1 7" fill="none" stroke="var(--line-strong)" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" />
+            refX="9"
+            refY="5"
+            viewBox="0 0 10 10">
+            <path d="M 1 1 L 9 5 L 1 9 Z" fill="var(--forest)" />
           </marker>
         </defs>
         <rect
@@ -152,10 +171,10 @@ export default function RpcRequestDiagram(): ReactNode {
           letterSpacing="1.4">
           {copy.application.toUpperCase()}
         </text>
-        <Arrow from={350} to={570} y={105} label={copy.request} labelY={91} />
-        <Arrow from={570} to={350} y={137} label={copy.response} labelY={162} />
-        <Arrow from={570} to={350} y={207} label={copy.dispatch} labelY={193} />
-        <Arrow from={350} to={570} y={239} label={copy.result} labelY={264} />
+        <Arrow from={360} to={560} y={105} label={copy.request} labelY={91} />
+        <Arrow from={560} to={360} y={207} label={copy.dispatch} labelY={193} />
+        <Arrow from={360} to={560} y={239} label={copy.result} labelY={264} />
+        <Arrow from={560} to={360} y={137} label={copy.response} labelY={162} />
         <Node title={copy.client} x={50} y={75} width={300} height={75} />
         <Node
           title={copy.worker}
@@ -166,14 +185,7 @@ export default function RpcRequestDiagram(): ReactNode {
           fill="var(--lime-soft)"
           textFill="var(--forest)"
         />
-        <Node
-          title={copy.server}
-          fill="var(--lime-soft)"
-          x={570}
-          y={100}
-          width={260}
-          height={145}
-        />
+        <DexServerNode title={copy.server} />
       </svg>
     </div>
   );

--- a/examples/go/primitives/rpc/controller.go
+++ b/examples/go/primitives/rpc/controller.go
@@ -76,7 +76,7 @@ func (controller *controller) trigger(request *gin.Context) {
 		controller.flow.Trigger,
 		message,
 		&output,
-		sdk.InvokeOptions{},
+		sdk.InvokeOptions{Timeout: 30 * time.Second},
 	)
 	httputil.RespondString(request, output, err)
 }

--- a/examples/go/primitives/rpc/workflow.go
+++ b/examples/go/primitives/rpc/workflow.go
@@ -23,8 +23,8 @@ package rpc
 import "github.com/superdurable/dex/sdk-go/dex"
 
 var (
-	Internal = dex.DefineChannel[dex.None]("rpc-internal")
-	Data     = dex.DefineAttribute[string]("rpc-data")
+	ExampleCh = dex.DefineChannel[dex.None]("rpc-internal")
+	Data      = dex.DefineAttribute[string]("rpc-data")
 )
 
 type RpcFlow struct {
@@ -39,13 +39,14 @@ func (*RpcFlow) GetSteps() []dex.StepDef {
 	return []dex.StepDef{
 		dex.DefineStartStep(rpcWaitStep{}),
 		dex.DefineStep(rpcCompleteStep{}),
+		dex.DefineStep(exampleStep{}),
 	}
 }
 
 func (*RpcFlow) GetPersistenceSchema() dex.PersistenceSchema {
 	return dex.PersistenceSchema{
 		Attributes: []dex.AttributeDef{Data},
-		Channels:   []dex.ChannelDef{Internal},
+		Channels:   []dex.ChannelDef{ExampleCh},
 	}
 }
 
@@ -54,7 +55,7 @@ type rpcWaitStep struct {
 }
 
 func (rpcWaitStep) WaitFor(_ dex.Context, _ int) (*dex.Wait, error) {
-	return dex.Until(Internal.ForOne()), nil
+	return dex.Until(ExampleCh.ForOne()), nil
 }
 
 func (rpcWaitStep) Execute(_ dex.Context, _ int) (*dex.StepDecision, error) {
@@ -69,14 +70,27 @@ func (rpcCompleteStep) Execute(_ dex.Context, input int) (*dex.StepDecision, err
 	return dex.GracefulComplete(input + 1), nil
 }
 
+type exampleStep struct {
+	dex.StepDefaultsNoWaitFor[string]
+}
+
+func (exampleStep) Execute(_ dex.Context, input string) (*dex.StepDecision, error) {
+	return dex.GracefulComplete(input), nil
+}
+
 func (*RpcFlow) Trigger(ctx dex.Context, input string) (*dex.RPCResult[string], error) {
 	if err := Data.Set(ctx, input); err != nil {
 		return nil, err
 	}
-	if err := Internal.Publish(ctx, nil); err != nil {
+	if err := ExampleCh.Publish(ctx, nil); err != nil {
 		return nil, err
 	}
-	return &dex.RPCResult[string]{Output: input}, nil
+	return &dex.RPCResult[string]{
+		Output: input,
+		NextSteps: []dex.StepMovement{
+			dex.MovementOf(exampleStep{}, input),
+		},
+	}, nil
 }
 
 var _ dex.Flow = (*RpcFlow)(nil)

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/rpc/RpcFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/rpc/RpcFlow.java
@@ -48,7 +48,7 @@ public class RpcFlow implements Flow<Integer> {
         return PersistenceSchema.of(data, exampleCh);
     }
 
-    @RPC
+    @RPC(timeoutSeconds = 30)
     public RPCResult<String> trigger(final Context context, final String input) {
         data.set(context, input);
         exampleCh.publish(context, null);

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/rpc/RpcFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/rpc/RpcFlow.java
@@ -26,31 +26,33 @@ import io.superdurable.dex.RPCResult;
 import io.superdurable.dex.Step;
 import io.superdurable.dex.StepDecision;
 import io.superdurable.dex.StepList;
+import io.superdurable.dex.StepMovement;
 import io.superdurable.dex.Wait;
 import org.springframework.stereotype.Component;
 
 @Component
 public class RpcFlow implements Flow<Integer> {
-    public final Channel<Void> internal = Channel.define("rpc-internal", Void.class);
+    public final Channel<Void> exampleCh = Channel.define("rpc-internal", Void.class);
     public final Attribute<String> data = Attribute.define("rpc-data", String.class);
     private final RpcCompleteStep complete = new RpcCompleteStep();
+    private final ExampleStep exampleStep = new ExampleStep();
     private final RpcWaitStep wait = new RpcWaitStep();
 
     @Override
     public StepList<Integer> getSteps() {
-        return StepList.startStep(wait).otherSteps(complete);
+        return StepList.startStep(wait).otherSteps(complete, exampleStep);
     }
 
     @Override
     public PersistenceSchema getPersistenceSchema() {
-        return PersistenceSchema.of(data, internal);
+        return PersistenceSchema.of(data, exampleCh);
     }
 
     @RPC
     public RPCResult<String> trigger(final Context context, final String input) {
         data.set(context, input);
-        internal.publish(context, null);
-        return RPCResult.of(input);
+        exampleCh.publish(context, null);
+        return RPCResult.of(input, StepMovement.of(exampleStep, input));
     }
 
     final class RpcWaitStep implements Step<Integer> {
@@ -61,7 +63,7 @@ public class RpcFlow implements Flow<Integer> {
 
         @Override
         public Wait waitFor(final Context context, final Integer input) {
-            return Wait.until(internal.forOne());
+            return Wait.until(exampleCh.forOne());
         }
 
         @Override
@@ -79,6 +81,18 @@ public class RpcFlow implements Flow<Integer> {
         @Override
         public StepDecision execute(final Context context, final Integer input) {
             return StepDecision.gracefulComplete(input + 1);
+        }
+    }
+
+    static final class ExampleStep implements Step<String> {
+        @Override
+        public Class<String> getInputType() {
+            return String.class;
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final String input) {
+            return StepDecision.gracefulComplete(input);
         }
     }
 }

--- a/examples/python/dex_examples/primitives/rpc/rpc_flow.py
+++ b/examples/python/dex_examples/primitives/rpc/rpc_flow.py
@@ -26,6 +26,7 @@ from dex import (
     Step,
     StepDecision,
     StepList,
+    StepMovement,
     Wait,
     go_to,
     graceful_complete,
@@ -53,22 +54,29 @@ class RpcCompleteStep(Step[int]):
         return graceful_complete(input + 1)
 
 
+class ExampleStep(Step[str]):
+    def execute(self, context: Context, input: str) -> StepDecision:
+        del context
+        return graceful_complete(input)
+
+
 class RpcFlow(Flow[int]):
-    internal = Channel[None]("rpc-internal", type(None))
+    example_ch = Channel[None]("rpc-internal", type(None))
     data = Attribute("rpc-data", str)
 
     def __init__(self) -> None:
         self.second = RpcCompleteStep()
-        self.first = RpcWaitStep(self.internal, self.second)
+        self.example_step = ExampleStep()
+        self.first = RpcWaitStep(self.example_ch, self.second)
 
     def get_steps(self) -> StepList[int]:
-        return StepList.start_step(self.first).other_steps(self.second)
+        return StepList.start_step(self.first).other_steps(self.second, self.example_step)
 
     def get_persistence_schema(self) -> PersistenceSchema:
-        return PersistenceSchema.of(self.data, self.internal)
+        return PersistenceSchema.of(self.data, self.example_ch)
 
     @rpc
     def trigger(self, context: Context, input: str) -> RPCResult[str]:
         self.data.set(context, input)
-        self.internal.publish(context, None)
-        return RPCResult(input)
+        self.example_ch.publish(context, None)
+        return RPCResult(input, next_steps=(StepMovement.of(self.example_step, input),))

--- a/examples/python/dex_examples/primitives/rpc/rpc_flow.py
+++ b/examples/python/dex_examples/primitives/rpc/rpc_flow.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 from dex import (
     Attribute,
     Channel,
@@ -75,7 +77,7 @@ class RpcFlow(Flow[int]):
     def get_persistence_schema(self) -> PersistenceSchema:
         return PersistenceSchema.of(self.data, self.example_ch)
 
-    @rpc
+    @rpc(timeout=timedelta(seconds=30))
     def trigger(self, context: Context, input: str) -> RPCResult[str]:
         self.data.set(context, input)
         self.example_ch.publish(context, None)

--- a/examples/rust/src/primitives/rpc/flow.rs
+++ b/examples/rust/src/primitives/rpc/flow.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use dex_sdk::{
     Attribute, Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, RpcResult,
     Step, StepDecision, StepList, StepMovement, Wait,
@@ -58,7 +60,7 @@ impl Flow for RpcFlow {
     }
 
     fn rpcs(&self) -> RpcList<Self> {
-        RpcList::new().function(RPC_TRIGGER, Self::trigger)
+        RpcList::new().function(RPC_TRIGGER.timeout(Duration::from_secs(30)), Self::trigger)
     }
 }
 

--- a/examples/rust/src/primitives/rpc/flow.rs
+++ b/examples/rust/src/primitives/rpc/flow.rs
@@ -14,12 +14,12 @@
 
 use dex_sdk::{
     Attribute, Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, RpcResult,
-    Step, StepDecision, StepList, Wait,
+    Step, StepDecision, StepList, StepMovement, Wait,
 };
 
 pub const RPC_TRIGGER: Rpc<String, String> = Rpc::new("RpcTrigger");
 
-fn internal() -> Channel<()> {
+fn example_ch() -> Channel<()> {
     Channel::new("rpc-internal")
 }
 
@@ -31,13 +31,14 @@ fn data() -> Attribute<String> {
 pub struct RpcFlow {
     wait: RpcWait,
     complete: RpcComplete,
+    example_step: ExampleStep,
 }
 
 impl RpcFlow {
     fn trigger(&self, context: &mut Context, input: String) -> HandlerResult<RpcResult<String>> {
         data().set(context, input.clone())?;
-        internal().publish(context, ())?;
-        Ok(RpcResult::new(input))
+        example_ch().publish(context, ())?;
+        Ok(RpcResult::new(input.clone()).then(StepMovement::to(&self.example_step, input)))
     }
 }
 
@@ -45,13 +46,15 @@ impl Flow for RpcFlow {
     type StartInput = i32;
 
     fn steps(&self) -> StepList<'_, Self::StartInput> {
-        StepList::start(&self.wait).and(&self.complete)
+        StepList::start(&self.wait)
+            .and(&self.complete)
+            .and(&self.example_step)
     }
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
             .attribute(&data())
-            .channel(&internal())
+            .channel(&example_ch())
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -66,7 +69,7 @@ impl Step for RpcWait {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
-        Ok(Wait::until(internal().for_one()))
+        Ok(Wait::until(example_ch().for_one()))
     }
 
     fn execute(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
@@ -82,5 +85,16 @@ impl Step for RpcComplete {
 
     fn execute(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
         Ok(StepDecision::graceful_complete(input + 1))
+    }
+}
+
+#[derive(Default)]
+struct ExampleStep;
+
+impl Step for ExampleStep {
+    type Input = String;
+
+    fn execute(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
+        Ok(StepDecision::graceful_complete(input))
     }
 }

--- a/examples/typescript/src/primitives/rpc/rpc-flow.ts
+++ b/examples/typescript/src/primitives/rpc/rpc-flow.ts
@@ -18,6 +18,7 @@ import {
   Attribute,
   Channel,
   StepList,
+  StepMovement,
   Wait,
   doubleCodec,
   goTo,
@@ -33,7 +34,7 @@ import {
   type StepDecision,
 } from "@superdurable/dex";
 
-const internal = new Channel("rpc-internal", voidCodec);
+const exampleCh = new Channel("rpc-internal", voidCodec);
 
 class RpcWait implements Step<number> {
   public readonly inputCodec = doubleCodec;
@@ -45,7 +46,7 @@ class RpcWait implements Step<number> {
   }
 
   public waitFor(_context: Context, _input: number): Wait {
-    return Wait.until(internal.forOne());
+    return Wait.until(exampleCh.forOne());
   }
 
   public execute(_context: Context, _input: number): StepDecision {
@@ -65,10 +66,23 @@ class RpcComplete implements Step<number> {
   }
 }
 
+class ExampleStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public getStepType(): string {
+    return "ExampleStep";
+  }
+
+  public execute(_context: Context, input: string): StepDecision {
+    return gracefulComplete(input);
+  }
+}
+
 export class RpcFlow implements Flow<number> {
   public readonly data = new Attribute("rpc-data", stringCodec);
   private readonly wait = new RpcWait(this);
   private readonly complete = new RpcComplete();
+  private readonly exampleStep = new ExampleStep();
 
   public get completeStep(): Step<number> {
     return this.complete;
@@ -79,18 +93,18 @@ export class RpcFlow implements Flow<number> {
   }
 
   public getSteps() {
-    return StepList.startStep(this.wait).otherSteps(this.complete);
+    return StepList.startStep(this.wait).otherSteps(this.complete, this.exampleStep);
   }
 
   public getPersistenceSchema(): PersistenceSchema {
-    return { attributes: [this.data], channels: [internal] };
+    return { attributes: [this.data], channels: [exampleCh] };
   }
 
   @rpc({ inputCodec: stringCodec, outputCodec: stringCodec })
   public trigger(context: Context, input: string): RPCResult<string> {
     this.data.set(context, input);
-    internal.publish(context, undefined);
-    return { output: input };
+    exampleCh.publish(context, undefined);
+    return { output: input, nextSteps: [StepMovement.of(this.exampleStep, input)] };
   }
 }
 

--- a/examples/typescript/src/primitives/rpc/rpc-flow.ts
+++ b/examples/typescript/src/primitives/rpc/rpc-flow.ts
@@ -100,7 +100,7 @@ export class RpcFlow implements Flow<number> {
     return { attributes: [this.data], channels: [exampleCh] };
   }
 
-  @rpc({ inputCodec: stringCodec, outputCodec: stringCodec })
+  @rpc({ inputCodec: stringCodec, outputCodec: stringCodec, timeoutMs: 30_000 })
   public trigger(context: Context, input: string): RPCResult<string> {
     this.data.set(context, input);
     exampleCh.publish(context, undefined);


### PR DESCRIPTION
## Summary

- Rewrite the RPC primitive documentation around defining and invoking an RPC.
- Add the matching Simplified Chinese RPC page.
- Cover RPC timeout, Attribute locks, and the Dex Server execution paths.
- Add Rust to both application snippet groups and repair the Attribute-to-RPC lock anchor.

## Rationale

The previous page mixed basic API usage with backend details, omitted Rust snippets, and had no Simplified Chinese translation. The new structure keeps the common path first and isolates operational behavior in an Advanced section.

## User impact

Readers can now follow runnable examples for all five SDKs and find the concurrency and backend constraints needed for read-modify-write RPCs.

## Validation

- `make docs-prose-check`
- `npm run check` (from `docs/`)
