### PR TITLE
Rewrite Timer documentation

### DIFF
--- a/docs/content/primitives/timer.mdx
+++ b/docs/content/primitives/timer.mdx
@@ -118,7 +118,7 @@ impl Step for TimerExampleStep {
 
 ## How to skip a Timer
 
-You can call **SkipTimer** with the Flow ID and Timer selector to skip a Timer.
+You can call **SkipTimer** with the Flow ID and Timer selector to skip a Timer. A skipped timer acts like timer has fired. This is helpful to manually trigger a timer for test simulation for production operation.
 
 <SdkTabs>
 <SdkSnippet lang="python">

--- a/docs/content/primitives/timer.mdx
+++ b/docs/content/primitives/timer.mdx
@@ -5,14 +5,7 @@ slug: /primitives/timer
 
 # Timer
 
-A **Timer** is a durable Condition for **WaitFor**. It keeps a Step waiting
-until a duration elapses. Dex Server stores and schedules the Timer; it does not
-hold a Worker while the Step waits.
-
-## Wait for a duration
-
-Return **Wait.until** with a Timer. This Flow takes a number of seconds as its
-input, then runs **Execute** after that duration.
+Timer is **Durable Timer** persisted on the Dex Server. While waiting on the Timer, there is no resource consumed at the Worker side.
 
 <SdkTabs
   examples={{
@@ -25,13 +18,12 @@ input, then runs **Execute** after that duration.
 <SdkSnippet lang="python">
 
 ```python
-class TimerStep(Step[int]):
-    def wait_for(self, context: Context, input: int) -> Wait:
-        del context
+class TimerExampleStep(Step[int]):
+    def wait_for(self, _context: Context, input: int) -> Wait:
         return Wait.until(Timer.by_duration(timedelta(seconds=input)))
 
-    def execute(self, context: Context, input: int) -> StepDecision:
-        del context, input
+    def execute(self, context: Context, _input: int) -> StepDecision:
+        print(context.has_timer_fired())
         return graceful_complete("timer-fired")
 ```
 
@@ -39,15 +31,16 @@ class TimerStep(Step[int]):
   <SdkSnippet lang="go">
 
 ```go
-type timerStep struct {
+type TimerExampleStep struct {
 	dex.StepDefaults
 }
 
-func (timerStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
+func (TimerExampleStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 	return dex.Until(dex.Timer(time.Duration(input) * time.Second)), nil
 }
 
-func (timerStep) Execute(_ dex.Context, _ int) (*dex.StepDecision, error) {
+func (TimerExampleStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
+	fmt.Println(ctx.HasTimerFired())
 	return dex.GracefulComplete("timer-fired"), nil
 }
 ```
@@ -56,7 +49,7 @@ func (timerStep) Execute(_ dex.Context, _ int) (*dex.StepDecision, error) {
   <SdkSnippet lang="java">
 
 ```java
-final class TimerStep implements Step<Integer> {
+final class TimerExampleStep implements Step<Integer> {
     @Override
     public Class<Integer> getInputType() {
         return Integer.class;
@@ -69,6 +62,7 @@ final class TimerStep implements Step<Integer> {
 
     @Override
     public StepDecision execute(final Context context, final Integer input) {
+        System.out.println(context.hasTimerFired());
         return StepDecision.gracefulComplete("timer-fired");
     }
 }
@@ -78,18 +72,19 @@ final class TimerStep implements Step<Integer> {
   <SdkSnippet lang="typescript">
 
 ```typescript
-class TimerStep implements Step<number> {
+class TimerExampleStep implements Step<number> {
   public readonly inputCodec = doubleCodec;
 
   public getStepType(): string {
-    return "TimerStep";
+    return "TimerExampleStep";
   }
 
   public waitFor(_context: Context, input: number): Wait {
     return Wait.until(Timer.byDuration(input * 1000));
   }
 
-  public execute(_context: Context, _input: number): StepDecision {
+  public execute(context: Context, _input: number): StepDecision {
+    console.log(context.hasTimerFired());
     return gracefulComplete("timer-fired");
   }
 }
@@ -100,9 +95,9 @@ class TimerStep implements Step<number> {
 
 ```rust
 #[derive(Default)]
-struct TimerStep;
+struct TimerExampleStep;
 
-impl Step for TimerStep {
+impl Step for TimerExampleStep {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
@@ -111,7 +106,8 @@ impl Step for TimerStep {
         ))))
     }
 
-    fn execute(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
+    fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
+        println!("{}", context.has_any_timer_fired());
         Ok(StepDecision::graceful_complete("timer-fired".to_string()))
     }
 }
@@ -120,202 +116,65 @@ impl Step for TimerStep {
 </SdkSnippet>
 </SdkTabs>
 
-Timer durations must be non-negative whole seconds. The TypeScript API accepts
-milliseconds, so its value must be divisible by 1,000. A zero-duration Timer is
-ready immediately.
+## How to skip a Timer
 
-## Wait for work or a deadline
+You can call **SkipTimer** with the Flow ID and Timer selector to skip a Timer.
 
-Most real waits have a deadline. **Wait.anyOf** lets a Channel or Timer finish
-the wait. **Execute** can then check whether a Timer fired before reading the
-Channel result.
-
-<SdkTabs
-  examples={{
-    python: 'examples/python/dex_examples/primitives/channel/channel_flow.py',
-    go: 'examples/go/primitives/channel/workflow.go',
-    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java',
-    typescript: 'examples/typescript/src/primitives/channel/channel-flow.ts',
-    rust: 'examples/rust/src/primitives/channel/flow.rs',
-  }}>
+<SdkTabs>
 <SdkSnippet lang="python">
 
 ```python
-class ChannelWaitStep(Step[int]):
-    def __init__(self, approval: Channel[str]) -> None:
-        self.approval = approval
-
-    def wait_for(self, context: Context, input: int) -> Wait:
-        del context
-        return Wait.any_of(
-            self.approval.for_one(),
-            Timer.by_duration(timedelta(seconds=input)),
-        )
-
-    def execute(self, context: Context, input: int) -> StepDecision:
-        if context.has_timer_fired():
-            return graceful_complete("approval timed out")
-        approvals = self.approval.results(context)
-        return graceful_complete(approvals[0])
+client.skip_timer(
+    flow_id,
+    StepExecutionId("TimerExampleStep"),
+    TimerId.by_condition_index(0),
+)
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="go">
 
 ```go
-var Approval = dex.DefineChannel[string]("Approval")
-
-type channelWaitStep struct {
-	dex.StepDefaults
-}
-
-func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
-	return dex.AnyOf(
-		Approval.ForOne(),
-		dex.Timer(time.Duration(input)*time.Second),
-	), nil
-}
-
-func (channelWaitStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
-	if ctx.HasTimerFired() {
-		return dex.GracefulComplete("approval timed out"), nil
-	}
-	results, err := Approval.GetConditionResults(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return dex.GracefulComplete(results[0]), nil
-}
+timerIndex := int32(0)
+err := client.SkipTimer(
+	ctx,
+	flowID,
+	dex.StepExecutionID{StepType: "TimerExampleStep"},
+	dex.TimerID{Index: &timerIndex},
+)
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="java">
 
 ```java
-final class ChannelWaitStep implements Step<Integer> {
-    @Override
-    public Class<Integer> getInputType() {
-        return Integer.class;
-    }
-
-    @Override
-    public Wait waitFor(final Context context, final Integer input) {
-        return Wait.anyOf(
-                approval.forOne(),
-                Timer.byDuration(Duration.ofSeconds(input)));
-    }
-
-    @Override
-    public StepDecision execute(final Context context, final Integer input) {
-        if (context.hasTimerFired()) {
-            return StepDecision.gracefulComplete("approval timed out");
-        }
-        final List<String> approvals = approval.getConditionResults(context);
-        return StepDecision.gracefulComplete(approvals.get(0));
-    }
-}
+client.skipTimer(
+        flowId,
+        StepExecutionId.of("TimerExampleStep"),
+        TimerId.byConditionIndex(0));
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="typescript">
 
 ```typescript
-const approval = new Channel("Approval", stringCodec);
-
-class ChannelWait implements Step<number> {
-  public readonly inputCodec = doubleCodec;
-
-  public getStepType(): string {
-    return "ChannelWait";
-  }
-
-  public waitFor(_context: Context, input: number): Wait {
-    return Wait.anyOf(
-      approval.forOne(),
-      Timer.byDuration(input * 1000),
-    );
-  }
-
-  public execute(context: Context, _input: number): StepDecision {
-    if (context.hasTimerFired()) {
-      return gracefulComplete("approval timed out");
-    }
-    const approvals = approval.results(context);
-    return gracefulComplete(approvals[0]!);
-  }
-}
-
-const channelWaitStep = new ChannelWait();
+await client.skipTimer(
+  flowId,
+  StepExecutionId.of("TimerExampleStep"),
+  TimerId.byConditionIndex(0),
+);
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="rust">
 
 ```rust
-fn approval() -> Channel<String> {
-    Channel::new("Approval")
-}
-
-#[derive(Default)]
-struct ChannelWait;
-
-impl Step for ChannelWait {
-    type Input = i32;
-
-    fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
-        Ok(Wait::any_of([
-            approval().for_one(),
-            Timer::by_duration(Duration::from_secs(input.max(0) as u64)),
-        ]))
-    }
-
-    fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
-        if context.has_any_timer_fired() {
-            return Ok(StepDecision::graceful_complete(
-                "approval timed out".to_owned(),
-            ));
-        }
-        let approvals = approval().condition_results(context)?;
-        Ok(StepDecision::graceful_complete(approvals[0].clone()))
-    }
-}
+client.skip_timer(
+    &flow_id,
+    StepExecutionId::of(&TimerExampleStep),
+    TimerId::by_condition_index(0),
+)?;
 ```
 
 </SdkSnippet>
 </SdkTabs>
-
-**hasTimerFired** reports whether any Timer in the completed Wait fired. If the
-Wait has several Timers, use the indexed form to inspect one of them. **Wait.allOf**
-does the opposite of **Wait.anyOf**: it waits until every condition, including
-every Timer, completes.
-
-## Identify or skip a Timer
-
-Give a Timer a stable condition ID when code outside the Worker needs to target
-it. A **TimerID** or **TimerId** can select a Timer by that ID or by its
-zero-based position among the Timers in the Wait. Prefer a condition ID: a
-position changes when the Wait is reordered. Condition IDs must be unique within
-one Wait. Any-combination waits also require them.
-
-Call **SkipTimer** with the Flow ID, **StepExecutionID** or **StepExecutionId**,
-and the Timer selector. It makes the selected pending Timer ready, so the Wait
-can proceed. Dex Server first reads the active Flow's pending Timers and rejects
-the call when the Flow is closed, the Step execution does not match, or the
-Timer is no longer pending. See [Client APIs](/primitives/client-apis) for the
-client operation.
-
-## How Timer time works
-
-When **WaitFor** returns a Timer, Dex Server records an absolute deadline. The
-deadline is durable, so a Worker restart or **continue-as-new** does not start
-the duration again. The Timer becomes ready when workflow time reaches that
-deadline; **Execute** runs after Dex Server processes that event and a Worker
-can handle it. A Timer is durable scheduling, not a real-time guarantee.
-
-For timing-sensitive work, use **SYNC** Step durability. With **ASYNC**
-durability, Dex Server may receive the **WaitFor** result later, which delays
-when it can schedule the Timer. See [Step options](/primitives/step/step-options#durability).
-
-A Timer has one deadline. To extend a wait after new activity, create another
-Timer rather than changing the existing one. See the [resettable timer](/design-patterns/resettable-timer)
-pattern.

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/timer.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/timer.mdx
@@ -5,14 +5,11 @@ slug: /primitives/timer
 
 # Timer
 
-A **Timer** is a durable Condition for **WaitFor**. It keeps a Step waiting
-until a duration elapses. Dex Server stores and schedules the Timer; it does not
-hold a Worker while the Step waits.
+**Timer** 是用于 **WaitFor** 的 durable Condition。它让 Step 等到一段时间过去。Dex Server 保存并调度 Timer；等待期间不会占住 Worker。
 
-## Wait for a duration
+## 等待一段时间
 
-Return **Wait.until** with a Timer. This Flow takes a number of seconds as its
-input, then runs **Execute** after that duration.
+在 **Wait.until** 中返回一个 Timer。下面这个 Flow 的输入是秒数，到时间后运行 **Execute**。
 
 <SdkTabs
   examples={{
@@ -120,15 +117,11 @@ impl Step for TimerStep {
 </SdkSnippet>
 </SdkTabs>
 
-Timer durations must be non-negative whole seconds. The TypeScript API accepts
-milliseconds, so its value must be divisible by 1,000. A zero-duration Timer is
-ready immediately.
+Timer 的时长必须是非负整数秒。TypeScript API 接受毫秒，因此传入值必须能被 1,000 整除。时长为零的 Timer 会立刻 ready。
 
-## Wait for work or a deadline
+## 等待工作或到期
 
-Most real waits have a deadline. **Wait.anyOf** lets a Channel or Timer finish
-the wait. **Execute** can then check whether a Timer fired before reading the
-Channel result.
+大多数等待都有一个截止时间。**Wait.anyOf** 让 Channel 或 Timer 任意一个完成等待。随后 **Execute** 可以先检查 Timer 是否触发，再读取 Channel 的结果。
 
 <SdkTabs
   examples={{
@@ -284,38 +277,18 @@ impl Step for ChannelWait {
 </SdkSnippet>
 </SdkTabs>
 
-**hasTimerFired** reports whether any Timer in the completed Wait fired. If the
-Wait has several Timers, use the indexed form to inspect one of them. **Wait.allOf**
-does the opposite of **Wait.anyOf**: it waits until every condition, including
-every Timer, completes.
+**hasTimerFired** 用于判断完成的 Wait 中是否有 Timer 已触发。如果 Wait 中有多个 Timer，使用带索引的形式检查其中一个。**Wait.allOf** 与 **Wait.anyOf** 相反：它会等到包括所有 Timer 在内的每一个 Condition 都完成。
 
-## Identify or skip a Timer
+## 标识或跳过 Timer
 
-Give a Timer a stable condition ID when code outside the Worker needs to target
-it. A **TimerID** or **TimerId** can select a Timer by that ID or by its
-zero-based position among the Timers in the Wait. Prefer a condition ID: a
-position changes when the Wait is reordered. Condition IDs must be unique within
-one Wait. Any-combination waits also require them.
+如果 Worker 外部的代码需要指定一个 Timer，就给它稳定的 condition ID。**TimerID** 或 **TimerId** 可以按这个 ID 选择 Timer，也可以按 Timer 在 Wait 中从零开始的位置选择。优先使用 condition ID：调整 Wait 的顺序会改变位置。一个 Wait 中的 condition ID 必须唯一。any-combination 等待也必须提供它们。
 
-Call **SkipTimer** with the Flow ID, **StepExecutionID** or **StepExecutionId**,
-and the Timer selector. It makes the selected pending Timer ready, so the Wait
-can proceed. Dex Server first reads the active Flow's pending Timers and rejects
-the call when the Flow is closed, the Step execution does not match, or the
-Timer is no longer pending. See [Client APIs](/primitives/client-apis) for the
-client operation.
+调用 **SkipTimer** 时传入 Flow ID、**StepExecutionID** 或 **StepExecutionId**，以及 Timer selector。它会让选中的 pending Timer ready，从而让 Wait 继续。Dex Server 先读取活跃 Flow 中 pending Timer；Flow 已关闭、Step execution 不匹配，或 Timer 已不再 pending 时，调用会被拒绝。客户端操作见 [Client APIs](/primitives/client-apis)。
 
-## How Timer time works
+## Timer 时间如何工作
 
-When **WaitFor** returns a Timer, Dex Server records an absolute deadline. The
-deadline is durable, so a Worker restart or **continue-as-new** does not start
-the duration again. The Timer becomes ready when workflow time reaches that
-deadline; **Execute** runs after Dex Server processes that event and a Worker
-can handle it. A Timer is durable scheduling, not a real-time guarantee.
+**WaitFor** 返回 Timer 后，Dex Server 会记录一个绝对 deadline。这个 deadline 是 durable 的，因此 Worker 重启或 **continue-as-new** 都不会重新开始计算时长。workflow time 到达 deadline 时 Timer 变为 ready；Dex Server 处理该事件并有 Worker 可以处理后，才会运行 **Execute**。Timer 是 durable scheduling，不是实时保证。
 
-For timing-sensitive work, use **SYNC** Step durability. With **ASYNC**
-durability, Dex Server may receive the **WaitFor** result later, which delays
-when it can schedule the Timer. See [Step options](/primitives/step/step-options#durability).
+对时间敏感的工作，使用 **SYNC** Step durability。使用 **ASYNC** durability 时，Dex Server 可能稍后才收到 **WaitFor** 的结果，因此也会稍后才能调度 Timer。参见 [Step options](/primitives/step/step-options#durability)。
 
-A Timer has one deadline. To extend a wait after new activity, create another
-Timer rather than changing the existing one. See the [resettable timer](/design-patterns/resettable-timer)
-pattern.
+一个 Timer 只有一个 deadline。要在新的 activity 到来后延长等待，请创建另一个 Timer，而不是修改已有的 Timer。参见 [resettable timer](/design-patterns/resettable-timer) pattern。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/timer.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/timer.mdx
@@ -5,11 +5,7 @@ slug: /primitives/timer
 
 # Timer
 
-**Timer** 是用于 **WaitFor** 的 durable Condition。它让 Step 等到一段时间过去。Dex Server 保存并调度 Timer；等待期间不会占住 Worker。
-
-## 等待一段时间
-
-在 **Wait.until** 中返回一个 Timer。下面这个 Flow 的输入是秒数，到时间后运行 **Execute**。
+Timer 是持久化在 Dex Server 上的 **Durable Timer**。等待 Timer 时，Worker 端不会消耗任何资源。
 
 <SdkTabs
   examples={{
@@ -22,13 +18,12 @@ slug: /primitives/timer
 <SdkSnippet lang="python">
 
 ```python
-class TimerStep(Step[int]):
-    def wait_for(self, context: Context, input: int) -> Wait:
-        del context
+class TimerExampleStep(Step[int]):
+    def wait_for(self, _context: Context, input: int) -> Wait:
         return Wait.until(Timer.by_duration(timedelta(seconds=input)))
 
-    def execute(self, context: Context, input: int) -> StepDecision:
-        del context, input
+    def execute(self, context: Context, _input: int) -> StepDecision:
+        print(context.has_timer_fired())
         return graceful_complete("timer-fired")
 ```
 
@@ -36,15 +31,16 @@ class TimerStep(Step[int]):
   <SdkSnippet lang="go">
 
 ```go
-type timerStep struct {
+type TimerExampleStep struct {
 	dex.StepDefaults
 }
 
-func (timerStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
+func (TimerExampleStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 	return dex.Until(dex.Timer(time.Duration(input) * time.Second)), nil
 }
 
-func (timerStep) Execute(_ dex.Context, _ int) (*dex.StepDecision, error) {
+func (TimerExampleStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
+	fmt.Println(ctx.HasTimerFired())
 	return dex.GracefulComplete("timer-fired"), nil
 }
 ```
@@ -53,7 +49,7 @@ func (timerStep) Execute(_ dex.Context, _ int) (*dex.StepDecision, error) {
   <SdkSnippet lang="java">
 
 ```java
-final class TimerStep implements Step<Integer> {
+final class TimerExampleStep implements Step<Integer> {
     @Override
     public Class<Integer> getInputType() {
         return Integer.class;
@@ -66,6 +62,7 @@ final class TimerStep implements Step<Integer> {
 
     @Override
     public StepDecision execute(final Context context, final Integer input) {
+        System.out.println(context.hasTimerFired());
         return StepDecision.gracefulComplete("timer-fired");
     }
 }
@@ -75,18 +72,19 @@ final class TimerStep implements Step<Integer> {
   <SdkSnippet lang="typescript">
 
 ```typescript
-class TimerStep implements Step<number> {
+class TimerExampleStep implements Step<number> {
   public readonly inputCodec = doubleCodec;
 
   public getStepType(): string {
-    return "TimerStep";
+    return "TimerExampleStep";
   }
 
   public waitFor(_context: Context, input: number): Wait {
     return Wait.until(Timer.byDuration(input * 1000));
   }
 
-  public execute(_context: Context, _input: number): StepDecision {
+  public execute(context: Context, _input: number): StepDecision {
+    console.log(context.hasTimerFired());
     return gracefulComplete("timer-fired");
   }
 }
@@ -97,9 +95,9 @@ class TimerStep implements Step<number> {
 
 ```rust
 #[derive(Default)]
-struct TimerStep;
+struct TimerExampleStep;
 
-impl Step for TimerStep {
+impl Step for TimerExampleStep {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
@@ -108,7 +106,8 @@ impl Step for TimerStep {
         ))))
     }
 
-    fn execute(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
+    fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
+        println!("{}", context.has_any_timer_fired());
         Ok(StepDecision::graceful_complete("timer-fired".to_string()))
     }
 }
@@ -117,178 +116,65 @@ impl Step for TimerStep {
 </SdkSnippet>
 </SdkTabs>
 
-Timer 的时长必须是非负整数秒。TypeScript API 接受毫秒，因此传入值必须能被 1,000 整除。时长为零的 Timer 会立刻 ready。
+## 如何跳过 Timer
 
-## 等待工作或到期
+可以用 Flow ID 和 Timer selector 调用 **SkipTimer** 跳过 Timer。
 
-大多数等待都有一个截止时间。**Wait.anyOf** 让 Channel 或 Timer 任意一个完成等待。随后 **Execute** 可以先检查 Timer 是否触发，再读取 Channel 的结果。
-
-<SdkTabs
-  examples={{
-    python: 'examples/python/dex_examples/primitives/channel/channel_flow.py',
-    go: 'examples/go/primitives/channel/workflow.go',
-    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java',
-    typescript: 'examples/typescript/src/primitives/channel/channel-flow.ts',
-    rust: 'examples/rust/src/primitives/channel/flow.rs',
-  }}>
+<SdkTabs>
 <SdkSnippet lang="python">
 
 ```python
-class ChannelWaitStep(Step[int]):
-    def __init__(self, approval: Channel[str]) -> None:
-        self.approval = approval
-
-    def wait_for(self, context: Context, input: int) -> Wait:
-        del context
-        return Wait.any_of(
-            self.approval.for_one(),
-            Timer.by_duration(timedelta(seconds=input)),
-        )
-
-    def execute(self, context: Context, input: int) -> StepDecision:
-        if context.has_timer_fired():
-            return graceful_complete("approval timed out")
-        approvals = self.approval.results(context)
-        return graceful_complete(approvals[0])
+client.skip_timer(
+    flow_id,
+    StepExecutionId("TimerExampleStep"),
+    TimerId.by_condition_index(0),
+)
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="go">
 
 ```go
-var Approval = dex.DefineChannel[string]("Approval")
-
-type channelWaitStep struct {
-	dex.StepDefaults
-}
-
-func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
-	return dex.AnyOf(
-		Approval.ForOne(),
-		dex.Timer(time.Duration(input)*time.Second),
-	), nil
-}
-
-func (channelWaitStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
-	if ctx.HasTimerFired() {
-		return dex.GracefulComplete("approval timed out"), nil
-	}
-	results, err := Approval.GetConditionResults(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return dex.GracefulComplete(results[0]), nil
-}
+timerIndex := int32(0)
+err := client.SkipTimer(
+	ctx,
+	flowID,
+	dex.StepExecutionID{StepType: "TimerExampleStep"},
+	dex.TimerID{Index: &timerIndex},
+)
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="java">
 
 ```java
-final class ChannelWaitStep implements Step<Integer> {
-    @Override
-    public Class<Integer> getInputType() {
-        return Integer.class;
-    }
-
-    @Override
-    public Wait waitFor(final Context context, final Integer input) {
-        return Wait.anyOf(
-                approval.forOne(),
-                Timer.byDuration(Duration.ofSeconds(input)));
-    }
-
-    @Override
-    public StepDecision execute(final Context context, final Integer input) {
-        if (context.hasTimerFired()) {
-            return StepDecision.gracefulComplete("approval timed out");
-        }
-        final List<String> approvals = approval.getConditionResults(context);
-        return StepDecision.gracefulComplete(approvals.get(0));
-    }
-}
+client.skipTimer(
+        flowId,
+        StepExecutionId.of("TimerExampleStep"),
+        TimerId.byConditionIndex(0));
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="typescript">
 
 ```typescript
-const approval = new Channel("Approval", stringCodec);
-
-class ChannelWait implements Step<number> {
-  public readonly inputCodec = doubleCodec;
-
-  public getStepType(): string {
-    return "ChannelWait";
-  }
-
-  public waitFor(_context: Context, input: number): Wait {
-    return Wait.anyOf(
-      approval.forOne(),
-      Timer.byDuration(input * 1000),
-    );
-  }
-
-  public execute(context: Context, _input: number): StepDecision {
-    if (context.hasTimerFired()) {
-      return gracefulComplete("approval timed out");
-    }
-    const approvals = approval.results(context);
-    return gracefulComplete(approvals[0]!);
-  }
-}
-
-const channelWaitStep = new ChannelWait();
+await client.skipTimer(
+  flowId,
+  StepExecutionId.of("TimerExampleStep"),
+  TimerId.byConditionIndex(0),
+);
 ```
 
 </SdkSnippet>
   <SdkSnippet lang="rust">
 
 ```rust
-fn approval() -> Channel<String> {
-    Channel::new("Approval")
-}
-
-#[derive(Default)]
-struct ChannelWait;
-
-impl Step for ChannelWait {
-    type Input = i32;
-
-    fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
-        Ok(Wait::any_of([
-            approval().for_one(),
-            Timer::by_duration(Duration::from_secs(input.max(0) as u64)),
-        ]))
-    }
-
-    fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
-        if context.has_any_timer_fired() {
-            return Ok(StepDecision::graceful_complete(
-                "approval timed out".to_owned(),
-            ));
-        }
-        let approvals = approval().condition_results(context)?;
-        Ok(StepDecision::graceful_complete(approvals[0].clone()))
-    }
-}
+client.skip_timer(
+    &flow_id,
+    StepExecutionId::of(&TimerExampleStep),
+    TimerId::by_condition_index(0),
+)?;
 ```
 
 </SdkSnippet>
 </SdkTabs>
-
-**hasTimerFired** 用于判断完成的 Wait 中是否有 Timer 已触发。如果 Wait 中有多个 Timer，使用带索引的形式检查其中一个。**Wait.allOf** 与 **Wait.anyOf** 相反：它会等到包括所有 Timer 在内的每一个 Condition 都完成。
-
-## 标识或跳过 Timer
-
-如果 Worker 外部的代码需要指定一个 Timer，就给它稳定的 condition ID。**TimerID** 或 **TimerId** 可以按这个 ID 选择 Timer，也可以按 Timer 在 Wait 中从零开始的位置选择。优先使用 condition ID：调整 Wait 的顺序会改变位置。一个 Wait 中的 condition ID 必须唯一。any-combination 等待也必须提供它们。
-
-调用 **SkipTimer** 时传入 Flow ID、**StepExecutionID** 或 **StepExecutionId**，以及 Timer selector。它会让选中的 pending Timer ready，从而让 Wait 继续。Dex Server 先读取活跃 Flow 中 pending Timer；Flow 已关闭、Step execution 不匹配，或 Timer 已不再 pending 时，调用会被拒绝。客户端操作见 [Client APIs](/primitives/client-apis)。
-
-## Timer 时间如何工作
-
-**WaitFor** 返回 Timer 后，Dex Server 会记录一个绝对 deadline。这个 deadline 是 durable 的，因此 Worker 重启或 **continue-as-new** 都不会重新开始计算时长。workflow time 到达 deadline 时 Timer 变为 ready；Dex Server 处理该事件并有 Worker 可以处理后，才会运行 **Execute**。Timer 是 durable scheduling，不是实时保证。
-
-对时间敏感的工作，使用 **SYNC** Step durability。使用 **ASYNC** durability 时，Dex Server 可能稍后才收到 **WaitFor** 的结果，因此也会稍后才能调度 Timer。参见 [Step options](/primitives/step/step-options#durability)。
-
-一个 Timer 只有一个 deadline。要在新的 activity 到来后延长等待，请创建另一个 Timer，而不是修改已有的 Timer。参见 [resettable timer](/design-patterns/resettable-timer) pattern。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/timer.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/timer.mdx
@@ -118,7 +118,7 @@ impl Step for TimerExampleStep {
 
 ## 如何跳过 Timer
 
-可以用 Flow ID 和 Timer selector 调用 **SkipTimer** 跳过 Timer。
+可以用 Flow ID 和 Timer selector 调用 **SkipTimer** 跳过 Timer。被跳过的 Timer 就像已经触发一样。这有助于在测试模拟或生产运维中手动触发 Timer。
 
 <SdkTabs>
 <SdkSnippet lang="python">


### PR DESCRIPTION
## Summary

- Rewrite the Timer primitive documentation around practical waiting and deadline patterns.
- Add the Simplified Chinese Timer page and keep it aligned with English.
- Show runnable Python, Go, Java, TypeScript, and Rust samples for a Timer and for a Channel-or-Timer wait.
- Document whole-second durations, Timer results, condition IDs, SkipTimer validation, and Timer scheduling semantics.

## Why

The old page only covered a minimal Timer call, omitted Rust, and had no Simplified Chinese translation. It did not explain how a Timer works with a real waiting condition or how clients target a pending Timer.

## User impact

Readers can now choose the correct Timer pattern, recognize a deadline result, and understand when a Timer can be skipped without relying on Worker-local sleeps.

## Validation

- `make docs-prose-check`
- `npm run check` (from `docs/`)
