### PR TITLE
docs: align canonical URLs with redirects

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -22,6 +22,7 @@ const config: Config = {
 
   url: 'https://docs.superdurable.io',
   baseUrl: '/',
+  trailingSlash: true,
 
   organizationName: 'superdurable',
   projectName: 'dex',

--- a/docs/tests/site-smoke.mjs
+++ b/docs/tests/site-smoke.mjs
@@ -7,6 +7,7 @@ const root = join(dirname(fileURLToPath(import.meta.url)), '..', 'build');
 const home = await readFile(join(root, 'index.html'), 'utf8');
 const cloud = await readFile(join(root, 'cloud', 'index.html'), 'utf8');
 const production = await readFile(join(root, 'production', 'index.html'), 'utf8');
+const zhSubflow = await readFile(join(root, 'zh-Hans', 'primitives', 'subflow', 'index.html'), 'utf8');
 const sitemap = await readFile(join(root, 'sitemap.xml'), 'utf8');
 
 assert.match(home, /Super Durable home/);
@@ -47,6 +48,7 @@ assert.match(cloud, /Coming Soon/);
 assert.match(cloud, /Explore Dex OSS Docs/);
 assert.match(cloud, /https:\/\/superdurable\.io\/byoc/);
 assert.match(production, /rel="canonical" href="https:\/\/docs\.superdurable\.io\/production\/"/);
+assert.match(zhSubflow, /rel="canonical" href="https:\/\/docs\.superdurable\.io\/zh-Hans\/primitives\/subflow\/"/);
 assert.match(sitemap, /<loc>https:\/\/docs\.superdurable\.io\/production\/<\/loc>/);
 assert.doesNotMatch(sitemap, /<loc>https:\/\/docs\.superdurable\.io\/production<\/loc>/);
 

--- a/docs/tests/site-smoke.mjs
+++ b/docs/tests/site-smoke.mjs
@@ -6,6 +6,8 @@ import {dirname, join} from 'node:path';
 const root = join(dirname(fileURLToPath(import.meta.url)), '..', 'build');
 const home = await readFile(join(root, 'index.html'), 'utf8');
 const cloud = await readFile(join(root, 'cloud', 'index.html'), 'utf8');
+const production = await readFile(join(root, 'production', 'index.html'), 'utf8');
+const sitemap = await readFile(join(root, 'sitemap.xml'), 'utf8');
 
 assert.match(home, /Super Durable home/);
 assert.match(home, /https:\/\/superdurable\.io\/dex/);
@@ -44,6 +46,9 @@ assert.match(cloud, /Dex Cloud \/ BYOC/);
 assert.match(cloud, /Coming Soon/);
 assert.match(cloud, /Explore Dex OSS Docs/);
 assert.match(cloud, /https:\/\/superdurable\.io\/byoc/);
+assert.match(production, /rel="canonical" href="https:\/\/docs\.superdurable\.io\/production\/"/);
+assert.match(sitemap, /<loc>https:\/\/docs\.superdurable\.io\/production\/<\/loc>/);
+assert.doesNotMatch(sitemap, /<loc>https:\/\/docs\.superdurable\.io\/production<\/loc>/);
 
 await Promise.all([
   access(join(root, 'intro', 'what-is-durable-execution', 'index.html')),


### PR DESCRIPTION
## Summary

- Generate trailing-slash URLs for the documentation site.
- Align sitemap and canonical links with the documentation host redirect behavior.
- Add a regression check for the canonical and sitemap URL shape.

## Rationale

The host redirects slashless documentation URLs to trailing-slash URLs. Publishing slashless canonical and sitemap entries caused Google Search Console to report those pages as redirects.

## User impact

Search engines will receive the final URL directly from sitemap and canonical metadata, avoiding the unnecessary redirect during indexing.

## Validation

- `cd docs && npm run check`
