### PR TITLE
Record corporate CLA signature for yes-un

### DIFF
--- a/.github/cla-signatures.json
+++ b/.github/cla-signatures.json
@@ -4,6 +4,11 @@
       "github_handle": "longquanzheng",
       "agreement_type": "corporate",
       "agreement_date": "2026-08-04"
+    },
+    {
+      "github_handle": "yes-un",
+      "agreement_type": "corporate",
+      "agreement_date": "2026-08-21"
     }
   ],
   "exempt_bot_handles": [


### PR DESCRIPTION
Adds a corporate CLA record for `yes-un` (dated 2026-08-21) so the CLA check passes on their pull requests, including #348.