### PR TITLE
docs: rename durable primitives

### DIFF
--- a/docs/content/design-patterns/drain-internal-channels.mdx
+++ b/docs/content/design-patterns/drain-internal-channels.mdx
@@ -48,5 +48,5 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 
 ## Related
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/design-patterns/drain-signal-channels.mdx
+++ b/docs/content/design-patterns/drain-signal-channels.mdx
@@ -56,5 +56,5 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 
 ## Related
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/design-patterns/interruptible.mdx
+++ b/docs/content/design-patterns/interruptible.mdx
@@ -59,5 +59,5 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 
 ## Related
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/design-patterns/intervention.mdx
+++ b/docs/content/design-patterns/intervention.mdx
@@ -48,5 +48,5 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 
 ## Related
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/design-patterns/parallel.mdx
+++ b/docs/content/design-patterns/parallel.mdx
@@ -53,5 +53,5 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 
 ## Related
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/design-patterns/polling.mdx
+++ b/docs/content/design-patterns/polling.mdx
@@ -52,5 +52,5 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 
 ## Related
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/design-patterns/recovery.mdx
+++ b/docs/content/design-patterns/recovery.mdx
@@ -89,4 +89,4 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 ## Related
 
 - [Step options](/primitives/step/step-options)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)

--- a/docs/content/design-patterns/reminders.mdx
+++ b/docs/content/design-patterns/reminders.mdx
@@ -57,5 +57,5 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 
 ## Related
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/design-patterns/resettable-timer.mdx
+++ b/docs/content/design-patterns/resettable-timer.mdx
@@ -50,5 +50,5 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 
 ## Related
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/design-patterns/scalable-parallel.mdx
+++ b/docs/content/design-patterns/scalable-parallel.mdx
@@ -90,5 +90,5 @@ async execute(context: Context, _input: void): Promise<StepDecision> {
 
 ## Related
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/design-patterns/timeout.mdx
+++ b/docs/content/design-patterns/timeout.mdx
@@ -74,5 +74,5 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 
 ## Related
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/design-patterns/wait-for-step-completion.mdx
+++ b/docs/content/design-patterns/wait-for-step-completion.mdx
@@ -49,5 +49,5 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 
 ## Related
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -11,7 +11,7 @@ Dex is **Durable Execution** — an abstraction over distributed systems for bac
 - [What is Durable Execution?](/intro/what-is-durable-execution)
 - [Why Dex?](/intro/what-is-dex)
 - [Quick Start](/quick-start)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Design Patterns](/design-patterns)
 - [Product Examples](/use-cases)
 - [Production](/production)

--- a/docs/content/intro/what-is-dex.mdx
+++ b/docs/content/intro/what-is-dex.mdx
@@ -11,7 +11,7 @@ import OrderProcessingDiagram from '@site/src/components/intro/OrderProcessingDi
 
 Dex is a Durable Execution(D-Ex) platform.
 
-Dex is structural programming with only a few concepts as [durable primitives](/primitives). You use Dex to write a Flow filled with ordinary code: durable Steps, Attributes, RPCs, and durable conditions using Channels and Timers. Then you run Workers hosting your Flow. The Client calls Dex Server to start and interact with Flow instances. Dex Server dispatches Step and RPC invocation tasks to your Workers.
+Dex is structural programming with only a few concepts as [primitives](/primitives). You use Dex to write a Flow filled with ordinary code: durable Steps, Attributes, RPCs, and durable conditions using Channels and Timers. Then you run Workers hosting your Flow. The Client calls Dex Server to start and interact with Flow instances. Dex Server dispatches Step and RPC invocation tasks to your Workers.
 
 <DexSystemDiagram />
 
@@ -857,6 +857,6 @@ Dex does not ask you to write a replayable workflow function. You declare Steps 
 
 ## Next steps
 
-- [Durable Primitives](/primitives) — Step, Attribute, Channel, Timer, RPC, Client APIs
+- [Primitives](/primitives) — Step, Attribute, Channel, Timer, RPC, Client APIs
 - [Design Patterns](/design-patterns) — reusable Flow shapes
 - [Product Examples](/use-cases) — fuller product examples

--- a/docs/content/primitives/index.mdx
+++ b/docs/content/primitives/index.mdx
@@ -1,13 +1,13 @@
 ---
 id: index
-title: Durable Primitives
+title: Primitives
 sidebar_label: Overview
 slug: /primitives
 ---
 
-# Durable Primitives
+# Primitives
 
-Dex gives you a small set of durable primitives. Compose them into a Flow that meets any complex business requirement.
+Dex gives you a small set of primitives. Compose them into a Flow that meets any complex business requirement.
 
 - [Flow](/primitives/flow) — top-level durable program: Steps, Attributes, Channels, and RPCs
 - [Step](/primitives/step) — durable Steps run in the background with retries and more power

--- a/docs/content/quick-start/index.mdx
+++ b/docs/content/quick-start/index.mdx
@@ -1321,6 +1321,6 @@ The Timeline tab lists the same run:
 
 ## Next
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Why Dex?](/intro/what-is-dex)
 - [Product Examples](/use-cases)

--- a/docs/content/use-cases/ai-agent-email.mdx
+++ b/docs/content/use-cases/ai-agent-email.mdx
@@ -51,4 +51,4 @@ Python-only sample with its own UI (not on the shared playground). See **example
 ## Related
 
 - [Design Patterns](/design-patterns)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)

--- a/docs/content/use-cases/dataset-deal.mdx
+++ b/docs/content/use-cases/dataset-deal.mdx
@@ -62,4 +62,4 @@ make bins
 ## Related
 
 - [Design Patterns](/design-patterns)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)

--- a/docs/content/use-cases/engagement.mdx
+++ b/docs/content/use-cases/engagement.mdx
@@ -49,4 +49,4 @@ Long-running backend processes need durable waits, retries, and external interac
 ## Related
 
 - [Design Patterns](/design-patterns)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)

--- a/docs/content/use-cases/job-post.mdx
+++ b/docs/content/use-cases/job-post.mdx
@@ -49,4 +49,4 @@ Long-running backend processes need durable waits, retries, and external interac
 ## Related
 
 - [Design Patterns](/design-patterns)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)

--- a/docs/content/use-cases/microservice-orchestration.mdx
+++ b/docs/content/use-cases/microservice-orchestration.mdx
@@ -55,4 +55,4 @@ See archived microservice orchestration case study under **docs/archive/** for n
 ## Related
 
 - [Design Patterns](/design-patterns)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)

--- a/docs/content/use-cases/money-transfer.mdx
+++ b/docs/content/use-cases/money-transfer.mdx
@@ -49,4 +49,4 @@ Long-running backend processes need durable waits, retries, and external interac
 ## Related
 
 - [Design Patterns](/design-patterns)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)

--- a/docs/content/use-cases/polling.mdx
+++ b/docs/content/use-cases/polling.mdx
@@ -49,4 +49,4 @@ Long-running backend processes need durable waits, retries, and external interac
 ## Related
 
 - [Design Patterns](/design-patterns)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)

--- a/docs/content/use-cases/shortlist-candidates.mdx
+++ b/docs/content/use-cases/shortlist-candidates.mdx
@@ -49,4 +49,4 @@ Long-running backend processes need durable waits, retries, and external interac
 ## Related
 
 - [Design Patterns](/design-patterns)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)

--- a/docs/content/use-cases/signup.mdx
+++ b/docs/content/use-cases/signup.mdx
@@ -55,4 +55,4 @@ See also archived case study notes under **docs/archive/** (legacy iWF wording) 
 ## Related
 
 - [Design Patterns](/design-patterns)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)

--- a/docs/content/use-cases/subscription.mdx
+++ b/docs/content/use-cases/subscription.mdx
@@ -49,4 +49,4 @@ Long-running backend processes need durable waits, retries, and external interac
 ## Related
 
 - [Design Patterns](/design-patterns)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/index.mdx
@@ -11,7 +11,7 @@ Dex 是 **Durable Execution**——面向后端工程的分布式系统抽象。
 - [什么是 Durable Execution？](/intro/what-is-durable-execution)
 - [为什么是 Dex？](/intro/what-is-dex)
 - [Quick Start](/quick-start)
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [Design Patterns](/design-patterns)
 - [产品示例](/use-cases)
 - [Production](/production)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro/what-is-dex.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro/what-is-dex.mdx
@@ -11,7 +11,7 @@ import OrderProcessingDiagram from '@site/src/components/intro/OrderProcessingDi
 
 Dex 是 Durable Execution(D-Ex) 平台。
 
-Dex 是结构化编程，只有少数几个概念作为 [durable primitives](/primitives)。你用 Dex 写 Flow，里面填普通代码：durable 的 Step、Attribute、RPC，以及用 Channel 和 Timer 表达的 durable condition。然后跑托管 Flow 的 Worker。Client 调 Dex Server 去 start 并和 Flow 实例交互。Dex Server 把 Step / RPC 调用任务派发给你的 Worker。
+Dex 是结构化编程，只有少数几个概念作为 [primitives](/primitives)。你用 Dex 写 Flow，里面填普通代码：durable 的 Step、Attribute、RPC，以及用 Channel 和 Timer 表达的 durable condition。然后跑托管 Flow 的 Worker。Client 调 Dex Server 去 start 并和 Flow 实例交互。Dex Server 把 Step / RPC 调用任务派发给你的 Worker。
 
 <DexSystemDiagram />
 
@@ -857,6 +857,6 @@ Dex 不要求你写一段可 replay 的 workflow 函数。你声明 Step 和切�
 
 ## 接下来
 
-- [Durable Primitives](/primitives) — Step、Attribute、Channel、Timer、RPC、Client API
+- [Primitives](/primitives) — Step、Attribute、Channel、Timer、RPC、Client API
 - [Design Patterns](/design-patterns) — 可复用的 Flow 形状
 - [产品示例](/use-cases) — 更完整的产品例子

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quick-start/index.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quick-start/index.mdx
@@ -1317,6 +1317,6 @@ Timeline tab 列出同一次 run：
 
 ## 接下来
 
-- [Durable Primitives](/primitives)
+- [Primitives](/primitives)
 - [为什么是 Dex？](/intro/what-is-dex)
 - [产品示例](/use-cases)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -11,7 +11,7 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
-      label: 'Durable Primitives',
+      label: 'Primitives',
       link: {type: 'doc', id: 'primitives/index'},
       collapsed: false,
       items: [


### PR DESCRIPTION
## Summary

- Rename the documentation category from Durable Primitives to Primitives.
- Update English and Simplified Chinese navigation links and introductory references.

## Rationale

Client APIs are documented alongside the other primitives, so the prior category name was confusing.

## User impact

Documentation navigation and terminology now use Primitives consistently.

## Validation

- `cd docs && npm ci && npm run build`
