### PR TITLE
Fix Rust SDK release preparation

### DIFF
--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -90,10 +90,9 @@ jobs:
           --stage-protocol
       - name: Validate stamped workspace
         run: cargo metadata --locked --no-deps --format-version 1
-      - name: Build publishable crates
+      - name: Build independently publishable crates
         run: |
           cargo package --locked --allow-dirty -p dex-blob-cache -p dex-protocol
-          cargo package --locked --allow-dirty --no-verify -p dex-sdk
       - name: Upload crate archives
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

- package only Rust crates whose same-version dependencies already exist on crates.io during release preparation

## Rationale and user impact

dex-sdk depends on the new dex-blob-cache and dex-protocol versions, so cargo cannot package it before those crates are published. The publish job retains dependency order and publishes dex-sdk after both dependencies.

## Validation

- reviewed failed v0.2.1 release log
- `git diff --check`
