### PR TITLE
feat(cli): align flow operations with SDK client

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -124,6 +124,7 @@ Commands connect to `127.0.0.1:8801` by default. Override the target with
 
 ```bash
 dexcli health
+dexcli flow start order-123 --flow-type OrderFlow --start-step-type StartOrder --input '{"order":123}' --yes
 dexcli flow search --query 'FlowStatus = "Running"'
 dexcli flow inspect order-123 --all-history
 dexcli flow watch order-123 --follow-runs
@@ -144,6 +145,14 @@ Pass `--no-hydrate` to retain their references.
 The friendly Flow commands are:
 
 ```text
+dexcli flow start FLOW_ID --flow-type TYPE [--start-step-type TYPE]
+                  [--input JSON|@FILE|-] [--attributes JSON|@FILE|-]
+                  [--config JSON|@FILE|-] [--retry-policy JSON|@FILE|-]
+                  [--step-options PROTOBUF_JSON|@FILE|-]
+                  [--flow-timeout DURATION] [--flow-timeout-policy fail|cancel|handler]
+                  [--id-reuse-policy previous-failed|not-running|disallow|terminate-running]
+                  [--start-delay DURATION] [--ignore-already-started] [--request-id ID] --yes
+dexcli flow wait FLOW_ID [--needs-results] [--wait-time DURATION]
 dexcli flow search [--query QUERY] [--page-size N] [--page-token TOKEN] [--all]
 dexcli flow summary FLOW_ID [--run-id RUN_ID]
 dexcli flow state FLOW_ID [--run-id RUN_ID]
@@ -151,19 +160,48 @@ dexcli flow history FLOW_ID [--run-id RUN_ID] [--start-event-id N]
                     [--page-size N] [--page-token BASE64] [--all]
 dexcli flow inspect FLOW_ID [--run-id RUN_ID] [--all-history]
 dexcli flow watch FLOW_ID [--run-id RUN_ID] [--from-event-id N] [--follow-runs]
-dexcli flow stop FLOW_ID --run-id RUN_ID
-                 --type cancel|terminate|fail [--reason TEXT] --yes
-dexcli flow time-travel FLOW_ID --run-id RUN_ID
+dexcli flow stop FLOW_ID [--run-id RUN_ID]
+                 [--type cancel|terminate|fail] [--reason TEXT] --yes
+dexcli flow skip-timer FLOW_ID --step-type TYPE [--execution N]
+                    (--condition-id ID|--condition-index N) --yes
+dexcli flow wait-step FLOW_ID --step-type TYPE [--execution N] [--wait-time DURATION]
+dexcli flow update-config FLOW_ID --config JSON|@FILE|- --yes
+dexcli flow trigger-continue-as-new FLOW_ID --yes
+dexcli flow time-travel FLOW_ID [--run-id RUN_ID]
                         --type beginning|history-event-time|step-type|step-execution-id
                         [--target VALUE] [--step-method wait-for|execute]
-                        --reason TEXT --yes
+                        [--reason TEXT] --yes
 ```
 
 With the default JSON output, `watch` writes one object per line and exits when
 the run becomes terminal.
 `--follow-runs` continues into the current run after Continue-As-New. Stop and
-time travel require both an exact run ID and `--yes`, including in non-interactive use.
+time travel operate on the current run by default; pass `--run-id` to target an
+exact run. All mutating Flow commands require `--yes`, including in
+non-interactive use.
 `--step-method` is required with `--type step-execution-id` and invalid for other types.
+
+`start --input` and every `value` in `--attributes` use natural JSON. Strings,
+numbers, booleans, nulls, objects, and arrays are converted to Dex Values using
+the SDK encoding rules. For example:
+
+```bash
+dexcli flow start order-123 --flow-type OrderFlow --start-step-type StartOrder \
+  --input '{"orderId":"123","items":["book"]}' \
+  --attributes '[{"key":"status","value":"new","index":{"type":"keyword"},"sync":true}]' \
+  --yes
+```
+
+`--config` accepts a JSON object with optional `activeStepSearchMode` (`all`,
+`wait-for`, or `disabled`), Continue-As-New thresholds, `stepDurability`
+(`sync` or `async`), `workerTarget`, and `attributeStoreName`. `--retry-policy`
+uses `initialInterval`, `backoffCoefficient`, `maximumInterval`, and
+`maximumAttempts`; intervals are Go duration strings. `--step-options` accepts
+protobuf JSON because it mirrors the full nested StepOptions message. When a
+Flow timeout is set without `--flow-timeout-policy`, the server's `fail` default
+applies because dexcli cannot inspect the application's Flow registry.
+Only one option in a `start` command may use `-`, because stdin can be consumed
+once.
 
 ## Call any FlowService API
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,6 +3,7 @@ module github.com/superdurable/dex/cli
 go 1.26.0
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/superdurable/dex v0.0.0
 	github.com/superdurable/dex/web v0.0.0
 	go.temporal.io/sdk v1.47.1-superdurable.2
@@ -46,7 +47,6 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.0 // indirect
 	github.com/golang/mock v1.7.0-rc.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/cli/internal/command/app.go
+++ b/cli/internal/command/app.go
@@ -109,7 +109,7 @@ func (a *App) printUsage() {
 	fmt.Fprintln(a.stdout)
 	fmt.Fprintln(a.stdout, "Commands:")
 	fmt.Fprintln(a.stdout, "  health    Check Dex FlowService health")
-	fmt.Fprintln(a.stdout, "  flow      Search, inspect, watch, stop, or time travel Flows")
+	fmt.Fprintln(a.stdout, "  flow      Start, operate, inspect, or watch Flows")
 	fmt.Fprintln(a.stdout, "  api       List, describe, or call FlowService RPCs")
 	fmt.Fprintln(a.stdout)
 	fmt.Fprintln(a.stdout, "Global flags:")

--- a/cli/internal/command/command_integ_test.go
+++ b/cli/internal/command/command_integ_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"strings"
 	"sync"
@@ -29,13 +30,36 @@ import (
 type testFlowService struct {
 	dexpb.UnimplementedFlowServiceServer
 
-	mu                sync.Mutex
-	loadCalls         int
-	stopCalls         int
-	timeTravelCalls   int
-	timeTravelRequest *dexpb.ResetFlowRequest
-	waitStarted       chan struct{}
-	waitOnce          sync.Once
+	mu                   sync.Mutex
+	loadCalls            int
+	startCalls           int
+	stopCalls            int
+	skipTimerCalls       int
+	waitStepCalls        int
+	updateConfigCalls    int
+	continueAsNewCalls   int
+	startRequest         *dexpb.StartFlowRequest
+	stopRequest          *dexpb.StopFlowRequest
+	waitRequest          *dexpb.WaitForFlowRequest
+	skipTimerRequest     *dexpb.SkipTimerRequest
+	waitStepRequest      *dexpb.WaitForStepCompletionRequest
+	updateConfigRequest  *dexpb.UpdateFlowConfigRequest
+	continueAsNewRequest *dexpb.TriggerContinueAsNewRequest
+	timeTravelCalls      int
+	timeTravelRequest    *dexpb.ResetFlowRequest
+	waitStarted          chan struct{}
+	waitOnce             sync.Once
+}
+
+func (s *testFlowService) StartFlow(
+	_ context.Context,
+	request *dexpb.StartFlowRequest,
+) (*dexpb.StartFlowResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.startCalls++
+	s.startRequest = request
+	return &dexpb.StartFlowResponse{RunId: "run-started"}, nil
 }
 
 func (s *testFlowService) HealthCheck(context.Context, *emptypb.Empty) (*dexpb.HealthInfo, error) {
@@ -71,12 +95,73 @@ func (s *testFlowService) LoadBlobs(
 }
 
 func (s *testFlowService) StopFlow(
-	context.Context,
-	*dexpb.StopFlowRequest,
+	_ context.Context,
+	request *dexpb.StopFlowRequest,
 ) (*emptypb.Empty, error) {
 	s.mu.Lock()
+	s.stopRequest = request
 	s.stopCalls++
 	s.mu.Unlock()
+	return &emptypb.Empty{}, nil
+}
+
+func (s *testFlowService) WaitForFlow(
+	_ context.Context,
+	request *dexpb.WaitForFlowRequest,
+) (*dexpb.FlowResult, error) {
+	s.mu.Lock()
+	s.waitRequest = request
+	s.mu.Unlock()
+	return &dexpb.FlowResult{
+		FlowStatus: dexpb.FlowStatus_FLOW_STATUS_COMPLETED,
+		Results: []*dexpb.StepCompletionOutput{{
+			CompletedStepType: "ShipOrder", CompletedStepExecutionId: "ShipOrder-1",
+			CompletedStepOutput: &dexpb.Value{Kind: &dexpb.Value_InternalBlobIdForStringValue{InternalBlobIdForStringValue: "blob-1"}},
+		}},
+	}, nil
+}
+
+func (s *testFlowService) SkipTimer(
+	_ context.Context,
+	request *dexpb.SkipTimerRequest,
+) (*emptypb.Empty, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.skipTimerCalls++
+	s.skipTimerRequest = request
+	return &emptypb.Empty{}, nil
+}
+
+func (s *testFlowService) WaitForStepCompletion(
+	_ context.Context,
+	request *dexpb.WaitForStepCompletionRequest,
+) (*dexpb.WaitForStepCompletionResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.waitStepCalls++
+	s.waitStepRequest = request
+	return &dexpb.WaitForStepCompletionResponse{}, nil
+}
+
+func (s *testFlowService) UpdateFlowConfig(
+	_ context.Context,
+	request *dexpb.UpdateFlowConfigRequest,
+) (*emptypb.Empty, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.updateConfigCalls++
+	s.updateConfigRequest = request
+	return &emptypb.Empty{}, nil
+}
+
+func (s *testFlowService) TriggerContinueAsNew(
+	_ context.Context,
+	request *dexpb.TriggerContinueAsNewRequest,
+) (*emptypb.Empty, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.continueAsNewCalls++
+	s.continueAsNewRequest = request
 	return &emptypb.Empty{}, nil
 }
 
@@ -248,6 +333,120 @@ func TestTimeTravelRequiresConfirmationAndMapsStepMethod(t *testing.T) {
 	}
 }
 
+func TestFlowClientOperationsMapSDKEquivalentRequests(t *testing.T) {
+	service, address := startTestFlowService(t)
+	startResult := executeTestCommand(t, nil,
+		"flow", "start", "flow-1", "--flow-type", "OrderFlow", "--start-step-type", "StartOrder",
+		"--input", `{"order":42}`, "--attributes", `[{"key":"status","value":"new","index":{"type":"keyword"},"sync":true}]`,
+		"--config", `{"activeStepSearchMode":"all","continueAsNewThreshold":12,"stepDurability":"sync","workerTarget":{"address":"127.0.0.1:9000","headless":true}}`,
+		"--retry-policy", `{"initialInterval":"1500ms","backoffCoefficient":2,"maximumInterval":"5s","maximumAttempts":3}`,
+		"--step-options", `{"skipWaitFor":true}`, "--flow-timeout", "90s", "--flow-timeout-policy", "cancel",
+		"--id-reuse-policy", "not-running", "--start-delay", "1500ms", "--ignore-already-started", "--request-id", "request-1", "--yes", "--server", address,
+	)
+	if startResult["runId"] != "run-started" {
+		t.Fatalf("unexpected start result: %#v", startResult)
+	}
+
+	waitResult := executeTestCommand(t, nil, "flow", "wait", "flow-1", "--needs-results", "--wait-time", "3500ms", "--server", address)
+	if waitResult["flowStatus"] != "FLOW_STATUS_COMPLETED" {
+		t.Fatalf("unexpected wait result: %#v", waitResult)
+	}
+	results := waitResult["results"].([]any)
+	if results[0].(map[string]any)["completedStepOutput"] != "hydrated" {
+		t.Fatalf("wait did not hydrate result values: %#v", waitResult)
+	}
+
+	executeTestCommand(t, nil, "flow", "skip-timer", "flow-1", "--step-type", "WaitForPayment", "--execution", "2", "--condition-index", "3", "--yes", "--server", address)
+	executeTestCommand(t, nil, "flow", "wait-step", "flow-1", "--step-type", "ShipOrder", "--execution", "2", "--wait-time", "1500ms", "--server", address)
+	executeTestCommand(t, nil, "flow", "update-config", "flow-1", "--config", `{"continueAsNewPageSizeInBytes":1024,"attributeStoreName":""}`, "--yes", "--server", address)
+	executeTestCommand(t, nil, "flow", "trigger-continue-as-new", "flow-1", "--yes", "--server", address)
+
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	startRequest := service.startRequest
+	if service.startCalls != 1 || startRequest.GetFlowType() != "OrderFlow" || startRequest.GetFlowTimeoutSeconds() != 90 || startRequest.GetFlowTimeoutPolicy() != dexpb.FlowTimeoutPolicy_FLOW_TIMEOUT_POLICY_CANCEL || startRequest.GetRequestId() != "request-1" {
+		t.Fatalf("unexpected start request: %#v", startRequest)
+	}
+	if string(startRequest.GetStepInput().GetObjValue().GetPayload()) != `{"order":42}` || !startRequest.GetStepOptions().GetSkipWaitFor() {
+		t.Fatalf("unexpected start input: %#v", startRequest)
+	}
+	if startRequest.GetFlowStartOptions().GetFlowStartDelaySeconds() != 2 || startRequest.GetFlowStartOptions().GetIdReusePolicy() != dexpb.IdReusePolicy_ID_REUSE_POLICY_ALLOW_IF_NO_RUNNING || !startRequest.GetFlowStartOptions().GetFlowAlreadyStartedOptions().GetIgnoreAlreadyStartedError() {
+		t.Fatalf("unexpected start options: %#v", startRequest.GetFlowStartOptions())
+	}
+	attribute := startRequest.GetFlowStartOptions().GetAttributes()[0]
+	if attribute.GetKey() != "status" || attribute.GetValue().GetStringValue() != "new" || attribute.GetIndexConfig().GetType() != dexpb.IndexType_INDEX_TYPE_KEYWORD || !attribute.GetSyncConfig().GetEnabled() {
+		t.Fatalf("unexpected start attributes: %#v", attribute)
+	}
+	if startRequest.GetFlowStartOptions().GetFlowConfigOverride().GetActiveStepSearchMode() != dexpb.ActiveStepSearchMode_ACTIVE_STEP_SEARCH_MODE_ENABLED_FOR_ALL || !startRequest.GetFlowStartOptions().GetFlowConfigOverride().GetWorkerTarget().GetIsHeadlessAddress() {
+		t.Fatalf("unexpected start config: %#v", startRequest.GetFlowStartOptions().GetFlowConfigOverride())
+	}
+	if service.waitRequest.GetWaitTimeSeconds() != 4 || !service.waitRequest.GetNeedsResults() {
+		t.Fatalf("unexpected wait request: %#v", service.waitRequest)
+	}
+	if service.skipTimerRequest.GetStepExecutionId() != "WaitForPayment-2" || service.skipTimerRequest.GetTimerConditionIndex() != 3 {
+		t.Fatalf("unexpected skip timer request: %#v", service.skipTimerRequest)
+	}
+	if service.waitStepRequest.GetStepExecutionNumber() != "2" || service.waitStepRequest.GetWaitTimeSeconds() != 2 || service.waitStepRequest.GetRequestId() == "" {
+		t.Fatalf("unexpected wait-step request: %#v", service.waitStepRequest)
+	}
+	if service.updateConfigRequest.GetFlowConfig().GetContinueAsNewPageSizeInBytes() != 1024 || service.updateConfigRequest.GetFlowConfig().AttributeSyncConfigName == nil || *service.updateConfigRequest.GetFlowConfig().AttributeSyncConfigName != "" {
+		t.Fatalf("unexpected update-config request: %#v", service.updateConfigRequest)
+	}
+	if service.continueAsNewRequest.GetFlowId() != "flow-1" {
+		t.Fatalf("unexpected continue-as-new request: %#v", service.continueAsNewRequest)
+	}
+}
+
+func TestFlowMutationsRequireConfirmation(t *testing.T) {
+	service, address := startTestFlowService(t)
+	for _, args := range [][]string{
+		{"flow", "start", "flow-1", "--flow-type", "OrderFlow", "--server", address},
+		{"flow", "skip-timer", "flow-1", "--step-type", "Wait", "--condition-id", "timer", "--server", address},
+		{"flow", "update-config", "flow-1", "--config", `{}`, "--server", address},
+		{"flow", "trigger-continue-as-new", "flow-1", "--server", address},
+	} {
+		app := NewApp(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
+		if err := app.Execute(context.Background(), args); err == nil || ExitCode(err) != 2 {
+			t.Fatalf("expected confirmation error for %v, got %v", args, err)
+		}
+	}
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	if service.startCalls != 0 || service.skipTimerCalls != 0 || service.updateConfigCalls != 0 || service.continueAsNewCalls != 0 {
+		t.Fatalf("mutation reached service without confirmation: %#v", service)
+	}
+}
+
+func TestFlowClientOperationValidation(t *testing.T) {
+	_, address := startTestFlowService(t)
+	for _, args := range [][]string{
+		{"flow", "start", "flow-1", "--flow-type", "OrderFlow", "--input", "not-json", "--yes", "--server", address},
+		{"flow", "start", "flow-1", "--flow-type", "OrderFlow", "--config", `{"activeStepSearchMode":"unknown"}`, "--yes", "--server", address},
+		{"flow", "wait", "flow-1", "--wait-time", "not-a-duration", "--server", address},
+		{"flow", "skip-timer", "flow-1", "--step-type", "Wait", "--condition-id", "timer", "--condition-index", "0", "--yes", "--server", address},
+		{"flow", "wait-step", "flow-1", "--step-type", "Ship", "--execution", "0", "--server", address},
+	} {
+		app := NewApp(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
+		if err := app.Execute(context.Background(), args); err == nil || ExitCode(err) != 2 {
+			t.Fatalf("expected usage error for %v, got %v", args, err)
+		}
+	}
+}
+
+func TestStopAndTimeTravelDefaultToCurrentRun(t *testing.T) {
+	service, address := startTestFlowService(t)
+	executeTestCommand(t, nil, "flow", "stop", "flow-1", "--yes", "--server", address)
+	result := executeTestCommand(t, nil, "flow", "time-travel", "flow-1", "--type", "beginning", "--yes", "--server", address)
+	if result["previousRunId"] != "" {
+		t.Fatalf("unexpected time-travel result: %#v", result)
+	}
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	if service.stopRequest.GetRunId() != "" || service.stopRequest.GetStopType() != dexpb.StopType_STOP_TYPE_CANCEL || service.timeTravelRequest.GetRunId() != "" || service.timeTravelRequest.GetReason() != "" {
+		t.Fatalf("operations did not target current run: stop=%#v reset=%#v", service.stopRequest, service.timeTravelRequest)
+	}
+}
+
 func TestHistoryUsesCurrentRunAndReturnsSemanticEvents(t *testing.T) {
 	_, address := startTestFlowService(t)
 	result := executeTestCommand(t, nil, "flow", "history", "flow-1", "--server", address)
@@ -343,7 +542,7 @@ func startTestFlowService(t *testing.T) (*testFlowService, string) {
 	}()
 	t.Cleanup(func() {
 		server.GracefulStop()
-		if err := <-serveFinished; err != nil {
+		if err := <-serveFinished; err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			t.Errorf("serve FlowService: %v", err)
 		}
 	})

--- a/cli/internal/command/flow.go
+++ b/cli/internal/command/flow.go
@@ -38,6 +38,10 @@ func (c *flowCommand) Execute(ctx context.Context, args []string, options option
 		return nil
 	}
 	switch args[0] {
+	case "start":
+		return executeStart(c, ctx, args[1:], options)
+	case "wait":
+		return executeWait(c, ctx, args[1:], options)
 	case "search":
 		return c.search(ctx, args[1:], options)
 	case "summary":
@@ -52,6 +56,14 @@ func (c *flowCommand) Execute(ctx context.Context, args []string, options option
 		return executeWatch(c, ctx, args[1:], options)
 	case "stop":
 		return executeStop(c, ctx, args[1:], options)
+	case "skip-timer":
+		return executeSkipTimer(c, ctx, args[1:], options)
+	case "wait-step":
+		return executeWaitStep(c, ctx, args[1:], options)
+	case "update-config":
+		return executeUpdateConfig(c, ctx, args[1:], options)
+	case "trigger-continue-as-new":
+		return executeTriggerContinueAsNew(c, ctx, args[1:], options)
 	case "time-travel":
 		return executeTimeTravel(c, ctx, args[1:], options)
 	case "help", "--help", "-h":
@@ -294,7 +306,7 @@ func protoTimestamp(timestamp *timestamppb.Timestamp) any {
 func (c *flowCommand) printUsage() {
 	fmt.Fprintln(c.stdout, "Usage: dexcli flow <command>")
 	fmt.Fprintln(c.stdout)
-	fmt.Fprintln(c.stdout, "Commands: search, summary, state, history, inspect, watch, stop, time-travel")
+	fmt.Fprintln(c.stdout, "Commands: start, wait, search, summary, state, history, inspect, watch, stop, skip-timer, wait-step, update-config, trigger-continue-as-new, time-travel")
 }
 
 func parseInt32(value string, name string) (int32, error) {

--- a/cli/internal/command/flow_client_operations.go
+++ b/cli/internal/command/flow_client_operations.go
@@ -1,0 +1,632 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package command
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/superdurable/dex/gen/dexpb"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+type flowConfigInput struct {
+	ActiveStepSearchMode         *string            `json:"activeStepSearchMode"`
+	ContinueAsNewThreshold       *int32             `json:"continueAsNewThreshold"`
+	ContinueAsNewPageSizeInBytes *int32             `json:"continueAsNewPageSizeInBytes"`
+	StepDurability               *string            `json:"stepDurability"`
+	WorkerTarget                 *workerTargetInput `json:"workerTarget"`
+	AttributeStoreName           *string            `json:"attributeStoreName"`
+}
+
+type workerTargetInput struct {
+	Address  string `json:"address"`
+	Headless bool   `json:"headless"`
+}
+
+type flowRetryPolicyInput struct {
+	InitialInterval    string  `json:"initialInterval"`
+	BackoffCoefficient float64 `json:"backoffCoefficient"`
+	MaximumInterval    string  `json:"maximumInterval"`
+	MaximumAttempts    int32   `json:"maximumAttempts"`
+}
+
+type initialAttributeInput struct {
+	Key   string               `json:"key"`
+	Value json.RawMessage      `json:"value"`
+	Index *attributeIndexInput `json:"index"`
+	Sync  bool                 `json:"sync"`
+}
+
+type attributeIndexInput struct {
+	Type string `json:"type"`
+	Key  string `json:"key"`
+}
+
+func executeStart(c *flowCommand, ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow start", c.stderr)
+	flowType := flags.String("flow-type", "", "registered Flow type")
+	startStepType := flags.String("start-step-type", "", "starting Step type")
+	inputSource := flags.String("input", "null", "natural JSON, @file, or - for stdin")
+	attributesSource := flags.String("attributes", "", "initial Attribute JSON, @file, or - for stdin")
+	configSource := flags.String("config", "", "Flow configuration JSON, @file, or - for stdin")
+	retryPolicySource := flags.String("retry-policy", "", "Flow retry policy JSON, @file, or - for stdin")
+	stepOptionsSource := flags.String("step-options", "", "StepOptions protobuf JSON, @file, or - for stdin")
+	flowTimeout := flags.String("flow-timeout", "", "Flow timeout duration")
+	timeoutPolicy := flags.String("flow-timeout-policy", "", "fail, cancel, or handler")
+	idReusePolicy := flags.String("id-reuse-policy", "", "previous-failed, not-running, disallow, or terminate-running")
+	startDelay := flags.String("start-delay", "", "delay before the starting Step")
+	ignoreAlreadyStarted := flags.Bool("ignore-already-started", false, "return the existing run when the request ID matches")
+	requestID := flags.String("request-id", "", "idempotency request ID")
+	yes := flags.Bool("yes", false, "confirm the operation")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow start FLOW_ID --flow-type TYPE [flags] --yes"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow start")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*flowType) == "" {
+		return newUsageError("flow start", fmt.Errorf("flow-type is required"))
+	}
+	if err := atMostOneStdinSource(*inputSource, *attributesSource, *configSource, *retryPolicySource, *stepOptionsSource); err != nil {
+		return newUsageError("flow start", err)
+	}
+	request, err := startFlowRequest(c.stdin, flowID, *flowType, *startStepType, *inputSource, *attributesSource, *configSource, *retryPolicySource, *stepOptionsSource, *flowTimeout, *timeoutPolicy, *idReusePolicy, *startDelay, *ignoreAlreadyStarted, *requestID)
+	if err != nil {
+		return newUsageError("flow start", err)
+	}
+	if !*yes {
+		return newConfirmationError("flow start")
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		response, callErr := client.service.StartFlow(callCtx, request)
+		if callErr != nil {
+			return newOperationError("flow start", callErr)
+		}
+		return writeOutput(c.stdout, options.output, map[string]any{"flowId": flowID, "runId": response.GetRunId()})
+	})
+}
+
+func executeWait(c *flowCommand, ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow wait", c.stderr)
+	needsResults := flags.Bool("needs-results", false, "include completed Step outputs")
+	waitTime := flags.String("wait-time", "0s", "server long-poll duration")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow wait FLOW_ID [--needs-results] [--wait-time DURATION]"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow wait")
+	if err != nil {
+		return err
+	}
+	waitSeconds, err := parseDurationSeconds(*waitTime, "wait-time")
+	if err != nil {
+		return newUsageError("flow wait", err)
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		response, callErr := client.service.WaitForFlow(callCtx, &dexpb.WaitForFlowRequest{FlowId: flowID, NeedsResults: *needsResults, WaitTimeSeconds: waitSeconds})
+		if callErr != nil {
+			return newOperationError("flow wait", callErr)
+		}
+		mapped, warnings, mapErr := naturalMessage(callCtx, client.service, response, options.noHydrate)
+		if mapErr != nil {
+			return newOperationError("flow wait", mapErr)
+		}
+		mapped["flowId"] = flowID
+		if len(warnings) > 0 {
+			mapped["warnings"] = warnings
+		}
+		return writeOutput(c.stdout, options.output, mapped)
+	})
+}
+
+func executeSkipTimer(c *flowCommand, ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow skip-timer", c.stderr)
+	stepType := flags.String("step-type", "", "Step type")
+	execution := flags.Int("execution", 1, "Step execution number")
+	conditionID := flags.String("condition-id", "", "Timer condition ID")
+	conditionIndex := flags.String("condition-index", "", "zero-based Timer condition index")
+	yes := flags.Bool("yes", false, "confirm the operation")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow skip-timer FLOW_ID --step-type TYPE [--execution N] (--condition-id ID|--condition-index N) --yes"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow skip-timer")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*stepType) == "" || *execution <= 0 {
+		return newUsageError("flow skip-timer", fmt.Errorf("step-type is required and execution must be positive"))
+	}
+	request := &dexpb.SkipTimerRequest{FlowId: flowID, StepExecutionId: *stepType + "-" + strconv.Itoa(*execution)}
+	if (*conditionID == "") == (*conditionIndex == "") {
+		return newUsageError("flow skip-timer", fmt.Errorf("exactly one of condition-id or condition-index is required"))
+	}
+	if *conditionID != "" {
+		request.TimerConditionId = *conditionID
+	} else {
+		index, parseErr := parseInt32(*conditionIndex, "condition-index")
+		if parseErr != nil || index < 0 {
+			if parseErr != nil {
+				return newUsageError("flow skip-timer", parseErr)
+			}
+			return newUsageError("flow skip-timer", fmt.Errorf("condition-index must not be negative"))
+		}
+		request.TimerConditionIndex = &index
+	}
+	if !*yes {
+		return newConfirmationError("flow skip-timer")
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		if _, callErr := client.service.SkipTimer(callCtx, request); callErr != nil {
+			return newOperationError("flow skip-timer", callErr)
+		}
+		return writeOutput(c.stdout, options.output, map[string]any{"flowId": flowID, "stepExecutionId": request.GetStepExecutionId(), "skipped": true})
+	})
+}
+
+func executeWaitStep(c *flowCommand, ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow wait-step", c.stderr)
+	stepType := flags.String("step-type", "", "Step type")
+	execution := flags.Int("execution", 1, "Step execution number")
+	waitTime := flags.String("wait-time", "0s", "server long-poll duration")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow wait-step FLOW_ID --step-type TYPE [--execution N] [--wait-time DURATION]"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow wait-step")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*stepType) == "" || *execution <= 0 {
+		return newUsageError("flow wait-step", fmt.Errorf("step-type is required and execution must be positive"))
+	}
+	waitSeconds, err := parseDurationSeconds(*waitTime, "wait-time")
+	if err != nil {
+		return newUsageError("flow wait-step", err)
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		_, callErr := client.service.WaitForStepCompletion(callCtx, &dexpb.WaitForStepCompletionRequest{FlowId: flowID, StepType: *stepType, StepExecutionNumber: strconv.Itoa(*execution), WaitTimeSeconds: waitSeconds, RequestId: uuid.NewString()})
+		if callErr != nil {
+			return newOperationError("flow wait-step", callErr)
+		}
+		return writeOutput(c.stdout, options.output, map[string]any{"flowId": flowID, "stepType": *stepType, "execution": *execution, "completed": true})
+	})
+}
+
+func executeUpdateConfig(c *flowCommand, ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow update-config", c.stderr)
+	configSource := flags.String("config", "", "Flow configuration JSON, @file, or - for stdin")
+	yes := flags.Bool("yes", false, "confirm the operation")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow update-config FLOW_ID --config JSON|@FILE|- --yes"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow update-config")
+	if err != nil {
+		return err
+	}
+	if *configSource == "" {
+		return newUsageError("flow update-config", fmt.Errorf("config is required"))
+	}
+	config, err := parseFlowConfig(c.stdin, *configSource)
+	if err != nil {
+		return newUsageError("flow update-config", err)
+	}
+	if !*yes {
+		return newConfirmationError("flow update-config")
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		if _, callErr := client.service.UpdateFlowConfig(callCtx, &dexpb.UpdateFlowConfigRequest{FlowId: flowID, FlowConfig: config}); callErr != nil {
+			return newOperationError("flow update-config", callErr)
+		}
+		return writeOutput(c.stdout, options.output, map[string]any{"flowId": flowID, "updated": true})
+	})
+}
+
+func executeTriggerContinueAsNew(c *flowCommand, ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow trigger-continue-as-new", c.stderr)
+	yes := flags.Bool("yes", false, "confirm the operation")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow trigger-continue-as-new FLOW_ID --yes"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow trigger-continue-as-new")
+	if err != nil {
+		return err
+	}
+	if !*yes {
+		return newConfirmationError("flow trigger-continue-as-new")
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		if _, callErr := client.service.TriggerContinueAsNew(callCtx, &dexpb.TriggerContinueAsNewRequest{FlowId: flowID}); callErr != nil {
+			return newOperationError("flow trigger-continue-as-new", callErr)
+		}
+		return writeOutput(c.stdout, options.output, map[string]any{"flowId": flowID, "requested": true})
+	})
+}
+
+func startFlowRequest(reader io.Reader, flowID string, flowType string, startStepType string, inputSource string, attributesSource string, configSource string, retryPolicySource string, stepOptionsSource string, flowTimeout string, timeoutPolicy string, idReusePolicy string, startDelay string, ignoreAlreadyStarted bool, requestID string) (*dexpb.StartFlowRequest, error) {
+	input, err := parseNaturalValue(reader, inputSource)
+	if err != nil {
+		return nil, fmt.Errorf("input: %w", err)
+	}
+	attributes, err := parseInitialAttributes(reader, attributesSource)
+	if err != nil {
+		return nil, fmt.Errorf("attributes: %w", err)
+	}
+	config, err := parseOptionalFlowConfig(reader, configSource)
+	if err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	retryPolicy, err := parseOptionalRetryPolicy(reader, retryPolicySource)
+	if err != nil {
+		return nil, fmt.Errorf("retry-policy: %w", err)
+	}
+	stepOptions, err := parseOptionalStepOptions(reader, stepOptionsSource)
+	if err != nil {
+		return nil, fmt.Errorf("step-options: %w", err)
+	}
+	timeoutSeconds, err := parseOptionalDurationSeconds(flowTimeout, "flow-timeout")
+	if err != nil {
+		return nil, err
+	}
+	policy, err := parseFlowTimeoutPolicy(timeoutPolicy)
+	if err != nil {
+		return nil, err
+	}
+	if policy != dexpb.FlowTimeoutPolicy_FLOW_TIMEOUT_POLICY_UNSPECIFIED && timeoutSeconds == 0 {
+		return nil, fmt.Errorf("flow-timeout-policy requires a positive flow-timeout")
+	}
+	reusePolicy, err := parseIDReusePolicy(idReusePolicy)
+	if err != nil {
+		return nil, err
+	}
+	startDelaySeconds, err := parseOptionalDurationSeconds(startDelay, "start-delay")
+	if err != nil {
+		return nil, err
+	}
+	if requestID == "" {
+		requestID = uuid.NewString()
+	}
+	startOptions := &dexpb.FlowStartOptions{IdReusePolicy: reusePolicy, FlowStartDelaySeconds: startDelaySeconds, RetryPolicy: retryPolicy, Attributes: attributes, FlowConfigOverride: config}
+	if ignoreAlreadyStarted {
+		startOptions.FlowAlreadyStartedOptions = &dexpb.FlowAlreadyStartedOptions{IgnoreAlreadyStartedError: true}
+	}
+	return &dexpb.StartFlowRequest{FlowId: flowID, FlowType: flowType, FlowTimeoutSeconds: timeoutSeconds, FlowTimeoutPolicy: policy, StartStepType: startStepType, StepInput: input, StepOptions: stepOptions, RequestId: requestID, FlowStartOptions: startOptions}, nil
+}
+
+func atMostOneStdinSource(sources ...string) error {
+	stdinSources := 0
+	for _, source := range sources {
+		if source == "-" {
+			stdinSources++
+		}
+	}
+	if stdinSources > 1 {
+		return fmt.Errorf("only one JSON option may read from stdin")
+	}
+	return nil
+}
+
+func parseNaturalValue(reader io.Reader, source string) (*dexpb.Value, error) {
+	data, err := readFlowJSON(reader, source)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON: %w", err)
+		}
+		return nil, fmt.Errorf("input must contain exactly one JSON value")
+	}
+	return mapNaturalValue(value)
+}
+
+func mapNaturalValue(value any) (*dexpb.Value, error) {
+	switch typed := value.(type) {
+	case nil:
+		return jsonObjectValue(nil)
+	case string:
+		return &dexpb.Value{Kind: &dexpb.Value_StringValue{StringValue: typed}}, nil
+	case bool:
+		return &dexpb.Value{Kind: &dexpb.Value_BoolValue{BoolValue: typed}}, nil
+	case json.Number:
+		if integer, err := typed.Int64(); err == nil {
+			return &dexpb.Value{Kind: &dexpb.Value_IntValue{IntValue: integer}}, nil
+		}
+		floating, err := typed.Float64()
+		if err != nil || math.IsInf(floating, 0) || math.IsNaN(floating) {
+			return nil, fmt.Errorf("number %q is outside Dex's numeric range", typed)
+		}
+		return &dexpb.Value{Kind: &dexpb.Value_DoubleValue{DoubleValue: floating}}, nil
+	default:
+		return jsonObjectValue(typed)
+	}
+}
+
+func jsonObjectValue(value any) (*dexpb.Value, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode JSON value: %w", err)
+	}
+	return &dexpb.Value{Kind: &dexpb.Value_ObjValue{ObjValue: &dexpb.EncodedObject{Encoding: "json", Payload: payload}}}, nil
+}
+
+func parseInitialAttributes(reader io.Reader, source string) ([]*dexpb.AttributeWrite, error) {
+	if source == "" {
+		return nil, nil
+	}
+	data, err := readFlowJSON(reader, source)
+	if err != nil {
+		return nil, err
+	}
+	var inputs []initialAttributeInput
+	if err := json.Unmarshal(data, &inputs); err != nil {
+		return nil, fmt.Errorf("must be a JSON array: %w", err)
+	}
+	attributes := make([]*dexpb.AttributeWrite, 0, len(inputs))
+	for _, input := range inputs {
+		if strings.TrimSpace(input.Key) == "" || len(input.Value) == 0 {
+			return nil, fmt.Errorf("every attribute requires key and value")
+		}
+		value, valueErr := parseNaturalValue(bytes.NewReader(input.Value), "-")
+		if valueErr != nil {
+			return nil, fmt.Errorf("attribute %q: %w", input.Key, valueErr)
+		}
+		index, indexErr := mapAttributeIndex(input.Index)
+		if indexErr != nil {
+			return nil, fmt.Errorf("attribute %q: %w", input.Key, indexErr)
+		}
+		attribute := &dexpb.AttributeWrite{Key: input.Key, Value: value, IndexConfig: index}
+		if input.Sync {
+			attribute.SyncConfig = &dexpb.AttributeSyncConfig{Enabled: true}
+		}
+		attributes = append(attributes, attribute)
+	}
+	return attributes, nil
+}
+
+func mapAttributeIndex(input *attributeIndexInput) (*dexpb.IndexConfig, error) {
+	if input == nil {
+		return nil, nil
+	}
+	indexType, err := parseIndexType(input.Type)
+	if err != nil {
+		return nil, err
+	}
+	return &dexpb.IndexConfig{Enable: true, Type: indexType, IndexKey: input.Key}, nil
+}
+
+func parseIndexType(value string) (dexpb.IndexType, error) {
+	switch value {
+	case "keyword":
+		return dexpb.IndexType_INDEX_TYPE_KEYWORD, nil
+	case "text":
+		return dexpb.IndexType_INDEX_TYPE_TEXT, nil
+	case "keyword-array":
+		return dexpb.IndexType_INDEX_TYPE_KEYWORD_ARRAY, nil
+	case "int":
+		return dexpb.IndexType_INDEX_TYPE_INT, nil
+	case "double":
+		return dexpb.IndexType_INDEX_TYPE_DOUBLE, nil
+	case "bool":
+		return dexpb.IndexType_INDEX_TYPE_BOOL, nil
+	case "datetime":
+		return dexpb.IndexType_INDEX_TYPE_DATETIME, nil
+	default:
+		return dexpb.IndexType_INDEX_TYPE_UNSPECIFIED, fmt.Errorf("index type must be keyword, text, keyword-array, int, double, bool, or datetime")
+	}
+}
+
+func parseOptionalFlowConfig(reader io.Reader, source string) (*dexpb.FlowConfig, error) {
+	if source == "" {
+		return nil, nil
+	}
+	return parseFlowConfig(reader, source)
+}
+
+func parseFlowConfig(reader io.Reader, source string) (*dexpb.FlowConfig, error) {
+	data, err := readFlowJSON(reader, source)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.HasPrefix(bytes.TrimSpace(data), []byte("{")) {
+		return nil, fmt.Errorf("config must be a JSON object")
+	}
+	var input flowConfigInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return nil, fmt.Errorf("invalid config JSON: %w", err)
+	}
+	config := &dexpb.FlowConfig{ContinueAsNewThreshold: input.ContinueAsNewThreshold, ContinueAsNewPageSizeInBytes: input.ContinueAsNewPageSizeInBytes, AttributeSyncConfigName: input.AttributeStoreName}
+	if input.ActiveStepSearchMode != nil {
+		mode, modeErr := parseActiveStepSearchMode(*input.ActiveStepSearchMode)
+		if modeErr != nil {
+			return nil, modeErr
+		}
+		config.ActiveStepSearchMode = &mode
+	}
+	if input.StepDurability != nil {
+		durability, durabilityErr := parseStepDurability(*input.StepDurability)
+		if durabilityErr != nil {
+			return nil, durabilityErr
+		}
+		config.StepDurability = &durability
+	}
+	if input.WorkerTarget != nil {
+		if strings.TrimSpace(input.WorkerTarget.Address) == "" {
+			return nil, fmt.Errorf("workerTarget.address is required")
+		}
+		config.WorkerTarget = &dexpb.WorkerTarget{Address: input.WorkerTarget.Address, IsHeadlessAddress: input.WorkerTarget.Headless}
+	}
+	return config, nil
+}
+
+func parseActiveStepSearchMode(value string) (dexpb.ActiveStepSearchMode, error) {
+	switch value {
+	case "all":
+		return dexpb.ActiveStepSearchMode_ACTIVE_STEP_SEARCH_MODE_ENABLED_FOR_ALL, nil
+	case "wait-for":
+		return dexpb.ActiveStepSearchMode_ACTIVE_STEP_SEARCH_MODE_ENABLED_FOR_STEPS_WITH_WAIT_FOR, nil
+	case "disabled":
+		return dexpb.ActiveStepSearchMode_ACTIVE_STEP_SEARCH_MODE_DISABLED, nil
+	default:
+		return dexpb.ActiveStepSearchMode_ACTIVE_STEP_SEARCH_MODE_UNSPECIFIED, fmt.Errorf("activeStepSearchMode must be all, wait-for, or disabled")
+	}
+}
+
+func parseStepDurability(value string) (dexpb.StepDurability, error) {
+	switch value {
+	case "sync":
+		return dexpb.StepDurability_STEP_DURABILITY_SYNC, nil
+	case "async":
+		return dexpb.StepDurability_STEP_DURABILITY_ASYNC, nil
+	default:
+		return dexpb.StepDurability_STEP_DURABILITY_UNSPECIFIED, fmt.Errorf("stepDurability must be sync or async")
+	}
+}
+
+func parseOptionalRetryPolicy(reader io.Reader, source string) (*dexpb.FlowRetryPolicy, error) {
+	if source == "" {
+		return nil, nil
+	}
+	data, err := readFlowJSON(reader, source)
+	if err != nil {
+		return nil, err
+	}
+	var input flowRetryPolicyInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return nil, fmt.Errorf("invalid retry-policy JSON: %w", err)
+	}
+	initial, err := parseOptionalDurationSeconds(input.InitialInterval, "retry-policy.initialInterval")
+	if err != nil {
+		return nil, err
+	}
+	maximum, err := parseOptionalDurationSeconds(input.MaximumInterval, "retry-policy.maximumInterval")
+	if err != nil {
+		return nil, err
+	}
+	if math.IsNaN(input.BackoffCoefficient) || math.IsInf(input.BackoffCoefficient, 0) || input.BackoffCoefficient > math.MaxFloat32 || input.BackoffCoefficient < -math.MaxFloat32 {
+		return nil, fmt.Errorf("retry-policy.backoffCoefficient must be a finite float32")
+	}
+	return &dexpb.FlowRetryPolicy{InitialIntervalSeconds: initial, BackoffCoefficient: float32(input.BackoffCoefficient), MaximumIntervalSeconds: maximum, MaximumAttempts: input.MaximumAttempts}, nil
+}
+
+func parseOptionalStepOptions(reader io.Reader, source string) (*dexpb.StepOptions, error) {
+	if source == "" {
+		return nil, nil
+	}
+	data, err := readFlowJSON(reader, source)
+	if err != nil {
+		return nil, err
+	}
+	options := &dexpb.StepOptions{}
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(data, options); err != nil {
+		return nil, fmt.Errorf("invalid StepOptions protobuf JSON: %w", err)
+	}
+	return options, nil
+}
+
+func parseFlowTimeoutPolicy(value string) (dexpb.FlowTimeoutPolicy, error) {
+	switch value {
+	case "":
+		return dexpb.FlowTimeoutPolicy_FLOW_TIMEOUT_POLICY_UNSPECIFIED, nil
+	case "fail":
+		return dexpb.FlowTimeoutPolicy_FLOW_TIMEOUT_POLICY_FAIL, nil
+	case "cancel":
+		return dexpb.FlowTimeoutPolicy_FLOW_TIMEOUT_POLICY_CANCEL, nil
+	case "handler":
+		return dexpb.FlowTimeoutPolicy_FLOW_TIMEOUT_POLICY_HANDLER, nil
+	default:
+		return dexpb.FlowTimeoutPolicy_FLOW_TIMEOUT_POLICY_UNSPECIFIED, fmt.Errorf("flow-timeout-policy must be fail, cancel, or handler")
+	}
+}
+
+func parseIDReusePolicy(value string) (dexpb.IdReusePolicy, error) {
+	switch value {
+	case "":
+		return dexpb.IdReusePolicy_ID_REUSE_POLICY_UNSPECIFIED, nil
+	case "previous-failed":
+		return dexpb.IdReusePolicy_ID_REUSE_POLICY_ALLOW_IF_PREVIOUS_EXISTS_ABNORMALLY, nil
+	case "not-running":
+		return dexpb.IdReusePolicy_ID_REUSE_POLICY_ALLOW_IF_NO_RUNNING, nil
+	case "disallow":
+		return dexpb.IdReusePolicy_ID_REUSE_POLICY_DISALLOW_REUSE, nil
+	case "terminate-running":
+		return dexpb.IdReusePolicy_ID_REUSE_POLICY_ALLOW_TERMINATE_IF_RUNNING, nil
+	default:
+		return dexpb.IdReusePolicy_ID_REUSE_POLICY_UNSPECIFIED, fmt.Errorf("id-reuse-policy must be previous-failed, not-running, disallow, or terminate-running")
+	}
+}
+
+func parseOptionalDurationSeconds(value string, name string) (int32, error) {
+	if value == "" {
+		return 0, nil
+	}
+	return parseDurationSeconds(value, name)
+}
+
+func parseDurationSeconds(value string, name string) (int32, error) {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a duration: %w", name, err)
+	}
+	if duration < 0 {
+		return 0, fmt.Errorf("%s must not be negative", name)
+	}
+	seconds := duration / time.Second
+	if duration%time.Second != 0 {
+		seconds++
+	}
+	if seconds > math.MaxInt32 {
+		return 0, fmt.Errorf("%s exceeds int32 seconds", name)
+	}
+	return int32(seconds), nil
+}
+
+func readFlowJSON(reader io.Reader, source string) ([]byte, error) {
+	switch {
+	case source == "-":
+		data, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, fmt.Errorf("read stdin: %w", err)
+		}
+		return data, nil
+	case strings.HasPrefix(source, "@"):
+		path := strings.TrimPrefix(source, "@")
+		if path == "" {
+			return nil, fmt.Errorf("JSON file path must not be empty")
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read JSON file: %w", err)
+		}
+		return data, nil
+	default:
+		return []byte(source), nil
+	}
+}

--- a/cli/internal/command/flow_operations.go
+++ b/cli/internal/command/flow_operations.go
@@ -315,26 +315,20 @@ func watchRun(
 func executeStop(c *flowCommand, ctx context.Context, args []string, options options) error {
 	flags := newFlagSet("dexcli flow stop", c.stderr)
 	runID := flags.String("run-id", "", "Flow run ID")
-	stopTypeName := flags.String("type", "", "cancel, terminate, or fail")
+	stopTypeName := flags.String("type", "cancel", "cancel, terminate, or fail")
 	reason := flags.String("reason", "", "stop reason")
 	yes := flags.Bool("yes", false, "confirm the operation")
 	addCommonFlags(flags, &options)
-	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow stop FLOW_ID --run-id ID --type TYPE --yes"); done || err != nil {
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow stop FLOW_ID [--run-id ID] [--type TYPE] [--reason TEXT] --yes"); done || err != nil {
 		return err
 	}
 	flowID, err := oneFlowID(flags, "flow stop")
 	if err != nil {
 		return err
 	}
-	if *runID == "" {
-		return newUsageError("flow stop", fmt.Errorf("run-id is required"))
-	}
 	stopType, err := parseStopType(*stopTypeName)
 	if err != nil {
 		return newUsageError("flow stop", err)
-	}
-	if stopType != dexpb.StopType_STOP_TYPE_CANCEL && strings.TrimSpace(*reason) == "" {
-		return newUsageError("flow stop", fmt.Errorf("reason is required for terminate and fail"))
 	}
 	if !*yes {
 		return newConfirmationError("flow stop")
@@ -379,7 +373,7 @@ func executeTimeTravel(c *flowCommand, ctx context.Context, args []string, optio
 	)
 	yes := flags.Bool("yes", false, "confirm the operation")
 	addCommonFlags(flags, &options)
-	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow time-travel FLOW_ID --run-id ID --type TYPE --reason TEXT --yes"); done || err != nil {
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow time-travel FLOW_ID [--run-id ID] --type TYPE [--reason TEXT] --yes"); done || err != nil {
 		return err
 	}
 	flowID, err := oneFlowID(flags, "flow time-travel")
@@ -420,9 +414,6 @@ func timeTravelRequest(
 	stepMethodName string,
 	reason string,
 ) (*dexpb.ResetFlowRequest, error) {
-	if runID == "" || strings.TrimSpace(reason) == "" {
-		return nil, fmt.Errorf("run-id and reason are required")
-	}
 	request := &dexpb.ResetFlowRequest{FlowId: flowID, RunId: runID, Reason: reason}
 	switch typeName {
 	case "beginning":


### PR DESCRIPTION
# Summary

- Align dexcli Flow operations with the Go, Java, and Python SDK Client surface.
- Add start, wait, skip-timer, wait-step, update-config, and trigger-continue-as-new commands.
- Let stop and time-travel target the current run by default while retaining optional run IDs.

# Rationale and user impact

Operators can now perform every core SDK Flow operation with a friendly dexcli command. Start accepts natural JSON values and structured JSON options, and every mutation requires explicit `--yes` confirmation.

# Validation

- `make -C cli integration-test`
- `make copyright-check`
