### PR TITLE
Isolate docs deployment concurrency

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,7 +19,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: deploy-docs
+  group: deploy-docs-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- isolate docs workflow concurrency by pull request or ref
- prevent PR docs builds from cancelling main deployment builds

## Validation
- actionlint .github/workflows/deploy-docs.yml
- npm -C docs run check