### PR TITLE
Simplify Channel documentation

### DIFF
--- a/docs/content/primitives/channel.mdx
+++ b/docs/content/primitives/channel.mdx
@@ -17,7 +17,7 @@ A Channel is scoped to one Flow execution. Messages never cross between Flow exe
 
 ## Persistence schema {#persistence-schema}
 
-A Channel has a stable name and a message type. Define it and add it to the Flow persistence schema. Defining a Channel alone does not register it with the Flow. Dex Server rejects a publish, wait, or read that uses a Channel the Flow did not declare in its persistence schema.
+A Channel has a stable name and a message type. Define it and add it to the Flow persistence schema.
 
 This example has an **Approval** Channel. Its start Step waits for either one approval or a Timer. The **approve** RPC publishes the approval message. The same Flow can also receive a message directly through the Client **PublishToChannel** API.
 
@@ -283,7 +283,7 @@ The Timer branch returns before reading Channel results. If the approval wins, t
 
 ## Wait and consume {#wait-and-consume}
 
-Returning a Channel condition from **WaitFor** is a consume operation. Dex Server keeps messages until a waiting Step wins them, then removes the selected messages from the queue in FIFO order and passes them to **Execute** as Channel results.
+Returning a Channel condition from **WaitFor** waits for the Channel. When the condition is met, it consumes messages from the Channel. Dex Server keeps messages until a waiting Step wins them, then removes the selected messages from the queue in FIFO order and passes them to **Execute** as Channel results.
 
 | Condition | When it proceeds | What it consumes |
 | --- | --- | --- |
@@ -292,18 +292,6 @@ Returning a Channel condition from **WaitFor** is a consume operation. Dex Serve
 | **AtLeast** | At least the requested number is queued. | Every message currently available. |
 | **AtMost** | The queue has no more than the requested number. An empty queue matches. | Up to the requested number of messages. |
 | **AtLeastAtMost** | The queue has a number of messages in the inclusive range. | From the lower bound up to the upper bound. |
-
-**AtMost** is not a wait for a new message. It can let **Execute** run immediately when the Channel is empty.
-
-Use **Wait.anyOf** when a Step can proceed on a Channel, a Timer, or a SubFlow. When the Timer wins, the Channel messages stay queued. Use **Wait.allOf** when every condition must be ready. See [Waiting](/primitives/step/waiting-condition) for combinations and condition IDs.
-
-Do not use one Channel as a broadcast mechanism. If two waiting Steps target the same Channel, a message consumed by one Step is not available to the other. Use separate Channels when both Steps must see the event.
-
-## Read Channel results {#read-channel-results}
-
-Read the values selected for the current Step execution through the Channel result method shown in the example. It returns only messages consumed by that Channel condition. If the Step proceeded because another condition won, the result for this Channel is empty.
-
-**Size** reads the queued message count visible to the current Step or RPC invocation. It is useful for decisions made by that handler; it does not replace a **WaitFor** condition.
 
 ## Publish messages {#publish-messages}
 
@@ -316,11 +304,3 @@ Messages can arrive before a Step starts waiting. Dex Server keeps them in the C
 ## ChannelMap {#channelmap}
 
 Use **ChannelMap** when one Flow has an unbounded set of independent queues, such as one Channel per order, customer, or job. A ChannelMap has one declared name and one value type. Each instance key has its own FIFO queue.
-
-Every operation on a ChannelMap takes the instance key: publish, **ForOne**, **ForN**, range conditions, **Size**, and condition results. A wait on the **order-42** instance never consumes a message from **order-43**.
-
-During an RPC, a ChannelMap can also list its non-empty instance keys and count them. Those methods include messages published earlier in the same RPC, omit empty instances, and return keys in ascending order. They are RPC-only because they inspect the Flow's current queue state.
-
-## What Dex Server stores {#what-dex-server-stores}
-
-Dex Server stores Channel messages with the Flow state. It evaluates Channel conditions against that durable queue, removes messages only when a waiting Step wins them, and sends the selected values to the Worker for **Execute**. Worker restarts do not lose queued messages or a Step's pending wait.

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
@@ -17,7 +17,7 @@ Channel 只属于一个 Flow execution。消息不会跨 Flow execution。
 
 ## Persistence schema {#persistence-schema}
 
-Channel 有稳定的名字和消息类型。先定义它，再加到 Flow 的 persistence schema。只定义 Channel 不会把它注册到 Flow。Dex Server 会拒绝对 Flow persistence schema 未声明的 Channel 做 publish、wait 或 read。
+Channel 有稳定的名字和消息类型。先定义它，再加到 Flow 的 persistence schema。
 
 下面的例子有一个 **Approval** Channel。start Step 等一条 approval 或一个 Timer。**approve** RPC 发布 approval 消息。这个 Flow 也可以通过 Client 的 **PublishToChannel** API 直接接收消息。
 
@@ -283,7 +283,7 @@ Timer 分支会先返回，不会读取 Channel 结果。approval 胜出时，Ch
 
 ## 等待并消费 {#wait-and-consume}
 
-在 **WaitFor** 里返回 Channel condition 就是在消费。Dex Server 会保留消息，直到某个 waiting Step 赢得它们；然后按 FIFO 顺序从队列移除选中的消息，并以 Channel results 传给 **Execute**。
+在 **WaitFor** 里返回 Channel condition 会等待这个 Channel。condition 满足后，它会从 Channel 消费消息。Dex Server 会保留消息，直到某个 waiting Step 赢得它们；然后按 FIFO 顺序从队列移除选中的消息，并以 Channel results 传给 **Execute**。
 
 | Condition | 何时继续 | 消费什么 |
 | --- | --- | --- |
@@ -292,18 +292,6 @@ Timer 分支会先返回，不会读取 Channel 结果。approval 胜出时，Ch
 | **AtLeast** | 至少有指定数量的消息。 | 当时所有可用的消息。 |
 | **AtMost** | 队列不超过指定数量。空队列也匹配。 | 最多指定数量的消息。 |
 | **AtLeastAtMost** | 队列消息数落在闭区间内。 | 从下界到上界数量的消息。 |
-
-**AtMost** 不是等待新消息。Channel 为空时，它也可以让 **Execute** 立即运行。
-
-Step 可以在 **Wait.anyOf** 里等 Channel、Timer 或 SubFlow 的任意一个。Timer 胜出时，Channel 消息会继续留在队列里。所有 condition 都必须 ready 时用 **Wait.allOf**。组合与 condition ID 见 [Waiting](/primitives/step/waiting-condition)。
-
-不要把一个 Channel 当广播机制。如果两个 waiting Step 都在等同一个 Channel，一条被其中一个 Step 消费的消息不会再给另一个 Step。两个 Step 都需要看到事件时，用两个 Channel。
-
-## 读取 Channel 结果 {#read-channel-results}
-
-用例子里的 Channel result method 读取当前 Step execution 选中的值。它只返回这个 Channel condition 消费的消息。如果 Step 是因为其他 condition 胜出而继续，这个 Channel 的结果为空。
-
-**Size** 读取当前 Step 或 RPC invocation 可见的排队消息数。它适合该 handler 内的决策，但不能替代 **WaitFor** condition。
 
 ## 发布消息 {#publish-messages}
 
@@ -316,11 +304,3 @@ Worker 外的代码可以用 Client **PublishToChannel** API 直接发布。Clie
 ## ChannelMap {#channelmap}
 
 一个 Flow 有一组数量不受限、彼此独立的队列时，用 **ChannelMap**，例如每个订单、客户或 job 一条 Channel。ChannelMap 只声明一个名字和一个值类型，每个 instance key 都有自己的 FIFO 队列。
-
-ChannelMap 的每个操作都要带 instance key：publish、**ForOne**、**ForN**、范围 condition、**Size** 和 condition results。等 **order-42** instance 时，绝不会消费 **order-43** 的消息。
-
-在 RPC 内，ChannelMap 还可以列出非空 instance key 并计数。这些方法会包含同一个 RPC 之前发布的消息，省略空 instance，并按升序返回 key。它们只能在 RPC 内调用，因为它们读取的是 Flow 当前的队列状态。
-
-## Dex Server 存什么 {#what-dex-server-stores}
-
-Dex Server 把 Channel 消息和 Flow state 一起存储。它针对这个 durable 队列判断 Channel condition，只有 waiting Step 赢得消息时才移除消息，并把选中的值发给 Worker 的 **Execute**。Worker 重启不会丢掉队列里的消息，也不会丢掉 Step 的 pending wait。

--- a/docs/src/components/primitives/channel/ChannelScopeDiagram.tsx
+++ b/docs/src/components/primitives/channel/ChannelScopeDiagram.tsx
@@ -219,11 +219,10 @@ function Publisher({kicker, name}: {kicker: string; name: string}): ReactNode {
 function DatabaseIcon(): ReactNode {
   return (
     <svg className="channel-execution-database" viewBox="0 0 180 88" aria-hidden="true">
-      <g transform="translate(90 44) rotate(-90) scale(2 1.4) translate(-700 -194)">
-        <path d="M 678 180 C 678 175 688 171 700 171 C 712 171 722 175 722 180 V 208 C 722 213 712 217 700 217 C 688 217 678 213 678 208 Z" />
-        <ellipse cx="700" cy="180" rx="22" ry="9" />
-        <path d="M 678 194 C 678 199 688 203 700 203 C 712 203 722 199 722 194" fill="none" />
-      </g>
+      <path d="M28 20h124v48H28z" />
+      <ellipse cx="28" cy="44" rx="18" ry="24" />
+      <ellipse cx="152" cy="44" rx="18" ry="24" />
+      <path d="M28 57h124" fill="none" />
     </svg>
   );
 }

--- a/docs/src/components/primitives/channel/ChannelScopeDiagram.tsx
+++ b/docs/src/components/primitives/channel/ChannelScopeDiagram.tsx
@@ -219,9 +219,11 @@ function Publisher({kicker, name}: {kicker: string; name: string}): ReactNode {
 function DatabaseIcon(): ReactNode {
   return (
     <svg className="channel-execution-database" viewBox="0 0 180 88" aria-hidden="true">
-      <path d="M29 25c0-7 10-12 22-12h78c12 0 22 5 22 12v38c0 7-10 12-22 12H51c-12 0-22-5-22-12V25Z" />
-      <ellipse cx="51" cy="44" rx="22" ry="31" />
-      <path d="M29 57c0 7 10 12 22 12h78c12 0 22-5 22-12" fill="none" />
+      <g transform="translate(90 44) rotate(-90) scale(2 1.4) translate(-700 -194)">
+        <path d="M 678 180 C 678 175 688 171 700 171 C 712 171 722 175 722 180 V 208 C 722 213 712 217 700 217 C 688 217 678 213 678 208 Z" />
+        <ellipse cx="700" cy="180" rx="22" ry="9" />
+        <path d="M 678 194 C 678 199 688 203 700 203 C 712 203 722 199 722 194" fill="none" />
+      </g>
     </svg>
   );
 }


### PR DESCRIPTION
## Summary

- fix the horizontal Channel queue icon
- remove the requested Channel sections and operational detail
- clarify Channel consumption when a WaitFor condition is met

## User impact

The Channel page is shorter and its diagram renders the queue clearly.

## Validation

- `make docs-prose-check`
- `make copyright-check`
- `cd docs && npm run typecheck && npm run build && npm run test:site`
