### PR TITLE
Default Step durability to async(except steps with recovery)

### DIFF
--- a/server/service/interpreter/config/flowConfiger.go
+++ b/server/service/interpreter/config/flowConfiger.go
@@ -117,7 +117,7 @@ func (fc *FlowConfiger) ResolveExecuteDurability(opts *dexpb.StepOptions) dexpb.
 	)
 }
 
-// resolveDurability applies step, recovery, flow, then synchronous precedence.
+// resolveDurability applies step, recovery, flow, then asynchronous precedence.
 func resolveDurability(
 	override dexpb.StepDurability,
 	recoveryEnabled bool,
@@ -132,7 +132,7 @@ func resolveDurability(
 	if flowLevel != dexpb.StepDurability_STEP_DURABILITY_UNSPECIFIED {
 		return flowLevel
 	}
-	return dexpb.StepDurability_STEP_DURABILITY_SYNC
+	return dexpb.StepDurability_STEP_DURABILITY_ASYNC
 }
 
 // ValidateFlowConfig rejects negative sizes and unknown enum numbers.

--- a/server/service/interpreter/config/flowConfiger_test.go
+++ b/server/service/interpreter/config/flowConfiger_test.go
@@ -46,8 +46,8 @@ func TestFlowConfiger_ZeroDefaults(t *testing.T) {
 	assert.Equal(t,
 		dexpb.ActiveStepSearchMode_ACTIVE_STEP_SEARCH_MODE_ENABLED_FOR_STEPS_WITH_WAIT_FOR,
 		flowConfiger.EffectiveActiveStepSearchMode())
-	assert.Equal(t, dexpb.StepDurability_STEP_DURABILITY_SYNC, flowConfiger.ResolveWaitForDurability(nil))
-	assert.Equal(t, dexpb.StepDurability_STEP_DURABILITY_SYNC, flowConfiger.ResolveExecuteDurability(nil))
+	assert.Equal(t, dexpb.StepDurability_STEP_DURABILITY_ASYNC, flowConfiger.ResolveWaitForDurability(nil))
+	assert.Equal(t, dexpb.StepDurability_STEP_DURABILITY_ASYNC, flowConfiger.ResolveExecuteDurability(nil))
 }
 
 func TestFlowConfiger_DurabilityPrecedence(t *testing.T) {


### PR DESCRIPTION
## Summary

- Default unresolved Step durability to ASYNC.
- Preserve SYNC durability when recovery is enabled.

## Rationale

This aligns the server resolver with the documented server default while preserving the recovery safety behavior and explicit Step overrides.

## User impact

Steps without a Step or Flow durability setting now run asynchronously, except recovery-enabled methods, which remain synchronous by default.

## Validation

- `make -C server unitTests`
