### PR TITLE
Rewrite Channel documentation

### DIFF
--- a/docs/content/glossary.mdx
+++ b/docs/content/glossary.mdx
@@ -55,7 +55,7 @@ Decision to go to another Step (or complete/fail).
 
 #### [Time Travel](/production/application-operations)
 
-Create a new Flow run from an earlier Step after a fix.
+Create a new Flow execution from an earlier Step after a fix.
 
 #### [RPC](/primitives/rpc)
 
@@ -63,7 +63,7 @@ Worker handler for external read/write against a running Flow.
 
 #### [Run ID](/primitives/flow/basic#identifiers)
 
-Engine-assigned ID for a particular Flow run.
+Engine-assigned ID for a backend run attempt within a Flow execution.
 
 #### [Step](/primitives/step)
 

--- a/docs/content/primitives/attribute.mdx
+++ b/docs/content/primitives/attribute.mdx
@@ -6,11 +6,11 @@ slug: /primitives/attribute
 
 # Attribute
 
-An **Attribute** lets you store data within a Flow run, as persistence storage.
+An **Attribute** lets you store data within a Flow execution, as persistence storage.
 
-This is especially useful for intermediate data during a Flow run. It eliminates the work of setting up and managing a database dependency.
+This is especially useful for intermediate data during a Flow execution. It eliminates the work of setting up and managing a database dependency.
 
-Dex Attribute is not to replace your databases. An obvious limitation is that Attribute exists only for the lifetime of its Flow run. Dex deletes it when it deletes the Flow run, after the configurable retention period following Flow closure.
+Dex Attribute is not to replace your databases. An obvious limitation is that Attribute exists only for the lifetime of its Flow execution. Dex deletes it when it deletes the Flow execution, after the configurable retention period following Flow closure.
 
 However, Dex allows you to sync Attribute values to your application database as permanent storage. This also lets you build more powerful database indexes to query Attributes.
 
@@ -314,7 +314,7 @@ Clients use **GetAttributes** and **SetAttributes** with the same registered Att
 
 ## Indexed Attributes {#indexed-attributes}
 
-Dex lets you configure indexes for Attributes. With indexing, you can use the field in **SearchFlows** queries to find the Flow runs that match the query.
+Dex lets you configure indexes for Attributes. With indexing, you can use the field in **SearchFlows** queries to find the Flow executions that match the query.
 
 | Index type | Value |
 | --- | --- |
@@ -380,7 +380,7 @@ let status = Attribute::new("primitive-attribute-status")
 </SdkSnippet>
 </SdkTabs>
 
-For example, the status Attribute above uses **OrderStatus** as its index key. To find Flow runs whose status is completed, use this query:
+For example, the status Attribute above uses **OrderStatus** as its index key. To find Flow executions whose status is completed, use this query:
 
 ```text
 OrderStatus = 'completed'

--- a/docs/content/primitives/channel.mdx
+++ b/docs/content/primitives/channel.mdx
@@ -7,11 +7,11 @@ import ChannelScopeDiagram from '@site/src/components/primitives/channel/Channel
 
 # Channel
 
-**Channel** is a durable first-in, first-out (FIFO) queue inside one Flow run. Steps, RPCs, and Clients append typed messages. A Step consumes messages by returning a Channel condition from **WaitFor**.
+**Channel** is a durable first-in, first-out (FIFO) queue inside one Flow execution. Steps, RPCs, and Clients append typed messages. A Step consumes messages by returning a Channel condition from **WaitFor**.
 
 A Channel keeps messages in arrival order. A message can be consumed by one matching wait, once. It is not copied to other waiting Steps.
 
-A Channel is scoped to one Flow run. Another Flow run has its own Channel queues; messages never cross between Flow runs.
+A Channel is scoped to one Flow execution. Messages never cross between Flow executions.
 
 <ChannelScopeDiagram />
 

--- a/docs/content/primitives/channel.mdx
+++ b/docs/content/primitives/channel.mdx
@@ -7,11 +7,11 @@ import ChannelScopeDiagram from '@site/src/components/primitives/channel/Channel
 
 # Channel
 
-**Channel** is a durable first-in, first-out (FIFO) queue inside one Flow execution. Steps, RPCs, and Clients append typed messages. A Step consumes messages by returning a Channel condition from **WaitFor**.
+**Channel** is a durable first-in, first-out (FIFO) queue inside one Flow run. Steps, RPCs, and Clients append typed messages. A Step consumes messages by returning a Channel condition from **WaitFor**.
 
 A Channel keeps messages in arrival order. A message can be consumed by one matching wait, once. It is not copied to other waiting Steps.
 
-A Channel is scoped to one Flow execution. Another Flow execution has its own Channel queues; messages never cross between Flow executions.
+A Channel is scoped to one Flow run. Another Flow run has its own Channel queues; messages never cross between Flow runs.
 
 <ChannelScopeDiagram />
 

--- a/docs/content/primitives/channel.mdx
+++ b/docs/content/primitives/channel.mdx
@@ -3,11 +3,17 @@ title: Channel
 slug: /primitives/channel
 ---
 
+import ChannelScopeDiagram from '@site/src/components/primitives/channel/ChannelScopeDiagram';
+
 # Channel
 
-**Channel** is a durable FIFO queue inside one Flow. Steps, RPCs, and Clients append typed messages. A Step consumes messages by returning a Channel condition from **WaitFor**.
+**Channel** is a durable first-in, first-out (FIFO) queue inside one Flow execution. Steps, RPCs, and Clients append typed messages. A Step consumes messages by returning a Channel condition from **WaitFor**.
 
-A Channel is useful when a Flow must wait for an external event, or when one Step hands work to another Step. It is a queue, not a broadcast topic: one message wakes at most one matching waiting Step.
+A Channel keeps messages in arrival order. A message can be consumed by one matching wait, once. It is not copied to other waiting Steps.
+
+A Channel is scoped to one Flow execution. Another Flow execution has its own Channel queues; messages never cross between Flow executions.
+
+<ChannelScopeDiagram />
 
 ## Persistence schema {#persistence-schema}
 

--- a/docs/content/primitives/channel.mdx
+++ b/docs/content/primitives/channel.mdx
@@ -9,9 +9,9 @@ slug: /primitives/channel
 
 A Channel is useful when a Flow must wait for an external event, or when one Step hands work to another Step. It is a queue, not a broadcast topic: one message wakes at most one matching waiting Step.
 
-## Define a Channel {#define-a-channel}
+## Persistence schema {#persistence-schema}
 
-A Channel has a stable name and a message type. Add it to the Flow persistence schema. Dex Server rejects a publish, wait, or read that uses a Channel the Flow did not declare.
+A Channel has a stable name and a message type. Define it and add it to the Flow persistence schema. Defining a Channel alone does not register it with the Flow. Dex Server rejects a publish, wait, or read that uses a Channel the Flow did not declare in its persistence schema.
 
 This example has an **Approval** Channel. Its start Step waits for either one approval or a Timer. The **approve** RPC publishes the approval message. The same Flow can also receive a message directly through the Client **PublishToChannel** API.
 

--- a/docs/content/primitives/client-apis.mdx
+++ b/docs/content/primitives/client-apis.mdx
@@ -13,7 +13,7 @@ Starting work, sending a message, reading Attributes, waiting for a Step, search
 
 ## Start, inspect, and search
 
-- **StartFlow** — start a Flow run
+- **StartFlow** — start a Flow execution
 - **GetAttributes** / **SetAttributes** — read or write durable Attributes
 - **SearchFlows** — query Flows, including Indexed Attributes and **DexParentFlowID** for SubFlows
 
@@ -128,10 +128,10 @@ unknown name is rejected by StartFlow and UpdateFlowConfig.
 
 ## Control execution
 
-- **StopFlow** — cancel or terminate a run
+- **StopFlow** — cancel or terminate a Flow execution
 - **SkipTimer** — fire a pending [Timer](/primitives/timer) early
-- **TimeTravel** — create a new run from an earlier Step after a fix
-- **TriggerContinueAsNew** — bound history by starting a fresh run that carries state forward
+- **TimeTravel** — create a new Flow execution from an earlier Step after a fix
+- **TriggerContinueAsNew** — bound history by starting a fresh backend run that carries state forward
 
 <SdkTabs>
 <SdkSnippet lang="python">

--- a/docs/content/primitives/flow/basic.mdx
+++ b/docs/content/primitives/flow/basic.mdx
@@ -159,13 +159,13 @@ impl Flow for ExampleFlow {
 
 Dex uses these identifiers throughout its APIs and documentation.
 
-First, when mentioning **Flow**,  depending on the context, it usually means a Flow definition identified by its **FlowType**, or a Flow run instance identified by its **Flow ID**.
+First, when mentioning **Flow**, depending on the context, it usually means a Flow definition identified by its **FlowType**, or a Flow execution identified by its **Flow ID**.
 
 | Identifier | Who sets it | Meaning |
 |----------|-------------|---------|
 | **FlowType** | Application (via Flow implementation) | Stable type name Dex uses to route Worker calls and search results. |
-| **Flow ID** | Application client on start           | Business identity for one logical Flow. Reuse policy controls whether a new run may replace or attach to an existing ID. |
-| **Run ID** | Dex Server | Identity of one run attempt. Time travel and continue-as-new start a fresh Run ID while optionally keeping the same Flow ID. |
+| **Flow ID** | Application client on start           | Business identity for one Flow execution. ID reuse policy controls whether another Flow execution may start with the same Flow ID. |
+| **Run ID** | Dex Server | Identity of one backend run attempt. Time travel and continue-as-new assign a fresh Run ID while keeping the same Flow execution. |
 | **StepType** | Application (via Step implementation) | Stable name for a Step definition inside the Flow. |
 | **StepExecutionID** | Dex Server | One execution instance of a Step type, formatted as **StepType-Number**. |
 

--- a/docs/content/primitives/flow/flow-options.mdx
+++ b/docs/content/primitives/flow/flow-options.mdx
@@ -283,7 +283,7 @@ The ID reuse policy determines whether Dex rejects the start in the first place:
 
 #### What Dex Server does
 
-Dex Server requires a non-empty **RequestID**. An SDK generates one before sending the request when you omit it. The server records it with the Flow run, then asks the configured backend to start the Flow using the requested ID reuse policy. **IDReuseDefault** uses the server default: start a new run when no run is active.
+Dex Server requires a non-empty **RequestID**. An SDK generates one before sending the request when you omit it. The server records it with the Flow execution, then asks the configured backend to start the Flow using the requested ID reuse policy. **IDReuseDefault** uses the server default: start a new Flow execution when no execution is active.
 
 If the backend reports that the Flow is already started, Dex checks **AlreadyStartedOptions.IgnoreError**. When it is on, Dex reads the existing run's recorded RequestID. It returns that Run ID only when the two RequestIDs match. Otherwise it returns the already-started error.
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
@@ -6,11 +6,11 @@ slug: /primitives/attribute
 
 # Attribute
 
-一个 **Attribute** 让你可以在一个 Flow run 内存储数据，作为 persistence storage。
+一个 **Attribute** 让你可以在一个 Flow execution 内存储数据，作为 persistence storage。
 
-这尤其适合在 Flow run 期间存储中间数据，省去设置和管理 database dependency 的工作。
+这尤其适合在 Flow execution 期间存储中间数据，省去设置和管理 database dependency 的工作。
 
-Dex Attribute 不是用来替代 database 的。一个明显的限制是，Attribute 只在它所属的 Flow run 生命周期内存在。Dex 会在 Flow 关闭后的 configurable retention period 结束后删除 Flow run 时，一并删除 Attribute。
+Dex Attribute 不是用来替代 database 的。一个明显的限制是，Attribute 只在它所属的 Flow execution 生命周期内存在。Dex 会在 Flow 关闭后的 configurable retention period 结束后删除 Flow execution 时，一并删除 Attribute。
 
 不过，Dex 允许你将 Attribute values 同步到 application database，作为 permanent storage。这也让你可以构建更强大的 database indexes 来查询 Attribute。
 
@@ -314,7 +314,7 @@ Client 使用同一个已注册的 Attribute definition 调用 **GetAttributes**
 
 ## Indexed Attribute {#indexed-attributes}
 
-Dex 让你可以为 Attribute 配置 index。有了 indexing，就可以在 **SearchFlows** query 中使用这个 field，找出匹配 query 的 Flow run。
+Dex 让你可以为 Attribute 配置 index。有了 indexing，就可以在 **SearchFlows** query 中使用这个 field，找出匹配 query 的 Flow execution。
 
 | Index type | 值 |
 | --- | --- |
@@ -380,7 +380,7 @@ let status = Attribute::new("primitive-attribute-status")
 </SdkSnippet>
 </SdkTabs>
 
-上面的 status Attribute 使用 **OrderStatus** 作为 index key。要找 status 为 completed 的 Flow run，可以使用这个 query：
+上面的 status Attribute 使用 **OrderStatus** 作为 index key。要找 status 为 completed 的 Flow execution，可以使用这个 query：
 
 ```text
 OrderStatus = 'completed'

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
@@ -7,11 +7,11 @@ import ChannelScopeDiagram from '@site/src/components/primitives/channel/Channel
 
 # Channel
 
-**Channel** 是一条单个 Flow run 内部 durable 的 first-in, first-out (FIFO) 队列。Step、RPC 与 Client 都能往里面追加有类型的消息。Step 通过在 **WaitFor** 里返回 Channel condition 来消费消息。
+**Channel** 是一条单个 Flow execution 内部 durable 的 first-in, first-out (FIFO) 队列。Step、RPC 与 Client 都能往里面追加有类型的消息。Step 通过在 **WaitFor** 里返回 Channel condition 来消费消息。
 
 Channel 会按到达顺序保留消息。一条消息只能被一个匹配的 wait 消费一次，不会复制给其他 waiting Step。
 
-Channel 只属于一个 Flow run。另一个 Flow run 有自己的 Channel 队列；消息不会跨 Flow run。
+Channel 只属于一个 Flow execution。消息不会跨 Flow execution。
 
 <ChannelScopeDiagram />
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
@@ -7,11 +7,11 @@ import ChannelScopeDiagram from '@site/src/components/primitives/channel/Channel
 
 # Channel
 
-**Channel** 是一条单个 Flow execution 内部 durable 的 first-in, first-out (FIFO) 队列。Step、RPC 与 Client 都能往里面追加有类型的消息。Step 通过在 **WaitFor** 里返回 Channel condition 来消费消息。
+**Channel** 是一条单个 Flow run 内部 durable 的 first-in, first-out (FIFO) 队列。Step、RPC 与 Client 都能往里面追加有类型的消息。Step 通过在 **WaitFor** 里返回 Channel condition 来消费消息。
 
 Channel 会按到达顺序保留消息。一条消息只能被一个匹配的 wait 消费一次，不会复制给其他 waiting Step。
 
-Channel 只属于一个 Flow execution。另一个 Flow execution 有自己的 Channel 队列；消息不会跨 Flow execution。
+Channel 只属于一个 Flow run。另一个 Flow run 有自己的 Channel 队列；消息不会跨 Flow run。
 
 <ChannelScopeDiagram />
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
@@ -5,15 +5,15 @@ slug: /primitives/channel
 
 # Channel
 
-**Channel** is a durable FIFO queue inside one Flow. Steps, RPCs, and Clients append typed messages. A Step consumes messages by returning a Channel condition from **WaitFor**.
+**Channel** 是一条 Flow 内部 durable 的 FIFO 队列。Step、RPC 与 Client 都能往里面追加有类型的消息。Step 通过在 **WaitFor** 里返回 Channel condition 来消费消息。
 
-A Channel is useful when a Flow must wait for an external event, or when one Step hands work to another Step. It is a queue, not a broadcast topic: one message wakes at most one matching waiting Step.
+Channel 适合等外部事件，也适合让一个 Step 把工作交给另一个 Step。它是队列，不是广播 topic：一条消息最多唤醒一个匹配的 waiting Step。
 
-## Define a Channel {#define-a-channel}
+## 定义 Channel {#define-a-channel}
 
-A Channel has a stable name and a message type. Add it to the Flow persistence schema. Dex Server rejects a publish, wait, or read that uses a Channel the Flow did not declare.
+Channel 有稳定的名字和消息类型。把它加到 Flow 的 persistence schema。Dex Server 会拒绝对 Flow 未声明的 Channel 做 publish、wait 或 read。
 
-This example has an **Approval** Channel. Its start Step waits for either one approval or a Timer. The **approve** RPC publishes the approval message. The same Flow can also receive a message directly through the Client **PublishToChannel** API.
+下面的例子有一个 **Approval** Channel。start Step 等一条 approval 或一个 Timer。**approve** RPC 发布 approval 消息。这个 Flow 也可以通过 Client 的 **PublishToChannel** API 直接接收消息。
 
 <SdkTabs
 examples={{
@@ -273,48 +273,48 @@ impl Step for ChannelWait {
 </SdkSnippet>
 </SdkTabs>
 
-The Timer branch returns before reading Channel results. If the approval wins, the Channel condition has consumed one message, so the first result is present.
+Timer 分支会先返回，不会读取 Channel 结果。approval 胜出时，Channel condition 已消费一条消息，所以第一个结果一定存在。
 
-## Wait and consume {#wait-and-consume}
+## 等待并消费 {#wait-and-consume}
 
-Returning a Channel condition from **WaitFor** is a consume operation. Dex Server keeps messages until a waiting Step wins them, then removes the selected messages from the queue in FIFO order and passes them to **Execute** as Channel results.
+在 **WaitFor** 里返回 Channel condition 就是在消费。Dex Server 会保留消息，直到某个 waiting Step 赢得它们；然后按 FIFO 顺序从队列移除选中的消息，并以 Channel results 传给 **Execute**。
 
-| Condition | When it proceeds | What it consumes |
+| Condition | 何时继续 | 消费什么 |
 | --- | --- | --- |
-| **ForOne** | At least one message is queued. | Exactly one message. |
-| **ForN** | At least the requested number is queued. | Exactly that number of messages. |
-| **AtLeast** | At least the requested number is queued. | Every message currently available. |
-| **AtMost** | The queue has no more than the requested number. An empty queue matches. | Up to the requested number of messages. |
-| **AtLeastAtMost** | The queue has a number of messages in the inclusive range. | From the lower bound up to the upper bound. |
+| **ForOne** | 至少有一条消息。 | 恰好一条消息。 |
+| **ForN** | 至少有指定数量的消息。 | 恰好指定数量的消息。 |
+| **AtLeast** | 至少有指定数量的消息。 | 当时所有可用的消息。 |
+| **AtMost** | 队列不超过指定数量。空队列也匹配。 | 最多指定数量的消息。 |
+| **AtLeastAtMost** | 队列消息数落在闭区间内。 | 从下界到上界数量的消息。 |
 
-**AtMost** is not a wait for a new message. It can let **Execute** run immediately when the Channel is empty.
+**AtMost** 不是等待新消息。Channel 为空时，它也可以让 **Execute** 立即运行。
 
-Use **Wait.anyOf** when a Step can proceed on a Channel, a Timer, or a SubFlow. When the Timer wins, the Channel messages stay queued. Use **Wait.allOf** when every condition must be ready. See [Waiting](/primitives/step/waiting-condition) for combinations and condition IDs.
+Step 可以在 **Wait.anyOf** 里等 Channel、Timer 或 SubFlow 的任意一个。Timer 胜出时，Channel 消息会继续留在队列里。所有 condition 都必须 ready 时用 **Wait.allOf**。组合与 condition ID 见 [Waiting](/primitives/step/waiting-condition)。
 
-Do not use one Channel as a broadcast mechanism. If two waiting Steps target the same Channel, a message consumed by one Step is not available to the other. Use separate Channels when both Steps must see the event.
+不要把一个 Channel 当广播机制。如果两个 waiting Step 都在等同一个 Channel，一条被其中一个 Step 消费的消息不会再给另一个 Step。两个 Step 都需要看到事件时，用两个 Channel。
 
-## Read Channel results {#read-channel-results}
+## 读取 Channel 结果 {#read-channel-results}
 
-Read the values selected for the current Step execution through the Channel result method shown in the example. It returns only messages consumed by that Channel condition. If the Step proceeded because another condition won, the result for this Channel is empty.
+用例子里的 Channel result method 读取当前 Step execution 选中的值。它只返回这个 Channel condition 消费的消息。如果 Step 是因为其他 condition 胜出而继续，这个 Channel 的结果为空。
 
-**Size** reads the queued message count visible to the current Step or RPC invocation. It is useful for decisions made by that handler; it does not replace a **WaitFor** condition.
+**Size** 读取当前 Step 或 RPC invocation 可见的排队消息数。它适合该 handler 内的决策，但不能替代 **WaitFor** condition。
 
-## Publish messages {#publish-messages}
+## 发布消息 {#publish-messages}
 
-Inside a Step or RPC, call the Channel publish method with the handler **Context**. Dex appends the message when it accepts that handler result.
+在 Step 或 RPC 内，用 handler 的 **Context** 调 Channel 的 publish method。Dex 会在接受这个 handler result 时追加消息。
 
-Code outside a Worker can publish directly through the Client **PublishToChannel** API. A client publishes to an active Flow, and a batch keeps the order in which its values were supplied. See [Client APIs](/primitives/client-apis#interact-with-a-running-flow).
+Worker 外的代码可以用 Client **PublishToChannel** API 直接发布。Client 只能往 active Flow 发布；批量发布的值保持传入顺序。见 [Client APIs](/primitives/client-apis#interact-with-a-running-flow)。
 
-Messages can arrive before a Step starts waiting. Dex Server keeps them in the Channel until a later wait consumes them.
+消息可以先于 Step 的 wait 到达。Dex Server 会把它保留在 Channel 里，直到之后的 wait 消费它。
 
 ## ChannelMap {#channelmap}
 
-Use **ChannelMap** when one Flow has an unbounded set of independent queues, such as one Channel per order, customer, or job. A ChannelMap has one declared name and one value type. Each instance key has its own FIFO queue.
+一个 Flow 有一组数量不受限、彼此独立的队列时，用 **ChannelMap**，例如每个订单、客户或 job 一条 Channel。ChannelMap 只声明一个名字和一个值类型，每个 instance key 都有自己的 FIFO 队列。
 
-Every operation on a ChannelMap takes the instance key: publish, **ForOne**, **ForN**, range conditions, **Size**, and condition results. A wait on the **order-42** instance never consumes a message from **order-43**.
+ChannelMap 的每个操作都要带 instance key：publish、**ForOne**、**ForN**、范围 condition、**Size** 和 condition results。等 **order-42** instance 时，绝不会消费 **order-43** 的消息。
 
-During an RPC, a ChannelMap can also list its non-empty instance keys and count them. Those methods include messages published earlier in the same RPC, omit empty instances, and return keys in ascending order. They are RPC-only because they inspect the Flow's current queue state.
+在 RPC 内，ChannelMap 还可以列出非空 instance key 并计数。这些方法会包含同一个 RPC 之前发布的消息，省略空 instance，并按升序返回 key。它们只能在 RPC 内调用，因为它们读取的是 Flow 当前的队列状态。
 
-## What Dex Server stores {#what-dex-server-stores}
+## Dex Server 存什么 {#what-dex-server-stores}
 
-Dex Server stores Channel messages with the Flow state. It evaluates Channel conditions against that durable queue, removes messages only when a waiting Step wins them, and sends the selected values to the Worker for **Execute**. Worker restarts do not lose queued messages or a Step's pending wait.
+Dex Server 把 Channel 消息和 Flow state 一起存储。它针对这个 durable 队列判断 Channel condition，只有 waiting Step 赢得消息时才移除消息，并把选中的值发给 Worker 的 **Execute**。Worker 重启不会丢掉队列里的消息，也不会丢掉 Step 的 pending wait。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
@@ -3,11 +3,17 @@ title: Channel
 slug: /primitives/channel
 ---
 
+import ChannelScopeDiagram from '@site/src/components/primitives/channel/ChannelScopeDiagram';
+
 # Channel
 
-**Channel** 是一条 Flow 内部 durable 的 FIFO 队列。Step、RPC 与 Client 都能往里面追加有类型的消息。Step 通过在 **WaitFor** 里返回 Channel condition 来消费消息。
+**Channel** 是一条单个 Flow execution 内部 durable 的 first-in, first-out (FIFO) 队列。Step、RPC 与 Client 都能往里面追加有类型的消息。Step 通过在 **WaitFor** 里返回 Channel condition 来消费消息。
 
-Channel 适合等外部事件，也适合让一个 Step 把工作交给另一个 Step。它是队列，不是广播 topic：一条消息最多唤醒一个匹配的 waiting Step。
+Channel 会按到达顺序保留消息。一条消息只能被一个匹配的 wait 消费一次，不会复制给其他 waiting Step。
+
+Channel 只属于一个 Flow execution。另一个 Flow execution 有自己的 Channel 队列；消息不会跨 Flow execution。
+
+<ChannelScopeDiagram />
 
 ## Persistence schema {#persistence-schema}
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
@@ -9,9 +9,9 @@ slug: /primitives/channel
 
 Channel 适合等外部事件，也适合让一个 Step 把工作交给另一个 Step。它是队列，不是广播 topic：一条消息最多唤醒一个匹配的 waiting Step。
 
-## 定义 Channel {#define-a-channel}
+## Persistence schema {#persistence-schema}
 
-Channel 有稳定的名字和消息类型。把它加到 Flow 的 persistence schema。Dex Server 会拒绝对 Flow 未声明的 Channel 做 publish、wait 或 read。
+Channel 有稳定的名字和消息类型。先定义它，再加到 Flow 的 persistence schema。只定义 Channel 不会把它注册到 Flow。Dex Server 会拒绝对 Flow persistence schema 未声明的 Channel 做 publish、wait 或 read。
 
 下面的例子有一个 **Approval** Channel。start Step 等一条 approval 或一个 Timer。**approve** RPC 发布 approval 消息。这个 Flow 也可以通过 Client 的 **PublishToChannel** API 直接接收消息。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/basic.mdx
@@ -159,13 +159,13 @@ impl Flow for ExampleFlow {
 
 Dex 在其 API 和文档中使用这些标识符。
 
-首先，说到 **Flow** 时，它通常依上下文指由 **FlowType** 标识的 Flow 定义，或由 **Flow ID** 标识的一次 Flow run instance。
+首先，说到 **Flow** 时，它通常依上下文指由 **FlowType** 标识的 Flow 定义，或由 **Flow ID** 标识的一次 Flow execution。
 
 | 标识符 | 谁设置 | 含义 |
 |--------|--------|------|
 | **FlowType** | 应用（Flow 实现） | Dex 路由 Worker 调用与搜索结果使用的稳定类型名。 |
-| **Flow ID** | 应用在 start 时 | 一个逻辑 Flow 的业务身份。Reuse policy 决定新 run 能否 attach、替换或拒绝已有 ID。 |
-| **Run ID** | Dex Server | 一次 run 尝试的身份。Time travel 与 continue-as-new 会保留 Flow ID 并开启新的 Run ID。 |
+| **Flow ID** | 应用在 start 时 | 一个 Flow execution 的业务身份。ID reuse policy 控制是否可以使用同一个 Flow ID 启动另一个 Flow execution。 |
+| **Run ID** | Dex Server | 一次 backend run attempt 的身份。Time travel 与 continue-as-new 会保留同一个 Flow execution 并分配新的 Run ID。 |
 | **StepType** | 应用（Step 实现） | Flow 内 Step 定义的 stable 名称。 |
 | **StepExecutionID** | Dex Server | 某个 Step type 的一次执行实例，格式为 **StepType-Number**。 |
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/flow-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/flow-options.mdx
@@ -283,7 +283,7 @@ ID reuse policy 决定 Dex 是否会首先拒绝启动：
 
 #### Dex Server 的逻辑
 
-Dex Server 要求 **RequestID** 非空。省略时，SDK 会在发送请求前生成它。服务端将它记录在 Flow run 中，再使用请求的 ID reuse policy 让已配置的 backend 启动 Flow。**IDReuseDefault** 使用服务端默认行为：没有 active run 时启动新的 run。
+Dex Server 要求 **RequestID** 非空。省略时，SDK 会在发送请求前生成它。服务端将它记录在 Flow execution 中，再使用请求的 ID reuse policy 让已配置的 backend 启动 Flow。**IDReuseDefault** 使用服务端默认行为：没有 active execution 时启动新的 Flow execution。
 
 如果 backend 返回 Flow 已启动，Dex 会检查 **AlreadyStartedOptions.IgnoreError**。启用时，Dex 读取已有 run 记录的 RequestID。只有两个 RequestID 相同时才返回该 Run ID；否则仍然返回 already-started error。
 

--- a/docs/src/components/primitives/channel/ChannelScopeDiagram.tsx
+++ b/docs/src/components/primitives/channel/ChannelScopeDiagram.tsx
@@ -9,80 +9,327 @@
 import React, {type ReactNode} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
-import {CompactCard, GraphArrow} from '../step/flowGraphShared';
-
 type Copy = {
   label: string;
-  executionA: string;
-  executionB: string;
-  publish: string;
-  publishers: string;
-  publisherDetail: string;
-  queued: string;
+  run: string;
+  otherRun: string;
+  runID: string;
+  otherRunID: string;
+  stepExecution: string;
+  waitFor: string;
+  execute: string;
+  waitDetail: string;
+  executeDetail: string;
+  publisherStep: string;
+  publisherStepDetail: string;
+  rpc: string;
+  rpcDetail: string;
+  channel: string;
+  channelName: string;
   fifo: string;
-  firstMessage: string;
-  secondMessage: string;
-  consumed: string;
-  consumedDetail: string;
-  append: string;
-  consume: string;
-  noCross: string;
-  separateQueue: string;
+  consumeOnce: string;
+  waitsFor: string;
+  publish: string;
+  independent: string;
 };
 
 const EN: Copy = {
   label:
-    'A Channel is a FIFO queue scoped to one Flow execution. The first queued message is consumed once by a waiting Step and never crosses to another Flow execution.',
-  executionA: 'Flow execution A',
-  executionB: 'Flow execution B',
-  publish: 'PUBLISH MESSAGES',
-  publishers: 'RPC · Step · Client',
-  publisherDetail: 'each appends to this queue',
-  queued: 'Approval Channel',
-  fifo: 'FIRST-IN, FIRST-OUT',
-  firstMessage: '1. approved',
-  secondMessage: '2. approved',
-  consumed: 'Waiting Step',
-  consumedDetail: 'message 1 consumed and removed',
-  append: 'append in arrival order',
-  consume: 'consume the first message once',
-  noCross: 'no messages cross execution boundaries',
-  separateQueue: 'separate Approval Channel queue',
+    'One Flow run owns a messages Channel. A Step waits on it, another Step and an RPC publish to it, and another Flow run has an independent FIFO Channel.',
+  run: 'Flow run',
+  otherRun: 'Another Flow run',
+  runID: 'Run ID: run-a',
+  otherRunID: 'Run ID: run-b',
+  stepExecution: 'Step execution',
+  waitFor: 'WaitFor',
+  execute: 'Execute',
+  waitDetail: 'messages.forOne()',
+  executeDetail: 'first message is consumed once',
+  publisherStep: 'Step execution',
+  publisherStepDetail: 'publish messages',
+  rpc: 'RPC',
+  rpcDetail: 'publish messages',
+  channel: 'CHANNEL',
+  channelName: 'messages',
+  fifo: 'FIFO queue',
+  consumeOnce: 'each message is consumed once',
+  waitsFor: 'waits for',
+  publish: 'publish',
+  independent: 'independent FIFO Channel',
 };
 
 const ZH: Copy = {
   label:
-    'Channel 是只属于一个 Flow execution 的 FIFO 队列。第一个排队消息由 waiting Step 消费一次，不会跨到另一个 Flow execution。',
-  executionA: 'Flow execution A',
-  executionB: 'Flow execution B',
-  publish: '发布消息',
-  publishers: 'RPC · Step · Client',
-  publisherDetail: '都会追加到这条队列',
-  queued: 'Approval Channel',
-  fifo: 'FIRST-IN, FIRST-OUT',
-  firstMessage: '1. approved',
-  secondMessage: '2. approved',
-  consumed: 'Waiting Step',
-  consumedDetail: '消息 1 被消费并移除',
-  append: '按到达顺序追加',
-  consume: '消费第一条消息一次',
-  noCross: '消息不会跨 execution 边界',
-  separateQueue: '独立的 Approval Channel 队列',
+    '一个 Flow run 拥有 messages Channel。一个 Step 等待它，另一个 Step 和一个 RPC 往它发布消息；另一个 Flow run 有独立的 FIFO Channel。',
+  run: 'Flow run',
+  otherRun: '另一个 Flow run',
+  runID: 'Run ID: run-a',
+  otherRunID: 'Run ID: run-b',
+  stepExecution: 'Step execution',
+  waitFor: 'WaitFor',
+  execute: 'Execute',
+  waitDetail: 'messages.forOne()',
+  executeDetail: '第一条消息只消费一次',
+  publisherStep: 'Step execution',
+  publisherStepDetail: '发布消息',
+  rpc: 'RPC',
+  rpcDetail: '发布消息',
+  channel: 'CHANNEL',
+  channelName: 'messages',
+  fifo: 'FIFO 队列',
+  consumeOnce: '每条消息只消费一次',
+  waitsFor: '等待',
+  publish: '发布',
+  independent: '独立的 FIFO Channel',
 };
 
-function Queue({copy}: {copy: Copy}): ReactNode {
+const css = String.raw`
+  .channel-run-diagram {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: stretch;
+    gap: 1rem;
+  }
+  .channel-run-frame {
+    padding: 0.85rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 14px;
+    background: color-mix(in srgb, var(--surface-solid) 84%, transparent);
+  }
+  .channel-run-frame-small {
+    padding: 0.75rem;
+  }
+  .channel-run-heading {
+    display: flex;
+    margin-bottom: 0.8rem;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+  .channel-run-heading b {
+    font-size: 0.86rem;
+  }
+  .channel-run-heading span,
+  .channel-run-node > span,
+  .channel-run-queue span {
+    color: var(--muted);
+    font-size: 0.62rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .channel-run-main {
+    display: grid;
+    grid-template-columns: minmax(7rem, 1fr) 3.75rem minmax(10rem, 1.2fr) 3.75rem minmax(7rem, 1fr);
+    grid-template-rows: auto auto;
+    align-items: center;
+    row-gap: 0.8rem;
+  }
+  .channel-run-wait { grid-column: 1; grid-row: 1; }
+  .channel-run-wait-arrow { grid-column: 2; grid-row: 1; }
+  .channel-run-queue-main { grid-column: 3; grid-row: 1 / span 2; }
+  .channel-run-rpc-arrow { grid-column: 4; grid-row: 1; }
+  .channel-run-rpc { grid-column: 5; grid-row: 1; }
+  .channel-run-step-publish { grid-column: 1; grid-row: 2; }
+  .channel-run-step-arrow { grid-column: 2; grid-row: 2; }
+  .channel-run-node {
+    display: flex;
+    min-height: 5rem;
+    padding: 0.65rem;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.25rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 9px;
+    background: var(--surface-solid);
+  }
+  .channel-run-node b,
+  .channel-run-queue strong {
+    font-size: 0.78rem;
+  }
+  .channel-run-node small,
+  .channel-run-queue small {
+    color: var(--muted);
+    font-size: 0.68rem;
+  }
+  .channel-run-step {
+    padding: 0;
+    overflow: hidden;
+  }
+  .channel-run-step > span {
+    padding: 0.65rem 0.65rem 0.25rem;
+  }
+  .channel-run-step > div {
+    display: flex;
+    padding: 0.5rem 0.65rem;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .channel-run-step > div + div {
+    border-top: 1px solid var(--line);
+    background: color-mix(in srgb, var(--cyan) 10%, var(--surface-solid));
+  }
+  .channel-run-queue {
+    display: flex;
+    min-height: 8.8rem;
+    padding: 0.8rem;
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.35rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--cyan) 13%, var(--surface-solid));
+    text-align: center;
+  }
+  .channel-run-queue > div {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.16rem;
+    align-items: center;
+  }
+  .channel-run-queue-icon {
+    width: min(100%, 7.5rem);
+    height: auto;
+    flex: 0 0 auto;
+    fill: none;
+    stroke: var(--forest);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2.5;
+  }
+  .channel-run-arrow {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.2rem;
+    color: var(--muted);
+    font-size: 0.62rem;
+    font-weight: 700;
+    line-height: 1.1;
+    text-align: center;
+  }
+  .channel-run-arrow i {
+    position: relative;
+    display: block;
+    min-width: 1rem;
+    height: 1px;
+    flex: 1 1 auto;
+    background: currentColor;
+  }
+  .channel-run-arrow-right i::after,
+  .channel-run-arrow-left i::after {
+    position: absolute;
+    top: -3px;
+    width: 0;
+    height: 0;
+    border-top: 3.5px solid transparent;
+    border-bottom: 3.5px solid transparent;
+    content: '';
+  }
+  .channel-run-arrow-right i::after {
+    right: -1px;
+    border-left: 5px solid currentColor;
+  }
+  .channel-run-arrow-left {
+    flex-direction: row-reverse;
+  }
+  .channel-run-arrow-left i::after {
+    left: -1px;
+    border-right: 5px solid currentColor;
+  }
+  .channel-run-secondary {
+    display: flex;
+    width: min(100%, 17rem);
+    min-height: 9rem;
+    flex-direction: column;
+    justify-content: center;
+    justify-self: end;
+  }
+  .channel-run-queue-small {
+    min-height: 6rem;
+    padding: 0.65rem;
+  }
+  .channel-run-queue-small .channel-run-queue-icon {
+    width: min(100%, 5rem);
+  }
+  @media (max-width: 760px) {
+    .channel-run-main {
+      grid-template-columns: minmax(7rem, 1fr) 3.25rem minmax(9rem, 1.1fr);
+    }
+    .channel-run-rpc-arrow { grid-column: 2; grid-row: 3; }
+    .channel-run-rpc { grid-column: 1; grid-row: 3; }
+    .channel-run-queue-main { grid-row: 1 / span 3; }
+    .channel-run-arrow-left {
+      flex-direction: row;
+    }
+    .channel-run-arrow-left i::after {
+      right: -1px;
+      left: auto;
+      border-right: 0;
+      border-left: 5px solid currentColor;
+    }
+  }
+`;
+
+function Arrow({direction, label}: {direction: 'left' | 'right'; label: string}): ReactNode {
   return (
-    <div className="flow-graph-card flow-graph-card-waiting">
-      <div className="flow-graph-heading">
-        <span>{copy.fifo}</span>
-        <b>{copy.queued}</b>
+    <div className={'channel-run-arrow channel-run-arrow-' + direction} aria-hidden="true">
+      <span>{label}</span>
+      <i />
+    </div>
+  );
+}
+
+function QueueIcon(): ReactNode {
+  return (
+    <svg className="channel-run-queue-icon" viewBox="0 0 180 88" aria-hidden="true">
+      <ellipse cx="20" cy="44" rx="14" ry="31" />
+      <path d="M20 13h124c16 0 29 14 29 31s-13 31-29 31H20" />
+      <ellipse cx="144" cy="44" rx="14" ry="31" />
+      <path d="M29 26h113M29 44h113M29 62h113" />
+    </svg>
+  );
+}
+
+function Queue({copy, small = false}: {copy: Copy; small?: boolean}): ReactNode {
+  return (
+    <div className={small ? 'channel-run-queue channel-run-queue-small' : 'channel-run-queue'}>
+      <QueueIcon />
+      <div>
+        <span>{copy.channel}</span>
+        <strong>{copy.channelName}</strong>
+        <small>{small ? copy.independent : copy.fifo + ' · ' + copy.consumeOnce}</small>
       </div>
-      <div className="flow-graph-methods flow-graph-methods-execute-only">
-        <div className="flow-graph-method">
-          <strong>{copy.firstMessage}</strong>
-          <strong>{copy.secondMessage}</strong>
-        </div>
+    </div>
+  );
+}
+
+function StepWait({copy}: {copy: Copy}): ReactNode {
+  return (
+    <div className="channel-run-node channel-run-step">
+      <span>{copy.stepExecution}</span>
+      <div>
+        <b>{copy.waitFor}</b>
+        <small>{copy.waitDetail}</small>
       </div>
+      <div>
+        <b>{copy.execute}</b>
+        <small>{copy.executeDetail}</small>
+      </div>
+    </div>
+  );
+}
+
+function Publisher({title, detail}: {title: string; detail: string}): ReactNode {
+  return (
+    <div className="channel-run-node">
+      <span>{title}</span>
+      <b>{detail}</b>
+      <small>messages</small>
     </div>
   );
 }
@@ -92,26 +339,44 @@ export default function ChannelScopeDiagram(): ReactNode {
   const copy = i18n.currentLocale === 'zh-Hans' ? ZH : EN;
   return (
     <div className="exec-diagram" role="img" aria-label={copy.label}>
-      <div className="flow-graph">
-        <CompactCard kicker="FLOW" title={copy.executionA} tone="source" />
-        <GraphArrow label={copy.append} />
-        <CompactCard
-          kicker={copy.publish}
-          title={copy.publishers}
-          detail={copy.publisherDetail}
-          tone="source"
-        />
-        <GraphArrow />
-        <Queue copy={copy} />
-        <GraphArrow label={copy.consume} />
-        <CompactCard
-          kicker="WAITFOR"
-          title={copy.consumed}
-          detail={copy.consumedDetail}
-          tone="done"
-        />
-        <GraphArrow label={copy.noCross} />
-        <CompactCard kicker="FLOW" title={copy.executionB} detail={copy.separateQueue} tone="source" />
+      <style>{css}</style>
+      <div className="channel-run-diagram">
+        <section className="channel-run-frame">
+          <div className="channel-run-heading">
+            <b>{copy.run}</b>
+            <span>{copy.runID}</span>
+          </div>
+          <div className="channel-run-main">
+            <div className="channel-run-wait">
+              <StepWait copy={copy} />
+            </div>
+            <div className="channel-run-wait-arrow">
+              <Arrow direction="right" label={copy.waitsFor} />
+            </div>
+            <div className="channel-run-queue-main">
+              <Queue copy={copy} />
+            </div>
+            <div className="channel-run-rpc-arrow">
+              <Arrow direction="left" label={copy.publish} />
+            </div>
+            <div className="channel-run-rpc">
+              <Publisher title={copy.rpc} detail={copy.rpcDetail} />
+            </div>
+            <div className="channel-run-step-publish">
+              <Publisher title={copy.publisherStep} detail={copy.publisherStepDetail} />
+            </div>
+            <div className="channel-run-step-arrow">
+              <Arrow direction="right" label={copy.publish} />
+            </div>
+          </div>
+        </section>
+        <section className="channel-run-frame channel-run-frame-small channel-run-secondary">
+          <div className="channel-run-heading">
+            <b>{copy.otherRun}</b>
+            <span>{copy.otherRunID}</span>
+          </div>
+          <Queue copy={copy} small />
+        </section>
       </div>
     </div>
   );

--- a/docs/src/components/primitives/channel/ChannelScopeDiagram.tsx
+++ b/docs/src/components/primitives/channel/ChannelScopeDiagram.tsx
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+import React, {type ReactNode} from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+import {CompactCard, GraphArrow} from '../step/flowGraphShared';
+
+type Copy = {
+  label: string;
+  executionA: string;
+  executionB: string;
+  publish: string;
+  publishers: string;
+  publisherDetail: string;
+  queued: string;
+  fifo: string;
+  firstMessage: string;
+  secondMessage: string;
+  consumed: string;
+  consumedDetail: string;
+  append: string;
+  consume: string;
+  noCross: string;
+  separateQueue: string;
+};
+
+const EN: Copy = {
+  label:
+    'A Channel is a FIFO queue scoped to one Flow execution. The first queued message is consumed once by a waiting Step and never crosses to another Flow execution.',
+  executionA: 'Flow execution A',
+  executionB: 'Flow execution B',
+  publish: 'PUBLISH MESSAGES',
+  publishers: 'RPC · Step · Client',
+  publisherDetail: 'each appends to this queue',
+  queued: 'Approval Channel',
+  fifo: 'FIRST-IN, FIRST-OUT',
+  firstMessage: '1. approved',
+  secondMessage: '2. approved',
+  consumed: 'Waiting Step',
+  consumedDetail: 'message 1 consumed and removed',
+  append: 'append in arrival order',
+  consume: 'consume the first message once',
+  noCross: 'no messages cross execution boundaries',
+  separateQueue: 'separate Approval Channel queue',
+};
+
+const ZH: Copy = {
+  label:
+    'Channel 是只属于一个 Flow execution 的 FIFO 队列。第一个排队消息由 waiting Step 消费一次，不会跨到另一个 Flow execution。',
+  executionA: 'Flow execution A',
+  executionB: 'Flow execution B',
+  publish: '发布消息',
+  publishers: 'RPC · Step · Client',
+  publisherDetail: '都会追加到这条队列',
+  queued: 'Approval Channel',
+  fifo: 'FIRST-IN, FIRST-OUT',
+  firstMessage: '1. approved',
+  secondMessage: '2. approved',
+  consumed: 'Waiting Step',
+  consumedDetail: '消息 1 被消费并移除',
+  append: '按到达顺序追加',
+  consume: '消费第一条消息一次',
+  noCross: '消息不会跨 execution 边界',
+  separateQueue: '独立的 Approval Channel 队列',
+};
+
+function Queue({copy}: {copy: Copy}): ReactNode {
+  return (
+    <div className="flow-graph-card flow-graph-card-waiting">
+      <div className="flow-graph-heading">
+        <span>{copy.fifo}</span>
+        <b>{copy.queued}</b>
+      </div>
+      <div className="flow-graph-methods flow-graph-methods-execute-only">
+        <div className="flow-graph-method">
+          <strong>{copy.firstMessage}</strong>
+          <strong>{copy.secondMessage}</strong>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ChannelScopeDiagram(): ReactNode {
+  const {i18n} = useDocusaurusContext();
+  const copy = i18n.currentLocale === 'zh-Hans' ? ZH : EN;
+  return (
+    <div className="exec-diagram" role="img" aria-label={copy.label}>
+      <div className="flow-graph">
+        <CompactCard kicker="FLOW" title={copy.executionA} tone="source" />
+        <GraphArrow label={copy.append} />
+        <CompactCard
+          kicker={copy.publish}
+          title={copy.publishers}
+          detail={copy.publisherDetail}
+          tone="source"
+        />
+        <GraphArrow />
+        <Queue copy={copy} />
+        <GraphArrow label={copy.consume} />
+        <CompactCard
+          kicker="WAITFOR"
+          title={copy.consumed}
+          detail={copy.consumedDetail}
+          tone="done"
+        />
+        <GraphArrow label={copy.noCross} />
+        <CompactCard kicker="FLOW" title={copy.executionB} detail={copy.separateQueue} tone="source" />
+      </div>
+    </div>
+  );
+}

--- a/docs/src/components/primitives/channel/ChannelScopeDiagram.tsx
+++ b/docs/src/components/primitives/channel/ChannelScopeDiagram.tsx
@@ -9,199 +9,143 @@
 import React, {type ReactNode} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
+import {StepCard} from '../step/flowGraphShared';
+
 type Copy = {
   label: string;
-  run: string;
-  otherRun: string;
-  runID: string;
-  otherRunID: string;
-  stepExecution: string;
+  execution: string;
+  publisherStep: string;
+  publisherRPC: string;
+  consumerStep: string;
   waitFor: string;
   execute: string;
-  waitDetail: string;
-  executeDetail: string;
-  publisherStep: string;
-  publisherStepDetail: string;
-  rpc: string;
-  rpcDetail: string;
   channel: string;
   channelName: string;
   fifo: string;
   consumeOnce: string;
-  waitsFor: string;
   publish: string;
-  independent: string;
+  consume: string;
 };
 
 const EN: Copy = {
   label:
-    'One Flow run owns a messages Channel. A Step waits on it, another Step and an RPC publish to it, and another Flow run has an independent FIFO Channel.',
-  run: 'Flow run',
-  otherRun: 'Another Flow run',
-  runID: 'Run ID: run-a',
-  otherRunID: 'Run ID: run-b',
-  stepExecution: 'Step execution',
-  waitFor: 'WaitFor',
-  execute: 'Execute',
-  waitDetail: 'messages.forOne()',
-  executeDetail: 'first message is consumed once',
-  publisherStep: 'Step execution',
-  publisherStepDetail: 'publish messages',
-  rpc: 'RPC',
-  rpcDetail: 'publish messages',
+    'A Flow execution owns a requests_queue Channel. ExampleStepA and ExampleRpc publish messages to it. ExampleStepB waits for and consumes messages from it.',
+  execution: 'Flow execution',
+  publisherStep: 'ExampleStepA',
+  publisherRPC: 'ExampleRpc',
+  consumerStep: 'ExampleStepB',
+  waitFor: 'requests_queue.for_one()',
+  execute: 'process request',
   channel: 'CHANNEL',
-  channelName: 'messages',
+  channelName: 'requests_queue',
   fifo: 'FIFO queue',
   consumeOnce: 'each message is consumed once',
-  waitsFor: 'waits for',
-  publish: 'publish',
-  independent: 'independent FIFO Channel',
+  publish: 'publish messages',
+  consume: 'consume',
 };
 
 const ZH: Copy = {
   label:
-    '一个 Flow run 拥有 messages Channel。一个 Step 等待它，另一个 Step 和一个 RPC 往它发布消息；另一个 Flow run 有独立的 FIFO Channel。',
-  run: 'Flow run',
-  otherRun: '另一个 Flow run',
-  runID: 'Run ID: run-a',
-  otherRunID: 'Run ID: run-b',
-  stepExecution: 'Step execution',
-  waitFor: 'WaitFor',
-  execute: 'Execute',
-  waitDetail: 'messages.forOne()',
-  executeDetail: '第一条消息只消费一次',
-  publisherStep: 'Step execution',
-  publisherStepDetail: '发布消息',
-  rpc: 'RPC',
-  rpcDetail: '发布消息',
+    '一个 Flow execution 拥有 requests_queue Channel。ExampleStepA 和 ExampleRpc 往它发布消息。ExampleStepB 等待并从中消费消息。',
+  execution: 'Flow execution',
+  publisherStep: 'ExampleStepA',
+  publisherRPC: 'ExampleRpc',
+  consumerStep: 'ExampleStepB',
+  waitFor: 'requests_queue.for_one()',
+  execute: '处理请求',
   channel: 'CHANNEL',
-  channelName: 'messages',
+  channelName: 'requests_queue',
   fifo: 'FIFO 队列',
   consumeOnce: '每条消息只消费一次',
-  waitsFor: '等待',
-  publish: '发布',
-  independent: '独立的 FIFO Channel',
+  publish: '发布消息',
+  consume: '消费',
 };
 
 const css = String.raw`
-  .channel-run-diagram {
+  .channel-execution-frame {
     position: relative;
     z-index: 1;
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    justify-items: stretch;
-    gap: 1rem;
-  }
-  .channel-run-frame {
     padding: 0.85rem;
     border: 1px solid var(--line-strong);
     border-radius: 14px;
     background: color-mix(in srgb, var(--surface-solid) 84%, transparent);
   }
-  .channel-run-frame-small {
-    padding: 0.75rem;
-  }
-  .channel-run-heading {
-    display: flex;
+  .channel-execution-heading {
     margin-bottom: 0.8rem;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 0.5rem;
-  }
-  .channel-run-heading b {
+    color: var(--text);
     font-size: 0.86rem;
   }
-  .channel-run-heading span,
-  .channel-run-node > span,
-  .channel-run-queue span {
+  .channel-execution-main {
+    display: grid;
+    grid-template-columns: minmax(8.5rem, 1fr) 4.5rem minmax(11rem, 1.15fr) 4.5rem minmax(10.5rem, 1fr);
+    grid-template-rows: auto auto;
+    align-items: center;
+    row-gap: 0.8rem;
+  }
+  .channel-execution-publisher-step { grid-column: 1; grid-row: 1; }
+  .channel-execution-publisher-rpc { grid-column: 1; grid-row: 2; }
+  .channel-execution-step-arrow { grid-column: 2; grid-row: 1; }
+  .channel-execution-rpc-arrow { grid-column: 2; grid-row: 2; }
+  .channel-execution-queue { grid-column: 3; grid-row: 1 / span 2; }
+  .channel-execution-consume-arrow { grid-column: 4; grid-row: 1 / span 2; }
+  .channel-execution-consumer { grid-column: 5; grid-row: 1 / span 2; }
+  .channel-execution-node {
+    display: flex;
+    min-height: 4.8rem;
+    padding: 0.7rem;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.28rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 9px;
+    background: var(--surface-solid);
+  }
+  .channel-execution-node span,
+  .channel-execution-queue span {
     color: var(--muted);
     font-size: 0.62rem;
     font-weight: 800;
     letter-spacing: 0.04em;
     text-transform: uppercase;
   }
-  .channel-run-main {
-    display: grid;
-    grid-template-columns: minmax(7rem, 1fr) 3.75rem minmax(10rem, 1.2fr) 3.75rem minmax(7rem, 1fr);
-    grid-template-rows: auto auto;
-    align-items: center;
-    row-gap: 0.8rem;
+  .channel-execution-node b,
+  .channel-execution-queue strong {
+    font-size: 0.8rem;
   }
-  .channel-run-wait { grid-column: 1; grid-row: 1; }
-  .channel-run-wait-arrow { grid-column: 2; grid-row: 1; }
-  .channel-run-queue-main { grid-column: 3; grid-row: 1 / span 2; }
-  .channel-run-rpc-arrow { grid-column: 4; grid-row: 1; }
-  .channel-run-rpc { grid-column: 5; grid-row: 1; }
-  .channel-run-step-publish { grid-column: 1; grid-row: 2; }
-  .channel-run-step-arrow { grid-column: 2; grid-row: 2; }
-  .channel-run-node {
+  .channel-execution-queue-box {
     display: flex;
-    min-height: 5rem;
-    padding: 0.65rem;
-    flex-direction: column;
-    justify-content: center;
-    gap: 0.25rem;
-    border: 1px solid var(--line-strong);
-    border-radius: 9px;
-    background: var(--surface-solid);
-  }
-  .channel-run-node b,
-  .channel-run-queue strong {
-    font-size: 0.78rem;
-  }
-  .channel-run-node small,
-  .channel-run-queue small {
-    color: var(--muted);
-    font-size: 0.68rem;
-  }
-  .channel-run-step {
-    padding: 0;
-    overflow: hidden;
-  }
-  .channel-run-step > span {
-    padding: 0.65rem 0.65rem 0.25rem;
-  }
-  .channel-run-step > div {
-    display: flex;
-    padding: 0.5rem 0.65rem;
-    flex-direction: column;
-    gap: 0.15rem;
-  }
-  .channel-run-step > div + div {
-    border-top: 1px solid var(--line);
-    background: color-mix(in srgb, var(--cyan) 10%, var(--surface-solid));
-  }
-  .channel-run-queue {
-    display: flex;
-    min-height: 8.8rem;
+    min-height: 10.4rem;
     padding: 0.8rem;
     align-items: center;
     flex-direction: column;
     justify-content: center;
-    gap: 0.35rem;
+    gap: 0.45rem;
     border: 1px solid var(--line-strong);
     border-radius: 10px;
     background: color-mix(in srgb, var(--cyan) 13%, var(--surface-solid));
     text-align: center;
   }
-  .channel-run-queue > div {
+  .channel-execution-queue-box > div {
     display: flex;
     min-width: 0;
     flex-direction: column;
-    gap: 0.16rem;
     align-items: center;
+    gap: 0.16rem;
   }
-  .channel-run-queue-icon {
+  .channel-execution-queue-box small {
+    color: var(--muted);
+    font-size: 0.68rem;
+  }
+  .channel-execution-database {
     width: min(100%, 7.5rem);
     height: auto;
-    flex: 0 0 auto;
-    fill: none;
+    fill: var(--surface-solid);
     stroke: var(--forest);
     stroke-linecap: round;
     stroke-linejoin: round;
-    stroke-width: 2.5;
+    stroke-width: 2;
   }
-  .channel-run-arrow {
+  .channel-execution-arrow {
     display: flex;
     min-width: 0;
     align-items: center;
@@ -212,7 +156,7 @@ const css = String.raw`
     line-height: 1.1;
     text-align: center;
   }
-  .channel-run-arrow i {
+  .channel-execution-arrow i {
     position: relative;
     display: block;
     min-width: 1rem;
@@ -220,116 +164,77 @@ const css = String.raw`
     flex: 1 1 auto;
     background: currentColor;
   }
-  .channel-run-arrow-right i::after,
-  .channel-run-arrow-left i::after {
+  .channel-execution-arrow i::after {
     position: absolute;
     top: -3px;
+    right: -1px;
     width: 0;
     height: 0;
     border-top: 3.5px solid transparent;
     border-bottom: 3.5px solid transparent;
+    border-left: 5px solid currentColor;
     content: '';
   }
-  .channel-run-arrow-right i::after {
-    right: -1px;
-    border-left: 5px solid currentColor;
-  }
-  .channel-run-arrow-left {
-    flex-direction: row-reverse;
-  }
-  .channel-run-arrow-left i::after {
-    left: -1px;
-    border-right: 5px solid currentColor;
-  }
-  .channel-run-secondary {
-    display: flex;
-    width: min(100%, 17rem);
-    min-height: 9rem;
-    flex-direction: column;
-    justify-content: center;
-    justify-self: end;
-  }
-  .channel-run-queue-small {
-    min-height: 6rem;
-    padding: 0.65rem;
-  }
-  .channel-run-queue-small .channel-run-queue-icon {
-    width: min(100%, 5rem);
+  .channel-execution-consumer .flow-graph-card {
+    min-width: 0;
   }
   @media (max-width: 760px) {
-    .channel-run-main {
-      grid-template-columns: minmax(7rem, 1fr) 3.25rem minmax(9rem, 1.1fr);
+    .channel-execution-main {
+      grid-template-columns: minmax(8rem, 1fr) 3.8rem minmax(10rem, 1.1fr);
+      grid-template-rows: auto auto auto;
     }
-    .channel-run-rpc-arrow { grid-column: 2; grid-row: 3; }
-    .channel-run-rpc { grid-column: 1; grid-row: 3; }
-    .channel-run-queue-main { grid-row: 1 / span 3; }
-    .channel-run-arrow-left {
-      flex-direction: row;
+    .channel-execution-queue { grid-column: 3; grid-row: 1 / span 3; }
+    .channel-execution-consume-arrow { grid-column: 2; grid-row: 3; }
+    .channel-execution-consumer { grid-column: 1; grid-row: 3; }
+    .channel-execution-consume-arrow .channel-execution-arrow {
+      flex-direction: row-reverse;
     }
-    .channel-run-arrow-left i::after {
-      right: -1px;
-      left: auto;
-      border-right: 0;
-      border-left: 5px solid currentColor;
+    .channel-execution-consume-arrow .channel-execution-arrow i::after {
+      right: auto;
+      left: -1px;
+      border-right: 5px solid currentColor;
+      border-left: 0;
     }
   }
 `;
 
-function Arrow({direction, label}: {direction: 'left' | 'right'; label: string}): ReactNode {
+function Arrow({label}: {label: string}): ReactNode {
   return (
-    <div className={'channel-run-arrow channel-run-arrow-' + direction} aria-hidden="true">
+    <div className="channel-execution-arrow" aria-hidden="true">
       <span>{label}</span>
       <i />
     </div>
   );
 }
 
-function QueueIcon(): ReactNode {
+function Publisher({kicker, name}: {kicker: string; name: string}): ReactNode {
   return (
-    <svg className="channel-run-queue-icon" viewBox="0 0 180 88" aria-hidden="true">
-      <ellipse cx="20" cy="44" rx="14" ry="31" />
-      <path d="M20 13h124c16 0 29 14 29 31s-13 31-29 31H20" />
-      <ellipse cx="144" cy="44" rx="14" ry="31" />
-      <path d="M29 26h113M29 44h113M29 62h113" />
+    <div className="channel-execution-node">
+      <span>{kicker}</span>
+      <b>{name}</b>
+    </div>
+  );
+}
+
+function DatabaseIcon(): ReactNode {
+  return (
+    <svg className="channel-execution-database" viewBox="0 0 180 88" aria-hidden="true">
+      <path d="M29 25c0-7 10-12 22-12h78c12 0 22 5 22 12v38c0 7-10 12-22 12H51c-12 0-22-5-22-12V25Z" />
+      <ellipse cx="51" cy="44" rx="22" ry="31" />
+      <path d="M29 57c0 7 10 12 22 12h78c12 0 22-5 22-12" fill="none" />
     </svg>
   );
 }
 
-function Queue({copy, small = false}: {copy: Copy; small?: boolean}): ReactNode {
+function Queue({copy}: {copy: Copy}): ReactNode {
   return (
-    <div className={small ? 'channel-run-queue channel-run-queue-small' : 'channel-run-queue'}>
-      <QueueIcon />
+    <div className="channel-execution-queue-box">
+      <DatabaseIcon />
       <div>
         <span>{copy.channel}</span>
         <strong>{copy.channelName}</strong>
-        <small>{small ? copy.independent : copy.fifo + ' · ' + copy.consumeOnce}</small>
+        <small>{copy.fifo + ' · ' + copy.consumeOnce}</small>
       </div>
-    </div>
-  );
-}
-
-function StepWait({copy}: {copy: Copy}): ReactNode {
-  return (
-    <div className="channel-run-node channel-run-step">
-      <span>{copy.stepExecution}</span>
-      <div>
-        <b>{copy.waitFor}</b>
-        <small>{copy.waitDetail}</small>
-      </div>
-      <div>
-        <b>{copy.execute}</b>
-        <small>{copy.executeDetail}</small>
-      </div>
-    </div>
-  );
-}
-
-function Publisher({title, detail}: {title: string; detail: string}): ReactNode {
-  return (
-    <div className="channel-run-node">
-      <span>{title}</span>
-      <b>{detail}</b>
-      <small>messages</small>
     </div>
   );
 }
@@ -340,44 +245,37 @@ export default function ChannelScopeDiagram(): ReactNode {
   return (
     <div className="exec-diagram" role="img" aria-label={copy.label}>
       <style>{css}</style>
-      <div className="channel-run-diagram">
-        <section className="channel-run-frame">
-          <div className="channel-run-heading">
-            <b>{copy.run}</b>
-            <span>{copy.runID}</span>
+      <section className="channel-execution-frame">
+        <b className="channel-execution-heading">{copy.execution}</b>
+        <div className="channel-execution-main">
+          <div className="channel-execution-publisher-step">
+            <Publisher kicker="STEP" name={copy.publisherStep} />
           </div>
-          <div className="channel-run-main">
-            <div className="channel-run-wait">
-              <StepWait copy={copy} />
-            </div>
-            <div className="channel-run-wait-arrow">
-              <Arrow direction="right" label={copy.waitsFor} />
-            </div>
-            <div className="channel-run-queue-main">
-              <Queue copy={copy} />
-            </div>
-            <div className="channel-run-rpc-arrow">
-              <Arrow direction="left" label={copy.publish} />
-            </div>
-            <div className="channel-run-rpc">
-              <Publisher title={copy.rpc} detail={copy.rpcDetail} />
-            </div>
-            <div className="channel-run-step-publish">
-              <Publisher title={copy.publisherStep} detail={copy.publisherStepDetail} />
-            </div>
-            <div className="channel-run-step-arrow">
-              <Arrow direction="right" label={copy.publish} />
-            </div>
+          <div className="channel-execution-publisher-rpc">
+            <Publisher kicker="RPC" name={copy.publisherRPC} />
           </div>
-        </section>
-        <section className="channel-run-frame channel-run-frame-small channel-run-secondary">
-          <div className="channel-run-heading">
-            <b>{copy.otherRun}</b>
-            <span>{copy.otherRunID}</span>
+          <div className="channel-execution-step-arrow">
+            <Arrow label={copy.publish} />
           </div>
-          <Queue copy={copy} small />
-        </section>
-      </div>
+          <div className="channel-execution-rpc-arrow">
+            <Arrow label={copy.publish} />
+          </div>
+          <div className="channel-execution-queue">
+            <Queue copy={copy} />
+          </div>
+          <div className="channel-execution-consume-arrow">
+            <Arrow label={copy.consume} />
+          </div>
+          <div className="channel-execution-consumer">
+            <StepCard
+              name={copy.consumerStep}
+              execute={copy.execute}
+              waitFor={{channel: copy.waitFor}}
+              tone="waiting"
+            />
+          </div>
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Rewrite the Channel primitive documentation around durable FIFO queue and consume semantics.
- Add the matching Simplified Chinese Channel page.
- Use the five runnable Channel examples for every application-code snippet.
- Include the pending StepDecision wording correction from the branch base.

## Why

The previous Channel page used outdated API names and omitted message consumption, Channel results, ChannelMap, and Dex Server behavior.

## User impact

Readers can now see how a Channel is declared, waited on, consumed, published, and used with a Timer or ChannelMap in every supported SDK.

## Validation

- `make docs-prose-check`
- `cd docs && npm run build`
