### PR TITLE
Use Step classes for SDK transitions

### DIFF
--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -106,14 +106,10 @@ A successful Step can cancel queued or active executions by registered Step
 type while still choosing its normal next or close action:
 
 ```java
-private final QuoteCarrierA carrierA = new QuoteCarrierA();
-private final QuoteCarrierB carrierB = new QuoteCarrierB();
-private final RecordQuote recordQuote = new RecordQuote();
-
 @Override
 public StepDecision execute(Context context, Quote quote) {
-    return StepDecision.goTo(recordQuote, quote)
-            .withCancelingSiblingSteps(carrierA, carrierB);
+    return StepDecision.goTo(RecordQuote.class, quote)
+            .withCancelingSiblingSteps(QuoteCarrierA.class, QuoteCarrierB.class);
 }
 ```
 
@@ -121,8 +117,8 @@ public StepDecision execute(Context context, Quote quote) {
 type in the current Flow. `withCancelingSiblingSteps(...)` selects only
 executions whose `Context.getFromStepExecutionId()` is the same as the current
 execution's source. Both methods are immutable: repeated calls form a union,
-duplicate registered Steps are removed, and a Flow-wide selector supersedes a
-sibling selector for the same Step type. Passing an unregistered or null Step
+duplicate registered Step classes are removed, and a Flow-wide selector supersedes a
+sibling selector for the same Step type. Passing an unregistered or null Step class
 causes an invalid Step result.
 
 Dex resolves selectors from a snapshot after the current execution succeeds.

--- a/sdk-java/src/main/java/io/superdurable/dex/CancellationSteps.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/CancellationSteps.java
@@ -18,15 +18,16 @@ final class CancellationSteps {
     private CancellationSteps() {
     }
 
-    static List<Step<?>> add(
-            final List<Step<?>> existing,
-            final Step<?>[] additions) {
-        final List<Step<?>> combined = new ArrayList<Step<?>>(existing);
+    static List<Class<? extends Step<?>>> add(
+            final List<Class<? extends Step<?>>> existing,
+            final Class<? extends Step<?>>[] additions) {
+        final List<Class<? extends Step<?>>> combined =
+                new ArrayList<Class<? extends Step<?>>>(existing);
         if (additions == null) {
             combined.add(null);
             return combined;
         }
-        for (Step<?> addition : additions) {
+        for (Class<? extends Step<?>> addition : additions) {
             if (!contains(combined, addition)) {
                 combined.add(addition);
             }
@@ -35,8 +36,8 @@ final class CancellationSteps {
     }
 
     static void remove(
-            final List<Step<?>> target,
-            final List<Step<?>> removals) {
+            final List<Class<? extends Step<?>>> target,
+            final List<Class<? extends Step<?>>> removals) {
         for (int index = target.size() - 1; index >= 0; index--) {
             if (contains(removals, target.get(index))) {
                 target.remove(index);
@@ -44,15 +45,17 @@ final class CancellationSteps {
         }
     }
 
-    static List<Step<?>> immutable(final List<Step<?>> steps) {
-        return Collections.unmodifiableList(new ArrayList<Step<?>>(steps));
+    static List<Class<? extends Step<?>>> immutable(
+            final List<Class<? extends Step<?>>> steps) {
+        return Collections.unmodifiableList(
+                new ArrayList<Class<? extends Step<?>>>(steps));
     }
 
     private static boolean contains(
-            final List<Step<?>> steps,
-            final Step<?> candidate) {
-        for (Step<?> step : steps) {
-            if (step == candidate) {
+            final List<Class<? extends Step<?>>> steps,
+            final Class<? extends Step<?>> candidate) {
+        for (Class<? extends Step<?>> stepClass : steps) {
+            if (stepClass == candidate) {
                 return true;
             }
         }

--- a/sdk-java/src/main/java/io/superdurable/dex/Client.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Client.java
@@ -222,6 +222,7 @@ public final class Client implements AutoCloseable {
             request.setStartStepType(registered.getStartStep().getName())
                     .setStepInput(values.encode(input));
             final io.superdurable.gen.StepOptions stepOptions = mappings.mapStepOptions(
+                    registered,
                     registered.getStartStep().getStep().getStepOptions());
             final io.superdurable.gen.StepOptions.Builder mappedStep = stepOptions == null
                     ? io.superdurable.gen.StepOptions.newBuilder()

--- a/sdk-java/src/main/java/io/superdurable/dex/RPCResult.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/RPCResult.java
@@ -28,8 +28,8 @@ import java.util.List;
  * <pre>{@code
  * @RPC
  * public RPCResult<OrderStatus> approve(Context context, Approval input) {
- *     return RPCResult.of(OrderStatus.APPROVED, StepMovement.of(shipOrder, input.order))
- *             .withCancelingSteps(quoteCarrier, approvalTimeout);
+ *     return RPCResult.of(OrderStatus.APPROVED, StepMovement.of(ShipOrder.class, input.order))
+ *             .withCancelingSteps(QuoteCarrier.class, ApprovalTimeout.class);
  * }
  * }</pre>
  *
@@ -38,12 +38,12 @@ import java.util.List;
 public final class RPCResult<O> {
     private final O output;
     private final List<StepMovement<?>> nextSteps;
-    private final List<Step<?>> cancelingSteps;
+    private final List<Class<? extends Step<?>>> cancelingSteps;
 
     private RPCResult(
             final O output,
             final List<StepMovement<?>> nextSteps,
-            final List<Step<?>> cancelingSteps) {
+            final List<Class<? extends Step<?>>> cancelingSteps) {
         this.output = output;
         this.nextSteps = Collections.unmodifiableList(nextSteps);
         this.cancelingSteps = CancellationSteps.immutable(cancelingSteps);
@@ -60,7 +60,7 @@ public final class RPCResult<O> {
         return new RPCResult<O>(
                 output,
                 Collections.<StepMovement<?>>emptyList(),
-                Collections.<Step<?>>emptyList());
+                Collections.<Class<? extends Step<?>>>emptyList());
     }
 
     /**
@@ -77,7 +77,7 @@ public final class RPCResult<O> {
         return new RPCResult<O>(
                 output,
                 Arrays.<StepMovement<?>>asList(nextSteps.clone()),
-                Collections.<Step<?>>emptyList());
+                Collections.<Class<? extends Step<?>>>emptyList());
     }
 
     /**
@@ -89,19 +89,20 @@ public final class RPCResult<O> {
      * cancellation reaches its Worker and continues with this result's next Steps without waiting
      * for that handler to return.
      *
-     * <p>Repeated calls take the union of their arguments. Each argument must be the exact Step
-     * instance registered with the current Flow; a {@code null} or external Step causes an invalid
+     * <p>Repeated calls take the union of their arguments. Each argument must be a Step class
+     * registered with the current Flow; a {@code null} or external Step class causes an invalid
      * RPC result. RPC results cannot select sibling executions because separate invocations do not
      * share an invocation-scoped Step execution lineage.
      *
-     * @param steps registered Steps whose queued or active executions should be canceled
+     * @param stepClasses registered Step classes whose queued or active executions should be canceled
      * @return a new RPC result containing the combined cancellation selection
      */
-    public RPCResult<O> withCancelingSteps(final Step<?>... steps) {
+    public RPCResult<O> withCancelingSteps(
+            final Class<? extends Step<?>>... stepClasses) {
         return new RPCResult<O>(
                 output,
                 nextSteps,
-                CancellationSteps.add(cancelingSteps, steps));
+                CancellationSteps.add(cancelingSteps, stepClasses));
     }
 
     O getOutput() {
@@ -112,7 +113,7 @@ public final class RPCResult<O> {
         return nextSteps;
     }
 
-    List<Step<?>> getCancelingSteps() {
+    List<Class<? extends Step<?>>> getCancelingSteps() {
         return cancelingSteps;
     }
 }

--- a/sdk-java/src/main/java/io/superdurable/dex/Registry.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Registry.java
@@ -122,6 +122,8 @@ public final class Registry {
         }
         final Map<String, RegisteredStep> steps =
                 new LinkedHashMap<String, RegisteredStep>();
+        final Map<Class<?>, RegisteredStep> stepsByClass =
+                new LinkedHashMap<Class<?>, RegisteredStep>();
         RegisteredStep startStep = null;
         for (StepDef definition : definitions.getDefinitions()) {
             if (definition == null || definition.getStep() == null) {
@@ -139,9 +141,15 @@ public final class Registry {
                 throw new FlowDefinitionException(
                         "Flow " + flowType + " has duplicate Step " + stepType);
             }
+            if (stepsByClass.containsKey(step.getClass())) {
+                throw new FlowDefinitionException(
+                        "Flow " + flowType + " has duplicate Step class "
+                                + step.getClass().getName());
+            }
             final RegisteredStep registered =
                     new RegisteredStep(stepType, step, definition.isStartStep());
             steps.put(stepType, registered);
+            stepsByClass.put(step.getClass(), registered);
             if (definition.isStartStep()) {
                 if (startStep != null) {
                     throw new FlowDefinitionException(
@@ -163,7 +171,14 @@ public final class Registry {
                 assemblePersistence(flowType, schema, attributeIndexes);
         final Map<String, RegisteredRpc> rpcs = assembleRpcs(flowType, flow, persistence);
         return new RegisteredFlow(
-                flowType, flow, overridesTimeoutHandler(flow), steps, startStep, rpcs, persistence);
+                flowType,
+                flow,
+                overridesTimeoutHandler(flow),
+                steps,
+                stepsByClass,
+                startStep,
+                rpcs,
+                persistence);
     }
 
     private static boolean overridesTimeoutHandler(final Flow<?> flow) {
@@ -467,6 +482,7 @@ public final class Registry {
         private final Flow<?> flow;
         private final boolean hasTimeoutHandler;
         private final Map<String, RegisteredStep> steps;
+        private final Map<Class<?>, RegisteredStep> stepsByClass;
         private final RegisteredStep startStep;
         private final Map<String, RegisteredRpc> rpcs;
         private final Map<String, PersistenceDefinition> persistence;
@@ -476,6 +492,7 @@ public final class Registry {
                 final Flow<?> flow,
                 final boolean hasTimeoutHandler,
                 final Map<String, RegisteredStep> steps,
+                final Map<Class<?>, RegisteredStep> stepsByClass,
                 final RegisteredStep startStep,
                 final Map<String, RegisteredRpc> rpcs,
                 final Map<String, PersistenceDefinition> persistence) {
@@ -483,6 +500,7 @@ public final class Registry {
             this.flow = flow;
             this.hasTimeoutHandler = hasTimeoutHandler;
             this.steps = Collections.unmodifiableMap(steps);
+            this.stepsByClass = Collections.unmodifiableMap(stepsByClass);
             this.startStep = startStep;
             this.rpcs = Collections.unmodifiableMap(rpcs);
             this.persistence = Collections.unmodifiableMap(persistence);
@@ -492,6 +510,19 @@ public final class Registry {
         Flow<?> getFlow() { return flow; }
         boolean hasTimeoutHandler() { return hasTimeoutHandler; }
         Map<String, RegisteredStep> getSteps() { return steps; }
+        RegisteredStep getStep(final Class<?> stepClass) {
+            if (stepClass == null) {
+                throw new FlowDefinitionException(
+                        "Flow " + name + " Step class is required");
+            }
+            final RegisteredStep step = stepsByClass.get(stepClass);
+            if (step == null) {
+                throw new FlowDefinitionException(
+                        "Flow " + name + " Step class is not registered: "
+                                + stepClass.getName());
+            }
+            return step;
+        }
         RegisteredStep getStartStep() { return startStep; }
         Map<String, RegisteredRpc> getRpcs() { return rpcs; }
         Map<String, PersistenceDefinition> getPersistence() { return persistence; }

--- a/sdk-java/src/main/java/io/superdurable/dex/StepDecision.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StepDecision.java
@@ -30,8 +30,8 @@ import java.util.List;
  * if (order.cancelled) {
  *     return StepDecision.forceComplete("cancelled");
  * }
- * return StepDecision.goTo(chargeOrder, order)
- *         .withCancelingSiblingSteps(reserveInventory, quoteShipping);
+ * return StepDecision.goTo(ChargeOrder.class, order)
+ *         .withCancelingSiblingSteps(ReserveInventory.class, QuoteShipping.class);
  * }</pre>
  */
 public final class StepDecision {
@@ -51,8 +51,8 @@ public final class StepDecision {
     private final String reason;
     private final List<Object> emptyChannels;
     private final StepMovement<?> fallback;
-    private final List<Step<?>> cancelingSteps;
-    private final List<Step<?>> cancelingSiblingSteps;
+    private final List<Class<? extends Step<?>>> cancelingSteps;
+    private final List<Class<? extends Step<?>>> cancelingSiblingSteps;
 
     private StepDecision(
             final Kind kind,
@@ -62,8 +62,8 @@ public final class StepDecision {
             final String reason,
             final List<Object> emptyChannels,
             final StepMovement<?> fallback,
-            final List<Step<?>> cancelingSteps,
-            final List<Step<?>> cancelingSiblingSteps) {
+            final List<Class<? extends Step<?>>> cancelingSteps,
+            final List<Class<? extends Step<?>>> cancelingSiblingSteps) {
         this.kind = kind;
         this.movements = Collections.unmodifiableList(movements);
         this.hasOutput = hasOutput;
@@ -78,13 +78,15 @@ public final class StepDecision {
     /**
      * Schedules one typed next Step.
      *
-     * @param step the target Step
+     * @param stepClass the target Step class
      * @param input the typed target input
      * @param <I> the target Step input type
      * @return a next-Step decision
      */
-    public static <I> StepDecision goTo(final Step<I> step, final I input) {
-        return goToMulti(StepMovement.of(step, input));
+    public static <I> StepDecision goTo(
+            final Class<? extends Step<I>> stepClass,
+            final I input) {
+        return goToMulti(StepMovement.of(stepClass, input));
     }
 
     /**
@@ -102,8 +104,8 @@ public final class StepDecision {
                 null,
                 Collections.<Object>emptyList(),
                 null,
-                Collections.<Step<?>>emptyList(),
-                Collections.<Step<?>>emptyList());
+                Collections.<Class<? extends Step<?>>>emptyList(),
+                Collections.<Class<? extends Step<?>>>emptyList());
     }
 
     /**
@@ -176,8 +178,8 @@ public final class StepDecision {
                 null,
                 Arrays.<Object>asList(channels.clone()),
                 fallback,
-                Collections.<Step<?>>emptyList(),
-                Collections.<Step<?>>emptyList());
+                Collections.<Class<? extends Step<?>>>emptyList(),
+                Collections.<Class<? extends Step<?>>>emptyList());
     }
 
     /**
@@ -212,8 +214,8 @@ public final class StepDecision {
                 reason,
                 Collections.<Object>emptyList(),
                 null,
-                Collections.<Step<?>>emptyList(),
-                Collections.<Step<?>>emptyList());
+                Collections.<Class<? extends Step<?>>>emptyList(),
+                Collections.<Class<? extends Step<?>>>emptyList());
     }
 
     /**
@@ -226,16 +228,17 @@ public final class StepDecision {
      * for that handler to return.
      *
      * <p>Repeated calls take the union of their arguments. A Flow-wide selection supersedes a
-     * sibling-only selection for the same registered Step. Each argument must be the exact Step
-     * instance registered with the current Flow; a {@code null} or external Step causes an invalid
-     * Step result.
+     * sibling-only selection for the same registered Step class. Each argument must be one class
+     * registered with the current Flow; a {@code null} or external Step class causes an invalid Step result.
      *
-     * @param steps registered Steps whose queued or active executions should be canceled
+     * @param stepClasses registered Step classes whose queued or active executions should be canceled
      * @return a new decision containing the combined cancellation selection
      */
-    public StepDecision withCancelingSteps(final Step<?>... steps) {
-        final List<Step<?>> global = CancellationSteps.add(cancelingSteps, steps);
-        final List<Step<?>> siblings = new ArrayList<Step<?>>(cancelingSiblingSteps);
+    public StepDecision withCancelingSteps(final Class<? extends Step<?>>... stepClasses) {
+        final List<Class<? extends Step<?>>> global =
+                CancellationSteps.add(cancelingSteps, stepClasses);
+        final List<Class<? extends Step<?>>> siblings =
+                new ArrayList<Class<? extends Step<?>>>(cancelingSiblingSteps);
         CancellationSteps.remove(siblings, global);
         return copy(global, siblings);
     }
@@ -245,21 +248,23 @@ public final class StepDecision {
      *
      * <p>A sibling has the same {@link Context#getFromStepExecutionId()} as the execution returning
      * this decision. Dex applies the same snapshot, no-op, and handler interruption semantics as
-     * {@link #withCancelingSteps(Step[])}. Repeated calls take the union of their arguments, while a
+     * {@link #withCancelingSteps(Class[])}. Repeated calls take the union of their arguments, while a
      * Flow-wide selection for a Step type supersedes its sibling-only selection.
      *
-     * @param steps registered Steps whose matching sibling executions should be canceled
+     * @param stepClasses registered Step classes whose matching sibling executions should be canceled
      * @return a new decision containing the combined sibling cancellation selection
      */
-    public StepDecision withCancelingSiblingSteps(final Step<?>... steps) {
-        final List<Step<?>> siblings = CancellationSteps.add(cancelingSiblingSteps, steps);
+    public StepDecision withCancelingSiblingSteps(
+            final Class<? extends Step<?>>... stepClasses) {
+        final List<Class<? extends Step<?>>> siblings =
+                CancellationSteps.add(cancelingSiblingSteps, stepClasses);
         CancellationSteps.remove(siblings, cancelingSteps);
         return copy(cancelingSteps, siblings);
     }
 
     private StepDecision copy(
-            final List<Step<?>> global,
-            final List<Step<?>> siblings) {
+            final List<Class<? extends Step<?>>> global,
+            final List<Class<? extends Step<?>>> siblings) {
         return new StepDecision(
                 kind,
                 movements,
@@ -300,11 +305,11 @@ public final class StepDecision {
         return fallback;
     }
 
-    List<Step<?>> getCancelingSteps() {
+    List<Class<? extends Step<?>>> getCancelingSteps() {
         return cancelingSteps;
     }
 
-    List<Step<?>> getCancelingSiblingSteps() {
+    List<Class<? extends Step<?>>> getCancelingSiblingSteps() {
         return cancelingSiblingSteps;
     }
 }

--- a/sdk-java/src/main/java/io/superdurable/dex/StepMovement.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StepMovement.java
@@ -18,19 +18,22 @@ package io.superdurable.dex;
  *
  * <pre>{@code
  * return StepDecision.goToMulti(
- *         StepMovement.of(reserveInventory, order),
- *         StepMovement.of(authorizePayment, order, paymentOptions));
+ *         StepMovement.of(ReserveInventory.class, order),
+ *         StepMovement.of(AuthorizePayment.class, order, paymentOptions));
  * }</pre>
  *
  * @param <I> the target Step's input type
  */
 public final class StepMovement<I> {
-    private final Step<I> step;
+    private final Class<? extends Step<I>> stepClass;
     private final I input;
     private final StepOptions options;
 
-    private StepMovement(final Step<I> step, final I input, final StepOptions options) {
-        this.step = step;
+    private StepMovement(
+            final Class<? extends Step<I>> stepClass,
+            final I input,
+            final StepOptions options) {
+        this.stepClass = stepClass;
         this.input = input;
         this.options = options;
     }
@@ -38,33 +41,35 @@ public final class StepMovement<I> {
     /**
      * Creates a movement using the target Step's default options.
      *
-     * @param step the target Step
+     * @param stepClass the target Step class
      * @param input the typed input for that Step
      * @param <I> the target Step's input type
      * @return the typed Step movement
      */
-    public static <I> StepMovement<I> of(final Step<I> step, final I input) {
-        return new StepMovement<I>(step, input, null);
+    public static <I> StepMovement<I> of(
+            final Class<? extends Step<I>> stepClass,
+            final I input) {
+        return new StepMovement<I>(stepClass, input, null);
     }
 
     /**
      * Creates a movement with per-execution Step options.
      *
-     * @param step the target Step
+     * @param stepClass the target Step class
      * @param input the typed input for that Step
      * @param options the per-execution options, or {@code null} to use Step defaults
      * @param <I> the target Step's input type
      * @return the typed Step movement
      */
     public static <I> StepMovement<I> of(
-            final Step<I> step,
+            final Class<? extends Step<I>> stepClass,
             final I input,
             final StepOptions options) {
-        return new StepMovement<I>(step, input, options);
+        return new StepMovement<I>(stepClass, input, options);
     }
 
-    Step<I> getStep() {
-        return step;
+    Class<? extends Step<I>> getStepClass() {
+        return stepClass;
     }
 
     I getInput() {

--- a/sdk-java/src/main/java/io/superdurable/dex/StepOptions.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StepOptions.java
@@ -233,34 +233,35 @@ public final class StepOptions {
          * accepts that an extreme failure after the recovery Step begins can cause Dex to execute the
          * earlier Step again.
          *
-         * @param step the nonnull recovery Step
+         * @param stepClass the nonnull recovery Step class
          * @param <I> the recovery Step input type
          * @return this builder
-         * @throws NullPointerException if {@code step} is {@code null}
+         * @throws NullPointerException if {@code stepClass} is {@code null}
          */
-        public <I> Builder onExecuteFailureProceedTo(final Step<I> step) {
-            return onExecuteFailureProceedTo(step, null);
+        public <I> Builder onExecuteFailureProceedTo(
+                final Class<? extends Step<I>> stepClass) {
+            return onExecuteFailureProceedTo(stepClass, null);
         }
 
         /**
          * Continues to a recovery Step with per-execution options after execute retries fail.
          *
          * <p>The same durability guidance as
-         * {@link #onExecuteFailureProceedTo(Step)} applies. The {@code options} parameter configures
+         * {@link #onExecuteFailureProceedTo(Class)} applies. The {@code options} parameter configures
          * the recovery Step execution; configure the failing Step's execute durability on the builder
          * receiving this method call.
          *
-         * @param step the nonnull recovery Step
+         * @param stepClass the nonnull recovery Step class
          * @param options recovery execution options, or {@code null} for the Step defaults
          * @param <I> the recovery Step input type
          * @return this builder
-         * @throws NullPointerException if {@code step} is {@code null}
+         * @throws NullPointerException if {@code stepClass} is {@code null}
          */
         public <I> Builder onExecuteFailureProceedTo(
-                final Step<I> step,
+                final Class<? extends Step<I>> stepClass,
                 final StepOptions options) {
             executeFailureTarget = new ExecuteFailureTarget(
-                    Objects.requireNonNull(step, "step"),
+                    Objects.requireNonNull(stepClass, "stepClass"),
                     options);
             return this;
         }
@@ -288,7 +289,7 @@ public final class StepOptions {
          *
          * <p>This method-level value takes precedence over {@link FlowConfig}'s default and Dex's
          * {@link StepDurability#SYNC} default when this builder also uses
-         * {@link #onExecuteFailureProceedTo(Step)}. The application may choose
+         * {@link #onExecuteFailureProceedTo(Class)}. The application may choose
          * {@link StepDurability#ASYNC} when it accepts that an extreme failure after recovery begins
          * can cause the earlier Step to execute again. See {@link StepDurability} for latency and
          * throughput details.
@@ -334,16 +335,18 @@ public final class StepOptions {
     }
 
     static final class ExecuteFailureTarget {
-        private final Step<?> step;
+        private final Class<? extends Step<?>> stepClass;
         private final StepOptions options;
 
-        private ExecuteFailureTarget(final Step<?> step, final StepOptions options) {
-            this.step = step;
+        private ExecuteFailureTarget(
+                final Class<? extends Step<?>> stepClass,
+                final StepOptions options) {
+            this.stepClass = stepClass;
             this.options = options;
         }
 
-        Step<?> getStep() {
-            return step;
+        Class<? extends Step<?>> getStepClass() {
+            return stepClass;
         }
 
         StepOptions getOptions() {

--- a/sdk-java/src/main/java/io/superdurable/dex/WorkerDispatcher.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/WorkerDispatcher.java
@@ -354,16 +354,17 @@ final class WorkerDispatcher {
     private List<String> mapCancellationSteps(
             final Registry.RegisteredFlow flow,
             final String source,
-            final List<Step<?>> steps) {
-        final List<String> mapped = new ArrayList<String>(steps.size());
-        for (Step<?> cancellationStep : steps) {
-            if (cancellationStep == null) {
+            final List<Class<? extends Step<?>>> stepClasses) {
+        final List<String> mapped = new ArrayList<String>(stepClasses.size());
+        for (Class<? extends Step<?>> stepClass : stepClasses) {
+            if (stepClass == null) {
                 throw new InvalidStepResultException(
                         source + " cancellation Step is required");
             }
-            final Registry.RegisteredStep registered =
-                    flow.getSteps().get(cancellationStep.getStepType());
-            if (registered == null || registered.getStep() != cancellationStep) {
+            final Registry.RegisteredStep registered;
+            try {
+                registered = flow.getStep(stepClass);
+            } catch (FlowDefinitionException exception) {
                 throw new InvalidStepResultException(
                         source + " cancellation Step does not belong to Flow");
             }
@@ -401,9 +402,10 @@ final class WorkerDispatcher {
             throw new InvalidStepResultException(
                     "Flow " + flow.getName() + " Step movement is required");
         }
-        final Registry.RegisteredStep target =
-                flow.getSteps().get(movement.getStep().getStepType());
-        if (target == null || target.getStep() != movement.getStep()) {
+        final Registry.RegisteredStep target;
+        try {
+            target = flow.getStep(movement.getStepClass());
+        } catch (FlowDefinitionException exception) {
             throw new InvalidStepResultException(
                     "Flow " + flow.getName() + " Step movement target does not belong to Flow");
         }
@@ -411,6 +413,7 @@ final class WorkerDispatcher {
                 .setStepType(target.getName())
                 .setStepInput(values.encode(movement.getInput()));
         final io.superdurable.gen.StepOptions options = mapStepOptions(
+                flow,
                 movement.getOptions() == null
                         ? target.getStep().getStepOptions()
                         : movement.getOptions());
@@ -424,7 +427,9 @@ final class WorkerDispatcher {
         return mapped.build();
     }
 
-    io.superdurable.gen.StepOptions mapStepOptions(final StepOptions options) {
+    io.superdurable.gen.StepOptions mapStepOptions(
+            final Registry.RegisteredFlow flow,
+            final StepOptions options) {
         if (options == null) {
             return null;
         }
@@ -455,19 +460,27 @@ final class WorkerDispatcher {
                         .WAIT_FOR_METHOD_FAILURE_POLICY_FAIL_FLOW_ON_FAILURE);
         if (options.getExecuteFailureTarget() != null) {
             final StepOptions.ExecuteFailureTarget target = options.getExecuteFailureTarget();
+            final Registry.RegisteredStep registeredTarget;
+            try {
+                registeredTarget = flow.getStep(target.getStepClass());
+            } catch (FlowDefinitionException exception) {
+                throw new InvalidStepResultException(
+                        "Flow " + flow.getName()
+                                + " execute failure Step does not belong to Flow");
+            }
             mapped.setExecuteFailurePolicy(ExecuteMethodFailurePolicy
                     .EXECUTE_METHOD_FAILURE_POLICY_PROCEED_TO_CONFIGURED_STEP)
-                    .setExecuteFailureProceedStepType(target.getStep().getStepType());
+                    .setExecuteFailureProceedStepType(registeredTarget.getName());
             final io.superdurable.gen.StepOptions targetOptions =
-                    mapStepOptions(target.getOptions() == null
-                            ? target.getStep().getStepOptions()
+                    mapStepOptions(flow, target.getOptions() == null
+                            ? registeredTarget.getStep().getStepOptions()
                             : target.getOptions());
-            if (targetOptions != null || Registry.skipsWaitFor(target.getStep())) {
+            if (targetOptions != null || registeredTarget.skipsWaitFor()) {
                 final io.superdurable.gen.StepOptions.Builder mappedTarget =
                         targetOptions == null
                                 ? io.superdurable.gen.StepOptions.newBuilder()
                                 : targetOptions.toBuilder();
-                mappedTarget.setSkipWaitFor(Registry.skipsWaitFor(target.getStep()));
+                mappedTarget.setSkipWaitFor(registeredTarget.skipsWaitFor());
                 mapped.setExecuteFailureProceedStepOptions(mappedTarget);
             }
         }
@@ -672,7 +685,7 @@ final class WorkerDispatcher {
                     .setOptions(mappedOptions)
                     .setSubFlowIndex(index);
             final io.superdurable.gen.StepOptions stepOptions =
-                    mapStepOptions(start.getStep().getStepOptions());
+                    mapStepOptions(target, start.getStep().getStepOptions());
             if (stepOptions != null || start.skipsWaitFor()) {
                 final io.superdurable.gen.StepOptions.Builder mappedStepOptions =
                         stepOptions == null

--- a/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
@@ -747,7 +747,7 @@ final class WorkerServiceIntegrationTest {
     private static class BridgeFlow implements Flow<String> {
         private final Channel<Void> commands = Channel.define("commands", Void.class);
         private final BridgeOtherStep other = new BridgeOtherStep();
-        private final BridgeStep start = new BridgeStep(commands, other);
+        private final BridgeStep start = new BridgeStep(commands);
         private final Attribute<String> status = Attribute.define(
                 "status",
                 String.class,
@@ -775,17 +775,17 @@ final class WorkerServiceIntegrationTest {
         public RPCResult<String> cancellationRpc(final Context context, final String input) {
             if ("cancel-foreign".equals(input)) {
                 return RPCResult.of(input)
-                        .withCancelingSteps(new BridgeOtherStep());
+                        .withCancelingSteps(ForeignBridgeStep.class);
             }
             if ("cancel-null".equals(input)) {
                 return RPCResult.of(input)
-                        .withCancelingSteps((Step<?>[]) null);
+                        .withCancelingSteps((Class<? extends Step<?>>[]) null);
             }
             final RPCResult<String> base = RPCResult.of(
                     input,
-                    StepMovement.of(start, "next"));
+                    StepMovement.of(BridgeStep.class, "next"));
             baseRpcResult.set(base);
-            return base.withCancelingSteps(other, other)
+            return base.withCancelingSteps(BridgeOtherStep.class, BridgeOtherStep.class)
                     .withCancelingSteps();
         }
 
@@ -804,11 +804,8 @@ final class WorkerServiceIntegrationTest {
         private final CountDownLatch blockStarted = new CountDownLatch(1);
         private final CountDownLatch cancellationObserved = new CountDownLatch(1);
         private final Channel<Void> commands;
-        private final BridgeOtherStep other;
-
-        private BridgeStep(final Channel<Void> commands, final BridgeOtherStep other) {
+        private BridgeStep(final Channel<Void> commands) {
             this.commands = commands;
-            this.other = other;
         }
 
         @Override
@@ -882,18 +879,19 @@ final class WorkerServiceIntegrationTest {
             if ("cancel".equals(input)) {
                 final StepDecision base = StepDecision.gracefulComplete(input);
                 baseDecision.set(base);
-                return base.withCancelingSiblingSteps(other, this, other)
-                        .withCancelingSteps(other, other)
+                return base.withCancelingSiblingSteps(
+                                BridgeOtherStep.class, BridgeStep.class, BridgeOtherStep.class)
+                        .withCancelingSteps(BridgeOtherStep.class, BridgeOtherStep.class)
                         .withCancelingSteps()
                         .withCancelingSiblingSteps();
             }
             if ("cancel-foreign".equals(input)) {
                 return StepDecision.gracefulComplete()
-                        .withCancelingSteps(new BridgeOtherStep());
+                        .withCancelingSteps(ForeignBridgeStep.class);
             }
             if ("cancel-null".equals(input)) {
                 return StepDecision.gracefulComplete()
-                        .withCancelingSteps((Step<?>[]) null);
+                        .withCancelingSteps((Class<? extends Step<?>>[]) null);
             }
             if ("heartbeat".equals(input)) {
                 return heartbeatDecision(Duration.ofSeconds(10));
@@ -925,13 +923,25 @@ final class WorkerServiceIntegrationTest {
 
         private StepDecision heartbeatDecision(final Duration timeout) {
             return StepDecision.goToMulti(StepMovement.of(
-                    other,
+                    BridgeOtherStep.class,
                     "next",
                     StepOptions.newBuilder().heartbeatTimeout(timeout).build()));
         }
     }
 
     private static final class BridgeOtherStep implements Step<String> {
+        @Override
+        public Class<String> getInputType() {
+            return String.class;
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final String input) {
+            return StepDecision.deadEnd();
+        }
+    }
+
+    private static final class ForeignBridgeStep implements Step<String> {
         @Override
         public Class<String> getInputType() {
             return String.class;

--- a/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
@@ -124,6 +124,15 @@ public class UserContractsTest {
     }
 
     @Test
+    public void registryRejectsDuplicateStepClasses() {
+        final FlowDefinitionException exception = Assertions.assertThrows(
+                FlowDefinitionException.class,
+                () -> new Registry(Collections.<Flow<?>>singletonList(
+                        new DuplicateStepClassFlow())));
+        Assertions.assertTrue(exception.getMessage().contains("duplicate Step class"));
+    }
+
+    @Test
     public void clientValidatesInputBeforeTransport() {
         final Client client = new Client(
                 new Registry(Collections.<Flow<?>>singletonList(ORDERS)),
@@ -277,6 +286,37 @@ public class UserContractsTest {
         @Override
         public StepList<String> getSteps() {
             return uncheckedStartStep(new IntegerStartStep());
+        }
+    }
+
+    public static class DuplicateStepClassFlow implements Flow<Integer> {
+        @Override
+        public StepList<Integer> getSteps() {
+            return StepList.startStep(new NamedIntegerStep("first"))
+                    .otherSteps(new NamedIntegerStep("second"));
+        }
+    }
+
+    public static class NamedIntegerStep implements Step<Integer> {
+        private final String stepType;
+
+        public NamedIntegerStep(final String stepType) {
+            this.stepType = stepType;
+        }
+
+        @Override
+        public String getStepType() {
+            return stepType;
+        }
+
+        @Override
+        public Class<Integer> getInputType() {
+            return Integer.class;
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final Integer input) {
+            return StepDecision.gracefulComplete(input);
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/BasicEmptyInputWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/BasicEmptyInputWorkflow.java
@@ -40,7 +40,7 @@ final class BasicEmptyInputWorkflow implements Flow<Void> {
 
         @Override
         public StepDecision execute(final Context context, final Void input) {
-            return StepDecision.goTo(second, null);
+            return StepDecision.goTo(EmptySecondStep.class, null);
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/BasicImmutableStepOptionsWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/BasicImmutableStepOptionsWorkflow.java
@@ -44,7 +44,8 @@ final class BasicImmutableStepOptionsWorkflow implements Flow<Integer> {
                     .waitForRetry(RetryPolicy.newBuilder().maximumAttempts(1).build())
                     .waitForFailure(WaitForFailurePolicy.PROCEED)
                     .build();
-            return StepDecision.goToMulti(StepMovement.of(failingWait, 1, override));
+            return StepDecision.goToMulti(
+                    StepMovement.of(FailingWaitStep.class, 1, override));
         }
     }
 
@@ -65,7 +66,7 @@ final class BasicImmutableStepOptionsWorkflow implements Flow<Integer> {
                 throw new IllegalStateException("wait failure was not reported");
             }
             if (input == 1) {
-                return StepDecision.goTo(failingWait, 2);
+                return StepDecision.goTo(FailingWaitStep.class, 2);
             }
             return StepDecision.gracefulComplete(input);
         }

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/BasicProceedOnWaitFailureWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/BasicProceedOnWaitFailureWorkflow.java
@@ -44,7 +44,7 @@ final class BasicProceedOnWaitFailureWorkflow implements Flow<String> {
 
         @Override
         public StepDecision execute(final Context context, final String input) {
-            return StepDecision.goTo(second, input + "-recovered");
+            return StepDecision.goTo(CompleteStep.class, input + "-recovered");
         }
 
         @Override

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/BasicWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/BasicWorkflow.java
@@ -42,7 +42,7 @@ final class BasicWorkflow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
-            return StepDecision.goTo(second, input + 1);
+            return StepDecision.goTo(BasicSecondStep.class, input + 1);
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/ConditionalCompleteWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/ConditionalCompleteWorkflow.java
@@ -65,7 +65,7 @@ class ConditionalCompleteWorkflow implements Flow<Boolean> {
             final Channel<Void> selected = useSignal ? signal : internal;
             return StepDecision.forceCompleteIfChannelsEmpty(
                     next,
-                    StepMovement.of(this, useSignal),
+                    StepMovement.of(ConditionalStep.class, useSignal),
                     selected);
         }
     }

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/InternalChannelWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/InternalChannelWorkflow.java
@@ -54,8 +54,8 @@ final class InternalChannelWorkflow implements Flow<Integer> {
         @Override
         public StepDecision execute(final Context context, final Integer input) {
             return StepDecision.goToMulti(
-                    StepMovement.of(consumer, input),
-                    StepMovement.of(publisher, input));
+                    StepMovement.of(ConsumeStep.class, input),
+                    StepMovement.of(PublishStep.class, input));
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/MultiOutputWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/MultiOutputWorkflow.java
@@ -49,8 +49,8 @@ final class MultiOutputWorkflow implements Flow<Void> {
         @Override
         public StepDecision execute(final Context context, final Void input) {
             return StepDecision.goToMulti(
-                    StepMovement.of(stringStep, null),
-                    StepMovement.of(integerStep, null));
+                    StepMovement.of(MultiOutputStringStep.class, null),
+                    StepMovement.of(MultiOutputIntegerStep.class, null));
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/NoStartStateDeadEndWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/NoStartStateDeadEndWorkflow.java
@@ -56,7 +56,8 @@ class NoStartStateDeadEndWorkflow implements Flow<Void> {
         if (context.getFlowId().isEmpty() || context.getRunId().isEmpty()) {
             throw new IllegalStateException("invalid RPC context");
         }
-        return RPCResult.of(RPC_OUTPUT, StepMovement.of(complete, null));
+        return RPCResult.of(
+                RPC_OUTPUT, StepMovement.of(NoStartStateCompleteStep.class, null));
     }
 }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/NoStartStateWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/NoStartStateWorkflow.java
@@ -35,7 +35,7 @@ class NoStartStateWorkflow implements Flow<Void> {
         if (context.getFlowId().isEmpty() || context.getRunId().isEmpty()) {
             throw new IllegalStateException("invalid RPC context");
         }
-        return RPCResult.of(RPC_OUTPUT, StepMovement.of(triggered, null));
+        return RPCResult.of(RPC_OUTPUT, StepMovement.of(TriggeredStep.class, null));
     }
 
     static final class TriggeredStep implements Step<Void> {

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/ResetWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/ResetWorkflow.java
@@ -68,7 +68,7 @@ class ResetWorkflow implements Flow<Void> {
     public RPCResult<Void> withLocking(final Context context) {
         writeAttributes(context);
         channel.publish(context, null);
-        return RPCResult.<Void>of(null, StepMovement.of(second, null));
+        return RPCResult.<Void>of(null, StepMovement.of(LockCompleteStep.class, null));
     }
 
     @RPC(lockAttributeMaps = {
@@ -82,7 +82,7 @@ class ResetWorkflow implements Flow<Void> {
     public RPCResult<Void> withoutLocking(final Context context) {
         writeAttributes(context);
         channel.publish(context, null);
-        return RPCResult.<Void>of(null, StepMovement.of(second, null));
+        return RPCResult.<Void>of(null, StepMovement.of(LockCompleteStep.class, null));
     }
 
     private void writeAttributes(final Context context) {
@@ -104,7 +104,7 @@ class ResetWorkflow implements Flow<Void> {
 
         @Override
         public StepDecision execute(final Context context, final Void input) {
-            return StepDecision.goTo(second, null);
+            return StepDecision.goTo(LockCompleteStep.class, null);
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/RpcWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/RpcWorkflow.java
@@ -146,7 +146,7 @@ class RpcWorkflow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
-            return StepDecision.goTo(output, 0);
+            return StepDecision.goTo(RpcOutputStep.class, 0);
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/SignalWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/SignalWorkflow.java
@@ -63,7 +63,7 @@ final class SignalWorkflow implements Flow<Integer> {
                 throw new IllegalStateException("second signal should still be waiting");
             }
             final int value = first.getConditionResults(context).get(0);
-            return StepDecision.goTo(combination, input + value);
+            return StepDecision.goTo(SignalCombinationStep.class, input + value);
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/SkipWaitUntilMixedWaitWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/SkipWaitUntilMixedWaitWorkflow.java
@@ -43,7 +43,7 @@ final class SkipWaitUntilMixedWaitWorkflow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
-            return StepDecision.goTo(second, input + 1);
+            return StepDecision.goTo(MixedTimerStep.class, input + 1);
         }
 
         @Override

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/SkipWaitUntilWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/SkipWaitUntilWorkflow.java
@@ -35,7 +35,7 @@ final class SkipWaitUntilWorkflow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
-            return StepDecision.goTo(second, input + 1);
+            return StepDecision.goTo(ExecuteOnlySecondStep.class, input + 1);
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsLockingWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsLockingWorkflow.java
@@ -57,9 +57,9 @@ final class StateOptionsLockingWorkflow implements Flow<Integer> {
         public StepDecision execute(final Context context, final Integer parallelism) {
             final StepMovement<?>[] movements = new StepMovement<?>[parallelism + 1];
             for (int index = 0; index < parallelism; index++) {
-                movements[index] = StepMovement.of(locked, index);
+                movements[index] = StepMovement.of(LockedStep.class, index);
             }
-            movements[parallelism] = StepMovement.of(complete, parallelism);
+            movements[parallelism] = StepMovement.of(CompleteStep.class, parallelism);
             return StepDecision.goToMulti(movements);
         }
     }

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsOverrideWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsOverrideWorkflow.java
@@ -53,7 +53,8 @@ final class StateOptionsOverrideWorkflow implements Flow<String> {
                     .waitForFailure(WaitForFailurePolicy.PROCEED)
                     .build();
             output += "_state1_decide";
-            return StepDecision.goToMulti(StepMovement.of(second, output, options));
+            return StepDecision.goToMulti(
+                    StepMovement.of(CompleteStep.class, output, options));
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsWorkflow.java
@@ -52,7 +52,7 @@ final class StateOptionsWorkflow implements Flow<Void> {
             executeValue.set(context, "execute");
             waitValue.set(context, "wait_until");
             bothValue.set(context, "both");
-            return StepDecision.goTo(second, null);
+            return StepDecision.goTo(OptionsSecondStep.class, null);
         }
     }
 
@@ -87,7 +87,7 @@ final class StateOptionsWorkflow implements Flow<Void> {
             if (!"both".equals(bothValue.get(context))) {
                 throw new IllegalStateException("shared attribute was not loaded in execute");
             }
-            return StepDecision.goTo(third, null);
+            return StepDecision.goTo(OptionsThirdStep.class, null);
         }
 
         @Override

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StateRecoveryNoWaitWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StateRecoveryNoWaitWorkflow.java
@@ -47,7 +47,7 @@ final class StateRecoveryNoWaitWorkflow implements Flow<Integer> {
                             .maximumAttempts(1)
                             .backoffCoefficient(2.0)
                             .build())
-                    .onExecuteFailureProceedTo(recover)
+                    .onExecuteFailureProceedTo(RecoverNoWaitStep.class)
                     .build();
         }
     }
@@ -64,7 +64,7 @@ final class StateRecoveryNoWaitWorkflow implements Flow<Integer> {
                 return StepDecision.gracefulComplete(input);
             }
             if (input == 5) {
-                return StepDecision.goTo(start, input * 2);
+                return StepDecision.goTo(FailingNoWaitStep.class, input * 2);
             }
             return StepDecision.forceFail("unexpected input " + input);
         }

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StateRecoveryWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StateRecoveryWorkflow.java
@@ -53,7 +53,7 @@ final class StateRecoveryWorkflow implements Flow<Integer> {
                             .maximumAttempts(1)
                             .backoffCoefficient(2.0)
                             .build())
-                    .onExecuteFailureProceedTo(recover)
+                    .onExecuteFailureProceedTo(RecoverStep.class)
                     .build();
         }
     }
@@ -75,7 +75,7 @@ final class StateRecoveryWorkflow implements Flow<Integer> {
                 return StepDecision.gracefulComplete(input);
             }
             if (input == 5) {
-                return StepDecision.goTo(start, input * 2);
+                return StepDecision.goTo(FailingStep.class, input * 2);
             }
             return StepDecision.forceFail("unexpected input " + input);
         }

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationWorkflow.java
@@ -196,17 +196,17 @@ final class StepCancellationWorkflow implements Flow<Void> {
             switch (scenario) {
                 case HEARTBEAT_WAIT_FOR:
                     return StepDecision.goToMulti(
-                            StepMovement.of(blockingWaitFor, null),
-                            StepMovement.of(winner, null));
+                            StepMovement.of(StepCancellationBlockingWaitForStep.class, null),
+                            StepMovement.of(StepCancellationWinnerStep.class, null));
                 case GLOBAL_SELECTOR:
                 case SIBLING_SELECTOR:
                     return StepDecision.goToMulti(
-                            StepMovement.of(firstParent, null),
-                            StepMovement.of(secondParent, null));
+                            StepMovement.of(StepCancellationFirstParentStep.class, null),
+                            StepMovement.of(StepCancellationSecondParentStep.class, null));
                 default:
                     return StepDecision.goToMulti(
-                            StepMovement.of(blockingExecute, null),
-                            StepMovement.of(winner, null));
+                            StepMovement.of(StepCancellationBlockingExecuteStep.class, null),
+                            StepMovement.of(StepCancellationWinnerStep.class, null));
             }
         }
     }
@@ -232,14 +232,14 @@ final class StepCancellationWorkflow implements Flow<Void> {
             }
             lateWrite.set(context, "late");
             lateHandlerReturned.countDown();
-            return StepDecision.goTo(recovery, null);
+            return StepDecision.goTo(StepCancellationRecoveryStep.class, null);
         }
 
         @Override
         public StepOptions getStepOptions() {
             final StepOptions.Builder options = StepOptions.newBuilder()
                     .executeMethodTimeout(HANDLER_TIMEOUT)
-                    .onExecuteFailureProceedTo(recovery);
+                    .onExecuteFailureProceedTo(StepCancellationRecoveryStep.class);
             if (scenario == Scenario.LOCAL_EXECUTE) {
                 return options.executeDurability(StepDurability.ASYNC).build();
             }
@@ -304,10 +304,11 @@ final class StepCancellationWorkflow implements Flow<Void> {
             if (scenario == Scenario.LOCAL_EXECUTE) {
                 awaitLocalWinnerDelay();
             }
-            final Step<?> canceled = scenario == Scenario.HEARTBEAT_WAIT_FOR
-                    ? blockingWaitFor
-                    : blockingExecute;
-            return StepDecision.goTo(finalStep, scenario.name()).withCancelingSteps(canceled);
+            final Class<? extends Step<?>> canceled = scenario == Scenario.HEARTBEAT_WAIT_FOR
+                    ? StepCancellationBlockingWaitForStep.class
+                    : StepCancellationBlockingExecuteStep.class;
+            return StepDecision.goTo(StepCancellationFinalStep.class, scenario.name())
+                    .withCancelingSteps(canceled);
         }
 
         private void awaitLocalWinnerDelay() {
@@ -368,8 +369,8 @@ final class StepCancellationWorkflow implements Flow<Void> {
         @Override
         public StepDecision execute(final Context context, final Void input) {
             return StepDecision.goToMulti(
-                    StepMovement.of(selectorWinner, null),
-                    StepMovement.of(selectorWaiting, "first"));
+                    StepMovement.of(StepCancellationSelectorWinnerStep.class, null),
+                    StepMovement.of(StepCancellationSelectorWaitingStep.class, "first"));
         }
     }
 
@@ -381,7 +382,7 @@ final class StepCancellationWorkflow implements Flow<Void> {
 
         @Override
         public StepDecision execute(final Context context, final Void input) {
-            return StepDecision.goTo(selectorWaiting, "second");
+            return StepDecision.goTo(StepCancellationSelectorWaitingStep.class, "second");
         }
     }
 
@@ -398,10 +399,11 @@ final class StepCancellationWorkflow implements Flow<Void> {
 
         @Override
         public StepDecision execute(final Context context, final Void input) {
-            final StepDecision decision = StepDecision.goTo(finalStep, scenario.name());
+            final StepDecision decision = StepDecision.goTo(
+                    StepCancellationFinalStep.class, scenario.name());
             return scenario == Scenario.GLOBAL_SELECTOR
-                    ? decision.withCancelingSteps(selectorWaiting)
-                    : decision.withCancelingSiblingSteps(selectorWaiting);
+                    ? decision.withCancelingSteps(StepCancellationSelectorWaitingStep.class)
+                    : decision.withCancelingSiblingSteps(StepCancellationSelectorWaitingStep.class);
         }
     }
 

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -129,9 +129,9 @@ its normal decision:
 
 ```python
 return (
-    dex.go_to(self.record_quote, quote)
-    .with_canceling_sibling_steps(self.carrier_a, self.carrier_b)
-    .with_canceling_steps(self.global_quote_timeout)
+    dex.go_to(RecordQuote, quote)
+    .with_canceling_sibling_steps(QuoteCarrierA, QuoteCarrierB)
+    .with_canceling_steps(GlobalQuoteTimeout)
 )
 ```
 

--- a/sdk-python/dex/_worker_dispatcher.py
+++ b/sdk-python/dex/_worker_dispatcher.py
@@ -531,7 +531,7 @@ class WorkerDispatcher:
     def _map_cancellation_steps(
         self,
         flow: _RegisteredFlow,
-        steps: tuple[Step[Any], ...],
+        steps: tuple[type[Step[Any]], ...],
     ) -> list[str]:
         step_types: list[str] = []
         seen: set[str] = set()
@@ -587,13 +587,9 @@ class WorkerDispatcher:
     @staticmethod
     def _registered_movement_target(
         flow: _RegisteredFlow,
-        step: object,
+        step: type[Step[Any]],
     ) -> _RegisteredStep:
-        step_type = getattr(step, "get_step_type", lambda: "")()
-        target = flow.step(step_type)
-        if target.step is not step:
-            raise ValueError("Step movement target does not belong to Flow")
-        return target
+        return flow.step_class(step)
 
     @staticmethod
     def _require_persistence_identity(

--- a/sdk-python/dex/flow.py
+++ b/sdk-python/dex/flow.py
@@ -128,9 +128,9 @@ class RPCResult(Generic[OutputT]):
 
     output: OutputT
     next_steps: tuple[StepMovement[Any], ...] = ()
-    canceling_steps: tuple[Step[Any], ...] = ()
+    canceling_steps: tuple[type[Step[Any]], ...] = ()
 
-    def with_canceling_steps(self, *steps: Step[Any]) -> RPCResult[OutputT]:
+    def with_canceling_steps(self, *steps: type[Step[Any]]) -> RPCResult[OutputT]:
         """Return a result canceling all current executions of selected Step types.
 
         Dex resolves the selection after RPC persistence commits and before ``next_steps``.
@@ -138,7 +138,7 @@ class RPCResult(Generic[OutputT]):
         siblings because an RPC has no Step execution lineage.
 
         Args:
-            *steps: Exact Step instances registered with the current Flow.
+            *steps: Step classes registered with the current Flow.
 
         Returns:
             A new RPCResult containing the combined cancellation selectors.
@@ -271,6 +271,7 @@ class _RegisteredFlow:
     flow: Flow[Any]
     has_timeout_handler: bool
     steps: MappingProxyType[str, _RegisteredStep]
+    steps_by_class: MappingProxyType[type[Step[Any]], _RegisteredStep]
     start_step: _RegisteredStep | None
     rpcs: MappingProxyType[str, _RegisteredRPC]
     persistence: MappingProxyType[str, _PersistenceDefinition]
@@ -281,6 +282,15 @@ class _RegisteredFlow:
         except KeyError as error:
             raise FlowDefinitionError(
                 f"Flow {self.name} Step is not registered: {name}"
+            ) from error
+
+    def step_class(self, step_class: type[Step[Any]]) -> _RegisteredStep:
+        try:
+            return self.steps_by_class[step_class]
+        except KeyError as error:
+            raise FlowDefinitionError(
+                f"Flow {self.name} Step class is not registered: "
+                f"{step_class.__qualname__}"
             ) from error
 
     def rpc(self, name: str) -> _RegisteredRPC:
@@ -424,6 +434,7 @@ class Registry:
         if not isinstance(definitions, StepList):
             raise TypeError("Flow steps must be a StepList")
         registered_steps: dict[str, _RegisteredStep] = {}
+        registered_steps_by_class: dict[type[Step[Any]], _RegisteredStep] = {}
         start_step: _RegisteredStep | None = None
         for definition in definitions:
             if not isinstance(definition, _StepDef):
@@ -436,6 +447,9 @@ class Registry:
             require_name(step_name)
             if step_name in registered_steps:
                 raise ValueError(f"duplicate Step {step_name}")
+            step_class = type(step)
+            if step_class in registered_steps_by_class:
+                raise ValueError(f"duplicate Step class {step_class.__qualname__}")
             registered_step = _RegisteredStep(
                 step_name,
                 step,
@@ -448,6 +462,7 @@ class Registry:
                 type(step).wait_for is Step.wait_for,
             )
             registered_steps[step_name] = registered_step
+            registered_steps_by_class[step_class] = registered_step
             if definition.is_start_step:
                 start_step = registered_step
 
@@ -489,6 +504,7 @@ class Registry:
                 flow, allow_async_handlers=allow_async_handlers
             ),
             MappingProxyType(registered_steps),
+            MappingProxyType(registered_steps_by_class),
             start_step,
             MappingProxyType(registered_rpcs),
             MappingProxyType(persistence),

--- a/sdk-python/dex/step.py
+++ b/sdk-python/dex/step.py
@@ -107,12 +107,12 @@ class StepOptions:
     execute_durability: StepDurability = StepDurability.DEFAULT
     wait_for_lock_attributes: tuple[AttributeLock, ...] = ()
     execute_lock_attributes: tuple[AttributeLock, ...] = ()
-    _execute_failure_target: Step[Any] | None = None
+    _execute_failure_target: type[Step[Any]] | None = None
     _execute_failure_options: StepOptions | None = None
 
     def on_execute_failure_proceed_to(
         self,
-        step: Step[Any],
+        step: type[Step[Any]],
         options: StepOptions | None = None,
     ) -> StepOptions:
         """Return a copy that routes exhausted ``execute`` retries to another Step.
@@ -277,18 +277,18 @@ class StepMovement(Generic[InputT]):
     """Schedule one registered Step with typed input and optional options.
 
     Attributes:
-        step: The destination Step instance from the containing Registry.
+        step: The destination Step class from the containing Registry.
         input: The value decoded by the destination Step's input codec.
         options: Optional per-movement StepOptions override.
     """
 
-    step: Step[InputT]
+    step: type[Step[InputT]]
     input: InputT
     options: StepOptions | None = None
 
     @staticmethod
     def of(
-        step: Step[InputT],
+        step: type[Step[InputT]],
         input: InputT,
         *,
         options: StepOptions | None = None,
@@ -342,13 +342,13 @@ class StepDecision:
     reason: str = ""
     empty_channels: tuple[Channel[Any] | ChannelMap[Any], ...] = ()
     fallback: StepMovement[Any] | None = None
-    canceling_steps: tuple[Step[Any], ...] = ()
-    canceling_sibling_steps: tuple[Step[Any], ...] = ()
+    canceling_steps: tuple[type[Step[Any]], ...] = ()
+    canceling_sibling_steps: tuple[type[Step[Any]], ...] = ()
 
     def _has_output(self) -> bool:
         return self.output is not _NO_OUTPUT
 
-    def with_canceling_steps(self, *steps: Step[Any]) -> StepDecision:
+    def with_canceling_steps(self, *steps: type[Step[Any]]) -> StepDecision:
         """Return a decision canceling all current executions of selected Step types.
 
         Dex resolves one snapshot after this Execute succeeds. Finished, already-canceled,
@@ -356,7 +356,7 @@ class StepDecision:
         Repeated calls take the union, and Flow-wide selection supersedes sibling selection.
 
         Args:
-            *steps: Exact Step instances registered with the current Flow.
+            *steps: Step classes registered with the current Flow.
 
         Returns:
             A new decision containing the combined Flow-wide selectors.
@@ -373,7 +373,7 @@ class StepDecision:
             canceling_sibling_steps=sibling_steps,
         )
 
-    def with_canceling_sibling_steps(self, *steps: Step[Any]) -> StepDecision:
+    def with_canceling_sibling_steps(self, *steps: type[Step[Any]]) -> StepDecision:
         """Return a decision canceling selected same-source Step executions.
 
         A sibling has the same ``Context.from_step_execution_id`` as the execution
@@ -381,7 +381,7 @@ class StepDecision:
         ``with_canceling_steps``. Flow-wide selection wins for the same Step type.
 
         Args:
-            *steps: Exact Step instances registered with the current Flow.
+            *steps: Step classes registered with the current Flow.
 
         Returns:
             A new decision containing the combined sibling selectors.
@@ -396,9 +396,9 @@ class StepDecision:
 
 
 def _union_steps(
-    existing: tuple[Step[Any], ...],
-    added: tuple[Step[Any], ...],
-) -> tuple[Step[Any], ...]:
+    existing: tuple[type[Step[Any]], ...],
+    added: tuple[type[Step[Any]], ...],
+) -> tuple[type[Step[Any]], ...]:
     combined = list(existing)
     for step in added:
         if all(step is not current for current in combined):
@@ -406,7 +406,7 @@ def _union_steps(
     return tuple(combined)
 
 
-def go_to(step: Step[InputT], input: InputT) -> StepDecision:
+def go_to(step: type[Step[InputT]], input: InputT) -> StepDecision:
     """Create a decision that schedules one next Step.
 
     Args:

--- a/sdk-python/tests/integ/basic_flow.py
+++ b/sdk-python/tests/integ/basic_flow.py
@@ -36,7 +36,7 @@ class BasicFirstStep(Step[int]):
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to(self.second, input + 1)
+        return go_to(BasicSecondStep, input + 1)
 
 
 class BasicFlow(Flow[int]):

--- a/sdk-python/tests/integ/basic_internal_channel_flow.py
+++ b/sdk-python/tests/integ/basic_internal_channel_flow.py
@@ -63,8 +63,8 @@ class ForkStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
         return go_to_multi(
-            StepMovement.of(self.consumer, input),
-            StepMovement.of(self.publisher, input),
+            StepMovement.of(ConsumeStep, input),
+            StepMovement.of(PublishStep, input),
         )
 
 

--- a/sdk-python/tests/integ/conditional_complete_flow.py
+++ b/sdk-python/tests/integ/conditional_complete_flow.py
@@ -45,7 +45,7 @@ class ConditionalStep(Step[bool]):
         selected = self.signal if input else self.internal
         return force_complete_if_channels_empty(
             next_value,
-            StepMovement.of(self, input),
+            StepMovement.of(ConditionalStep, input),
             selected,
         )
 

--- a/sdk-python/tests/integ/dead_end_flow.py
+++ b/sdk-python/tests/integ/dead_end_flow.py
@@ -67,5 +67,5 @@ class DeadEndFlow(Flow[None]):
             raise RuntimeError("invalid RPC context")
         return RPCResult(
             self.RPC_OUTPUT,
-            (StepMovement.of(self.complete, None),),
+            (StepMovement.of(DeadEndCompleteStep, None),),
         )

--- a/sdk-python/tests/integ/empty_input_flow.py
+++ b/sdk-python/tests/integ/empty_input_flow.py
@@ -23,7 +23,7 @@ class EmptyFirstStep(Step[None]):
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
-        return go_to(self.second, None)
+        return go_to(EmptySecondStep, None)
 
 
 class EmptyInputFlow(Flow[None]):

--- a/sdk-python/tests/integ/execute_only_flow.py
+++ b/sdk-python/tests/integ/execute_only_flow.py
@@ -23,7 +23,7 @@ class ExecuteOnlyFirstStep(Step[int]):
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to(self.second, input + 1)
+        return go_to(ExecuteOnlySecondStep, input + 1)
 
 
 class ExecuteOnlyFlow(Flow[int]):

--- a/sdk-python/tests/integ/immutable_step_options_flow.py
+++ b/sdk-python/tests/integ/immutable_step_options_flow.py
@@ -37,7 +37,9 @@ class ImmutableOptionsStartStep(Step[int]):
             wait_for_retry=RetryPolicy(maximum_attempts=1),
             wait_for_failure=WaitForFailurePolicy.PROCEED,
         )
-        return go_to_multi(StepMovement.of(self.failing_wait, 1, options=override))
+        return go_to_multi(
+            StepMovement.of(ImmutableOptionsFailingWaitStep, 1, options=override)
+        )
 
 
 class ImmutableOptionsFailingWaitStep(Step[int]):
@@ -49,7 +51,7 @@ class ImmutableOptionsFailingWaitStep(Step[int]):
         if not context.wait_for_method_failed():
             raise RuntimeError("wait failure was not reported")
         if input == 1:
-            return go_to(self, 2)
+            return go_to(ImmutableOptionsFailingWaitStep, 2)
         return graceful_complete(input)
 
     def get_step_options(self) -> StepOptions:

--- a/sdk-python/tests/integ/mixed_wait_flow.py
+++ b/sdk-python/tests/integ/mixed_wait_flow.py
@@ -47,7 +47,7 @@ class MixedImmediateStep(Step[int]):
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to(self.second, input + 1)
+        return go_to(MixedTimerStep, input + 1)
 
     def get_step_options(self) -> StepOptions:
         return self.options

--- a/sdk-python/tests/integ/multi_output_flow.py
+++ b/sdk-python/tests/integ/multi_output_flow.py
@@ -44,8 +44,8 @@ class MultiOutputStartStep(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
         return go_to_multi(
-            StepMovement.of(self.string_step, None),
-            StepMovement.of(self.int_step, None),
+            StepMovement.of(MultiOutputStringStep, None),
+            StepMovement.of(MultiOutputIntStep, None),
         )
 
 

--- a/sdk-python/tests/integ/no_start_flow.py
+++ b/sdk-python/tests/integ/no_start_flow.py
@@ -43,5 +43,5 @@ class NoStartFlow(Flow[None]):
             raise RuntimeError("invalid RPC context")
         return RPCResult(
             self.RPC_OUTPUT,
-            (StepMovement.of(self.triggered, None),),
+            (StepMovement.of(TriggeredStep, None),),
         )

--- a/sdk-python/tests/integ/proceed_on_wait_failure_flow.py
+++ b/sdk-python/tests/integ/proceed_on_wait_failure_flow.py
@@ -34,7 +34,7 @@ class FailingWaitStep(Step[str]):
 
     def execute(self, context: Context, input: str) -> StepDecision:
         del context
-        return go_to(self.second, input + "-recovered")
+        return go_to(CompleteStringStep, input + "-recovered")
 
     def get_step_options(self) -> StepOptions:
         return StepOptions(

--- a/sdk-python/tests/integ/reset_flow.py
+++ b/sdk-python/tests/integ/reset_flow.py
@@ -44,7 +44,7 @@ class ResetWaitStep(Step[None]):
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
-        return go_to(self.complete, None)
+        return go_to(ResetCompleteStep, None)
 
 
 class ResetFlow(Flow[None]):

--- a/sdk-python/tests/integ/rpc_flow.py
+++ b/sdk-python/tests/integ/rpc_flow.py
@@ -44,7 +44,7 @@ class RpcFirstStep(Step[int]):
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context, input
-        return go_to(self.second, 0)
+        return go_to(RpcSecondStep, 0)
 
 
 class RpcFlow(Flow[int]):

--- a/sdk-python/tests/integ/rpc_locking_flow.py
+++ b/sdk-python/tests/integ/rpc_locking_flow.py
@@ -44,7 +44,7 @@ class LockWaitStep(Step[None]):
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
-        return go_to(self.second, None)
+        return go_to(LockCompleteStep, None)
 
 
 class RpcLockingFlow(Flow[None]):

--- a/sdk-python/tests/integ/signal_flow.py
+++ b/sdk-python/tests/integ/signal_flow.py
@@ -87,7 +87,7 @@ class SignalFirstStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
         if self.second.results(context):
             raise RuntimeError("second signal should still be waiting")
-        return go_to(self.combination, input + self.first.results(context)[0])
+        return go_to(SignalCombinationStep, input + self.first.results(context)[0])
 
 
 class SignalFlow(Flow[int]):

--- a/sdk-python/tests/integ/state_options_flow.py
+++ b/sdk-python/tests/integ/state_options_flow.py
@@ -77,7 +77,7 @@ class OptionsSecondStep(Step[None]):
             raise RuntimeError("wait_for attribute was not loaded in execute")
         if self.both_value.get(context) != "both":
             raise RuntimeError("shared attribute was not loaded in execute")
-        return go_to(self.third, None)
+        return go_to(OptionsThirdStep, None)
 
     def get_step_options(self) -> StepOptions:
         return StepOptions(
@@ -104,7 +104,7 @@ class OptionsFirstStep(Step[None]):
         self.execute_value.set(context, "execute")
         self.wait_value.set(context, "wait_until")
         self.both_value.set(context, "both")
-        return go_to(self.second, None)
+        return go_to(OptionsSecondStep, None)
 
 
 class StateOptionsFlow(Flow[None]):

--- a/sdk-python/tests/integ/state_options_override_flow.py
+++ b/sdk-python/tests/integ/state_options_override_flow.py
@@ -43,7 +43,9 @@ class OverrideFirstStep(Step[str]):
             wait_for_retry=RetryPolicy(maximum_attempts=2),
             wait_for_failure=WaitForFailurePolicy.PROCEED,
         )
-        return go_to_multi(StepMovement.of(self.second, self.output, options=options))
+        return go_to_multi(
+            StepMovement.of(OverrideCompleteStep, self.output, options=options)
+        )
 
 
 class OverrideCompleteStep(Step[str]):

--- a/sdk-python/tests/integ/state_recovery_flow.py
+++ b/sdk-python/tests/integ/state_recovery_flow.py
@@ -26,9 +26,6 @@ from dex import (
 
 
 class RecoverStep(Step[int]):
-    def __init__(self) -> None:
-        self.failing: FailingStep | None = None
-
     def wait_for(self, context: Context, input: int) -> Wait:
         del context, input
         return Wait.skip_immediately()
@@ -37,15 +34,12 @@ class RecoverStep(Step[int]):
         del context
         if input == 10:
             return graceful_complete(input)
-        if input == 5 and self.failing is not None:
-            return go_to(self.failing, input * 2)
+        if input == 5:
+            return go_to(FailingStep, input * 2)
         return force_fail(f"unexpected input {input}")
 
 
 class FailingStep(Step[int]):
-    def __init__(self, recover: RecoverStep) -> None:
-        self.recover = recover
-
     def wait_for(self, context: Context, input: int) -> Wait:
         del context, input
         return Wait.skip_immediately()
@@ -60,14 +54,13 @@ class FailingStep(Step[int]):
                 maximum_attempts=1,
                 backoff_coefficient=2.0,
             )
-        ).on_execute_failure_proceed_to(self.recover)
+        ).on_execute_failure_proceed_to(RecoverStep)
 
 
 class StateRecoveryFlow(Flow[int]):
     def __init__(self) -> None:
         self.recover = RecoverStep()
-        self.start = FailingStep(self.recover)
-        self.recover.failing = self.start
+        self.start = FailingStep()
 
     def get_steps(self) -> StepList[int]:
         return StepList.start_step(self.start).other_steps(self.recover)

--- a/sdk-python/tests/integ/state_recovery_no_wait_flow.py
+++ b/sdk-python/tests/integ/state_recovery_no_wait_flow.py
@@ -25,22 +25,16 @@ from dex import (
 
 
 class RecoverNoWaitStep(Step[int]):
-    def __init__(self) -> None:
-        self.failing: FailingNoWaitStep | None = None
-
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
         if input == 10:
             return graceful_complete(input)
-        if input == 5 and self.failing is not None:
-            return go_to(self.failing, input * 2)
+        if input == 5:
+            return go_to(FailingNoWaitStep, input * 2)
         return force_fail(f"unexpected input {input}")
 
 
 class FailingNoWaitStep(Step[int]):
-    def __init__(self, recover: RecoverNoWaitStep) -> None:
-        self.recover = recover
-
     def execute(self, context: Context, input: int) -> StepDecision:
         del context, input
         raise RuntimeError("execute failure")
@@ -51,14 +45,13 @@ class FailingNoWaitStep(Step[int]):
                 maximum_attempts=1,
                 backoff_coefficient=2.0,
             )
-        ).on_execute_failure_proceed_to(self.recover)
+        ).on_execute_failure_proceed_to(RecoverNoWaitStep)
 
 
 class StateRecoveryNoWaitFlow(Flow[int]):
     def __init__(self) -> None:
         self.recover = RecoverNoWaitStep()
-        self.start = FailingNoWaitStep(self.recover)
-        self.recover.failing = self.start
+        self.start = FailingNoWaitStep()
 
     def get_steps(self) -> StepList[int]:
         return StepList.start_step(self.start).other_steps(self.recover)

--- a/sdk-python/tests/integ/step_cancellation_flow.py
+++ b/sdk-python/tests/integ/step_cancellation_flow.py
@@ -56,20 +56,20 @@ class CancellationStart(Step[str]):
         scenario = self.flow.scenario
         if scenario is CancellationScenario.HEARTBEAT_WAIT_FOR:
             return go_to_multi(
-                StepMovement.of(self.flow.blocking_wait_for, None),
-                StepMovement.of(self.flow.winner, None),
+                StepMovement.of(CancellationBlockingWaitFor, None),
+                StepMovement.of(CancellationWinner, None),
             )
         if scenario in {
             CancellationScenario.GLOBAL_SELECTOR,
             CancellationScenario.SIBLING_SELECTOR,
         }:
             return go_to_multi(
-                StepMovement.of(self.flow.first_parent, None),
-                StepMovement.of(self.flow.second_parent, None),
+                StepMovement.of(CancellationFirstParent, None),
+                StepMovement.of(CancellationSecondParent, None),
             )
         return go_to_multi(
-            StepMovement.of(self.flow.blocking_execute, None),
-            StepMovement.of(self.flow.winner, None),
+            StepMovement.of(CancellationBlockingExecute, None),
+            StepMovement.of(CancellationWinner, None),
         )
 
 
@@ -94,7 +94,7 @@ class CancellationBlockingExecute(Step[None]):
             self.flow.cancellation_observed.set()
         self.flow.late_write.set(context, "late")
         self.flow.late_handler_returned.set()
-        return go_to(self.flow.recovery, None)
+        return go_to(CancellationRecovery, None)
 
     def get_step_options(self) -> StepOptions:
         options = StepOptions(
@@ -118,7 +118,7 @@ class CancellationBlockingExecute(Step[None]):
                 else StepDurability.SYNC
             ),
         )
-        return options.on_execute_failure_proceed_to(self.flow.recovery)
+        return options.on_execute_failure_proceed_to(CancellationRecovery)
 
 
 class CancellationBlockingWaitFor(Step[None]):
@@ -172,10 +172,10 @@ class CancellationWinner(Step[None]):
         if self.flow.scenario is CancellationScenario.LOCAL_EXECUTE:
             await asyncio.wait_for(self.flow.blocking_started.wait(), timeout=10)
             await asyncio.sleep(1)
-        selected: Step[Any] = self.flow.blocking_execute
+        selected: type[Step[Any]] = CancellationBlockingExecute
         if self.flow.scenario is CancellationScenario.HEARTBEAT_WAIT_FOR:
-            selected = self.flow.blocking_wait_for
-        return go_to(self.flow.final, self.flow.scenario.value).with_canceling_steps(
+            selected = CancellationBlockingWaitFor
+        return go_to(CancellationFinal, self.flow.scenario.value).with_canceling_steps(
             selected
         )
 
@@ -207,8 +207,8 @@ class CancellationFirstParent(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
         return go_to_multi(
-            StepMovement.of(self.flow.selector_winner, None),
-            StepMovement.of(self.flow.selector_waiting, "first"),
+            StepMovement.of(CancellationSelectorWinner, None),
+            StepMovement.of(CancellationSelectorWaiting, "first"),
         )
 
 
@@ -218,7 +218,7 @@ class CancellationSecondParent(Step[None]):
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
-        return go_to(self.flow.selector_waiting, "second")
+        return go_to(CancellationSelectorWaiting, "second")
 
 
 class CancellationSelectorWinner(Step[None]):
@@ -234,10 +234,10 @@ class CancellationSelectorWinner(Step[None]):
     ) -> StepDecision:
         del context, input
         await asyncio.wait_for(self.flow.selector_waits_registered.wait(), timeout=10)
-        decision = go_to(self.flow.final, self.flow.scenario.value)
+        decision = go_to(CancellationFinal, self.flow.scenario.value)
         if self.flow.scenario is CancellationScenario.GLOBAL_SELECTOR:
-            return decision.with_canceling_steps(self.flow.selector_waiting)
-        return decision.with_canceling_sibling_steps(self.flow.selector_waiting)
+            return decision.with_canceling_steps(CancellationSelectorWaiting)
+        return decision.with_canceling_sibling_steps(CancellationSelectorWaiting)
 
 
 class CancellationSelectorWaiting(Step[str]):

--- a/sdk-python/tests/integ/test_async_runtime.py
+++ b/sdk-python/tests/integ/test_async_runtime.py
@@ -145,7 +145,7 @@ class StartChild(Step[int]):
         child_id = unique_id("async-child")
         await client.start_flow(self._child, child_id, 0)
         (await client.wait_for_flow(child_id, WAIT_TIMEOUT)).single_output(int)
-        return go_to(self._finish, input)
+        return go_to(Finish, input)
 
 
 class Finish(Step[int]):

--- a/sdk-python/tests/test_contracts.py
+++ b/sdk-python/tests/test_contracts.py
@@ -215,6 +215,28 @@ def test_registry_rejects_duplicate_interfaces() -> None:
         Registry((ORDERS, ORDERS))
 
 
+def test_registry_rejects_duplicate_step_classes() -> None:
+    class DuplicateStep(Step[int]):
+        def __init__(self, step_type: str) -> None:
+            self._step_type = step_type
+
+        def get_step_type(self) -> str:
+            return self._step_type
+
+        def execute(self, context: Context, input: int) -> StepDecision:
+            del context
+            return graceful_complete(input)
+
+    class DuplicateStepFlow(Flow[int]):
+        def get_steps(self) -> StepList[int]:
+            return StepList.start_step(DuplicateStep("first")).other_steps(
+                DuplicateStep("second")
+            )
+
+    with pytest.raises(FlowDefinitionError, match="duplicate Step class"):
+        Registry((DuplicateStepFlow(),))
+
+
 def test_registry_wraps_user_definition_failures_with_flow_context() -> None:
     class BrokenFlow(Flow[None]):
         def get_steps(self) -> StepList[None]:

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -75,11 +75,11 @@ its normal decision:
 ```typescript
 return withCancelingSteps(
   withCancelingSiblingSteps(
-    goTo(this.recordQuote, quote),
-    this.carrierA,
-    this.carrierB,
+    goTo(RecordQuote, quote),
+    QuoteCarrierA,
+    QuoteCarrierB,
   ),
-  this.globalQuoteTimeout,
+  GlobalQuoteTimeout,
 );
 ```
 
@@ -87,7 +87,7 @@ return withCancelingSteps(
 type. `withCancelingSiblingSteps` selects only executions whose
 `Context.fromStepExecutionId` matches the current execution. Both helpers return
 a new decision; repeated calls form a union, and Flow-wide selection wins for
-the same Step object. Unregistered selectors produce an invalid Step result.
+the same Step class. Unregistered selectors produce an invalid Step result.
 
 Dex resolves one snapshot after the current execution succeeds. Completed,
 already-canceled, and absent targets are no-ops. Next Steps created by that

--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -856,10 +856,9 @@ function mapStepOptions(
   flow: RegisteredFlow,
 ): ProtoStepOptions {
   const executeFailureStep = options?.executeFailure?.step;
-  const executeFailureDefinition =
-    executeFailureStep === undefined
-      ? undefined
-      : flow.steps.find((definition) => definition.step === executeFailureStep);
+  const executeFailureDefinition = executeFailureStep === undefined
+    ? undefined
+    : flow.stepsByClass.get(executeFailureStep);
   if (executeFailureStep !== undefined && executeFailureDefinition === undefined) {
     throw new TypeError("execute failure Step must belong to the Flow");
   }

--- a/sdk-typescript/src/flow.ts
+++ b/sdk-typescript/src/flow.ts
@@ -10,7 +10,7 @@ import { AttributeMap, IndexType, type Attribute, type PersistenceSchema } from 
 import { IndexType as ProtoIndexType } from "./gen/dex.js";
 import { FlowDefinitionError } from "./errors.js";
 import { registeredRPCs, type RegisteredRPC } from "./rpc.js";
-import { StepList, type Step, type StepDecision } from "./step.js";
+import { StepList, type Step, type StepClass, type StepDecision } from "./step.js";
 import { requireName } from "./validation.js";
 import type { Channel, ChannelMap } from "./wait.js";
 import type { Context } from "./context.js";
@@ -105,6 +105,7 @@ export interface RegisteredFlow {
   readonly flow: Flow<any>;
   readonly hasTimeoutHandler: boolean;
   readonly steps: readonly RegisteredStep[];
+  readonly stepsByClass: ReadonlyMap<StepClass<any>, RegisteredStep>;
   readonly startStep?: RegisteredStep;
   readonly rpcs: readonly RegisteredRPC[];
   readonly persistence: ReadonlyMap<
@@ -221,6 +222,7 @@ function doRegisterFlow(
   }
   const stepNames = new Set<string>();
   const steps: RegisteredStep[] = [];
+  const stepsByClass = new Map<StepClass<any>, RegisteredStep>();
   let startStep: RegisteredStep | undefined;
   let hasStartStep = false;
   for (const definition of stepDefinitions) {
@@ -231,13 +233,18 @@ function doRegisterFlow(
       hasStartStep = true;
     }
     const step = definition.step;
+    const stepClass = registeredStepClass(step);
     const stepName = stepType(name, step);
     if (stepNames.has(stepName)) {
       throw new FlowDefinitionError(`Flow ${name} has duplicate Step ${stepName}`);
     }
+    if (stepsByClass.has(stepClass)) {
+      throw new FlowDefinitionError(`Flow ${name} has duplicate Step class ${stepClass.name}`);
+    }
     stepNames.add(stepName);
     const registered = { name: stepName, step, isStartStep: definition.isStartStep };
     steps.push(registered);
+    stepsByClass.set(stepClass, registered);
     if (definition.isStartStep) {
       startStep = registered;
     }
@@ -284,10 +291,18 @@ function doRegisterFlow(
     flow,
     hasTimeoutHandler: typeof flow.handleTimeout === "function",
     steps: Object.freeze(steps),
+    stepsByClass,
     ...(startStep === undefined ? {} : { startStep }),
     rpcs,
     persistence,
   });
+}
+
+function registeredStepClass<Input>(step: Step<Input>): StepClass<Input> {
+  if (step.constructor === Object) {
+    throw new FlowDefinitionError("Step must be a class instance");
+  }
+  return step.constructor as StepClass<Input>;
 }
 
 function protoIndexType(indexType: IndexType): ProtoIndexType {

--- a/sdk-typescript/src/rpc.ts
+++ b/sdk-typescript/src/rpc.ts
@@ -10,7 +10,7 @@ import type { Codec } from "./codec.js";
 import type { Context } from "./context.js";
 import type { Flow } from "./flow.js";
 import type { AttributeLock } from "./persistence.js";
-import type { Step, StepMovement } from "./step.js";
+import type { StepClass, StepMovement } from "./step.js";
 import { requireName } from "./validation.js";
 
 /**
@@ -23,7 +23,7 @@ export interface RPCResult<Output> {
   /** Step movements applied atomically with handler persistence writes. */
   readonly nextSteps?: readonly StepMovement<unknown>[];
   /** Registered Step types canceled before `nextSteps` are scheduled. */
-  readonly cancelingSteps?: readonly Step<any>[];
+  readonly cancelingSteps?: readonly StepClass<any>[];
 }
 
 /**

--- a/sdk-typescript/src/step.ts
+++ b/sdk-typescript/src/step.ts
@@ -32,8 +32,8 @@ export interface RetryPolicy {
 
 /** Routes exhausted `execute` retries to a fallback Step. */
 export interface ExecuteFailure {
-  /** Registered fallback Step. */
-  readonly step: Step<unknown>;
+  /** Registered fallback Step class. */
+  readonly step: StepClass<any>;
   /** Options applied to the fallback movement. */
   readonly options?: StepOptions;
 }
@@ -43,13 +43,13 @@ export const ExecuteFailure = Object.freeze({
   /**
    * Routes exhausted execution retries to another Step.
    * @typeParam Input - Fallback Step input type.
-   * @param step - Registered fallback Step.
+   * @param step - Registered fallback Step class.
    * @param options - Optional options for the fallback movement.
    * @returns The failure-routing settings.
    */
-  proceedTo<Input>(step: Step<Input>, options?: StepOptions): ExecuteFailure {
+  proceedTo<Input>(step: StepClass<Input>, options?: StepOptions): ExecuteFailure {
     return {
-      step: step as Step<unknown>,
+      step: step as StepClass<any>,
       ...(options === undefined ? {} : { options }),
     };
   },
@@ -86,11 +86,13 @@ export interface StepOptions {
  *
  * @example
  * ```ts
- * const confirm: Step<{ id: string }> = {
- *   getStepType: () => "Confirm",
- *   waitFor: () => Wait.until(Timer.byDuration(1_000)),
- *   execute: (_context, input) => forceComplete(input),
- * };
+ * class Confirm implements Step<{ id: string }> {
+ *   public getStepType(): string { return "Confirm"; }
+ *   public waitFor(): Wait { return Wait.until(Timer.byDuration(1_000)); }
+ *   public execute(_context: Context, input: { id: string }): StepDecision {
+ *     return forceComplete(input);
+ *   }
+ * }
  * ```
  * @typeParam Input - Value passed by an incoming Step movement.
  */
@@ -128,6 +130,12 @@ export interface Step<Input> {
    */
   execute(context: Context, input: Input): StepDecision | Promise<StepDecision>;
 }
+
+/**
+ * Identifies one registered Step implementation by its runtime class.
+ * @typeParam Input - Value accepted by the Step implementation.
+ */
+export type StepClass<Input> = abstract new (...arguments_: any[]) => Step<Input>;
 
 interface StartStepDefinition<StartInput> {
   readonly step: Step<StartInput>;
@@ -214,8 +222,8 @@ export class StepList<StartInput> {
  * @typeParam Input - Destination Step input type.
  */
 export interface StepMovement<Input> {
-  /** Registered destination Step. */
-  readonly step: Step<Input>;
+  /** Registered destination Step class. */
+  readonly step: StepClass<Input>;
   /** Value encoded for the destination Step. */
   readonly input: Input;
   /** Optional per-movement Step options. */
@@ -227,12 +235,12 @@ export const StepMovement = Object.freeze({
   /**
    * Creates a movement to one Step.
    * @typeParam Input - Destination Step input type.
-   * @param step - Registered destination Step.
+   * @param step - Registered destination Step class.
    * @param input - Typed destination input.
    * @param options - Optional per-movement options.
    * @returns The new Step movement.
    */
-  of<Input>(step: Step<Input>, input: Input, options?: StepOptions): StepMovement<Input> {
+  of<Input>(step: StepClass<Input>, input: Input, options?: StepOptions): StepMovement<Input> {
     return {
       step,
       input,
@@ -244,9 +252,9 @@ export const StepMovement = Object.freeze({
 /** Selects queued or active Step executions canceled by a decision. */
 export interface StepCancellationSelection {
   /** Registered Step types canceled across the current Flow. */
-  readonly cancelingSteps?: readonly Step<any>[];
+  readonly cancelingSteps?: readonly StepClass<any>[];
   /** Registered Step types canceled only when they share the current scheduling source. */
-  readonly cancelingSiblingSteps?: readonly Step<any>[];
+  readonly cancelingSiblingSteps?: readonly StepClass<any>[];
 }
 
 /** Describes the durable transition returned by `Step.execute`. */
@@ -291,7 +299,7 @@ export type StepDecision = (
  * @param input - Typed destination input.
  * @returns A next decision containing one movement.
  */
-export const goTo = <Input>(step: Step<Input>, input: Input): StepDecision =>
+export const goTo = <Input>(step: StepClass<Input>, input: Input): StepDecision =>
   goToMulti(StepMovement.of(step, input));
 
 /**
@@ -354,12 +362,12 @@ export const deadEnd = (): StepDecision => ({ kind: "deadEnd" });
  * and absent executions are no-ops. Steps scheduled by the same decision are excluded.
  * Repeated calls take the union, and Flow-wide selection supersedes sibling selection.
  * @param decision - Decision to copy.
- * @param steps - Exact Step instances registered with the current Flow.
+ * @param steps - Step classes registered with the current Flow.
  * @returns A new decision containing the combined Flow-wide selectors.
  */
 export const withCancelingSteps = (
   decision: StepDecision,
-  ...steps: readonly Step<any>[]
+  ...steps: readonly StepClass<any>[]
 ): StepDecision => {
   const cancelingSteps = unionSteps(decision.cancelingSteps, steps);
   const cancelingSiblingSteps = (decision.cancelingSiblingSteps ?? []).filter(
@@ -374,12 +382,12 @@ export const withCancelingSteps = (
  * A sibling has the same `Context.fromStepExecutionId` as the execution returning
  * the decision. Snapshot and no-op behavior match {@link withCancelingSteps}.
  * @param decision - Decision to copy.
- * @param steps - Exact Step instances registered with the current Flow.
+ * @param steps - Step classes registered with the current Flow.
  * @returns A new decision containing the combined sibling selectors.
  */
 export const withCancelingSiblingSteps = (
   decision: StepDecision,
-  ...steps: readonly Step<any>[]
+  ...steps: readonly StepClass<any>[]
 ): StepDecision => ({
   ...decision,
   cancelingSiblingSteps: unionSteps(decision.cancelingSiblingSteps, steps).filter(
@@ -388,9 +396,9 @@ export const withCancelingSiblingSteps = (
 });
 
 function unionSteps(
-  existing: readonly Step<any>[] | undefined,
-  added: readonly Step<any>[],
-): readonly Step<any>[] {
+  existing: readonly StepClass<any>[] | undefined,
+  added: readonly StepClass<any>[],
+): readonly StepClass<any>[] {
   const combined = [...(existing ?? [])];
   for (const step of added) {
     if (!combined.includes(step)) {

--- a/sdk-typescript/src/worker-dispatcher.ts
+++ b/sdk-typescript/src/worker-dispatcher.ts
@@ -60,6 +60,7 @@ import type { RegisteredRPC } from "./rpc.js";
 import type {
   RetryPolicy,
   Step,
+  StepClass,
   StepDecision,
   StepMovement,
   StepOptions,
@@ -450,12 +451,12 @@ function withCancellationSelection(
 
 function mapCancellationSteps(
   flow: RegisteredFlow,
-  steps: readonly Step<any>[] | undefined,
+  steps: readonly StepClass<any>[] | undefined,
 ): string[] {
   const stepTypes: string[] = [];
   const seen = new Set<string>();
   for (const step of steps ?? []) {
-    const target = flow.steps.find((candidate) => candidate.step === step);
+    const target = flow.stepsByClass.get(step);
     if (target === undefined) {
       throw new TypeError("cancellation Step must belong to the Flow");
     }
@@ -470,7 +471,10 @@ function mapCancellationSteps(
 
 function rpcDecision(
   flow: RegisteredFlow,
-  result: { nextSteps?: readonly StepMovement<unknown>[]; cancelingSteps?: readonly Step<any>[] }
+  result: {
+    nextSteps?: readonly StepMovement<unknown>[];
+    cancelingSteps?: readonly StepClass<any>[];
+  }
     | undefined,
 ): ProtoStepDecision | undefined {
   if (result === undefined) {
@@ -492,7 +496,7 @@ function mapMovements(
 }
 
 function mapMovement(flow: RegisteredFlow, movement: StepMovement<unknown>): ProtoStepMovement {
-  const target = flow.steps.find((candidate) => candidate.step === movement.step);
+  const target = flow.stepsByClass.get(movement.step);
   if (target === undefined) {
     throw new TypeError("Step movement target does not belong to Flow");
   }
@@ -513,10 +517,9 @@ function mapStepOptions(
   skipWaitFor: boolean,
 ): ProtoStepOptions {
   const failureTarget = options?.executeFailure?.step;
-  const failureDefinition =
-    failureTarget === undefined
-      ? undefined
-      : flow.steps.find((candidate) => candidate.step === failureTarget);
+  const failureDefinition = failureTarget === undefined
+    ? undefined
+    : flow.stepsByClass.get(failureTarget);
   if (failureTarget !== undefined && failureDefinition === undefined) {
     throw new TypeError("execute failure Step must belong to the Flow");
   }

--- a/sdk-typescript/test/contracts.test.ts
+++ b/sdk-typescript/test/contracts.test.ts
@@ -288,6 +288,34 @@ test("registry rejects duplicate definitions", () => {
   assert.throws(() => new Registry([orders, orders]), FlowDefinitionError);
 });
 
+test("registry rejects duplicate Step classes", () => {
+  class DuplicateStep implements Step<number> {
+    public constructor(private readonly type: string) {}
+
+    public getStepType(): string {
+      return this.type;
+    }
+
+    public execute(_context: Context, input: number): StepDecision {
+      return gracefulComplete(input);
+    }
+  }
+
+  class DuplicateStepFlow implements Flow<number> {
+    public getFlowType(): string {
+      return "DuplicateStepFlow";
+    }
+
+    public getSteps(): StepList<number> {
+      return StepList.startStep(new DuplicateStep("first")).otherSteps(
+        new DuplicateStep("second"),
+      );
+    }
+  }
+
+  assert.throws(() => new Registry([new DuplicateStepFlow()]), /duplicate Step class/);
+});
+
 test("value mapping failures have a stable error type", () => {
   const invalid = {
     get orderId(): string {

--- a/sdk-typescript/test/integ/basic_flow.ts
+++ b/sdk-typescript/test/integ/basic_flow.ts
@@ -50,7 +50,7 @@ class BasicFirstStep implements Step<number> {
 
   public async execute(_context: Context, input: number): Promise<StepDecision> {
     await Promise.resolve();
-    return goTo(this.second, input + 1);
+    return goTo(BasicSecondStep, input + 1);
   }
 }
 

--- a/sdk-typescript/test/integ/basic_internal_channel_flow.ts
+++ b/sdk-typescript/test/integ/basic_internal_channel_flow.ts
@@ -83,8 +83,8 @@ class ForkStep implements Step<number> {
 
   public execute(_context: Context, input: number): StepDecision {
     return goToMulti(
-      StepMovement.of(this.consumer, input),
-      StepMovement.of(this.publisher, input),
+      StepMovement.of(ConsumeStep, input),
+      StepMovement.of(PublishStep, input),
     );
   }
 }

--- a/sdk-typescript/test/integ/conditional_complete_flow.ts
+++ b/sdk-typescript/test/integ/conditional_complete_flow.ts
@@ -49,7 +49,7 @@ class ConditionalStep implements Step<boolean> {
     const selected = useSignal ? this.signal : this.internal;
     return forceCompleteIfChannelsEmpty(
       next,
-      StepMovement.of(this, useSignal),
+      StepMovement.of(ConditionalStep, useSignal),
       selected,
     );
   }

--- a/sdk-typescript/test/integ/dead_end_flow.ts
+++ b/sdk-typescript/test/integ/dead_end_flow.ts
@@ -84,6 +84,6 @@ export class DeadEndFlow implements Flow {
     if (context.flowId === "" || context.runId === "") {
       throw new Error("invalid RPC context");
     }
-    return { output: 100, nextSteps: [StepMovement.of(this.complete, undefined)] };
+    return { output: 100, nextSteps: [StepMovement.of(DeadEndCompleteStep, undefined)] };
   }
 }

--- a/sdk-typescript/test/integ/empty_input_flow.ts
+++ b/sdk-typescript/test/integ/empty_input_flow.ts
@@ -43,7 +43,7 @@ class EmptyFirstStep implements Step<void> {
 
   public async execute(_context: Context, _input: void): Promise<StepDecision> {
     await Promise.resolve();
-    return goTo(this.second, undefined);
+    return goTo(EmptySecondStep, undefined);
   }
 }
 

--- a/sdk-typescript/test/integ/execute_only_flow.ts
+++ b/sdk-typescript/test/integ/execute_only_flow.ts
@@ -41,7 +41,7 @@ class ExecuteOnlyFirstStep implements Step<number> {
   }
 
   public execute(_context: Context, input: number): StepDecision {
-    return goTo(this.second, input + 1);
+    return goTo(ExecuteOnlySecondStep, input + 1);
   }
 }
 

--- a/sdk-typescript/test/integ/immutable_step_options_flow.ts
+++ b/sdk-typescript/test/integ/immutable_step_options_flow.ts
@@ -38,7 +38,7 @@ class ImmutableFailingWaitStep implements Step<number> {
     if (!context.waitForMethodFailed()) {
       throw new Error("wait failure was not reported");
     }
-    return input === 1 ? goTo(this, 2) : gracefulComplete(input);
+    return input === 1 ? goTo(ImmutableFailingWaitStep, 2) : gracefulComplete(input);
   }
 
   public getStepOptions(): StepOptions {
@@ -52,15 +52,13 @@ class ImmutableFailingWaitStep implements Step<number> {
 class ImmutableStartStep implements Step<number> {
   public readonly inputCodec = doubleCodec;
 
-  public constructor(private readonly failing: ImmutableFailingWaitStep) {}
-
   public getStepType(): string {
     return "ImmutableStartStep";
   }
 
   public execute(_context: Context, _input: number): StepDecision {
     return goToMulti(
-      StepMovement.of(this.failing, 1, {
+      StepMovement.of(ImmutableFailingWaitStep, 1, {
         waitForRetry: { maximumAttempts: 1 },
         waitForFailure: "proceed",
       }),
@@ -70,7 +68,7 @@ class ImmutableStartStep implements Step<number> {
 
 export class ImmutableStepOptionsFlow implements Flow<number> {
   private readonly failing = new ImmutableFailingWaitStep();
-  private readonly start = new ImmutableStartStep(this.failing);
+  private readonly start = new ImmutableStartStep();
 
   public getFlowType(): string {
     return "ImmutableStepOptionsFlow";

--- a/sdk-typescript/test/integ/mixed_sync_async_flow.ts
+++ b/sdk-typescript/test/integ/mixed_sync_async_flow.ts
@@ -29,8 +29,6 @@ import {
 class SyncWaitAsyncExecuteStep implements Step<string> {
   public readonly inputCodec = stringCodec;
 
-  public constructor(private readonly next: AsyncWaitSyncExecuteStep) {}
-
   public getStepType(): string {
     return "SyncWaitAsyncExecuteStep";
   }
@@ -43,15 +41,13 @@ class SyncWaitAsyncExecuteStep implements Step<string> {
   public async execute(context: Context, input: string): Promise<StepDecision> {
     await Promise.resolve();
     const prefix = context.getStepExecutionLocal("prefix", stringCodec) ?? input;
-    return goTo(this.next, `${prefix}-async-exec`);
+    return goTo(AsyncWaitSyncExecuteStep, `${prefix}-async-exec`);
   }
 }
 
 // Async waitFor + sync execute, then hands off to a fully sync step.
 class AsyncWaitSyncExecuteStep implements Step<string> {
   public readonly inputCodec = stringCodec;
-
-  public constructor(private readonly next: SyncCompleteStep) {}
 
   public getStepType(): string {
     return "AsyncWaitSyncExecuteStep";
@@ -63,7 +59,7 @@ class AsyncWaitSyncExecuteStep implements Step<string> {
   }
 
   public execute(_context: Context, input: string): StepDecision {
-    return goTo(this.next, `${input}-sync-exec`);
+    return goTo(SyncCompleteStep, `${input}-sync-exec`);
   }
 }
 
@@ -81,8 +77,8 @@ class SyncCompleteStep implements Step<string> {
 
 export class MixedSyncAsyncStepsFlow implements Flow<string> {
   private readonly third = new SyncCompleteStep();
-  private readonly second = new AsyncWaitSyncExecuteStep(this.third);
-  private readonly first = new SyncWaitAsyncExecuteStep(this.second);
+  private readonly second = new AsyncWaitSyncExecuteStep();
+  private readonly first = new SyncWaitAsyncExecuteStep();
 
   public getFlowType(): string {
     return "MixedSyncAsyncStepsFlow";

--- a/sdk-typescript/test/integ/mixed_wait_flow.ts
+++ b/sdk-typescript/test/integ/mixed_wait_flow.ts
@@ -57,7 +57,7 @@ class MixedImmediateStep implements Step<number> {
   }
 
   public execute(_context: Context, input: number): StepDecision {
-    return goTo(this.second, input + 1);
+    return goTo(MixedTimerStep, input + 1);
   }
 
   public getStepOptions(): StepOptions {

--- a/sdk-typescript/test/integ/multi_output_flow.ts
+++ b/sdk-typescript/test/integ/multi_output_flow.ts
@@ -58,8 +58,8 @@ class MultiOutputStartStep implements Step<void> {
 
   public execute(_context: Context, _input: void): StepDecision {
     return goToMulti(
-      StepMovement.of(this.stringStep, undefined),
-      StepMovement.of(this.numberStep, undefined),
+      StepMovement.of(MultiOutputStringStep, undefined),
+      StepMovement.of(MultiOutputNumberStep, undefined),
     );
   }
 }

--- a/sdk-typescript/test/integ/no_start_flow.ts
+++ b/sdk-typescript/test/integ/no_start_flow.ts
@@ -51,6 +51,6 @@ export class NoStartFlow implements Flow {
     if (_context.flowId === "" || _context.runId === "") {
       throw new Error("invalid RPC context");
     }
-    return { output: 100, nextSteps: [StepMovement.of(this.triggered, undefined)] };
+    return { output: 100, nextSteps: [StepMovement.of(TriggeredStep, undefined)] };
   }
 }

--- a/sdk-typescript/test/integ/proceed_on_wait_failure_flow.ts
+++ b/sdk-typescript/test/integ/proceed_on_wait_failure_flow.ts
@@ -36,7 +36,7 @@ class FailingWaitStep implements Step<string> {
   }
 
   public execute(_context: Context, input: string): StepDecision {
-    return goTo(this.second, `${input}-recovered`);
+    return goTo(CompleteStringStep, `${input}-recovered`);
   }
 
   public getStepOptions(): StepOptions {

--- a/sdk-typescript/test/integ/rpc_flow.ts
+++ b/sdk-typescript/test/integ/rpc_flow.ts
@@ -58,7 +58,7 @@ class RpcFirstStep implements Step<number> {
   }
 
   public execute(_context: Context, _input: number): StepDecision {
-    return goTo(this.second, 0);
+    return goTo(RpcSecondStep, 0);
   }
 }
 

--- a/sdk-typescript/test/integ/rpc_locking_flow.ts
+++ b/sdk-typescript/test/integ/rpc_locking_flow.ts
@@ -66,7 +66,7 @@ class LockWaitStep implements Step<void> {
   }
 
   public execute(_context: Context, _input: void): StepDecision {
-    return goTo(this.second, undefined);
+    return goTo(LockCompleteStep, undefined);
   }
 }
 

--- a/sdk-typescript/test/integ/signal_flow.ts
+++ b/sdk-typescript/test/integ/signal_flow.ts
@@ -92,7 +92,7 @@ class SignalFirstStep implements Step<number> {
     if (this.second.results(context).length !== 0) {
       throw new Error("second signal should still be waiting");
     }
-    return goTo(this.combination, input + (this.first.results(context)[0] ?? 0));
+    return goTo(SignalCombinationStep, input + (this.first.results(context)[0] ?? 0));
   }
 }
 

--- a/sdk-typescript/test/integ/state_options_flow.ts
+++ b/sdk-typescript/test/integ/state_options_flow.ts
@@ -92,7 +92,7 @@ class OptionsSecondStep implements Step<void> {
     if (this.bothValue.get(context) !== "both") {
       throw new Error("shared attribute was not loaded in execute");
     }
-    return goTo(this.third, undefined);
+    return goTo(OptionsThirdStep, undefined);
   }
 
   public getStepOptions(): StepOptions {
@@ -121,7 +121,7 @@ class OptionsFirstStep implements Step<void> {
     this.executeValue.set(context, "execute");
     this.waitValue.set(context, "wait_until");
     this.bothValue.set(context, "both");
-    return goTo(this.second, undefined);
+    return goTo(OptionsSecondStep, undefined);
   }
 }
 

--- a/sdk-typescript/test/integ/state_options_override_flow.ts
+++ b/sdk-typescript/test/integ/state_options_override_flow.ts
@@ -69,7 +69,7 @@ class OverrideFirstStep implements Step<string> {
   public execute(_context: Context, _input: string): StepDecision {
     this.output += "_state1_decide";
     return goToMulti(
-      StepMovement.of(this.second, this.output, {
+      StepMovement.of(CompleteStep, this.output, {
         waitForRetry: { maximumAttempts: 2 },
         waitForFailure: "proceed",
       }),

--- a/sdk-typescript/test/integ/state_recovery_flow.ts
+++ b/sdk-typescript/test/integ/state_recovery_flow.ts
@@ -26,8 +26,6 @@ import {
 class RecoverStep implements Step<number> {
   public readonly inputCodec = doubleCodec;
 
-  public constructor(private readonly failingStep: () => FailingStep) {}
-
   public getStepType(): string {
     return "RecoverStep";
   }
@@ -41,7 +39,7 @@ class RecoverStep implements Step<number> {
       return gracefulComplete(input);
     }
     if (input === 5) {
-      return goTo(this.failingStep(), input * 2);
+      return goTo(FailingStep, input * 2);
     }
     return forceFail(`unexpected input ${input}`);
   }
@@ -49,8 +47,6 @@ class RecoverStep implements Step<number> {
 
 class FailingStep implements Step<number> {
   public readonly inputCodec = doubleCodec;
-
-  public constructor(private readonly recover: RecoverStep) {}
 
   public getStepType(): string {
     return "FailingStep";
@@ -67,14 +63,14 @@ class FailingStep implements Step<number> {
   public getStepOptions(): StepOptions {
     return {
       executeRetry: { maximumAttempts: 1, backoffCoefficient: 2 },
-      executeFailure: ExecuteFailure.proceedTo(this.recover),
+      executeFailure: ExecuteFailure.proceedTo(RecoverStep),
     };
   }
 }
 
 export class StateRecoveryFlow implements Flow<number> {
-  private readonly recover: RecoverStep = new RecoverStep((): FailingStep => this.start);
-  private readonly start: FailingStep = new FailingStep(this.recover);
+  private readonly recover: RecoverStep = new RecoverStep();
+  private readonly start: FailingStep = new FailingStep();
 
   public getFlowType(): string {
     return "StateRecoveryFlow";

--- a/sdk-typescript/test/integ/state_recovery_no_wait_flow.ts
+++ b/sdk-typescript/test/integ/state_recovery_no_wait_flow.ts
@@ -25,8 +25,6 @@ import {
 class RecoverNoWaitStep implements Step<number> {
   public readonly inputCodec = doubleCodec;
 
-  public constructor(private readonly failingStep: () => FailingNoWaitStep) {}
-
   public getStepType(): string {
     return "RecoverNoWaitStep";
   }
@@ -36,7 +34,7 @@ class RecoverNoWaitStep implements Step<number> {
       return gracefulComplete(input);
     }
     if (input === 5) {
-      return goTo(this.failingStep(), input * 2);
+      return goTo(FailingNoWaitStep, input * 2);
     }
     return forceFail(`unexpected input ${input}`);
   }
@@ -44,8 +42,6 @@ class RecoverNoWaitStep implements Step<number> {
 
 class FailingNoWaitStep implements Step<number> {
   public readonly inputCodec = doubleCodec;
-
-  public constructor(private readonly recover: RecoverNoWaitStep) {}
 
   public getStepType(): string {
     return "FailingNoWaitStep";
@@ -58,16 +54,14 @@ class FailingNoWaitStep implements Step<number> {
   public getStepOptions(): StepOptions {
     return {
       executeRetry: { maximumAttempts: 1, backoffCoefficient: 2 },
-      executeFailure: ExecuteFailure.proceedTo(this.recover),
+      executeFailure: ExecuteFailure.proceedTo(RecoverNoWaitStep),
     };
   }
 }
 
 export class StateRecoveryNoWaitFlow implements Flow<number> {
-  private readonly recover: RecoverNoWaitStep = new RecoverNoWaitStep(
-    (): FailingNoWaitStep => this.start,
-  );
-  private readonly start: FailingNoWaitStep = new FailingNoWaitStep(this.recover);
+  private readonly recover: RecoverNoWaitStep = new RecoverNoWaitStep();
+  private readonly start: FailingNoWaitStep = new FailingNoWaitStep();
 
   public getFlowType(): string {
     return "StateRecoveryNoWaitFlow";

--- a/sdk-typescript/test/integ/step_cancellation_flow.ts
+++ b/sdk-typescript/test/integ/step_cancellation_flow.ts
@@ -63,19 +63,19 @@ class CancellationStart implements Step<string> {
   public execute(_context: Context, _input: string): StepDecision {
     if (this.flow.scenario === "heartbeat-wait-for") {
       return goToMulti(
-        StepMovement.of(this.flow.blockingWaitFor, undefined),
-        StepMovement.of(this.flow.winner, undefined),
+        StepMovement.of(CancellationBlockingWaitFor, undefined),
+        StepMovement.of(CancellationWinner, undefined),
       );
     }
     if (this.flow.scenario === "global-selector" || this.flow.scenario === "sibling-selector") {
       return goToMulti(
-        StepMovement.of(this.flow.firstParent, undefined),
-        StepMovement.of(this.flow.secondParent, undefined),
+        StepMovement.of(CancellationFirstParent, undefined),
+        StepMovement.of(CancellationSecondParent, undefined),
       );
     }
     return goToMulti(
-      StepMovement.of(this.flow.blockingExecute, undefined),
-      StepMovement.of(this.flow.winner, undefined),
+      StepMovement.of(CancellationBlockingExecute, undefined),
+      StepMovement.of(CancellationWinner, undefined),
     );
   }
 }
@@ -103,7 +103,7 @@ class CancellationBlockingExecute implements Step<void> {
           this.flow.scenario === "local-timeout-fallback"
           ? "async"
           : "sync",
-      executeFailure: ExecuteFailure.proceedTo(this.flow.recovery),
+      executeFailure: ExecuteFailure.proceedTo(CancellationRecovery),
     };
   }
 
@@ -126,7 +126,7 @@ class CancellationBlockingExecute implements Step<void> {
     }
     this.flow.lateWrite.set(context, "late");
     this.flow.markLateHandlerReturned();
-    return goTo(this.flow.recovery, undefined);
+    return goTo(CancellationRecovery, undefined);
   }
 }
 
@@ -190,10 +190,10 @@ class CancellationWinner implements Step<void> {
       await this.flow.blockingStarted;
       await delay(1_000);
     }
-    const selected: Step<any> = this.flow.scenario === "heartbeat-wait-for"
-      ? this.flow.blockingWaitFor
-      : this.flow.blockingExecute;
-    return withCancelingSteps(goTo(this.flow.final, this.flow.scenario), selected);
+    const selected = this.flow.scenario === "heartbeat-wait-for"
+      ? CancellationBlockingWaitFor
+      : CancellationBlockingExecute;
+    return withCancelingSteps(goTo(CancellationFinal, this.flow.scenario), selected);
   }
 }
 
@@ -239,8 +239,8 @@ class CancellationFirstParent implements Step<void> {
 
   public execute(_context: Context, _input: void): StepDecision {
     return goToMulti(
-      StepMovement.of(this.flow.selectorWinner, undefined),
-      StepMovement.of(this.flow.selectorWaiting, "first"),
+      StepMovement.of(CancellationSelectorWinner, undefined),
+      StepMovement.of(CancellationSelectorWaiting, "first"),
     );
   }
 }
@@ -255,7 +255,7 @@ class CancellationSecondParent implements Step<void> {
   }
 
   public execute(_context: Context, _input: void): StepDecision {
-    return goTo(this.flow.selectorWaiting, "second");
+    return goTo(CancellationSelectorWaiting, "second");
   }
 }
 
@@ -274,10 +274,10 @@ class CancellationSelectorWinner implements Step<void> {
 
   public async execute(_context: Context, _input: void): Promise<StepDecision> {
     await this.flow.selectorWaitsRegistered;
-    const decision = goTo(this.flow.final, this.flow.scenario);
+    const decision = goTo(CancellationFinal, this.flow.scenario);
     return this.flow.scenario === "global-selector"
-      ? withCancelingSteps(decision, this.flow.selectorWaiting)
-      : withCancelingSiblingSteps(decision, this.flow.selectorWaiting);
+      ? withCancelingSteps(decision, CancellationSelectorWaiting)
+      : withCancelingSiblingSteps(decision, CancellationSelectorWaiting);
   }
 }
 


### PR DESCRIPTION
## Summary
- use registered Step classes/types for Java, Python, and TypeScript transitions, cancellation, RPC movements, and execute-failure routing
- reject duplicate Step implementation classes during Flow registration
- migrate SDK tests and SDK READMEs to class/type targets

## Validation
- ./gradlew test --no-daemon (sdk-java)
- uv run --frozen mypy --strict tests/typecheck_contracts.py tests/integ (sdk-python)
- uv run --frozen pytest tests/test_contracts.py (sdk-python)
- npm run typecheck && npm run docs:check && npm test (sdk-typescript)