### PR TITLE
Check for Dex CLI updates at startup

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,6 +13,17 @@ brew install superdurable/tap/dexcli
 The Homebrew formula installs all runtime dependencies. Node.js is not required
 at runtime.
 
+When a released `dexcli` starts a local development environment, it checks the
+published `cli-v*` GitHub Releases in the background. If a newer version is
+available, the terminal shows a colored upgrade reminder:
+
+```bash
+brew update && brew upgrade dexcli
+```
+
+The check never delays startup. It is skipped for development builds and when
+GitHub cannot be reached.
+
 ## Start locally
 
 ```bash

--- a/cli/cmd/dexcli/main.go
+++ b/cli/cmd/dexcli/main.go
@@ -43,7 +43,7 @@ func run(ctx context.Context, args []string) error {
 	}
 	switch args[0] {
 	case "dev":
-		return dev.Execute(ctx, args[1:], os.Stdout, os.Stderr)
+		return dev.Execute(ctx, args[1:], os.Stdout, os.Stderr, version)
 	case "version", "--version", "-v":
 		fmt.Fprintf(os.Stdout, "dexcli %s (commit %s, built %s)\n", version, commit, date)
 		return nil

--- a/cli/internal/dev/command.go
+++ b/cli/internal/dev/command.go
@@ -18,7 +18,7 @@ import (
 	"io"
 )
 
-func Execute(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+func Execute(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, version string) error {
 	cfg, err := parseConfig(args, stderr)
 	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -26,6 +26,7 @@ func Execute(ctx context.Context, args []string, stdout io.Writer, stderr io.Wri
 		}
 		return err
 	}
+	cfg.version = version
 	supervisor := newSupervisor(cfg, stdout, stderr)
 	if err := supervisor.Run(ctx); err != nil {
 		return fmt.Errorf("Dex development environment failed: %w", err)

--- a/cli/internal/dev/config.go
+++ b/cli/internal/dev/config.go
@@ -85,6 +85,7 @@ type Config struct {
 	explicitLocalFlags map[string]bool
 	// blobStoreDirectoryDefault defaults true and allows SQLiteDBFilename to select its adjacent store.
 	blobStoreDirectoryDefault bool
+	version                   string
 }
 
 func parseConfig(args []string, output io.Writer) (*Config, error) {

--- a/cli/internal/dev/release.go
+++ b/cli/internal/dev/release.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const dexReleasesURL = "https://api.github.com/repos/superdurable/dex/releases?per_page=100"
+
+type releaseChecker struct {
+	httpClient  *http.Client
+	releasesURL string
+}
+
+type githubRelease struct {
+	TagName      string `json:"tag_name"`
+	IsDraft      bool   `json:"draft"`
+	IsPrerelease bool   `json:"prerelease"`
+}
+
+func newReleaseChecker() *releaseChecker {
+	return &releaseChecker{
+		httpClient:  &http.Client{Timeout: 2 * time.Second},
+		releasesURL: dexReleasesURL,
+	}
+}
+
+func (c *releaseChecker) Latest(ctx context.Context) (_ string, returnErr error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, c.releasesURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create GitHub releases request: %w", err)
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("User-Agent", "dexcli")
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("fetch GitHub releases: %w", err)
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, response.Body.Close())
+	}()
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch GitHub releases: unexpected status %s", response.Status)
+	}
+	var releases []githubRelease
+	if err := json.NewDecoder(response.Body).Decode(&releases); err != nil {
+		return "", fmt.Errorf("decode GitHub releases: %w", err)
+	}
+	latestVersion := ""
+	for _, release := range releases {
+		if release.IsDraft || release.IsPrerelease || !isCLIReleaseTag(release.TagName) {
+			continue
+		}
+		if latestVersion == "" || isNewerVersion(release.TagName, latestVersion) {
+			latestVersion = release.TagName
+		}
+	}
+	return latestVersion, nil
+}
+
+func isReleaseVersion(version string) bool {
+	_, isValid := releaseVersionParts(version)
+	return isValid
+}
+
+func isCLIReleaseTag(tagName string) bool {
+	return strings.HasPrefix(tagName, "cli-v") && isReleaseVersion(tagName)
+}
+
+func isNewerVersion(candidate string, current string) bool {
+	candidateParts, candidateIsValid := releaseVersionParts(candidate)
+	currentParts, currentIsValid := releaseVersionParts(current)
+	if !candidateIsValid || !currentIsValid {
+		return false
+	}
+	for index := range candidateParts {
+		if candidateParts[index] != currentParts[index] {
+			return candidateParts[index] > currentParts[index]
+		}
+	}
+	return false
+}
+
+func releaseVersionParts(version string) ([3]int, bool) {
+	version = strings.TrimPrefix(version, "cli-")
+	version = strings.TrimPrefix(version, "v")
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return [3]int{}, false
+	}
+	var parsed [3]int
+	for index, part := range parts {
+		value, err := strconv.Atoi(part)
+		if err != nil || value < 0 || strconv.Itoa(value) != part {
+			return [3]int{}, false
+		}
+		parsed[index] = value
+	}
+	return parsed, true
+}

--- a/cli/internal/dev/release_test.go
+++ b/cli/internal/dev/release_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package dev
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestReleaseCheckerFindsLatestPublishedCLIRelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/releases" {
+			t.Fatalf("unexpected path %q", request.URL.Path)
+		}
+		if _, err := writer.Write([]byte(`[
+			{"tag_name":"cli-v0.1.11","draft":false,"prerelease":false},
+			{"tag_name":"cli-v0.1.12","draft":true,"prerelease":false},
+			{"tag_name":"cli-v0.2.0","draft":false,"prerelease":true},
+			{"tag_name":"server/v0.3.0","draft":false,"prerelease":false},
+			{"tag_name":"cli-v0.1.13","draft":false,"prerelease":false}
+		]`)); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer server.Close()
+	checker := &releaseChecker{httpClient: server.Client(), releasesURL: server.URL + "/releases"}
+	latestVersion, err := checker.Latest(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if latestVersion != "cli-v0.1.13" {
+		t.Fatalf("latest version = %q, want cli-v0.1.13", latestVersion)
+	}
+}
+
+func TestIsNewerVersion(t *testing.T) {
+	testCases := []struct {
+		name      string
+		candidate string
+		current   string
+		isNewer   bool
+	}{
+		{name: "patch", candidate: "cli-v0.1.13", current: "v0.1.12", isNewer: true},
+		{name: "minor", candidate: "cli-v0.2.0", current: "v0.1.12", isNewer: true},
+		{name: "same", candidate: "cli-v0.1.12", current: "v0.1.12", isNewer: false},
+		{name: "older", candidate: "cli-v0.1.11", current: "v0.1.12", isNewer: false},
+		{name: "invalid", candidate: "cli-vnext", current: "v0.1.12", isNewer: false},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			isNewer := isNewerVersion(testCase.candidate, testCase.current)
+			if isNewer != testCase.isNewer {
+				t.Fatalf("isNewerVersion(%q, %q) = %t, want %t", testCase.candidate, testCase.current, isNewer, testCase.isNewer)
+			}
+		})
+	}
+}

--- a/cli/internal/dev/supervisor.go
+++ b/cli/internal/dev/supervisor.go
@@ -165,6 +165,7 @@ func (s *supervisor) Run(ctx context.Context) (runErr error) {
 	}
 
 	s.printReady(webURL, listeners.dex.Addr().String(), blobStoreDirectory)
+	s.printUpdateNotice(runCtx)
 	if s.cfg.OpenBrowser {
 		if err := openBrowser(webURL); err != nil {
 			return s.shutdown(runCtx, cancelRun, webServer, dexRuntime, err)
@@ -335,6 +336,24 @@ func (s *supervisor) printReady(webURL string, dexAddress string, blobStoreDirec
 	}
 	fmt.Fprintln(s.stdout)
 	fmt.Fprintln(s.stdout, "Press Ctrl+C to stop.")
+}
+
+func (s *supervisor) printUpdateNotice(ctx context.Context) {
+	if !isReleaseVersion(s.cfg.version) {
+		return
+	}
+	go func() {
+		latestVersion, err := newReleaseChecker().Latest(ctx)
+		if err != nil || !isNewerVersion(latestVersion, s.cfg.version) {
+			return
+		}
+		fmt.Fprintf(
+			s.stderr,
+			"\n\033[1;33mA new dexcli version is available: %s (you have %s).\033[0m\n\033[1;36mUpgrade with: brew update && brew upgrade dexcli\033[0m\n",
+			latestVersion,
+			s.cfg.version,
+		)
+	}()
 }
 
 func reserveOwnedListeners(cfg *Config) (*ownedListeners, error) {


### PR DESCRIPTION
## Summary

- Check published cli-v GitHub Releases asynchronously after dexcli dev is ready.
- Print a colored Homebrew upgrade reminder only when a newer released version exists.
- Skip development builds and unreachable GitHub without delaying startup.

## Rationale

Homebrew-installed users need a low-friction way to discover new Dex CLI releases.

## User impact

Users with an older released dexcli see the exact brew update and brew upgrade dexcli command after startup.

## Validation

- make -C cli test 2>&1 | tee /tmp/test-dexcli-update-notice-cli.log
- make -C cli integration-test 2>&1 | tee /tmp/test-dexcli-update-notice-integration.log
- make copyright-check 2>&1 | tee /tmp/test-dexcli-update-notice-copyright.log
