### PR TITLE
Fix Rust SDK release validation

### DIFF
--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -93,11 +93,7 @@ jobs:
       - name: Build publishable crates
         run: |
           cargo package --locked --allow-dirty -p dex-blob-cache -p dex-protocol
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            cargo package --locked --allow-dirty --no-verify -p dex-sdk
-          else
-            cargo package --locked --allow-dirty -p dex-sdk
-          fi
+          cargo package --locked --allow-dirty --no-verify -p dex-sdk
       - name: Upload crate archives
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

- allow release validation to package dex-sdk before its same-version workspace dependencies are published

## Rationale and user impact

The v0.2.1 Rust release failed during its pre-publish packaging check because dex-blob-cache v0.2.1 had not yet been uploaded. The actual publish job already uploads workspace crates in dependency order.

## Validation

- `cargo package --locked --allow-dirty --no-verify -p dex-sdk`
