### PR TITLE
Add verbose Temporal engine logs option

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -72,6 +72,10 @@ when it exits. Keep them with:
 dexcli dev --server-log-folder ./dex-logs
 ```
 
+When investigating the local Temporal Server, add `--verbose-engine-log`. It
+writes Temporal Server info logs to `temporal-engine-server.log` in that folder.
+Use `--server-log-folder` if you need the file after `dexcli` exits.
+
 Configure local Attribute Store projection with the same YAML section accepted
 by Dex Server:
 
@@ -103,6 +107,7 @@ must exist and be reachable before startup.
 --web-port int                     Dex Web port (default 8802)
 --sqlite-db-filename string        local SQLite file (default $HOME/.dex/dev/<port>/dex.sqlite.db)
 --server-log-folder string         keep server logs (default temp folder, deleted on exit)
+--verbose-engine-log               write Temporal Server logs to temporal-engine-server.log
 --external-temporal-address string      external Temporal host:port
 --external-temporal-namespace string    external Temporal namespace (default default)
 ```

--- a/cli/internal/dev/config.go
+++ b/cli/internal/dev/config.go
@@ -46,6 +46,7 @@ var flagOrder = []string{
 	"web-port",
 	"sqlite-db-filename",
 	"server-log-folder",
+	"verbose-engine-log",
 	"external-temporal-address",
 	"external-temporal-namespace",
 }
@@ -69,6 +70,8 @@ type Config struct {
 	SQLiteDBFilename string
 	// LogDirectory defaults to a temp directory deleted on clean exit.
 	LogDirectory string
+	// VerboseEngineLog defaults to false and writes Temporal Server info logs to temporal-engine-server.log in local mode.
+	VerboseEngineLog bool
 	// StateDirectory defaults to $HOME/.dex and stores auto-assigned Temporal SQLite files.
 	StateDirectory string
 	// BlobStoreDirectory defaults to $HOME/.dex/blobs unless SQLiteDBFilename selects its adjacent dex.blobs store.
@@ -123,6 +126,12 @@ func parseConfig(args []string, output io.Writer) (*Config, error) {
 		"",
 		"keep server logs in this folder (default temp folder, deleted on exit)",
 	)
+	flags.BoolVar(
+		&cfg.VerboseEngineLog,
+		"verbose-engine-log",
+		false,
+		"write Temporal Server logs to temporal-engine-server.log",
+	)
 	flags.StringVar(&cfg.ExternalTemporalAddress, "external-temporal-address", "", "external Temporal host:port")
 	flags.StringVar(
 		&cfg.TemporalNamespace,
@@ -143,7 +152,7 @@ func parseConfig(args []string, output io.Writer) (*Config, error) {
 	cfg.explicitLocalFlags = make(map[string]bool)
 	flags.Visit(func(item *flag.Flag) {
 		switch item.Name {
-		case "dex-port", "web-port", "sqlite-db-filename", "server-log-folder", "external-temporal-namespace":
+		case "dex-port", "web-port", "sqlite-db-filename", "server-log-folder", "verbose-engine-log", "external-temporal-namespace":
 			cfg.explicitLocalFlags[item.Name] = true
 		case "blob-store-dir":
 			cfg.blobStoreDirectoryDefault = false
@@ -220,7 +229,7 @@ func (c *Config) validate() error {
 		if _, _, err := net.SplitHostPort(c.ExternalTemporalAddress); err != nil {
 			return fmt.Errorf("external Temporal address must be host:port: %w", err)
 		}
-		for _, name := range []string{"sqlite-db-filename"} {
+		for _, name := range []string{"sqlite-db-filename", "verbose-engine-log"} {
 			if c.explicitLocalFlags[name] {
 				return fmt.Errorf("--%s cannot be used with --external-temporal-address", name)
 			}

--- a/cli/internal/dev/config_test.go
+++ b/cli/internal/dev/config_test.go
@@ -85,6 +85,26 @@ func TestServerLogFolderFlag(t *testing.T) {
 	}
 }
 
+func TestVerboseEngineLogFlag(t *testing.T) {
+	cfg, err := parseConfig([]string{"--verbose-engine-log"}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.VerboseEngineLog {
+		t.Fatal("expected verbose engine logs to be enabled")
+	}
+}
+
+func TestVerboseEngineLogRejectedWithExternalAddress(t *testing.T) {
+	_, err := parseConfig([]string{
+		"--external-temporal-address", "127.0.0.1:7233",
+		"--verbose-engine-log",
+	}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected --verbose-engine-log to fail with --external-temporal-address")
+	}
+}
+
 func TestSQLiteDBFilenameRejectedWithExternalAddress(t *testing.T) {
 	_, err := parseConfig([]string{
 		"--external-temporal-address", "127.0.0.1:7233",

--- a/cli/internal/dev/supervisor_integ_test.go
+++ b/cli/internal/dev/supervisor_integ_test.go
@@ -41,6 +41,7 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 	cfg.explicitLocalFlags["dex-port"] = true
 	cfg.explicitLocalFlags["web-port"] = true
 	cfg.LogDirectory = t.TempDir()
+	cfg.VerboseEngineLog = true
 	output := &synchronizedBuffer{}
 	runCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -149,6 +150,9 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 	}
 	if !strings.Contains(logText, cfg.sqliteDBDirectory()) {
 		t.Fatalf("workflow engine log missing DB directory: %s", logText)
+	}
+	if !strings.Contains(logText, "level=INFO") {
+		t.Fatalf("workflow engine log missing Temporal Server info logs: %s", logText)
 	}
 	dexLog, err := os.ReadFile(cfg.dexServerLogPath())
 	if err != nil {

--- a/cli/internal/dev/temporal_process.go
+++ b/cli/internal/dev/temporal_process.go
@@ -49,6 +49,9 @@ func startTemporalProcess(cfg *Config, logs io.Writer) (*temporalProcess, error)
 	if cfg.SQLiteDBFilename != "" {
 		arguments = append(arguments, "--db-filename", cfg.SQLiteDBFilename)
 	}
+	if cfg.VerboseEngineLog {
+		arguments = append(arguments, "--log-level", "info")
+	}
 	if logs == nil {
 		logs = io.Discard
 	}


### PR DESCRIPTION
## Summary

- add `dexcli dev --verbose-engine-log` for local Temporal Server diagnostics
- route Temporal Server info logs into `temporal-engine-server.log`
- reject the local-only option when using external Temporal

## Rationale and user impact

The default remains quiet. When diagnosing a local Temporal Engine issue, users can retain the structured server logs with:

```bash
dexcli dev --verbose-engine-log --server-log-folder ./dex-logs
```

## Validation

- `make -C cli test`
- `make -C cli integration-test`
- `make copyright-check`
