### PR TITLE
Update examples for SDK patch releases

### DIFF
--- a/docs/content/design-patterns/entity-store.mdx
+++ b/docs/content/design-patterns/entity-store.mdx
@@ -91,7 +91,7 @@ Attribute<String> displayName =
     Attribute.define("display_name", String.class).syncToAttributeStore();
 
 FlowConfig config = FlowConfig.newBuilder()
-    .attributeStoreNames(java.util.List.of("entityStore"))
+    .attributeStoreNames(List.of("entityStore"))
     .build();
 ```
 

--- a/docs/content/design-patterns/entity-store.mdx
+++ b/docs/content/design-patterns/entity-store.mdx
@@ -91,7 +91,7 @@ Attribute<String> displayName =
     Attribute.define("display_name", String.class).syncToAttributeStore();
 
 FlowConfig config = FlowConfig.newBuilder()
-    .attributeStoreNames(java.util.Collections.singletonList("entityStore"))
+    .attributeStoreNames(java.util.List.of("entityStore"))
     .build();
 ```
 

--- a/docs/content/design-patterns/entity-store.mdx
+++ b/docs/content/design-patterns/entity-store.mdx
@@ -64,7 +64,7 @@ await client.start_flow(
     None,
     StartFlowOptions(
         attributes=[...],
-        config_override=FlowConfig(attribute_store_name="entityStore"),
+        config_override=FlowConfig(attribute_store_names=["entityStore"]),
     ),
 )
 ```
@@ -79,7 +79,7 @@ var DisplayName = dex.DefineAttribute[string](
 )
 
 config := dex.FlowConfig{
-    AttributeStoreName: ptr.Any("entityStore"),
+    AttributeStoreNames: ptr.Any([]string{"entityStore"}),
 }
 ```
 
@@ -91,7 +91,7 @@ Attribute<String> displayName =
     Attribute.define("display_name", String.class).syncToAttributeStore();
 
 FlowConfig config = FlowConfig.newBuilder()
-    .attributeStoreName("entityStore")
+    .attributeStoreNames(java.util.Collections.singletonList("entityStore"))
     .build();
 ```
 
@@ -104,7 +104,7 @@ const displayName = new Attribute("display_name", stringCodec)
 
 const options = {
   attributes: [InitialAttribute.of(displayName, "Ada Lovelace")],
-  configOverride: { attributeStoreName: "entityStore" },
+  configOverride: { attributeStoreNames: ["entityStore"] },
 };
 ```
 

--- a/docs/content/design-patterns/entity-store.mdx
+++ b/docs/content/design-patterns/entity-store.mdx
@@ -79,7 +79,7 @@ var DisplayName = dex.DefineAttribute[string](
 )
 
 config := dex.FlowConfig{
-    AttributeStoreNames: ptr.Any([]string{"entityStore"}),
+    AttributeStoreNames: []string{"entityStore"},
 }
 ```
 

--- a/docs/content/design-patterns/recovery.mdx
+++ b/docs/content/design-patterns/recovery.mdx
@@ -47,7 +47,7 @@ after continue-as-new.
 public StepOptions getStepOptions() {
     return StepOptions.newBuilder()
             .executeRetry(RetryPolicy.newBuilder().maximumAttempts(3).build())
-            .onExecuteFailureProceedTo(compensateOrder)
+            .onExecuteFailureProceedTo(CompensateOrder.class)
             .build();
 }
 ```

--- a/docs/content/design-patterns/scalable-parallel.mdx
+++ b/docs/content/design-patterns/scalable-parallel.mdx
@@ -81,7 +81,7 @@ async execute(context: Context, _input: void): Promise<StepDecision> {
     requestId: context.stepExecutionId,
   });
   // track child ids on an Attribute; wait via ChannelMap / conditions
-  return goTo(this.flow.loopForNextMessageStep, undefined);
+  return goTo(LoopForNextMessage, undefined);
 }
 ```
 

--- a/docs/content/intro/what-is-dex.mdx
+++ b/docs/content/intro/what-is-dex.mdx
@@ -67,7 +67,7 @@ class ChargeStep(Step[OrderRequest]):
     def execute(self, context: Context, input: OrderRequest) -> StepDecision:
         self.service.charge_user(input.email, input.customer_id, input.amount)
         order_status.set(context, "charged")
-        return go_to(self.ship, input)
+        return go_to(ShipStep, input)
 
 
 class ShipStep(Step[OrderRequest]):
@@ -81,7 +81,7 @@ class ShipStep(Step[OrderRequest]):
                 total_duration=timedelta(hours=1),
             )
         ).on_execute_failure_proceed_to(
-            self.refund,
+            RefundStep,
             StepOptions(
                 execute_retry=RetryPolicy(
                     total_duration=timedelta(hours=1),
@@ -103,7 +103,7 @@ class ShipStep(Step[OrderRequest]):
                 "Reminder: approve shipment",
                 "Please approve or provide a tracking number.",
             )
-            return go_to(self, input)
+            return go_to(ShipStep, input)
         self.service.ship_item(input.order_id)
         order_status.set(context, "shipped")
         return graceful_complete(f"shipped:{input.order_id}")
@@ -345,7 +345,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
         public StepDecision execute(final Context context, final OrderRequest order) {
             service.chargeUser(order.email, order.customerId, order.amount);
             orderStatus.set(context, "charged");
-            return StepDecision.goTo(ship, order);
+            return StepDecision.goTo(ShipStep.class, order);
         }
     }
 
@@ -375,7 +375,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
                             .totalDuration(Duration.ofHours(1))
                             .build())
                     .onExecuteFailureProceedTo(
-                            refund,
+                            RefundStep.class,
                             StepOptions.newBuilder()
                                     .executeRetry(RetryPolicy.newBuilder()
                                             .totalDuration(Duration.ofHours(1))
@@ -398,7 +398,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
                         order.email,
                         "Reminder: approve shipment",
                         "Please approve or provide a tracking number.");
-                return StepDecision.goTo(this, order);
+                return StepDecision.goTo(ShipStep.class, order);
             }
             service.shipItem(order.orderId);
             orderStatus.set(context, "shipped");
@@ -503,7 +503,7 @@ class ChargeStep implements Step<OrderRequest> {
   public execute(context: Context, input: OrderRequest): StepDecision {
     this.service.chargeUser(input.email, input.customerId, input.amount);
     orderStatus.set(context, "charged");
-    return goTo(this.ship, input);
+    return goTo(ShipStep, input);
   }
 }
 
@@ -524,7 +524,7 @@ class ShipStep implements Step<OrderRequest> {
       executeRetry: {
         totalDurationMs: 60 * 60 * 1000,
       },
-      executeFailure: ExecuteFailure.proceedTo(this.refund, {
+      executeFailure: ExecuteFailure.proceedTo(RefundStep, {
         executeRetry: {
           totalDurationMs: 60 * 60 * 1000,
         },
@@ -543,7 +543,7 @@ class ShipStep implements Step<OrderRequest> {
         "Reminder: approve shipment",
         "Please approve or provide a tracking number.",
       );
-      return goTo(this, input);
+      return goTo(ShipStep, input);
     }
     this.service.shipItem(input.orderId);
     orderStatus.set(context, "shipped");

--- a/docs/content/primitives/attribute.mdx
+++ b/docs/content/primitives/attribute.mdx
@@ -598,7 +598,7 @@ _, err := client.StartFlow(ctx, flow, userID, nil, options)
 ```java
 final StartFlowOptions options = StartFlowOptions.newBuilder()
         .configOverride(FlowConfig.newBuilder()
-                .attributeStoreNames(java.util.List.of("entityStore"))
+                .attributeStoreNames(List.of("entityStore"))
                 .build())
         .build();
 final String runId = client.startFlow(flow, userId, null, options);

--- a/docs/content/primitives/attribute.mdx
+++ b/docs/content/primitives/attribute.mdx
@@ -598,7 +598,7 @@ _, err := client.StartFlow(ctx, flow, userID, nil, options)
 ```java
 final StartFlowOptions options = StartFlowOptions.newBuilder()
         .configOverride(FlowConfig.newBuilder()
-                .attributeStoreNames(java.util.Collections.singletonList("entityStore"))
+                .attributeStoreNames(java.util.List.of("entityStore"))
                 .build())
         .build();
 final String runId = client.startFlow(flow, userId, null, options);

--- a/docs/content/primitives/attribute.mdx
+++ b/docs/content/primitives/attribute.mdx
@@ -586,7 +586,7 @@ await client.start_flow(flow, user_id, None, options)
 ```go
 options := dex.StartFlowOptions{
 	ConfigOverride: &dex.FlowConfig{
-		AttributeStoreNames: ptr.Any([]string{"entityStore"}),
+		AttributeStoreNames: []string{"entityStore"},
 	},
 }
 _, err := client.StartFlow(ctx, flow, userID, nil, options)

--- a/docs/content/primitives/attribute.mdx
+++ b/docs/content/primitives/attribute.mdx
@@ -575,7 +575,7 @@ Then choose the same store name when starting the Flow:
 
 ```python
 options = StartFlowOptions(
-    config_override=FlowConfig(attribute_store_name="entityStore"),
+    config_override=FlowConfig(attribute_store_names=["entityStore"]),
 )
 await client.start_flow(flow, user_id, None, options)
 ```
@@ -586,7 +586,7 @@ await client.start_flow(flow, user_id, None, options)
 ```go
 options := dex.StartFlowOptions{
 	ConfigOverride: &dex.FlowConfig{
-		AttributeStoreName: ptr.Any("entityStore"),
+		AttributeStoreNames: ptr.Any([]string{"entityStore"}),
 	},
 }
 _, err := client.StartFlow(ctx, flow, userID, nil, options)
@@ -598,7 +598,7 @@ _, err := client.StartFlow(ctx, flow, userID, nil, options)
 ```java
 final StartFlowOptions options = StartFlowOptions.newBuilder()
         .configOverride(FlowConfig.newBuilder()
-                .attributeStoreName("entityStore")
+                .attributeStoreNames(java.util.Collections.singletonList("entityStore"))
                 .build())
         .build();
 final String runId = client.startFlow(flow, userId, null, options);
@@ -609,7 +609,7 @@ final String runId = client.startFlow(flow, userId, null, options);
 
 ```typescript
 const runId = await client.startFlow(flow, userId, undefined, {
-  configOverride: { attributeStoreName: "entityStore" },
+  configOverride: { attributeStoreNames: ["entityStore"] },
 });
 ```
 
@@ -618,7 +618,7 @@ const runId = await client.startFlow(flow, userId, undefined, {
 
 ```rust
 let options = StartFlowOptions::new()
-    .config_override(FlowConfig::new().attribute_store_name("entityStore"));
+    .config_override(FlowConfig::new().attribute_store_names(vec!["entityStore".to_owned()]));
 let run_id = client.start_flow_with_options(&flow, &user_id, (), options)?;
 ```
 

--- a/docs/content/primitives/flow/flow-options.mdx
+++ b/docs/content/primitives/flow/flow-options.mdx
@@ -313,7 +313,7 @@ At start, Dex applies the supplied fields over the Dex Server defaults. Omitted 
 | **ContinueAsNewPageSizeBytes** | Limit each page of state carried into continue-as-new. Zero uses 1 MiB.|
 | **StepDurability** | Default durability for Step writes. A Step override wins. Recovery uses synchronous durability unless you override it in StepOptions. |
 | **WorkerTarget** | WorkerService endpoint for Step and RPC invocation                                                                              |
-| **AttributeStoreName** | Dex Server Attribute Store for Attributes that opt in to attribute sync                                                         |
+| **AttributeStoreNames** | Dex Server Attribute Stores for Attributes that opt in to attribute sync                                                        |
 
 ### Update FlowConfig with a Client {#update-flow-config-with-a-client}
 

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -32,7 +32,7 @@ RPC can read and write durable state through Attributes, publish Channels, and t
 def trigger(self, context: Context, input: str) -> RPCResult[str]:
     self.data.set(context, input)
     self.example_ch.publish(context, None)
-    return RPCResult(input, next_steps=(StepMovement.of(self.example_step, input),))
+    return RPCResult(input, next_steps=(StepMovement.of(ExampleStep, input),))
 ```
 
 </SdkSnippet>
@@ -63,7 +63,7 @@ func (*RpcFlow) Trigger(ctx dex.Context, input string) (*dex.RPCResult[string], 
 public RPCResult<String> trigger(final Context context, final String input) {
     data.set(context, input);
     exampleCh.publish(context, null);
-    return RPCResult.of(input, StepMovement.of(exampleStep, input));
+    return RPCResult.of(input, StepMovement.of(ExampleStep.class, input));
 }
 ```
 
@@ -75,7 +75,7 @@ public RPCResult<String> trigger(final Context context, final String input) {
 public trigger(context: Context, input: string): RPCResult<string> {
   this.data.set(context, input);
   exampleCh.publish(context, undefined);
-  return { output: input, nextSteps: [StepMovement.of(this.exampleStep, input)] };
+  return { output: input, nextSteps: [StepMovement.of(ExampleStep, input)] };
 }
 ```
 

--- a/docs/content/primitives/step/basic.mdx
+++ b/docs/content/primitives/step/basic.mdx
@@ -68,7 +68,7 @@ class ExampleStep(Step[int]):
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to(self.second, input + 1)
+        return go_to(StepSecond, input + 1)
 ```
 
 </SdkSnippet>
@@ -115,7 +115,7 @@ final class ExampleStep implements Step<Integer> {
 
     @Override
     public StepDecision execute(final Context context, final Integer input) {
-        return StepDecision.goTo(second, input + 1);
+        return StepDecision.goTo(StepSecond.class, input + 1);
     }
 }
 
@@ -152,7 +152,7 @@ class ExampleStep implements Step<number> {
   }
 
   public execute(_context: Context, input: number): StepDecision {
-    return goTo(this.flow.secondStep, input + 1);
+    return goTo(StepSecond, input + 1);
   }
 }
 
@@ -530,7 +530,7 @@ public StepDecision execute(final Context context, final String input) {
     if (!context.waitForMethodFailed()) {
         throw new IllegalStateException("waitFor failure was not reported");
     }
-    return StepDecision.goTo(finish, input + "_recovered");
+    return StepDecision.goTo(FinishStep.class, input + "_recovered");
 }
 ```
 
@@ -551,7 +551,7 @@ def wait_for(self, context: Context, input: str) -> Wait:
 def execute(self, context: Context, input: str) -> StepDecision:
     if not context.wait_for_method_failed():
         raise RuntimeError("waitFor failure was not reported")
-    return go_to(self.finish, f"{input}_recovered")
+    return go_to(FinishStep, f"{input}_recovered")
 ```
 
 </SdkSnippet>
@@ -573,7 +573,7 @@ public execute(context: Context, input: string): StepDecision {
   if (!context.waitForMethodFailed()) {
     throw new Error("waitFor failure was not reported");
   }
-  return goTo(this.finish, `${input}_recovered`);
+  return goTo(FinishStep, `${input}_recovered`);
 }
 ```
 
@@ -635,7 +635,7 @@ func (updateItemQuantityStep) GetStepOptions() *dex.StepOptions {
 @Override
 public StepOptions getStepOptions() {
     return StepOptions.newBuilder()
-            .onExecuteFailureProceedTo(updateQuantityRecovery)
+            .onExecuteFailureProceedTo(UpdateQuantityRecovery.class)
             .executeRetry(RetryPolicy.newBuilder().maximumAttempts(5).build())
             .build();
 }
@@ -648,7 +648,7 @@ public StepOptions getStepOptions() {
 def get_step_options(self) -> StepOptions:
     return StepOptions(
         execute_retry=RetryPolicy(maximum_attempts=5)
-    ).on_execute_failure_proceed_to(self.update_quantity_recovery)
+    ).on_execute_failure_proceed_to(UpdateQuantityRecovery)
 ```
 
 </SdkSnippet>
@@ -657,7 +657,7 @@ def get_step_options(self) -> StepOptions:
 ```typescript
 public getStepOptions(): StepOptions {
   return {
-    executeFailure: ExecuteFailure.proceedTo(this.flow.updateQuantityRecoveryStep, {
+    executeFailure: ExecuteFailure.proceedTo(UpdateQuantityRecovery, {
       executeRetry: { maximumAttempts: 5 },
     }),
     executeRetry: { maximumAttempts: 5 },

--- a/docs/content/primitives/step/step-decision.mdx
+++ b/docs/content/primitives/step/step-decision.mdx
@@ -35,9 +35,9 @@ return dex.GoToMulti(
 
 ```java
 return StepDecision.goToMulti(
-        StepMovement.of(carrierAStep, quoteA),
-        StepMovement.of(carrierBStep, quoteB),
-        StepMovement.of(winnerStep, winnerQuote));
+        StepMovement.of(CarrierAStep.class, quoteA),
+        StepMovement.of(CarrierBStep.class, quoteB),
+        StepMovement.of(WinnerStep.class, winnerQuote));
 ```
 
 </SdkSnippet>
@@ -45,9 +45,9 @@ return StepDecision.goToMulti(
 
 ```python
 return go_to_multi(
-    StepMovement.of(self.flow.carrier_a, Quote(carrier="A", price=10)),
-    StepMovement.of(self.flow.carrier_b, Quote(carrier="B", price=12)),
-    StepMovement.of(self.flow.winner, quote),
+    StepMovement.of(CarrierAStep, Quote(carrier="A", price=10)),
+    StepMovement.of(CarrierBStep, Quote(carrier="B", price=12)),
+    StepMovement.of(WinnerStep, quote),
 )
 ```
 
@@ -56,9 +56,9 @@ return go_to_multi(
 
 ```typescript
 return goToMulti(
-  StepMovement.of(this.flow.carrierAStep, { carrier: "A", price: 10 }),
-  StepMovement.of(this.flow.carrierBStep, { carrier: "B", price: 12 }),
-  StepMovement.of(this.flow.winnerStep, quote),
+  StepMovement.of(CarrierAStep, { carrier: "A", price: 10 }),
+  StepMovement.of(CarrierBStep, { carrier: "B", price: 12 }),
+  StepMovement.of(WinnerStep, quote),
 );
 ```
 
@@ -125,8 +125,8 @@ case "graceful" -> {
 }
 case "dead-end" -> {
     return StepDecision.goToMulti(
-            StepMovement.of(branchWorkerStep, "left"),
-            StepMovement.of(branchWorkerStep, "right"));
+            StepMovement.of(BranchWorkerStep.class, "left"),
+            StepMovement.of(BranchWorkerStep.class, "right"));
 }
 
 return StepDecision.deadEnd();
@@ -140,8 +140,8 @@ if mode == "graceful":
     return graceful_complete("done")
 if mode == "dead-end":
     return go_to_multi(
-        StepMovement.of(self.flow.branch_worker, "left"),
-        StepMovement.of(self.flow.branch_worker, "right"),
+        StepMovement.of(BranchWorkerStep, "left"),
+        StepMovement.of(BranchWorkerStep, "right"),
     )
 
 return dead_end()
@@ -156,8 +156,8 @@ if (mode === "graceful") {
 }
 if (mode === "dead-end") {
   return goToMulti(
-    StepMovement.of(this.flow.branchWorkerStep, "left"),
-    StepMovement.of(this.flow.branchWorkerStep, "right"),
+    StepMovement.of(BranchWorkerStep, "left"),
+    StepMovement.of(BranchWorkerStep, "right"),
   );
 }
 
@@ -291,7 +291,7 @@ func (winnerStep) Execute(_ dex.Context, quote Quote) (*dex.StepDecision, error)
   <SdkSnippet lang="java">
 
 ```java
-return StepDecision.goTo(recordQuote, quote)
+return StepDecision.goTo(RecordQuoteStep.class, quote)
         .withCancelingSteps(carrierA, carrierB);
 ```
 
@@ -300,7 +300,7 @@ return StepDecision.goTo(recordQuote, quote)
 
 ```python
 return (
-    go_to(self.flow.record_quote, quote)
+    go_to(RecordQuoteStep, quote)
     .with_canceling_steps(self.flow.carrier_a, self.flow.carrier_b)
 )
 ```
@@ -310,7 +310,7 @@ return (
 
 ```typescript
 return withCancelingSteps(
-  goTo(this.flow.recordQuoteStep, quote),
+  goTo(RecordQuoteStep, quote),
   this.flow.carrierAStep,
   this.flow.carrierBStep,
 );
@@ -358,7 +358,7 @@ return dex.ForceCompleteIfChannelsEmpty(
 ```java
 return StepDecision.forceCompleteIfChannelsEmpty(
         null,
-        StepMovement.of(processSignal, null),
+        StepMovement.of(ProcessSignal.class, null),
         queueSignalChannel);
 ```
 
@@ -368,7 +368,7 @@ return StepDecision.forceCompleteIfChannelsEmpty(
 ```python
 return force_complete_if_channels_empty(
     None,
-    StepMovement.of(self, None),
+    StepMovement.of(ProcessSignal, None),
     self.queue_signal_channel,
 )
 ```
@@ -379,7 +379,7 @@ return force_complete_if_channels_empty(
 ```typescript
 return forceCompleteIfChannelsEmpty(
   null,
-  StepMovement.of(this, undefined),
+  StepMovement.of(ProcessSignal.class, undefined),
   this.flow.queueSignalChannel,
 );
 ```

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -342,7 +342,7 @@ final StepOptions options = StepOptions.newBuilder()
         .waitForRetry(RetryPolicy.newBuilder().maximumAttempts(2).build())
         .waitForFailure(WaitForFailurePolicy.PROCEED)
         .build();
-return StepDecision.goToMulti(StepMovement.of(second, output, options));
+return StepDecision.goToMulti(StepMovement.of(OverrideSecondStep.class, output, options));
 ```
 
 </SdkSnippet>
@@ -353,7 +353,7 @@ options = StepOptions(
     wait_for_retry=RetryPolicy(maximum_attempts=2),
     wait_for_failure=WaitForFailurePolicy.PROCEED,
 )
-return go_to_multi(StepMovement.of(second_step, output, options))
+return go_to_multi(StepMovement.of(OverrideSecondStep, output, options))
 ```
 
 </SdkSnippet>
@@ -364,7 +364,7 @@ const override: StepOptions = {
   waitForRetry: { maximumAttempts: 2 },
   waitForFailure: "proceed",
 };
-return goToMulti(StepMovement.of(this.flow.secondStep, payload, override));
+return goToMulti(StepMovement.of(OverrideSecondStep, payload, override));
 ```
 
 </SdkSnippet>

--- a/docs/content/quick-start/index.mdx
+++ b/docs/content/quick-start/index.mdx
@@ -70,7 +70,7 @@ class ChargeStep(Step[OrderRequest]):
     def execute(self, context: Context, input: OrderRequest) -> StepDecision:
         self.service.charge_user(input.email, input.customer_id, input.amount)
         order_status.set(context, "charged")
-        return go_to(self.ship, input)
+        return go_to(ShipStep, input)
 
 
 class ShipStep(Step[OrderRequest]):
@@ -84,7 +84,7 @@ class ShipStep(Step[OrderRequest]):
                 total_duration=timedelta(hours=1),
             )
         ).on_execute_failure_proceed_to(
-            self.refund,
+            RefundStep,
             StepOptions(
                 execute_retry=RetryPolicy(
                     total_duration=timedelta(hours=1),
@@ -106,7 +106,7 @@ class ShipStep(Step[OrderRequest]):
                 "Reminder: approve shipment",
                 "Please approve or provide a tracking number.",
             )
-            return go_to(self, input)
+            return go_to(ShipStep, input)
         self.service.ship_item(input.order_id)
         order_status.set(context, "shipped")
         return graceful_complete(f"shipped:{input.order_id}")
@@ -368,7 +368,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
         public StepDecision execute(final Context context, final OrderRequest order) {
             service.chargeUser(order.email, order.customerId, order.amount);
             orderStatus.set(context, "charged");
-            return StepDecision.goTo(ship, order);
+            return StepDecision.goTo(ShipStep.class, order);
         }
     }
 
@@ -398,7 +398,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
                             .totalDuration(Duration.ofHours(1))
                             .build())
                     .onExecuteFailureProceedTo(
-                            refund,
+                            RefundStep.class,
                             StepOptions.newBuilder()
                                     .executeRetry(RetryPolicy.newBuilder()
                                             .totalDuration(Duration.ofHours(1))
@@ -421,7 +421,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
                         order.email,
                         "Reminder: approve shipment",
                         "Please approve or provide a tracking number.");
-                return StepDecision.goTo(this, order);
+                return StepDecision.goTo(ShipStep.class, order);
             }
             service.shipItem(order.orderId);
             orderStatus.set(context, "shipped");
@@ -526,7 +526,7 @@ class ChargeStep implements Step<OrderRequest> {
   public execute(context: Context, input: OrderRequest): StepDecision {
     this.service.chargeUser(input.email, input.customerId, input.amount);
     orderStatus.set(context, "charged");
-    return goTo(this.ship, input);
+    return goTo(ShipStep, input);
   }
 }
 
@@ -547,7 +547,7 @@ class ShipStep implements Step<OrderRequest> {
       executeRetry: {
         totalDurationMs: 60 * 60 * 1000,
       },
-      executeFailure: ExecuteFailure.proceedTo(this.refund, {
+      executeFailure: ExecuteFailure.proceedTo(RefundStep, {
         executeRetry: {
           totalDurationMs: 60 * 60 * 1000,
         },
@@ -566,7 +566,7 @@ class ShipStep implements Step<OrderRequest> {
         "Reminder: approve shipment",
         "Please approve or provide a tracking number.",
       );
-      return goTo(this, input);
+      return goTo(ShipStep, input);
     }
     this.service.shipItem(input.orderId);
     orderStatus.set(context, "shipped");

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro/what-is-dex.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro/what-is-dex.mdx
@@ -67,7 +67,7 @@ class ChargeStep(Step[OrderRequest]):
     def execute(self, context: Context, input: OrderRequest) -> StepDecision:
         self.service.charge_user(input.email, input.customer_id, input.amount)
         order_status.set(context, "charged")
-        return go_to(self.ship, input)
+        return go_to(ShipStep, input)
 
 
 class ShipStep(Step[OrderRequest]):
@@ -81,7 +81,7 @@ class ShipStep(Step[OrderRequest]):
                 total_duration=timedelta(hours=1),
             )
         ).on_execute_failure_proceed_to(
-            self.refund,
+            RefundStep,
             StepOptions(
                 execute_retry=RetryPolicy(
                     total_duration=timedelta(hours=1),
@@ -103,7 +103,7 @@ class ShipStep(Step[OrderRequest]):
                 "Reminder: approve shipment",
                 "Please approve or provide a tracking number.",
             )
-            return go_to(self, input)
+            return go_to(ShipStep, input)
         self.service.ship_item(input.order_id)
         order_status.set(context, "shipped")
         return graceful_complete(f"shipped:{input.order_id}")
@@ -345,7 +345,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
         public StepDecision execute(final Context context, final OrderRequest order) {
             service.chargeUser(order.email, order.customerId, order.amount);
             orderStatus.set(context, "charged");
-            return StepDecision.goTo(ship, order);
+            return StepDecision.goTo(ShipStep.class, order);
         }
     }
 
@@ -375,7 +375,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
                             .totalDuration(Duration.ofHours(1))
                             .build())
                     .onExecuteFailureProceedTo(
-                            refund,
+                            RefundStep.class,
                             StepOptions.newBuilder()
                                     .executeRetry(RetryPolicy.newBuilder()
                                             .totalDuration(Duration.ofHours(1))
@@ -398,7 +398,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
                         order.email,
                         "Reminder: approve shipment",
                         "Please approve or provide a tracking number.");
-                return StepDecision.goTo(this, order);
+                return StepDecision.goTo(ShipStep.class, order);
             }
             service.shipItem(order.orderId);
             orderStatus.set(context, "shipped");
@@ -503,7 +503,7 @@ class ChargeStep implements Step<OrderRequest> {
   public execute(context: Context, input: OrderRequest): StepDecision {
     this.service.chargeUser(input.email, input.customerId, input.amount);
     orderStatus.set(context, "charged");
-    return goTo(this.ship, input);
+    return goTo(ShipStep, input);
   }
 }
 
@@ -524,7 +524,7 @@ class ShipStep implements Step<OrderRequest> {
       executeRetry: {
         totalDurationMs: 60 * 60 * 1000,
       },
-      executeFailure: ExecuteFailure.proceedTo(this.refund, {
+      executeFailure: ExecuteFailure.proceedTo(RefundStep, {
         executeRetry: {
           totalDurationMs: 60 * 60 * 1000,
         },
@@ -543,7 +543,7 @@ class ShipStep implements Step<OrderRequest> {
         "Reminder: approve shipment",
         "Please approve or provide a tracking number.",
       );
-      return goTo(this, input);
+      return goTo(ShipStep, input);
     }
     this.service.shipItem(input.orderId);
     orderStatus.set(context, "shipped");

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
@@ -598,7 +598,7 @@ _, err := client.StartFlow(ctx, flow, userID, nil, options)
 ```java
 final StartFlowOptions options = StartFlowOptions.newBuilder()
         .configOverride(FlowConfig.newBuilder()
-                .attributeStoreNames(java.util.List.of("entityStore"))
+                .attributeStoreNames(List.of("entityStore"))
                 .build())
         .build();
 final String runId = client.startFlow(flow, userId, null, options);

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
@@ -598,7 +598,7 @@ _, err := client.StartFlow(ctx, flow, userID, nil, options)
 ```java
 final StartFlowOptions options = StartFlowOptions.newBuilder()
         .configOverride(FlowConfig.newBuilder()
-                .attributeStoreNames(java.util.Collections.singletonList("entityStore"))
+                .attributeStoreNames(java.util.List.of("entityStore"))
                 .build())
         .build();
 final String runId = client.startFlow(flow, userId, null, options);

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
@@ -586,7 +586,7 @@ await client.start_flow(flow, user_id, None, options)
 ```go
 options := dex.StartFlowOptions{
 	ConfigOverride: &dex.FlowConfig{
-		AttributeStoreNames: ptr.Any([]string{"entityStore"}),
+		AttributeStoreNames: []string{"entityStore"},
 	},
 }
 _, err := client.StartFlow(ctx, flow, userID, nil, options)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
@@ -575,7 +575,7 @@ dexcli dev --attribute-store-config ./attribute-store.yaml
 
 ```python
 options = StartFlowOptions(
-    config_override=FlowConfig(attribute_store_name="entityStore"),
+    config_override=FlowConfig(attribute_store_names=["entityStore"]),
 )
 await client.start_flow(flow, user_id, None, options)
 ```
@@ -586,7 +586,7 @@ await client.start_flow(flow, user_id, None, options)
 ```go
 options := dex.StartFlowOptions{
 	ConfigOverride: &dex.FlowConfig{
-		AttributeStoreName: ptr.Any("entityStore"),
+		AttributeStoreNames: ptr.Any([]string{"entityStore"}),
 	},
 }
 _, err := client.StartFlow(ctx, flow, userID, nil, options)
@@ -598,7 +598,7 @@ _, err := client.StartFlow(ctx, flow, userID, nil, options)
 ```java
 final StartFlowOptions options = StartFlowOptions.newBuilder()
         .configOverride(FlowConfig.newBuilder()
-                .attributeStoreName("entityStore")
+                .attributeStoreNames(java.util.Collections.singletonList("entityStore"))
                 .build())
         .build();
 final String runId = client.startFlow(flow, userId, null, options);
@@ -609,7 +609,7 @@ final String runId = client.startFlow(flow, userId, null, options);
 
 ```typescript
 const runId = await client.startFlow(flow, userId, undefined, {
-  configOverride: { attributeStoreName: "entityStore" },
+  configOverride: { attributeStoreNames: ["entityStore"] },
 });
 ```
 
@@ -618,7 +618,7 @@ const runId = await client.startFlow(flow, userId, undefined, {
 
 ```rust
 let options = StartFlowOptions::new()
-    .config_override(FlowConfig::new().attribute_store_name("entityStore"));
+    .config_override(FlowConfig::new().attribute_store_names(vec!["entityStore".to_owned()]));
 let run_id = client.start_flow_with_options(&flow, &user_id, (), options)?;
 ```
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/flow-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/flow-options.mdx
@@ -313,7 +313,7 @@ Dex Server 要求 **RequestID** 非空。省略时，SDK 会在发送请求前�
 | **ContinueAsNewPageSizeBytes** | 限制 continue-as-new 带入的每一页 state。零使用 1 MiB。 |
 | **StepDurability** | Step 写入的默认 durability。Step override 优先。除非在 **StepOptions** 中覆盖，recovery 使用 synchronous durability。 |
 | **WorkerTarget** | 用于 Step 和 RPC invocation 的 WorkerService endpoint。 |
-| **AttributeStoreName** | Dex Server Attribute Store，供 opt-in attribute sync 的 Attribute 使用。 |
+| **AttributeStoreNames** | Dex Server Attribute Store 名称，供 opt-in attribute sync 的 Attribute 使用。 |
 
 ### 用 Client 更新 FlowConfig {#update-flow-config-with-a-client}
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -32,7 +32,7 @@ RPC 可以通过 Attribute 读取和写入 durable state、向 Channel publish�
 def trigger(self, context: Context, input: str) -> RPCResult[str]:
     self.data.set(context, input)
     self.example_ch.publish(context, None)
-    return RPCResult(input, next_steps=(StepMovement.of(self.example_step, input),))
+    return RPCResult(input, next_steps=(StepMovement.of(ExampleStep, input),))
 ```
 
 </SdkSnippet>
@@ -63,7 +63,7 @@ func (*RpcFlow) Trigger(ctx dex.Context, input string) (*dex.RPCResult[string], 
 public RPCResult<String> trigger(final Context context, final String input) {
     data.set(context, input);
     exampleCh.publish(context, null);
-    return RPCResult.of(input, StepMovement.of(exampleStep, input));
+    return RPCResult.of(input, StepMovement.of(ExampleStep.class, input));
 }
 ```
 
@@ -75,7 +75,7 @@ public RPCResult<String> trigger(final Context context, final String input) {
 public trigger(context: Context, input: string): RPCResult<string> {
   this.data.set(context, input);
   exampleCh.publish(context, undefined);
-  return { output: input, nextSteps: [StepMovement.of(this.exampleStep, input)] };
+  return { output: input, nextSteps: [StepMovement.of(ExampleStep, input)] };
 }
 ```
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
@@ -32,7 +32,7 @@ Dex Step 由原生代码实现。实现该 Step 的 struct 或 class 决定 **St
 ```python
 def execute(self, context: Context, input: int) -> StepDecision:
     del context
-    return go_to(self.second, input + 1)
+    return go_to(StepSecond, input + 1)
 
 def execute(self, context: Context, input: int) -> StepDecision:
     del context
@@ -57,7 +57,7 @@ func (stepSecondStep) Execute(_ dex.Context, input int) (*dex.StepDecision, erro
 
 ```java
 public StepDecision execute(final Context context, final Integer input) {
-    return StepDecision.goTo(second, input + 1);
+    return StepDecision.goTo(StepSecond.class, input + 1);
 }
 
 public StepDecision execute(final Context context, final Integer input) {
@@ -70,7 +70,7 @@ public StepDecision execute(final Context context, final Integer input) {
 
 ```typescript
 public execute(_context: Context, input: number): StepDecision {
-  return goTo(this.flow.secondStep, input + 1);
+  return goTo(StepSecond, input + 1);
 }
 
 public execute(_context: Context, input: number): StepDecision {
@@ -136,7 +136,7 @@ class ExampleStep(Step[int]):
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to(self.second, input + 1)
+        return go_to(StepSecond, input + 1)
 ```
 
 </SdkSnippet>
@@ -183,7 +183,7 @@ final class ExampleStep implements Step<Integer> {
 
     @Override
     public StepDecision execute(final Context context, final Integer input) {
-        return StepDecision.goTo(second, input + 1);
+        return StepDecision.goTo(StepSecond.class, input + 1);
     }
 }
 
@@ -220,7 +220,7 @@ class ExampleStep implements Step<number> {
   }
 
   public execute(_context: Context, input: number): StepDecision {
-    return goTo(this.flow.secondStep, input + 1);
+    return goTo(StepSecond, input + 1);
   }
 }
 
@@ -447,7 +447,7 @@ public StepDecision execute(final Context context, final String input) {
     if (!context.waitForMethodFailed()) {
         throw new IllegalStateException("waitFor failure was not reported");
     }
-    return StepDecision.goTo(finish, input + "_recovered");
+    return StepDecision.goTo(FinishStep.class, input + "_recovered");
 }
 ```
 
@@ -468,7 +468,7 @@ def wait_for(self, context: Context, input: str) -> Wait:
 def execute(self, context: Context, input: str) -> StepDecision:
     if not context.wait_for_method_failed():
         raise RuntimeError("waitFor failure was not reported")
-    return go_to(self.finish, f"{input}_recovered")
+    return go_to(FinishStep, f"{input}_recovered")
 ```
 
 </SdkSnippet>
@@ -490,7 +490,7 @@ public execute(context: Context, input: string): StepDecision {
   if (!context.waitForMethodFailed()) {
     throw new Error("waitFor failure was not reported");
   }
-  return goTo(this.finish, `${input}_recovered`);
+  return goTo(FinishStep, `${input}_recovered`);
 }
 ```
 
@@ -552,7 +552,7 @@ func (updateItemQuantityStep) GetStepOptions() *dex.StepOptions {
 @Override
 public StepOptions getStepOptions() {
     return StepOptions.newBuilder()
-            .onExecuteFailureProceedTo(updateQuantityRecovery)
+            .onExecuteFailureProceedTo(UpdateQuantityRecovery.class)
             .executeRetry(RetryPolicy.newBuilder().maximumAttempts(5).build())
             .build();
 }
@@ -565,7 +565,7 @@ public StepOptions getStepOptions() {
 def get_step_options(self) -> StepOptions:
     return StepOptions(
         execute_retry=RetryPolicy(maximum_attempts=5)
-    ).on_execute_failure_proceed_to(self.update_quantity_recovery)
+    ).on_execute_failure_proceed_to(UpdateQuantityRecovery)
 ```
 
 </SdkSnippet>
@@ -574,7 +574,7 @@ def get_step_options(self) -> StepOptions:
 ```typescript
 public getStepOptions(): StepOptions {
   return {
-    executeFailure: ExecuteFailure.proceedTo(this.flow.updateQuantityRecoveryStep, {
+    executeFailure: ExecuteFailure.proceedTo(UpdateQuantityRecovery, {
       executeRetry: { maximumAttempts: 5 },
     }),
     executeRetry: { maximumAttempts: 5 },

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
@@ -35,9 +35,9 @@ return dex.GoToMulti(
 
 ```java
 return StepDecision.goToMulti(
-        StepMovement.of(carrierAStep, quoteA),
-        StepMovement.of(carrierBStep, quoteB),
-        StepMovement.of(winnerStep, winnerQuote));
+        StepMovement.of(CarrierAStep.class, quoteA),
+        StepMovement.of(CarrierBStep.class, quoteB),
+        StepMovement.of(WinnerStep.class, winnerQuote));
 ```
 
 </SdkSnippet>
@@ -45,9 +45,9 @@ return StepDecision.goToMulti(
 
 ```python
 return go_to_multi(
-    StepMovement.of(self.flow.carrier_a, Quote(carrier="A", price=10)),
-    StepMovement.of(self.flow.carrier_b, Quote(carrier="B", price=12)),
-    StepMovement.of(self.flow.winner, quote),
+    StepMovement.of(CarrierAStep, Quote(carrier="A", price=10)),
+    StepMovement.of(CarrierBStep, Quote(carrier="B", price=12)),
+    StepMovement.of(WinnerStep, quote),
 )
 ```
 
@@ -56,9 +56,9 @@ return go_to_multi(
 
 ```typescript
 return goToMulti(
-  StepMovement.of(this.flow.carrierAStep, { carrier: "A", price: 10 }),
-  StepMovement.of(this.flow.carrierBStep, { carrier: "B", price: 12 }),
-  StepMovement.of(this.flow.winnerStep, quote),
+  StepMovement.of(CarrierAStep, { carrier: "A", price: 10 }),
+  StepMovement.of(CarrierBStep, { carrier: "B", price: 12 }),
+  StepMovement.of(WinnerStep, quote),
 );
 ```
 
@@ -125,8 +125,8 @@ case "graceful" -> {
 }
 case "dead-end" -> {
     return StepDecision.goToMulti(
-            StepMovement.of(branchWorkerStep, "left"),
-            StepMovement.of(branchWorkerStep, "right"));
+            StepMovement.of(BranchWorkerStep.class, "left"),
+            StepMovement.of(BranchWorkerStep.class, "right"));
 }
 
 return StepDecision.deadEnd();
@@ -140,8 +140,8 @@ if mode == "graceful":
     return graceful_complete("done")
 if mode == "dead-end":
     return go_to_multi(
-        StepMovement.of(self.flow.branch_worker, "left"),
-        StepMovement.of(self.flow.branch_worker, "right"),
+        StepMovement.of(BranchWorkerStep, "left"),
+        StepMovement.of(BranchWorkerStep, "right"),
     )
 
 return dead_end()
@@ -156,8 +156,8 @@ if (mode === "graceful") {
 }
 if (mode === "dead-end") {
   return goToMulti(
-    StepMovement.of(this.flow.branchWorkerStep, "left"),
-    StepMovement.of(this.flow.branchWorkerStep, "right"),
+    StepMovement.of(BranchWorkerStep, "left"),
+    StepMovement.of(BranchWorkerStep, "right"),
   );
 }
 
@@ -291,7 +291,7 @@ func (winnerStep) Execute(_ dex.Context, quote Quote) (*dex.StepDecision, error)
   <SdkSnippet lang="java">
 
 ```java
-return StepDecision.goTo(recordQuote, quote)
+return StepDecision.goTo(RecordQuoteStep.class, quote)
         .withCancelingSteps(carrierA, carrierB);
 ```
 
@@ -300,7 +300,7 @@ return StepDecision.goTo(recordQuote, quote)
 
 ```python
 return (
-    go_to(self.flow.record_quote, quote)
+    go_to(RecordQuoteStep, quote)
     .with_canceling_steps(self.flow.carrier_a, self.flow.carrier_b)
 )
 ```
@@ -310,7 +310,7 @@ return (
 
 ```typescript
 return withCancelingSteps(
-  goTo(this.flow.recordQuoteStep, quote),
+  goTo(RecordQuoteStep, quote),
   this.flow.carrierAStep,
   this.flow.carrierBStep,
 );
@@ -358,7 +358,7 @@ return dex.ForceCompleteIfChannelsEmpty(
 ```java
 return StepDecision.forceCompleteIfChannelsEmpty(
         null,
-        StepMovement.of(processSignal, null),
+        StepMovement.of(ProcessSignal.class, null),
         queueSignalChannel);
 ```
 
@@ -368,7 +368,7 @@ return StepDecision.forceCompleteIfChannelsEmpty(
 ```python
 return force_complete_if_channels_empty(
     None,
-    StepMovement.of(self, None),
+    StepMovement.of(ProcessSignal, None),
     self.queue_signal_channel,
 )
 ```
@@ -379,7 +379,7 @@ return force_complete_if_channels_empty(
 ```typescript
 return forceCompleteIfChannelsEmpty(
   null,
-  StepMovement.of(this, undefined),
+  StepMovement.of(ProcessSignal.class, undefined),
   this.flow.queueSignalChannel,
 );
 ```

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -341,7 +341,7 @@ final StepOptions options = StepOptions.newBuilder()
         .waitForRetry(RetryPolicy.newBuilder().maximumAttempts(2).build())
         .waitForFailure(WaitForFailurePolicy.PROCEED)
         .build();
-return StepDecision.goToMulti(StepMovement.of(second, output, options));
+return StepDecision.goToMulti(StepMovement.of(OverrideSecondStep.class, output, options));
 ```
 
 </SdkSnippet>
@@ -352,7 +352,7 @@ options = StepOptions(
     wait_for_retry=RetryPolicy(maximum_attempts=2),
     wait_for_failure=WaitForFailurePolicy.PROCEED,
 )
-return go_to_multi(StepMovement.of(second_step, output, options))
+return go_to_multi(StepMovement.of(OverrideSecondStep, output, options))
 ```
 
 </SdkSnippet>
@@ -363,7 +363,7 @@ const override: StepOptions = {
   waitForRetry: { maximumAttempts: 2 },
   waitForFailure: "proceed",
 };
-return goToMulti(StepMovement.of(this.flow.secondStep, payload, override));
+return goToMulti(StepMovement.of(OverrideSecondStep, payload, override));
 ```
 
 </SdkSnippet>

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quick-start/index.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quick-start/index.mdx
@@ -66,7 +66,7 @@ class ChargeStep(Step[OrderRequest]):
     def execute(self, context: Context, input: OrderRequest) -> StepDecision:
         self.service.charge_user(input.email, input.customer_id, input.amount)
         order_status.set(context, "charged")
-        return go_to(self.ship, input)
+        return go_to(ShipStep, input)
 
 
 class ShipStep(Step[OrderRequest]):
@@ -80,7 +80,7 @@ class ShipStep(Step[OrderRequest]):
                 total_duration=timedelta(hours=1),
             )
         ).on_execute_failure_proceed_to(
-            self.refund,
+            RefundStep,
             StepOptions(
                 execute_retry=RetryPolicy(
                     total_duration=timedelta(hours=1),
@@ -102,7 +102,7 @@ class ShipStep(Step[OrderRequest]):
                 "Reminder: approve shipment",
                 "Please approve or provide a tracking number.",
             )
-            return go_to(self, input)
+            return go_to(ShipStep, input)
         self.service.ship_item(input.order_id)
         order_status.set(context, "shipped")
         return graceful_complete(f"shipped:{input.order_id}")
@@ -364,7 +364,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
         public StepDecision execute(final Context context, final OrderRequest order) {
             service.chargeUser(order.email, order.customerId, order.amount);
             orderStatus.set(context, "charged");
-            return StepDecision.goTo(ship, order);
+            return StepDecision.goTo(ShipStep.class, order);
         }
     }
 
@@ -394,7 +394,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
                             .totalDuration(Duration.ofHours(1))
                             .build())
                     .onExecuteFailureProceedTo(
-                            refund,
+                            RefundStep.class,
                             StepOptions.newBuilder()
                                     .executeRetry(RetryPolicy.newBuilder()
                                             .totalDuration(Duration.ofHours(1))
@@ -417,7 +417,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
                         order.email,
                         "Reminder: approve shipment",
                         "Please approve or provide a tracking number.");
-                return StepDecision.goTo(this, order);
+                return StepDecision.goTo(ShipStep.class, order);
             }
             service.shipItem(order.orderId);
             orderStatus.set(context, "shipped");
@@ -522,7 +522,7 @@ class ChargeStep implements Step<OrderRequest> {
   public execute(context: Context, input: OrderRequest): StepDecision {
     this.service.chargeUser(input.email, input.customerId, input.amount);
     orderStatus.set(context, "charged");
-    return goTo(this.ship, input);
+    return goTo(ShipStep, input);
   }
 }
 
@@ -543,7 +543,7 @@ class ShipStep implements Step<OrderRequest> {
       executeRetry: {
         totalDurationMs: 60 * 60 * 1000,
       },
-      executeFailure: ExecuteFailure.proceedTo(this.refund, {
+      executeFailure: ExecuteFailure.proceedTo(RefundStep, {
         executeRetry: {
           totalDurationMs: 60 * 60 * 1000,
         },
@@ -562,7 +562,7 @@ class ShipStep implements Step<OrderRequest> {
         "Reminder: approve shipment",
         "Please approve or provide a tracking number.",
       );
-      return goTo(this, input);
+      return goTo(ShipStep, input);
     }
     this.service.shipItem(input.orderId);
     orderStatus.set(context, "shipped");

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -1,6 +1,6 @@
 # Dex Go examples
 
-These examples target `github.com/superdurable/dex/sdk-go v0.2.0`.
+These examples target `github.com/superdurable/dex/sdk-go v0.2.1`.
 
 `dex.None` marks a nil-only Step, RPC, or Channel payload. Calls pass `nil`.
 

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -1,6 +1,6 @@
 # Dex Go examples
 
-These examples target `github.com/superdurable/dex/sdk-go v0.2.1`.
+These examples target `github.com/superdurable/dex/sdk-go v0.2.2`.
 
 `dex.None` marks a nil-only Step, RPC, or Channel payload. Calls pass `nil`.
 

--- a/examples/go/cmd/deepverify/main.go
+++ b/examples/go/cmd/deepverify/main.go
@@ -871,7 +871,7 @@ func verifyEntityStore(ctx context.Context, client *dex.Client, stamp string) re
 	options := hourStartOptions()
 	options.Attributes = attributes
 	options.ConfigOverride = &dex.FlowConfig{
-		AttributeStoreNames: ptr.Any([]string{entitystore.StoreName}),
+		AttributeStoreNames: []string{entitystore.StoreName},
 	}
 	if _, err := client.StartFlow(ctx, registry.UserProfile, flowID, nil, options); err != nil {
 		return fail(name, "start", err)

--- a/examples/go/cmd/deepverify/main.go
+++ b/examples/go/cmd/deepverify/main.go
@@ -871,7 +871,7 @@ func verifyEntityStore(ctx context.Context, client *dex.Client, stamp string) re
 	options := hourStartOptions()
 	options.Attributes = attributes
 	options.ConfigOverride = &dex.FlowConfig{
-		AttributeStoreName: ptr.Any(entitystore.StoreName),
+		AttributeStoreNames: ptr.Any([]string{entitystore.StoreName}),
 	}
 	if _, err := client.StartFlow(ctx, registry.UserProfile, flowID, nil, options); err != nil {
 		return fail(name, "start", err)

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/stretchr/testify v1.11.1
 	github.com/superdurable/dex/blob-cache-go v0.1.0
-	github.com/superdurable/dex/sdk-go v0.2.0
+	github.com/superdurable/dex/sdk-go v0.2.1
 )
 
 require (

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/stretchr/testify v1.11.1
 	github.com/superdurable/dex/blob-cache-go v0.1.0
-	github.com/superdurable/dex/sdk-go v0.2.1
+	github.com/superdurable/dex/sdk-go v0.2.2
 )
 
 require (

--- a/examples/go/go.sum
+++ b/examples/go/go.sum
@@ -92,6 +92,8 @@ github.com/superdurable/dex/blob-cache-go v0.1.0 h1:+c3H5YBWG3DlICOHbgT9IUM5vTlf
 github.com/superdurable/dex/blob-cache-go v0.1.0/go.mod h1:Atepb7+sztvDCztVKmlvEKCSKFCkHKtDhoFYjaFmtEw=
 github.com/superdurable/dex/sdk-go v0.2.0 h1:HlV9MzsEvWGyxolA5hqi7a5FnqJDftpV4iEbSi7hWGs=
 github.com/superdurable/dex/sdk-go v0.2.0/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
+github.com/superdurable/dex/sdk-go v0.2.1 h1:kAdJgTOpUzftADvihVB14zNa1Zu7eR2qJ896LNomcAo=
+github.com/superdurable/dex/sdk-go v0.2.1/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=

--- a/examples/go/go.sum
+++ b/examples/go/go.sum
@@ -92,8 +92,8 @@ github.com/superdurable/dex/blob-cache-go v0.1.0 h1:+c3H5YBWG3DlICOHbgT9IUM5vTlf
 github.com/superdurable/dex/blob-cache-go v0.1.0/go.mod h1:Atepb7+sztvDCztVKmlvEKCSKFCkHKtDhoFYjaFmtEw=
 github.com/superdurable/dex/sdk-go v0.2.0 h1:HlV9MzsEvWGyxolA5hqi7a5FnqJDftpV4iEbSi7hWGs=
 github.com/superdurable/dex/sdk-go v0.2.0/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
-github.com/superdurable/dex/sdk-go v0.2.1 h1:kAdJgTOpUzftADvihVB14zNa1Zu7eR2qJ896LNomcAo=
-github.com/superdurable/dex/sdk-go v0.2.1/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
+github.com/superdurable/dex/sdk-go v0.2.2 h1:Axum23P4qp/D6NUdlYB66LaezyNTkwCJFtlfxXaaf4U=
+github.com/superdurable/dex/sdk-go v0.2.2/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=

--- a/examples/go/patterns/entity-store/controller.go
+++ b/examples/go/patterns/entity-store/controller.go
@@ -145,7 +145,7 @@ func entityStoreStartOptions(profile UserProfile) (sdk.StartFlowOptions, error) 
 	options := patternStartOptions()
 	options.Attributes = attributes
 	options.ConfigOverride = &sdk.FlowConfig{
-		AttributeStoreName: ptr.Any(StoreName),
+		AttributeStoreNames: ptr.Any([]string{StoreName}),
 	}
 	return options, nil
 }

--- a/examples/go/patterns/entity-store/controller.go
+++ b/examples/go/patterns/entity-store/controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/superdurable/dex/examples/go/server/httputil"
 	sdk "github.com/superdurable/dex/sdk-go/dex"
-	"github.com/superdurable/dex/sdk-go/dex/ptr"
 )
 
 type controller struct {
@@ -145,7 +144,7 @@ func entityStoreStartOptions(profile UserProfile) (sdk.StartFlowOptions, error) 
 	options := patternStartOptions()
 	options.Attributes = attributes
 	options.ConfigOverride = &sdk.FlowConfig{
-		AttributeStoreNames: ptr.Any([]string{StoreName}),
+		AttributeStoreNames: []string{StoreName},
 	}
 	return options, nil
 }

--- a/examples/go/primitives/attribute/workflow.go
+++ b/examples/go/primitives/attribute/workflow.go
@@ -22,7 +22,6 @@ package attribute
 
 import (
 	"github.com/superdurable/dex/sdk-go/dex"
-	"github.com/superdurable/dex/sdk-go/dex/ptr"
 )
 
 var (
@@ -38,7 +37,7 @@ var (
 		"primitive-attribute-progress",
 		dex.Indexed(dex.AttributeIndex{Type: dex.IndexKeyword, IndexKey: "OrderProgress"}),
 	)
-	AttributeStoreConfig = &dex.FlowConfig{AttributeStoreNames: ptr.Any([]string{"profiles"})}
+	AttributeStoreConfig = &dex.FlowConfig{AttributeStoreNames: []string{"profiles"}}
 )
 
 type AttributeFlow struct {

--- a/examples/go/primitives/attribute/workflow.go
+++ b/examples/go/primitives/attribute/workflow.go
@@ -38,7 +38,7 @@ var (
 		"primitive-attribute-progress",
 		dex.Indexed(dex.AttributeIndex{Type: dex.IndexKeyword, IndexKey: "OrderProgress"}),
 	)
-	AttributeStoreConfig = &dex.FlowConfig{AttributeStoreName: ptr.Any("profiles")}
+	AttributeStoreConfig = &dex.FlowConfig{AttributeStoreNames: ptr.Any([]string{"profiles"})}
 )
 
 type AttributeFlow struct {

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -1,6 +1,6 @@
 # Dex Java examples
 
-These examples target `io.superdurable:dex-sdk:0.2.0` (`io.superdurable.dex`).
+These examples target `io.superdurable:dex-sdk:0.2.1` (`io.superdurable.dex`).
 
 The sample process hosts one gRPC Worker on `127.0.0.1:8803` and an HTTP
 controller on port `8080`. One Registry and disk BlobCache are shared by its

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "io.superdurable:dex-sdk:0.2.0"
+    implementation "io.superdurable:dex-sdk:0.2.1"
 
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/cron/CronScheduleFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/cron/CronScheduleFlow.java
@@ -135,7 +135,7 @@ public class CronScheduleFlow implements Flow<CronScheduleFlow.Input> {
                     || input.interval.duration().isZero()) {
                 return StepDecision.forceFail("interval value and run count must be positive");
             }
-            return StepDecision.goTo(waitForSchedule, new ScheduleState(input.interval, input.runCount));
+            return StepDecision.goTo(WaitForSchedule.class, new ScheduleState(input.interval, input.runCount));
         }
     }
 
@@ -180,19 +180,19 @@ public class CronScheduleFlow implements Flow<CronScheduleFlow.Input> {
             return StepDecision.gracefulComplete();
         }
         return StepDecision.goTo(
-                waitForSchedule,
+                WaitForSchedule.class,
                 new ScheduleState(state.interval, state.remainingRuns - 1));
     }
 
     private StepDecision runNow(final ScheduleState state) {
         final RunInput runInput = new RunInput(state.remainingRuns, state.remainingRuns == 1);
         if (runInput.isFinal) {
-            return StepDecision.goTo(run, runInput);
+            return StepDecision.goTo(Run.class, runInput);
         }
         return StepDecision.goToMulti(
-                StepMovement.of(run, runInput),
+                StepMovement.of(Run.class, runInput),
                 StepMovement.of(
-                        waitForSchedule,
+                        WaitForSchedule.class,
                         new ScheduleState(state.interval, state.remainingRuns - 1)));
     }
 }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/drainchannels/internal/DrainInternalChannelsFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/drainchannels/internal/DrainInternalChannelsFlow.java
@@ -77,8 +77,8 @@ public class DrainInternalChannelsFlow implements Flow<String> {
         public StepDecision execute(final Context context, final String input) {
             processDataStateExecutionCounter.set(context, 0);
             return StepDecision.goToMulti(
-                    StepMovement.of(upsertMongoRecord, null),
-                    StepMovement.of(processData, input));
+                    StepMovement.of(UpsertMongoRecord.class, null),
+                    StepMovement.of(ProcessData.class, input));
         }
     }
 
@@ -114,7 +114,7 @@ public class DrainInternalChannelsFlow implements Flow<String> {
             if (document.finalCommand) {
                 return StepDecision.gracefulComplete();
             }
-            return StepDecision.goTo(upsertMongoRecord, null);
+            return StepDecision.goTo(UpsertMongoRecord.class, null);
         }
     }
 
@@ -154,9 +154,9 @@ public class DrainInternalChannelsFlow implements Flow<String> {
                     "a call to send metrics or add a log to logrepo");
 
             if (executionCount <= 3) {
-                return StepDecision.goTo(processData, input);
+                return StepDecision.goTo(ProcessData.class, input);
             }
-            return StepDecision.goTo(finalize, null);
+            return StepDecision.goTo(Finalize.class, null);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/drainchannels/signal/DrainSignalChannelsFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/drainchannels/signal/DrainSignalChannelsFlow.java
@@ -88,7 +88,7 @@ public class DrainSignalChannelsFlow implements Flow<String> {
 
             return StepDecision.forceCompleteIfChannelsEmpty(
                     null,
-                    StepMovement.of(processSignal, null),
+                    StepMovement.of(ProcessSignal.class, null),
                     queueSignalChannel);
         }
     }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/entitystore/EntityStoreController.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/entitystore/EntityStoreController.java
@@ -19,6 +19,7 @@ package io.superdurable.dex.patterns.entitystore;
 import io.superdurable.dex.Client;
 import io.superdurable.dex.FlowConfig;
 import io.superdurable.dex.StartFlowOptions;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -53,7 +54,7 @@ public class EntityStoreController {
                 .addAttribute(userProfileFlow.lastLoggedInTime, profile.lastLoggedInTime)
                 .addAttribute(userProfileFlow.metadata, profile.metadata)
                 .configOverride(FlowConfig.newBuilder()
-                        .attributeStoreNames(java.util.List.of(UserProfileFlow.STORE_NAME))
+                        .attributeStoreNames(List.of(UserProfileFlow.STORE_NAME))
                         .build())
                 .build();
         final String runId = client.startFlow(

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/entitystore/EntityStoreController.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/entitystore/EntityStoreController.java
@@ -53,7 +53,7 @@ public class EntityStoreController {
                 .addAttribute(userProfileFlow.lastLoggedInTime, profile.lastLoggedInTime)
                 .addAttribute(userProfileFlow.metadata, profile.metadata)
                 .configOverride(FlowConfig.newBuilder()
-                        .attributeStoreName(UserProfileFlow.STORE_NAME)
+                        .attributeStoreNames(java.util.Collections.singletonList(UserProfileFlow.STORE_NAME))
                         .build())
                 .build();
         final String runId = client.startFlow(

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/entitystore/EntityStoreController.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/entitystore/EntityStoreController.java
@@ -53,7 +53,7 @@ public class EntityStoreController {
                 .addAttribute(userProfileFlow.lastLoggedInTime, profile.lastLoggedInTime)
                 .addAttribute(userProfileFlow.metadata, profile.metadata)
                 .configOverride(FlowConfig.newBuilder()
-                        .attributeStoreNames(java.util.Collections.singletonList(UserProfileFlow.STORE_NAME))
+                        .attributeStoreNames(java.util.List.of(UserProfileFlow.STORE_NAME))
                         .build())
                 .build();
         final String runId = client.startFlow(

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/interruptible/InterruptibleExecutionFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/interruptible/InterruptibleExecutionFlow.java
@@ -67,8 +67,8 @@ public class InterruptibleExecutionFlow implements Flow<Void> {
         public StepDecision execute(final Context context, final Void unused) {
             final WorkJobParametersInput input = new WorkJobParametersInput(15, 1);
             return StepDecision.goToMulti(
-                    StepMovement.of(workAExecution, input),
-                    StepMovement.of(workNExecution, input));
+                    StepMovement.of(WorkAExecution.class, input),
+                    StepMovement.of(WorkNExecution.class, input));
         }
     }
 
@@ -105,7 +105,7 @@ public class InterruptibleExecutionFlow implements Flow<Void> {
 
             final WorkJobParametersInput next =
                     new WorkJobParametersInput(input.jobUpperBound, input.progress + 1);
-            return StepDecision.goTo(workAExecution, next);
+            return StepDecision.goTo(WorkAExecution.class, next);
         }
     }
 
@@ -143,7 +143,7 @@ public class InterruptibleExecutionFlow implements Flow<Void> {
 
             final WorkJobParametersInput next =
                     new WorkJobParametersInput(input.jobUpperBound, input.progress + 1);
-            return StepDecision.goTo(workNExecution, next);
+            return StepDecision.goTo(WorkNExecution.class, next);
         }
     }
 }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/intervention/ManualInterventionFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/intervention/ManualInterventionFlow.java
@@ -72,7 +72,7 @@ public class ManualInterventionFlow implements Flow<Void> {
         @Override
         public StepDecision execute(final Context context, final Void input) {
             numberOfRetries.set(context, 0);
-            return StepDecision.goTo(getData, false);
+            return StepDecision.goTo(GetData.class, false);
         }
     }
 
@@ -97,9 +97,9 @@ public class ManualInterventionFlow implements Flow<Void> {
             try {
                 pretendApiCall(context);
             } catch (final Exception e) {
-                return StepDecision.goTo(error, null);
+                return StepDecision.goTo(Error.class, null);
             }
-            return StepDecision.goTo(finalStep, null);
+            return StepDecision.goTo(Final.class, null);
         }
 
         private void pretendApiCall(final Context context) {
@@ -132,9 +132,9 @@ public class ManualInterventionFlow implements Flow<Void> {
             System.out.println("signal received: "
                     + (retry ? SIGNAL_CHANNEL_COMMAND_RETRY : SIGNAL_CHANNEL_COMMAND_SKIP));
             if (retry) {
-                return StepDecision.goTo(getData, true);
+                return StepDecision.goTo(GetData.class, true);
             }
-            return StepDecision.goTo(finalStep, null);
+            return StepDecision.goTo(Final.class, null);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/ParallelStatesWithAwaitFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/ParallelStatesWithAwaitFlow.java
@@ -58,10 +58,10 @@ public class ParallelStatesWithAwaitFlow implements Flow<Integer> {
         public StepDecision execute(final Context context, final Integer countOfJobSeekers) {
             final StepMovement<?>[] movements =
                     new StepMovement<?>[countOfJobSeekers + 1];
-            movements[0] = StepMovement.of(awaitAllUsersNotified, countOfJobSeekers);
+            movements[0] = StepMovement.of(AwaitAllUsersNotified.class, countOfJobSeekers);
             for (int i = 1; i <= countOfJobSeekers; i++) {
                 movements[i] = StepMovement.of(
-                        notifyUser,
+                        NotifyUser.class,
                         new JobSeeker(
                                 String.valueOf(i),
                                 "jobseeker@indeed.com",

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/SimpleParallelStatesFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/SimpleParallelStatesFlow.java
@@ -50,8 +50,8 @@ public class SimpleParallelStatesFlow implements Flow<JobSeeker> {
         @Override
         public StepDecision execute(final Context context, final JobSeeker input) {
             return StepDecision.goToMulti(
-                    StepMovement.of(sendTextMessage, input.phoneNumber),
-                    StepMovement.of(sendEmail, input.email));
+                    StepMovement.of(SendTextMessage.class, input.phoneNumber),
+                    StepMovement.of(SendEmail.class, input.email));
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/parentchild/ParentFlowV2.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/parentchild/ParentFlowV2.java
@@ -71,7 +71,7 @@ public class ParentFlowV2 implements Flow<Integer> {
 
             final List<StepMovement<?>> movements = new ArrayList<StepMovement<?>>();
             for (int i = 0; i < CONCURRENCY_PER_PARENT_WORKFLOW; i++) {
-                movements.add(StepMovement.of(loopForNextTask, null));
+                movements.add(StepMovement.of(LoopForNextTask.class, null));
             }
             return StepDecision.goToMulti(movements.toArray(new StepMovement<?>[0]));
         }
@@ -91,7 +91,7 @@ public class ParentFlowV2 implements Flow<Integer> {
         @Override
         public StepDecision execute(final Context context, final Void input) {
             final Integer request = taskQueue.getConditionResults(context).get(0);
-            return StepDecision.goTo(runSubFlow, request);
+            return StepDecision.goTo(RunSubFlow.class, request);
         }
     }
 
@@ -109,7 +109,7 @@ public class ParentFlowV2 implements Flow<Integer> {
         @Override
         public StepDecision execute(final Context context, final Integer request) {
             SubFlow.getConditionResults(context);
-            return StepDecision.goTo(loopForNextTask, null);
+            return StepDecision.goTo(LoopForNextTask.class, null);
         }
     }
 }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/polling/BackoffPollingFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/polling/BackoffPollingFlow.java
@@ -72,7 +72,7 @@ public class BackoffPollingFlow implements Flow<Void> {
         public StepDecision execute(final Context context, final Void input) {
             final String result =
                     service.attemptExternalApiCall("Read for BackoffPollingFlow");
-            return StepDecision.goTo(pollingComplete, result);
+            return StepDecision.goTo(PollingComplete.class, result);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/polling/SimplePollingFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/polling/SimplePollingFlow.java
@@ -57,9 +57,9 @@ public class SimplePollingFlow implements Flow<Void> {
         @Override
         public StepDecision execute(final Context context, final Void input) {
             if (isSystemReady()) {
-                return StepDecision.goTo(simplePollingComplete, null);
+                return StepDecision.goTo(SimplePollingComplete.class, null);
             }
-            return StepDecision.goTo(simplePolling, null);
+            return StepDecision.goTo(SimplePolling.class, null);
         }
 
         private boolean isSystemReady() {

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/recovery/FailureRecoveryFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/recovery/FailureRecoveryFlow.java
@@ -64,7 +64,7 @@ public class FailureRecoveryFlow implements Flow<FailureRecoveryWorkflowInput> {
         @Override
         public StepOptions getStepOptions() {
             return StepOptions.newBuilder()
-                    .onExecuteFailureProceedTo(updateQuantityRecovery)
+                    .onExecuteFailureProceedTo(UpdateQuantityRecovery.class)
                     .executeRetry(RetryPolicy.newBuilder().maximumAttempts(5).build())
                     .build();
         }
@@ -75,7 +75,7 @@ public class FailureRecoveryFlow implements Flow<FailureRecoveryWorkflowInput> {
                 final FailureRecoveryWorkflowInput input) {
             workflowInput.set(context, input);
             database.reduceQuantity(input.itemName, input.requestedQuantity);
-            return StepDecision.goTo(chargeForItems, input.requestedQuantity);
+            return StepDecision.goTo(ChargeForItems.class, input.requestedQuantity);
         }
     }
 
@@ -88,7 +88,7 @@ public class FailureRecoveryFlow implements Flow<FailureRecoveryWorkflowInput> {
         @Override
         public StepOptions getStepOptions() {
             return StepOptions.newBuilder()
-                    .onExecuteFailureProceedTo(voidPaymentRecovery)
+                    .onExecuteFailureProceedTo(VoidPaymentRecovery.class)
                     .executeRetry(RetryPolicy.newBuilder().maximumAttempts(5).build())
                     .build();
         }
@@ -131,7 +131,7 @@ public class FailureRecoveryFlow implements Flow<FailureRecoveryWorkflowInput> {
             final double itemValue = database.getItemPrice(workflow.itemName);
             final double orderValue = workflow.requestedQuantity * itemValue;
             paymentProcessor.voidPayment(orderValue);
-            return StepDecision.goTo(updateQuantityRecovery, workflow);
+            return StepDecision.goTo(UpdateQuantityRecovery.class, workflow);
         }
     }
 }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/reminders/ReminderFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/reminders/ReminderFlow.java
@@ -84,8 +84,8 @@ public class ReminderFlow implements Flow<Void> {
         public StepDecision execute(final Context context, final Void input) {
             status.set(context, Status.INITIATED.name());
             return StepDecision.goToMulti(
-                    StepMovement.of(processTimeout, null),
-                    StepMovement.of(reminder, null));
+                    StepMovement.of(ProcessTimeout.class, null),
+                    StepMovement.of(Reminder.class, null));
         }
     }
 
@@ -140,7 +140,7 @@ public class ReminderFlow implements Flow<Void> {
             }
 
             myService.sendEmail("Reminder:xxx please respond", "Hello xxx, ...");
-            return StepDecision.goTo(reminder, null);
+            return StepDecision.goTo(Reminder.class, null);
         }
     }
 }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/resettabletimer/ResettableTimerFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/resettabletimer/ResettableTimerFlow.java
@@ -76,9 +76,9 @@ public class ResettableTimerFlow implements Flow<Void> {
         @Override
         public StepDecision execute(final Context context, final Void input) {
             if (context.hasTimerFired()) {
-                return StepDecision.goTo(timerExpired, null);
+                return StepDecision.goTo(TimerExpired.class, null);
             }
-            return StepDecision.goTo(resettableTimer, null);
+            return StepDecision.goTo(ResettableTimerStep.class, null);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/scalableparallel/ParentFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/scalableparallel/ParentFlow.java
@@ -116,7 +116,7 @@ public class ParentFlow implements Flow<BatchEnqueueRequest> {
             for (final String uuid : initRequest.list) {
                 taskQueue.publish(context, uuid);
             }
-            return StepDecision.goTo(loopForNextMessage, null);
+            return StepDecision.goTo(LoopForNextMessage.class, null);
         }
     }
 
@@ -193,10 +193,10 @@ public class ParentFlow implements Flow<BatchEnqueueRequest> {
             if (newWaitList.isEmpty()) {
                 return StepDecision.forceCompleteIfChannelsEmpty(
                         null,
-                        StepMovement.of(loopForNextMessage, null),
+                        StepMovement.of(LoopForNextMessage.class, null),
                         taskQueue);
             }
-            return StepDecision.goTo(loopForNextMessage, null);
+            return StepDecision.goTo(LoopForNextMessage.class, null);
         }
     }
 }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/timeout/FlowGracefulTimeout.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/timeout/FlowGracefulTimeout.java
@@ -54,8 +54,8 @@ public class FlowGracefulTimeout implements Flow<Boolean> {
         @Override
         public StepDecision execute(final Context context, final Boolean workflowSuccessful) {
             return StepDecision.goToMulti(
-                    StepMovement.of(timeout, null),
-                    StepMovement.of(task, workflowSuccessful));
+                    StepMovement.of(Timeout.class, null),
+                    StepMovement.of(Task.class, workflowSuccessful));
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/waitforstatecompletion/WaitForStateCompletionFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/waitforstatecompletion/WaitForStateCompletionFlow.java
@@ -83,7 +83,7 @@ public class WaitForStateCompletionFlow implements Flow<JobSeekerData> {
                 throw new RuntimeException(e);
             }
             jobSeekerData.set(context, input);
-            return StepDecision.goTo(updateExternalSystem, input);
+            return StepDecision.goTo(UpdateExternalSystem.class, input);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/attribute/AttributeFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/attribute/AttributeFlow.java
@@ -49,7 +49,7 @@ public class AttributeFlow implements Flow<String> {
                     String.class,
                     new AttributeIndex(AttributeIndex.Type.KEYWORD, "OrderProgress"));
     private final FlowConfig attributeStoreConfig = FlowConfig.newBuilder()
-            .attributeStoreName("profiles")
+            .attributeStoreNames(java.util.Collections.singletonList("profiles"))
             .build();
     private final AttributeStep start = new AttributeStep();
 

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/attribute/AttributeFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/attribute/AttributeFlow.java
@@ -32,6 +32,7 @@ import io.superdurable.dex.StepDecision;
 import io.superdurable.dex.StepList;
 import io.superdurable.dex.StepOptions;
 import io.superdurable.dex.Wait;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -49,7 +50,7 @@ public class AttributeFlow implements Flow<String> {
                     String.class,
                     new AttributeIndex(AttributeIndex.Type.KEYWORD, "OrderProgress"));
     private final FlowConfig attributeStoreConfig = FlowConfig.newBuilder()
-            .attributeStoreNames(java.util.List.of("profiles"))
+            .attributeStoreNames(List.of("profiles"))
             .build();
     private final AttributeStep start = new AttributeStep();
 

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/attribute/AttributeFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/attribute/AttributeFlow.java
@@ -49,7 +49,7 @@ public class AttributeFlow implements Flow<String> {
                     String.class,
                     new AttributeIndex(AttributeIndex.Type.KEYWORD, "OrderProgress"));
     private final FlowConfig attributeStoreConfig = FlowConfig.newBuilder()
-            .attributeStoreNames(java.util.Collections.singletonList("profiles"))
+            .attributeStoreNames(java.util.List.of("profiles"))
             .build();
     private final AttributeStep start = new AttributeStep();
 

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/durability/DurabilityFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/durability/DurabilityFlow.java
@@ -56,9 +56,9 @@ public final class DurabilityFlow implements Flow<String> {
         @Override
         public StepDecision execute(final Context context, final String mode) {
             if ("async".equals(mode)) {
-                return StepDecision.goTo(asyncWork, mode);
+                return StepDecision.goTo(AsyncWorkStep.class, mode);
             }
-            return StepDecision.goTo(syncWork, mode);
+            return StepDecision.goTo(SyncWorkStep.class, mode);
         }
     }
 
@@ -70,7 +70,7 @@ public final class DurabilityFlow implements Flow<String> {
 
         @Override
         public StepDecision execute(final Context context, final String mode) {
-            return StepDecision.goTo(finish, "sync:" + mode);
+            return StepDecision.goTo(FinishDurabilityStep.class, "sync:" + mode);
         }
 
         @Override
@@ -89,7 +89,7 @@ public final class DurabilityFlow implements Flow<String> {
 
         @Override
         public StepDecision execute(final Context context, final String mode) {
-            return StepDecision.goTo(finish, "async:" + mode);
+            return StepDecision.goTo(FinishDurabilityStep.class, "async:" + mode);
         }
 
         @Override

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/flow/ExampleFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/flow/ExampleFlow.java
@@ -72,7 +72,7 @@ public class ExampleFlow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
-            return StepDecision.goTo(finishStep, input + 1);
+            return StepDecision.goTo(FinishStep.class, input + 1);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/optionsoverride/OptionsOverrideFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/optionsoverride/OptionsOverrideFlow.java
@@ -58,7 +58,7 @@ public final class OptionsOverrideFlow implements Flow<String> {
                     .build();
             final String payload = input + "_state1";
             return StepDecision.goToMulti(
-                    StepMovement.of(second, payload, override));
+                    StepMovement.of(OverrideSecondStep.class, payload, override));
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/proceedonwaitfailure/ProceedOnWaitFailureFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/proceedonwaitfailure/ProceedOnWaitFailureFlow.java
@@ -67,7 +67,7 @@ public final class ProceedOnWaitFailureFlow implements Flow<String> {
             if (!context.waitForMethodFailed()) {
                 throw new IllegalStateException("waitFor failure was not reported");
             }
-            return StepDecision.goTo(finish, input + "_recovered");
+            return StepDecision.goTo(FinishStep.class, input + "_recovered");
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/rpc/RpcFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/rpc/RpcFlow.java
@@ -52,7 +52,7 @@ public class RpcFlow implements Flow<Integer> {
     public RPCResult<String> trigger(final Context context, final String input) {
         data.set(context, input);
         exampleCh.publish(context, null);
-        return RPCResult.of(input, StepMovement.of(exampleStep, input));
+        return RPCResult.of(input, StepMovement.of(ExampleStep.class, input));
     }
 
     final class RpcWaitStep implements Step<Integer> {
@@ -68,7 +68,7 @@ public class RpcFlow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
-            return StepDecision.goTo(complete, 0);
+            return StepDecision.goTo(RpcCompleteStep.class, 0);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/step/StepFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/step/StepFlow.java
@@ -55,7 +55,7 @@ public final class StepFlow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
-            return StepDecision.goTo(second, input + 1);
+            return StepDecision.goTo(StepSecond.class, input + 1);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/stepdecision/StepDecisionFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/stepdecision/StepDecisionFlow.java
@@ -80,14 +80,14 @@ public final class StepDecisionFlow implements Flow<String> {
                     return StepDecision.gracefulComplete("done");
                 case "dead-end":
                     return StepDecision.goToMulti(
-                            StepMovement.of(branchWorker, "left"),
-                            StepMovement.of(branchWorker, "right"));
+                            StepMovement.of(BranchWorkerStep.class, "left"),
+                            StepMovement.of(BranchWorkerStep.class, "right"));
                 default:
                     final Quote quote = new Quote("winner", 9);
                     return StepDecision.goToMulti(
-                            StepMovement.of(carrierA, new Quote("A", 10)),
-                            StepMovement.of(carrierB, new Quote("B", 12)),
-                            StepMovement.of(winner, quote));
+                            StepMovement.of(CarrierAStep.class, new Quote("A", 10)),
+                            StepMovement.of(CarrierBStep.class, new Quote("B", 12)),
+                            StepMovement.of(WinnerStep.class, quote));
             }
         }
     }
@@ -146,8 +146,8 @@ public final class StepDecisionFlow implements Flow<String> {
 
         @Override
         public StepDecision execute(final Context context, final Quote quote) {
-            return StepDecision.goTo(recordQuote, quote)
-                    .withCancelingSteps(carrierA, carrierB);
+            return StepDecision.goTo(RecordQuoteStep.class, quote)
+                    .withCancelingSteps(CarrierAStep.class, CarrierBStep.class);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/products/engagement/EngagementFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/engagement/EngagementFlow.java
@@ -95,7 +95,7 @@ public class EngagementFlow implements Flow<EngagementInput> {
         updateStatus(context, Status.DECLINED, note);
         return RPCResult.of(
                 Status.DECLINED,
-                StepMovement.of(notifyExternalSystem, Status.DECLINED));
+                StepMovement.of(NotifyExternalSystem.class, Status.DECLINED));
     }
 
     @RPC
@@ -110,7 +110,7 @@ public class EngagementFlow implements Flow<EngagementInput> {
         completeProcess.publish(context, null);
         return RPCResult.of(
                 Status.ACCEPTED,
-                StepMovement.of(notifyExternalSystem, Status.ACCEPTED));
+                StepMovement.of(NotifyExternalSystem.class, Status.ACCEPTED));
     }
 
     private EngagementDescription describeEngagement(final Context context) {
@@ -148,9 +148,9 @@ public class EngagementFlow implements Flow<EngagementInput> {
             lastUpdateTimestamp.set(context, System.currentTimeMillis());
             notes.set(context, input.notes);
             return StepDecision.goToMulti(
-                    StepMovement.of(processTimeout, null),
-                    StepMovement.of(reminder, null),
-                    StepMovement.of(notifyExternalSystem, Status.INITIATED));
+                    StepMovement.of(ProcessTimeout.class, null),
+                    StepMovement.of(Reminder.class, null),
+                    StepMovement.of(NotifyExternalSystem.class, Status.INITIATED));
         }
     }
 
@@ -211,7 +211,7 @@ public class EngagementFlow implements Flow<EngagementInput> {
                     seekerId,
                     "Reminder: please respond",
                     "Please respond to the engagement.");
-            return StepDecision.goTo(reminder, null);
+            return StepDecision.goTo(Reminder.class, null);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/products/jobpost/JobPostFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/jobpost/JobPostFlow.java
@@ -85,7 +85,7 @@ public class JobPostFlow implements Flow<Void> {
         if (input.notes != null) {
             notes.set(context, input.notes);
         }
-        return RPCResult.of(null, StepMovement.of(externalUpdate, null));
+        return RPCResult.of(null, StepMovement.of(ExternalUpdate.class, null));
     }
 
     private JobInfo readJobInfo(final Context context) {

--- a/examples/java/src/main/java/io/superdurable/dex/products/microservices/OrchestrationFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/microservices/OrchestrationFlow.java
@@ -77,8 +77,8 @@ public class OrchestrationFlow implements Flow<String> {
             service.callAPI1(input);
             data.set(context, input);
             return StepDecision.goToMulti(
-                    StepMovement.of(callAPI2, null),
-                    StepMovement.of(callAPI3, null));
+                    StepMovement.of(CallAPI2.class, null),
+                    StepMovement.of(CallAPI3.class, null));
         }
     }
 
@@ -111,7 +111,7 @@ public class OrchestrationFlow implements Flow<String> {
             final String value = data.get(context);
             service.callAPI3(value);
             if (context.hasTimerFired()) {
-                return StepDecision.goTo(callAPI4, null);
+                return StepDecision.goTo(CallAPI4.class, null);
             }
             return StepDecision.gracefulComplete(value);
         }

--- a/examples/java/src/main/java/io/superdurable/dex/products/moneytransfer/MoneyTransferFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/moneytransfer/MoneyTransferFlow.java
@@ -58,7 +58,7 @@ public class MoneyTransferFlow implements Flow<TransferRequest> {
         return StepOptions.newBuilder()
                 .executeRetry(RetryPolicy.newBuilder().totalDuration(totalDuration).build())
                 .onExecuteFailureProceedTo(
-                        compensate,
+                        Compensate.class,
                         StepOptions.newBuilder()
                                 .executeRetry(RetryPolicy.newBuilder()
                                         .totalDuration(Duration.ofHours(24))
@@ -78,7 +78,7 @@ public class MoneyTransferFlow implements Flow<TransferRequest> {
             if (!service.checkBalance(request.fromAccount, request.amount)) {
                 return StepDecision.forceFail("insufficient funds");
             }
-            return StepDecision.goTo(createDebitMemo, request);
+            return StepDecision.goTo(CreateDebitMemo.class, request);
         }
     }
 
@@ -96,7 +96,7 @@ public class MoneyTransferFlow implements Flow<TransferRequest> {
         @Override
         public StepDecision execute(final Context context, final TransferRequest request) {
             service.createDebitMemo(request.fromAccount, request.amount, request.notes);
-            return StepDecision.goTo(debit, request);
+            return StepDecision.goTo(Debit.class, request);
         }
     }
 
@@ -114,7 +114,7 @@ public class MoneyTransferFlow implements Flow<TransferRequest> {
         @Override
         public StepDecision execute(final Context context, final TransferRequest request) {
             service.debit(request.fromAccount, request.amount);
-            return StepDecision.goTo(createCreditMemo, request);
+            return StepDecision.goTo(CreateCreditMemo.class, request);
         }
     }
 
@@ -132,7 +132,7 @@ public class MoneyTransferFlow implements Flow<TransferRequest> {
         @Override
         public StepDecision execute(final Context context, final TransferRequest request) {
             service.createCreditMemo(request.toAccount, request.amount, request.notes);
-            return StepDecision.goTo(credit, request);
+            return StepDecision.goTo(Credit.class, request);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/products/orderprocessing/OrderProcessingFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/orderprocessing/OrderProcessingFlow.java
@@ -110,7 +110,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
         public StepDecision execute(final Context context, final OrderRequest order) {
             service.chargeUser(order.email, order.customerId, order.amount);
             orderStatus.set(context, "charged");
-            return StepDecision.goTo(ship, order);
+            return StepDecision.goTo(ShipStep.class, order);
         }
     }
 
@@ -141,7 +141,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
                             .totalDuration(Duration.ofSeconds(3))
                             .build())
                     .onExecuteFailureProceedTo(
-                            refund,
+                            RefundStep.class,
                             StepOptions.newBuilder()
                                     .executeRetry(RetryPolicy.newBuilder()
                                             // .totalDuration(Duration.ofHours(1))
@@ -165,7 +165,7 @@ public class OrderProcessingFlow implements Flow<OrderRequest> {
                         order.email,
                         "Reminder: approve shipment",
                         "Please approve or provide a tracking number.");
-                return StepDecision.goTo(this, order);
+                return StepDecision.goTo(ShipStep.class, order);
             }
             service.shipItem(order.orderId, order.testFailAtShipping);
             orderStatus.set(context, "shipped");

--- a/examples/java/src/main/java/io/superdurable/dex/products/polling/PollingFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/polling/PollingFlow.java
@@ -77,8 +77,8 @@ public class PollingFlow implements Flow<Integer> {
         public StepDecision execute(final Context context, final Integer maximumPolls) {
             currentPolls.set(context, 0);
             return StepDecision.goToMulti(
-                    StepMovement.of(poll, maximumPolls),
-                    StepMovement.of(waitForTasks, null));
+                    StepMovement.of(Poll.class, maximumPolls),
+                    StepMovement.of(WaitForTasks.class, null));
         }
     }
 
@@ -122,7 +122,7 @@ public class PollingFlow implements Flow<Integer> {
                 return StepDecision.deadEnd();
             }
             currentPolls.set(context, polls + 1);
-            return StepDecision.goTo(poll, maximumPolls);
+            return StepDecision.goTo(Poll.class, maximumPolls);
         }
     }
 }

--- a/examples/java/src/main/java/io/superdurable/dex/products/shortlistcandidates/EmployerOptInFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/shortlistcandidates/EmployerOptInFlow.java
@@ -59,7 +59,7 @@ public class EmployerOptInFlow implements Flow<EmployerOptInInput> {
 
     @RPC
     public RPCResult<Void> optOut(final Context context) {
-        return RPCResult.of(null, StepMovement.of(optOut, null));
+        return RPCResult.of(null, StepMovement.of(OptOut.class, null));
     }
 
     final class OptIn implements Step<EmployerOptInInput> {

--- a/examples/java/src/main/java/io/superdurable/dex/products/shortlistcandidates/ShortlistFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/shortlistcandidates/ShortlistFlow.java
@@ -105,7 +105,7 @@ public class ShortlistFlow implements Flow<ShortlistInput> {
             employerId.set(context, input.employerId);
             candidateId.set(context, input.candidateId);
             emailSentTimestamp.set(context, 0L);
-            return StepDecision.goTo(sendEmail, null);
+            return StepDecision.goTo(SendEmail.class, null);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/products/signup/UserSignupFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/signup/UserSignupFlow.java
@@ -78,7 +78,7 @@ public class UserSignupFlow implements Flow<SignupForm> {
             form.set(context, input);
             status.set(context, "waiting");
             service.sendEmail(input.email, "please verify the signup", "content");
-            return StepDecision.goTo(verifyStep, null);
+            return StepDecision.goTo(Verify.class, null);
         }
     }
 
@@ -103,7 +103,7 @@ public class UserSignupFlow implements Flow<SignupForm> {
                 return StepDecision.gracefulComplete("done");
             }
             service.sendEmail(signupForm.email, "reminder", "please verify your email");
-            return StepDecision.goTo(verifyStep, null);
+            return StepDecision.goTo(Verify.class, null);
         }
     }
 }

--- a/examples/java/src/main/java/io/superdurable/dex/products/subscription/SubscriptionFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/subscription/SubscriptionFlow.java
@@ -88,9 +88,9 @@ public class SubscriptionFlow implements Flow<Customer> {
         public StepDecision execute(final Context context, final Customer customer) {
             customerDetails.set(context, customer);
             return StepDecision.goToMulti(
-                    StepMovement.of(trial, null),
-                    StepMovement.of(cancel, null),
-                    StepMovement.of(updateChargeAmountStep, null));
+                    StepMovement.of(Trial.class, null),
+                    StepMovement.of(Cancel.class, null),
+                    StepMovement.of(UpdateChargeAmount.class, null));
         }
     }
 
@@ -110,7 +110,7 @@ public class SubscriptionFlow implements Flow<Customer> {
         @Override
         public StepDecision execute(final Context context, final Void input) {
             billingPeriodNumber.set(context, 0);
-            return StepDecision.goTo(chargeCurrentBill, null);
+            return StepDecision.goTo(ChargeCurrentBill.class, null);
         }
     }
 
@@ -143,7 +143,7 @@ public class SubscriptionFlow implements Flow<Customer> {
                 return StepDecision.forceComplete("subscription ended");
             }
             SubscriptionBilling.chargeCurrentPeriod(customer, service);
-            return StepDecision.goTo(chargeCurrentBill, null);
+            return StepDecision.goTo(ChargeCurrentBill.class, null);
         }
     }
 
@@ -184,7 +184,7 @@ public class SubscriptionFlow implements Flow<Customer> {
             final Customer customer = customerDetails.get(context);
             SubscriptionBilling.applyChargeAmount(customer, amount);
             customerDetails.set(context, customer);
-            return StepDecision.goTo(updateChargeAmountStep, null);
+            return StepDecision.goTo(UpdateChargeAmount.class, null);
         }
     }
 }

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,6 +1,6 @@
 # Dex Python examples
 
-These examples target [`dex-python-sdk==0.2.0`](https://pypi.org/project/dex-python-sdk/0.2.0/)
+These examples target [`dex-python-sdk==0.2.1`](https://pypi.org/project/dex-python-sdk/ 0.2.1/)
 (`import dex`). Requires Python 3.11+.
 
 The primary sample process hosts one asyncio `AsyncWorker` on `127.0.0.1:8803` and a

--- a/examples/python/dex_examples/patterns/cron/cron_schedule_flow.py
+++ b/examples/python/dex_examples/patterns/cron/cron_schedule_flow.py
@@ -114,7 +114,7 @@ class _WaitForSchedule(Step[_ScheduleState]):
         if state.remaining_runs == 1:
             return graceful_complete()
         return go_to(
-            self,
+            _WaitForSchedule,
             _ScheduleState(state.interval, state.remaining_runs - 1),
         )
 

--- a/examples/python/dex_examples/patterns/cron/cron_schedule_flow.py
+++ b/examples/python/dex_examples/patterns/cron/cron_schedule_flow.py
@@ -79,16 +79,13 @@ class _RunInput:
 
 
 class _Start(Step[CronScheduleInput]):
-    def __init__(self, schedule: _WaitForSchedule) -> None:
-        self.schedule = schedule
-
     def execute(
         self, context: Context, input: CronScheduleInput
     ) -> StepDecision:
         del context
         if input.run_count <= 0 or input.interval.value <= 0:
             return force_fail("interval value and run count must be positive")
-        return go_to(self.schedule, _ScheduleState(input.interval, input.run_count))
+        return go_to(_WaitForSchedule, _ScheduleState(input.interval, input.run_count))
 
 
 class _WaitForSchedule(Step[_ScheduleState]):
@@ -96,11 +93,9 @@ class _WaitForSchedule(Step[_ScheduleState]):
         self,
         trigger: Channel[None],
         skip: Channel[None],
-        run: _Run,
     ) -> None:
         self.trigger = trigger
         self.skip = skip
-        self.run = run
 
     def wait_for(self, context: Context, state: _ScheduleState) -> Wait:
         del context
@@ -129,11 +124,11 @@ class _WaitForSchedule(Step[_ScheduleState]):
             is_final=state.remaining_runs == 1,
         )
         if run_input.is_final:
-            return go_to(self.run, run_input)
+            return go_to(_Run, run_input)
         return go_to_multi(
-            StepMovement.of(self.run, run_input),
+            StepMovement.of(_Run, run_input),
             StepMovement.of(
-                self,
+                _WaitForSchedule,
                 _ScheduleState(state.interval, state.remaining_runs - 1),
             ),
         )
@@ -150,8 +145,8 @@ class CronScheduleFlow(Flow[CronScheduleInput]):
         self.trigger = Channel[None]("cron-schedule-trigger", type(None))
         self.skip = Channel[None]("cron-schedule-skip", type(None))
         self.run = _Run()
-        self.schedule = _WaitForSchedule(self.trigger, self.skip, self.run)
-        self.start = _Start(self.schedule)
+        self.schedule = _WaitForSchedule(self.trigger, self.skip)
+        self.start = _Start()
 
     def get_steps(self) -> StepList[CronScheduleInput]:
         return StepList.start_step(self.start).other_steps(self.schedule, self.run)

--- a/examples/python/dex_examples/patterns/drain-channels/internal/drain_internal_channels_flow.py
+++ b/examples/python/dex_examples/patterns/drain-channels/internal/drain_internal_channels_flow.py
@@ -80,8 +80,8 @@ class ProcessData(Step[str]):
         )
 
         if execution_count <= 3:
-            return go_to(self, input)
-        return go_to(self.finalize, None)
+            return go_to(ProcessData, input)
+        return go_to(Finalize, None)
 
 
 class UpsertMongoRecord(Step[None]):
@@ -111,7 +111,7 @@ class UpsertMongoRecord(Step[None]):
 
         if document.final_command:
             return graceful_complete()
-        return go_to(self, None)
+        return go_to(UpsertMongoRecord, None)
 
 
 class Init(Step[str]):
@@ -128,8 +128,8 @@ class Init(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
         self.execution_counter.set(context, 0)
         return go_to_multi(
-            StepMovement.of(self.upsert_mongo_record, None),
-            StepMovement.of(self.process_data, input),
+            StepMovement.of(UpsertMongoRecord, None),
+            StepMovement.of(ProcessData, input),
         )
 
 

--- a/examples/python/dex_examples/patterns/drain-channels/signal/drain_signal_channels_flow.py
+++ b/examples/python/dex_examples/patterns/drain-channels/signal/drain_signal_channels_flow.py
@@ -61,7 +61,7 @@ class ProcessSignal(Step[str]):
 
         return force_complete_if_channels_empty(
             None,
-            StepMovement.of(self, None),
+            StepMovement.of(ProcessSignal, None),
             self.queue_signal_channel,
         )
 

--- a/examples/python/dex_examples/patterns/entity-store/controller.py
+++ b/examples/python/dex_examples/patterns/entity-store/controller.py
@@ -55,7 +55,7 @@ def create_entity_store_blueprint(app_state: ExampleApp) -> Blueprint:
         options = (
             StartFlowOptions(
                 timeout=timedelta(hours=1),
-                config_override=FlowConfig(attribute_store_name=STORE_NAME),
+                config_override=FlowConfig(attribute_store_names=[STORE_NAME]),
             )
             .with_attribute(app_state.user_profile.display_name, profile.display_name)
             .with_attribute(app_state.user_profile.email, profile.email)

--- a/examples/python/dex_examples/patterns/interruptible/interruptible_execution_flow.py
+++ b/examples/python/dex_examples/patterns/interruptible/interruptible_execution_flow.py
@@ -66,7 +66,7 @@ class WorkAExecution(Step[WorkJobParametersInput]):
             f"Doing job {input.progress}"
         )
         return go_to(
-            self,
+            WorkAExecution,
             WorkJobParametersInput(input.job_upper_bound, input.progress + 1),
         )
 
@@ -97,7 +97,7 @@ class WorkNExecution(Step[WorkJobParametersInput]):
             f"Processing job {input.progress}"
         )
         return go_to(
-            self,
+            WorkNExecution,
             WorkJobParametersInput(input.job_upper_bound, input.progress + 1),
         )
 
@@ -117,8 +117,8 @@ class Init(Step[None]):
         del context, input
         parameters = WorkJobParametersInput(15, 1)
         return go_to_multi(
-            StepMovement.of(self.work_a_execution, parameters),
-            StepMovement.of(self.work_n_execution, parameters),
+            StepMovement.of(WorkAExecution, parameters),
+            StepMovement.of(WorkNExecution, parameters),
         )
 
 

--- a/examples/python/dex_examples/patterns/intervention/manual_intervention_flow.py
+++ b/examples/python/dex_examples/patterns/intervention/manual_intervention_flow.py
@@ -16,8 +16,6 @@
 
 from __future__ import annotations
 
-from typing import Callable
-
 from dex import (
     Attribute,
     Channel,
@@ -46,12 +44,10 @@ class Final(Step[None]):
 class GetData(Step[bool]):
     def __init__(
         self,
-        error_provider: Callable[[], Error],
         final: Final,
         data_channel: Channel[str],
         number_of_retries: Attribute[int],
     ) -> None:
-        self.error_provider = error_provider
         self.final = final
         self.data_channel = data_channel
         self.number_of_retries = number_of_retries
@@ -67,8 +63,8 @@ class GetData(Step[bool]):
         try:
             self._pretend_api_call(context)
         except ValueError:
-            return go_to(self.error_provider(), None)
-        return go_to(self.final, None)
+            return go_to(Error, None)
+        return go_to(Final, None)
 
     def _pretend_api_call(self, context: Context) -> None:
         results = self.data_channel.results(context)
@@ -104,8 +100,8 @@ class Error(Step[None]):
             + (self.retry_signal.name if retry else self.skip_signal.name)
         )
         if retry:
-            return go_to(self.get_data, True)
-        return go_to(self.final, None)
+            return go_to(GetData, True)
+        return go_to(Final, None)
 
 
 class Init(Step[None]):
@@ -116,7 +112,7 @@ class Init(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
         del input
         self.number_of_retries.set(context, 0)
-        return go_to(self.get_data, False)
+        return go_to(GetData, False)
 
 
 class ManualInterventionFlow(Flow[None]):
@@ -133,7 +129,6 @@ class ManualInterventionFlow(Flow[None]):
     def __init__(self) -> None:
         self.final = Final(self.number_of_retries)
         self.get_data = GetData(
-            lambda: self.error,
             self.final,
             self.data_channel,
             self.number_of_retries,

--- a/examples/python/dex_examples/patterns/parallel/parallel_states_with_await_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/parallel_states_with_await_flow.py
@@ -80,12 +80,12 @@ class Starting(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
         movements: list[StepMovement[Any]] = [
-            StepMovement.of(self.await_all_users_notified, input)
+            StepMovement.of(AwaitAllUsersNotified, input)
         ]
         for index in range(1, input + 1):
             movements.append(
                 StepMovement.of(
-                    self.notify_user,
+                    NotifyUser,
                     JobSeeker(str(index), "jobseeker@indeed.com", "0987654321"),
                 )
             )

--- a/examples/python/dex_examples/patterns/parallel/simple_parallel_states_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/simple_parallel_states_flow.py
@@ -57,8 +57,8 @@ class Init(Step[JobSeeker]):
     def execute(self, context: Context, input: JobSeeker) -> StepDecision:
         del context
         return go_to_multi(
-            StepMovement.of(self.send_text_message, input.phone_number),
-            StepMovement.of(self.send_email, input.email),
+            StepMovement.of(SendTextMessage, input.phone_number),
+            StepMovement.of(SendEmail, input.email),
         )
 
 

--- a/examples/python/dex_examples/patterns/parent-child/parent_flow_v2.py
+++ b/examples/python/dex_examples/patterns/parent-child/parent_flow_v2.py
@@ -51,10 +51,8 @@ class AwaitChildWorkflowCompletion(Step[WaitForChildInput]):
     def __init__(
         self,
         client_provider: Callable[[], AsyncClient],
-        loop_for_next_task_provider: Callable[[], LoopForNextTask],
     ) -> None:
         self.client_provider = client_provider
-        self.loop_for_next_task_provider = loop_for_next_task_provider
 
     def wait_for(self, context: Context, input: WaitForChildInput) -> Wait:
         del context
@@ -71,13 +69,13 @@ class AwaitChildWorkflowCompletion(Step[WaitForChildInput]):
             )
         except LongPollTimeoutError:
             return go_to(
-                self,
+                AwaitChildWorkflowCompletion,
                 WaitForChildInput(
                     input.child_wf_id,
                     min(input.timer_seconds * 2, MAX_WAIT_SECONDS),
                 ),
             )
-        return go_to(self.loop_for_next_task_provider(), None)
+        return go_to(LoopForNextTask, None)
 
 
 class StartChildWorkflow(Step[int]):
@@ -106,7 +104,7 @@ class StartChildWorkflow(Step[int]):
         except FlowAlreadyStartedError:
             print("ignore this error because it is already started")
         return go_to(
-            self.await_child_workflow_completion,
+            AwaitChildWorkflowCompletion,
             WaitForChildInput(child_workflow_id, 1),
         )
 
@@ -127,7 +125,7 @@ class LoopForNextTask(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
         del input
         request = self.task_queue.results(context)[0]
-        return go_to(self.start_child_workflow, request)
+        return go_to(StartChildWorkflow, request)
 
 
 class Init(Step[int]):
@@ -145,7 +143,7 @@ class Init(Step[int]):
 
         return go_to_multi(
             *(
-                StepMovement.of(self.loop_for_next_task, None)
+                StepMovement.of(LoopForNextTask, None)
                 for _ in range(CONCURRENCY_PER_PARENT_WORKFLOW)
             )
         )
@@ -163,7 +161,6 @@ class ParentFlowV2(Flow[int]):
     ) -> None:
         self.await_child_workflow_completion = AwaitChildWorkflowCompletion(
             client_provider,
-            lambda: self.loop_for_next_task,
         )
         self.start_child_workflow = StartChildWorkflow(
             client_provider,

--- a/examples/python/dex_examples/patterns/polling/backoff_polling_flow.py
+++ b/examples/python/dex_examples/patterns/polling/backoff_polling_flow.py
@@ -62,7 +62,7 @@ class ReadExternalDep(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
         result = self.service.attempt_external_api_call("Read for BackoffPollingFlow")
-        return go_to(self.polling_complete, result)
+        return go_to(PollingComplete, result)
 
 
 class BackoffPollingFlow(Flow[None]):

--- a/examples/python/dex_examples/patterns/polling/simple_polling_flow.py
+++ b/examples/python/dex_examples/patterns/polling/simple_polling_flow.py
@@ -50,8 +50,8 @@ class SimplePolling(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
         if self._is_system_ready():
-            return go_to(self.simple_polling_complete, None)
-        return go_to(self, None)
+            return go_to(SimplePollingComplete, None)
+        return go_to(SimplePolling, None)
 
     @staticmethod
     def _is_system_ready() -> bool:

--- a/examples/python/dex_examples/patterns/recovery/README.md
+++ b/examples/python/dex_examples/patterns/recovery/README.md
@@ -35,7 +35,7 @@ def execute(self, context: Context, input: None) -> StepDecision:
         self._do_execute()
     except RetriableError:
         if context.attempt > 5:
-            return go_to(self.failure_recovery, None)
+            return go_to(FailureRecovery, None)
         raise
 ```
 
@@ -45,7 +45,7 @@ With it, the step body stays clean and the policy lives in the options:
 def get_step_options(self) -> StepOptions:
     return StepOptions(
         execute_retry=RetryPolicy(maximum_attempts=5),
-    ).on_execute_failure_proceed_to(self.failure_recovery)
+    ).on_execute_failure_proceed_to(FailureRecovery)
 
 def execute(self, context: Context, input: None) -> StepDecision:
     return self._do_execute()

--- a/examples/python/dex_examples/patterns/recovery/failure_recovery_flow.py
+++ b/examples/python/dex_examples/patterns/recovery/failure_recovery_flow.py
@@ -93,7 +93,7 @@ class VoidPaymentRecovery(Step[int]):
         workflow = self.workflow_input.get(context)
         item_value = self.database.get_item_price(workflow.item_name)
         self.payment_processor.void_payment(workflow.requested_quantity * item_value)
-        return go_to(self.update_quantity_recovery, workflow)
+        return go_to(UpdateQuantityRecovery, workflow)
 
 
 class ChargeForItems(Step[int]):
@@ -112,7 +112,7 @@ class ChargeForItems(Step[int]):
     def get_step_options(self) -> StepOptions:
         return StepOptions(
             execute_retry=RetryPolicy(maximum_attempts=5)
-        ).on_execute_failure_proceed_to(self.void_payment_recovery)
+        ).on_execute_failure_proceed_to(VoidPaymentRecovery)
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del input
@@ -138,7 +138,7 @@ class UpdateItemQuantity(Step[FailureRecoveryWorkflowInput]):
     def get_step_options(self) -> StepOptions:
         return StepOptions(
             execute_retry=RetryPolicy(maximum_attempts=5)
-        ).on_execute_failure_proceed_to(self.update_quantity_recovery)
+        ).on_execute_failure_proceed_to(UpdateQuantityRecovery)
 
     def execute(
         self,
@@ -147,7 +147,7 @@ class UpdateItemQuantity(Step[FailureRecoveryWorkflowInput]):
     ) -> StepDecision:
         self.workflow_input.set(context, input)
         self.database.reduce_quantity(input.item_name, input.requested_quantity)
-        return go_to(self.charge_for_items, input.requested_quantity)
+        return go_to(ChargeForItems, input.requested_quantity)
 
 
 class FailureRecoveryFlow(Flow[FailureRecoveryWorkflowInput]):

--- a/examples/python/dex_examples/patterns/reminders/reminder_flow.py
+++ b/examples/python/dex_examples/patterns/reminders/reminder_flow.py
@@ -102,7 +102,7 @@ class Reminder(Step[None]):
             return force_complete("done - opt out")
 
         self.service.send_email("Reminder:xxx please respond", "Hello xxx, ...")
-        return go_to(self, None)
+        return go_to(Reminder, None)
 
 
 class Init(Step[None]):
@@ -120,8 +120,8 @@ class Init(Step[None]):
         del input
         self.status.set(context, Status.INITIATED.value)
         return go_to_multi(
-            StepMovement.of(self.process_timeout, None),
-            StepMovement.of(self.reminder, None),
+            StepMovement.of(ProcessTimeout, None),
+            StepMovement.of(Reminder, None),
         )
 
 

--- a/examples/python/dex_examples/patterns/resettable-timer/resettable_timer_flow.py
+++ b/examples/python/dex_examples/patterns/resettable-timer/resettable_timer_flow.py
@@ -62,8 +62,8 @@ class ResettableTimerStep(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
         del input
         if context.has_timer_fired():
-            return go_to(self.timer_expired, None)
-        return go_to(self, None)
+            return go_to(TimerExpired, None)
+        return go_to(ResettableTimerStep, None)
 
 
 class ResettableTimerFlow(Flow[None]):

--- a/examples/python/dex_examples/patterns/resource-control/controller_flow.py
+++ b/examples/python/dex_examples/patterns/resource-control/controller_flow.py
@@ -115,14 +115,14 @@ class LoopForNextRequest(Step[None]):
         self.current_wait_child_wfs.set(context, waiting)
 
         if self.shutdown_requested.get(context):
-            return go_to(self.move_to_another_instance, None)
+            return go_to(MoveToAnotherInstance, None)
         if not waiting:
             return force_complete_if_channels_empty(
                 "done",
-                StepMovement.of(self, None),
+                StepMovement.of(LoopForNextRequest, None),
                 self.request_queue,
             )
-        return go_to(self, None)
+        return go_to(LoopForNextRequest, None)
 
     async def start_child_flow(self, context: Context, request: Request) -> str | None:
         """Returns the child Flow ID to wait for, or None when another run owns it."""
@@ -165,7 +165,7 @@ class Init(Step[Request]):
     def execute(self, context: Context, input: Request) -> StepDecision:
         self.request_queue.publish(context, input)
         self.current_wait_child_wfs.set(context, [])
-        return go_to(self.loop_for_next_request, None)
+        return go_to(LoopForNextRequest, None)
 
 
 class ControllerFlow(Flow[Request]):

--- a/examples/python/dex_examples/patterns/resource-control/processing_flow.py
+++ b/examples/python/dex_examples/patterns/resource-control/processing_flow.py
@@ -103,7 +103,7 @@ class GpuProcessingComplete(Step[None]):
             f"{self.instance_id.get(context)} by calling the instance API"
         )
         self.status.set(context, STATUS_PROCESSING_COMPLETED)
-        return go_to(self.complete, None)
+        return go_to(Complete, None)
 
 
 class GpuProcessingStart(Step[None]):
@@ -126,7 +126,7 @@ class GpuProcessingStart(Step[None]):
             f"{self.instance_id.get(context)} by calling the instance API"
         )
         self.status.set(context, STATUS_PROCESSING_STARTED)
-        return go_to(self.gpu_processing_complete, None)
+        return go_to(GpuProcessingComplete, None)
 
 
 class ValidationComplete(Step[None]):
@@ -151,7 +151,7 @@ class ValidationComplete(Step[None]):
             f"{self.instance_id.get(context)} by calling the instance API"
         )
         self.status.set(context, STATUS_VALIDATION_COMPLETED)
-        return go_to(self.gpu_processing_start, None)
+        return go_to(GpuProcessingStart, None)
 
 
 class ValidationStart(Step[Request]):
@@ -175,7 +175,7 @@ class ValidationStart(Step[Request]):
             f"{self.instance_id.get(context)} by calling the instance API"
         )
         self.status.set(context, STATUS_VALIDATION_STARTED)
-        return go_to(self.validation_complete, None)
+        return go_to(ValidationComplete, None)
 
 
 class ProcessingFlow(Flow[Request]):

--- a/examples/python/dex_examples/patterns/scalable-parallel/parent_flow.py
+++ b/examples/python/dex_examples/patterns/scalable-parallel/parent_flow.py
@@ -115,10 +115,10 @@ class LoopForNextMessage(Step[None]):
         if not new_wait_list:
             return force_complete_if_channels_empty(
                 None,
-                StepMovement.of(self, None),
+                StepMovement.of(LoopForNextMessage, None),
                 self.task_queue,
             )
-        return go_to(self, None)
+        return go_to(LoopForNextMessage, None)
 
 
 class Init(Step[BatchEnqueueRequest]):
@@ -133,7 +133,7 @@ class Init(Step[BatchEnqueueRequest]):
     def execute(self, context: Context, input: BatchEnqueueRequest) -> StepDecision:
         for uuid in input.items:
             self.task_queue.publish(context, uuid)
-        return go_to(self.loop_for_next_message, None)
+        return go_to(LoopForNextMessage, None)
 
 
 class ParentFlow(Flow[BatchEnqueueRequest]):

--- a/examples/python/dex_examples/patterns/timeout/flow_graceful_timeout.py
+++ b/examples/python/dex_examples/patterns/timeout/flow_graceful_timeout.py
@@ -65,8 +65,8 @@ class Init(Step[bool]):
     def execute(self, context: Context, input: bool) -> StepDecision:
         del context
         return go_to_multi(
-            StepMovement.of(self.timeout, None),
-            StepMovement.of(self.task, input),
+            StepMovement.of(Timeout, None),
+            StepMovement.of(Task, input),
         )
 
 

--- a/examples/python/dex_examples/patterns/wait-for-state-completion/wait_for_state_completion_flow.py
+++ b/examples/python/dex_examples/patterns/wait-for-state-completion/wait_for_state_completion_flow.py
@@ -63,7 +63,7 @@ class PersistData(Step[JobSeekerData]):
     def execute(self, context: Context, input: JobSeekerData) -> StepDecision:
         self.mongo_collection.upsert(input)
         self.job_seeker_data.set(context, input)
-        return go_to(self.update_external_system, input)
+        return go_to(UpdateExternalSystem, input)
 
 
 class WaitForStateCompletionFlow(Flow[JobSeekerData]):

--- a/examples/python/dex_examples/primitives/attribute/attribute_flow.py
+++ b/examples/python/dex_examples/primitives/attribute/attribute_flow.py
@@ -74,7 +74,7 @@ class AttributeFlow(Flow[str]):
         str,
         index=AttributeIndex(IndexType.KEYWORD, "OrderProgress"),
     )
-    attribute_store_config = FlowConfig(attribute_store_name="profiles")
+    attribute_store_config = FlowConfig(attribute_store_names=["profiles"])
 
     def __init__(self) -> None:
         self.start = AttributeStep(self)

--- a/examples/python/dex_examples/primitives/durability/durability_flow.py
+++ b/examples/python/dex_examples/primitives/durability/durability_flow.py
@@ -38,8 +38,8 @@ class RouteDurabilityStep(Step[str]):
     def execute(self, context: Context, mode: str) -> StepDecision:
         del context
         if mode == "async":
-            return go_to(self.flow.async_work, mode)
-        return go_to(self.flow.sync_work, mode)
+            return go_to(AsyncWorkStep, mode)
+        return go_to(SyncWorkStep, mode)
 
 
 class SyncWorkStep(Step[str]):
@@ -51,7 +51,7 @@ class SyncWorkStep(Step[str]):
 
     def execute(self, context: Context, mode: str) -> StepDecision:
         del context
-        return go_to(self.flow.finish, f"sync:{mode}")
+        return go_to(FinishDurabilityStep, f"sync:{mode}")
 
 
 class AsyncWorkStep(Step[str]):
@@ -63,7 +63,7 @@ class AsyncWorkStep(Step[str]):
 
     def execute(self, context: Context, mode: str) -> StepDecision:
         del context
-        return go_to(self.flow.finish, f"async:{mode}")
+        return go_to(FinishDurabilityStep, f"async:{mode}")
 
 
 class FinishDurabilityStep(Step[str]):

--- a/examples/python/dex_examples/primitives/flow/example_flow.py
+++ b/examples/python/dex_examples/primitives/flow/example_flow.py
@@ -51,7 +51,7 @@ class ExampleStep(Step[int]):
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to(self.finish, input + 1)
+        return go_to(FinishStep, input + 1)
 
 
 status = Attribute("status", str)

--- a/examples/python/dex_examples/primitives/options_override/options_override_flow.py
+++ b/examples/python/dex_examples/primitives/options_override/options_override_flow.py
@@ -41,7 +41,7 @@ class OverrideFirstStep(Step[str]):
             wait_for_failure=WaitForFailurePolicy.PROCEED,
         )
         payload = f"{input}_state1"
-        return go_to_multi(StepMovement.of(self.second, payload, options=override))
+        return go_to_multi(StepMovement.of(OverrideSecondStep, payload, options=override))
 
 
 class OverrideSecondStep(Step[str]):

--- a/examples/python/dex_examples/primitives/proceed_on_wait_failure/proceed_on_wait_failure_flow.py
+++ b/examples/python/dex_examples/primitives/proceed_on_wait_failure/proceed_on_wait_failure_flow.py
@@ -54,7 +54,7 @@ class FailingWaitStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
         if not context.wait_for_method_failed():
             raise RuntimeError("waitFor failure was not reported")
-        return go_to(self.finish, f"{input}_recovered")
+        return go_to(FinishStep, f"{input}_recovered")
 
 
 class ProceedOnWaitFailureFlow(Flow[str]):

--- a/examples/python/dex_examples/primitives/rpc/rpc_flow.py
+++ b/examples/python/dex_examples/primitives/rpc/rpc_flow.py
@@ -47,7 +47,7 @@ class RpcWaitStep(Step[int]):
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context, input
-        return go_to(self.second, 0)
+        return go_to(RpcCompleteStep, 0)
 
 
 class RpcCompleteStep(Step[int]):
@@ -81,4 +81,4 @@ class RpcFlow(Flow[int]):
     def trigger(self, context: Context, input: str) -> RPCResult[str]:
         self.data.set(context, input)
         self.example_ch.publish(context, None)
-        return RPCResult(input, next_steps=(StepMovement.of(self.example_step, input),))
+        return RPCResult(input, next_steps=(StepMovement.of(ExampleStep, input),))

--- a/examples/python/dex_examples/primitives/step/step_flow.py
+++ b/examples/python/dex_examples/primitives/step/step_flow.py
@@ -48,7 +48,7 @@ class ExampleStep(Step[int]):
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to(self.second, input + 1)
+        return go_to(StepSecond, input + 1)
 
 
 class StepFlow(Flow[int]):

--- a/examples/python/dex_examples/primitives/step_decision/step_decision_flow.py
+++ b/examples/python/dex_examples/primitives/step_decision/step_decision_flow.py
@@ -49,14 +49,14 @@ class RouteStep(Step[str]):
             return graceful_complete("done")
         if mode == "dead-end":
             return go_to_multi(
-                StepMovement.of(self.flow.branch_worker, "left"),
-                StepMovement.of(self.flow.branch_worker, "right"),
+                StepMovement.of(BranchWorkerStep, "left"),
+                StepMovement.of(BranchWorkerStep, "right"),
             )
         quote = Quote(carrier="winner", price=9)
         return go_to_multi(
-            StepMovement.of(self.flow.carrier_a, Quote(carrier="A", price=10)),
-            StepMovement.of(self.flow.carrier_b, Quote(carrier="B", price=12)),
-            StepMovement.of(self.flow.winner, quote),
+            StepMovement.of(CarrierAStep, Quote(carrier="A", price=10)),
+            StepMovement.of(CarrierBStep, Quote(carrier="B", price=12)),
+            StepMovement.of(WinnerStep, quote),
         )
 
 
@@ -92,8 +92,8 @@ class WinnerStep(Step[Quote]):
 
     def execute(self, context: Context, quote: Quote) -> StepDecision:
         del context
-        return go_to(self.flow.record_quote, quote).with_canceling_steps(
-            self.flow.carrier_a,
+        return go_to(RecordQuoteStep, quote).with_canceling_steps(
+            CarrierAStep,
             self.flow.carrier_b,
         )
 

--- a/examples/python/dex_examples/products/ai-agent-email/ai_agent_flow.py
+++ b/examples/python/dex_examples/products/ai-agent-email/ai_agent_flow.py
@@ -138,9 +138,9 @@ class Schedule(Step[None]):
         del input
         requests = user_input.results(context)
         if not requests:
-            return go_to(self.sending, None)
+            return go_to(Sending, None)
         user_input.publish(context, requests[0])
-        return go_to(self.flow.agent, None)
+        return go_to(Agent, None)
 
 
 class Agent(Step[None]):
@@ -193,8 +193,8 @@ class Agent(Step[None]):
             and self.flow.email_recipient.get(context)
             and self.flow.email_body.get(context)
         ):
-            return go_to(self.schedule, None)
-        return go_to(self, None)
+            return go_to(Schedule, None)
+        return go_to(Agent, None)
 
 
 class Init(Step[None]):
@@ -208,7 +208,7 @@ class Init(Step[None]):
 
         if google_credentials() is None:
             print("no Google credentials, the email will be drafted but not sent")
-        return go_to(self.flow.agent, None)
+        return go_to(Agent, None)
 
 
 class EmailAgentFlow(Flow[None]):

--- a/examples/python/dex_examples/products/engagement/engagement_flow.py
+++ b/examples/python/dex_examples/products/engagement/engagement_flow.py
@@ -86,7 +86,7 @@ class Reminder(Step[None]):
             "Reminder: please respond",
             "Please respond to the engagement.",
         )
-        return go_to(self, None)
+        return go_to(Reminder, None)
 
 
 class ProcessTimeout(Step[None]):
@@ -125,9 +125,9 @@ class Initialize(Step[EngagementInput]):
         self.flow.last_update_timestamp.set(context, current_time_millis())
         self.flow.notes.set(context, input.notes or "")
         return go_to_multi(
-            StepMovement.of(self.flow.process_timeout, None),
-            StepMovement.of(self.flow.reminder, None),
-            StepMovement.of(self.flow.notify_external_system, Status.INITIATED),
+            StepMovement.of(ProcessTimeout, None),
+            StepMovement.of(Reminder, None),
+            StepMovement.of(NotifyExternalSystem, Status.INITIATED),
         )
 
 
@@ -185,7 +185,7 @@ class EngagementFlow(Flow[EngagementInput]):
         return RPCResult(
             Status.DECLINED,
             next_steps=(
-                StepMovement.of(self.notify_external_system, Status.DECLINED),
+                StepMovement.of(NotifyExternalSystem, Status.DECLINED),
             ),
         )
 
@@ -202,7 +202,7 @@ class EngagementFlow(Flow[EngagementInput]):
         return RPCResult(
             Status.ACCEPTED,
             next_steps=(
-                StepMovement.of(self.notify_external_system, Status.ACCEPTED),
+                StepMovement.of(NotifyExternalSystem, Status.ACCEPTED),
             ),
         )
 

--- a/examples/python/dex_examples/products/job-post/job_post_flow.py
+++ b/examples/python/dex_examples/products/job-post/job_post_flow.py
@@ -106,7 +106,7 @@ class JobPostFlow(Flow[None]):
             self.notes.set(context, input.notes)
         return RPCResult(
             None,
-            next_steps=(StepMovement.of(self.external_update, None),),
+            next_steps=(StepMovement.of(ExternalUpdate, None),),
         )
 
     def read_job_info(self, context: Context) -> JobInfo:

--- a/examples/python/dex_examples/products/microservices/orchestration_flow.py
+++ b/examples/python/dex_examples/products/microservices/orchestration_flow.py
@@ -74,7 +74,7 @@ class CallAPI3(Step[None]):
         value = self.data.get(context)
         self.service.call_api3(value)
         if context.has_timer_fired():
-            return go_to(self.call_api4, None)
+            return go_to(CallAPI4, None)
         return graceful_complete(value)
 
 
@@ -106,8 +106,8 @@ class CallAPI1(Step[str]):
         self.service.call_api1(input)
         self.data.set(context, input)
         return go_to_multi(
-            StepMovement.of(self.call_api2, None),
-            StepMovement.of(self.call_api3, None),
+            StepMovement.of(CallAPI2, None),
+            StepMovement.of(CallAPI3, None),
         )
 
 

--- a/examples/python/dex_examples/products/money-transfer/money_transfer_flow.py
+++ b/examples/python/dex_examples/products/money-transfer/money_transfer_flow.py
@@ -62,13 +62,12 @@ class Compensate(Step[TransferRequest]):
 
 
 def compensated_step_options(
-    compensate: Compensate,
     total_duration: timedelta,
 ) -> StepOptions:
     return StepOptions(
         execute_retry=RetryPolicy(total_duration=total_duration)
     ).on_execute_failure_proceed_to(
-        compensate,
+        Compensate,
         StepOptions(execute_retry=COMPENSATE_RETRY),
     )
 
@@ -170,7 +169,7 @@ class MoneyTransferFlow(Flow[TransferRequest]):
     def __init__(self, service: MyDependencyService) -> None:
         self.service = service
         self.compensate = Compensate(service)
-        options = compensated_step_options(self.compensate, timedelta(hours=1))
+        options = compensated_step_options(timedelta(hours=1))
         self.credit = Credit(service, options)
         self.create_credit_memo = CreateCreditMemo(service, self.credit, options)
         self.debit = Debit(service, self.create_credit_memo, options)

--- a/examples/python/dex_examples/products/money-transfer/money_transfer_flow.py
+++ b/examples/python/dex_examples/products/money-transfer/money_transfer_flow.py
@@ -107,7 +107,7 @@ class CreateCreditMemo(Step[TransferRequest]):
     def execute(self, context: Context, input: TransferRequest) -> StepDecision:
         del context
         self.service.create_credit_memo(input.to_account, input.amount, input.notes)
-        return go_to(self.credit, input)
+        return go_to(Credit, input)
 
 
 class Debit(Step[TransferRequest]):
@@ -127,7 +127,7 @@ class Debit(Step[TransferRequest]):
     def execute(self, context: Context, input: TransferRequest) -> StepDecision:
         del context
         self.service.debit(input.from_account, input.amount)
-        return go_to(self.create_credit_memo, input)
+        return go_to(CreateCreditMemo, input)
 
 
 class CreateDebitMemo(Step[TransferRequest]):
@@ -147,7 +147,7 @@ class CreateDebitMemo(Step[TransferRequest]):
     def execute(self, context: Context, input: TransferRequest) -> StepDecision:
         del context
         self.service.create_debit_memo(input.from_account, input.amount, input.notes)
-        return go_to(self.debit, input)
+        return go_to(Debit, input)
 
 
 class CheckBalance(Step[TransferRequest]):
@@ -163,7 +163,7 @@ class CheckBalance(Step[TransferRequest]):
         del context
         if not self.service.check_balance(input.from_account, input.amount):
             return force_fail("insufficient funds")
-        return go_to(self.create_debit_memo, input)
+        return go_to(CreateDebitMemo, input)
 
 
 class MoneyTransferFlow(Flow[TransferRequest]):

--- a/examples/python/dex_examples/products/order-processing/order_processing_flow.py
+++ b/examples/python/dex_examples/products/order-processing/order_processing_flow.py
@@ -64,7 +64,7 @@ class ChargeStep(Step[OrderRequest]):
     def execute(self, context: Context, input: OrderRequest) -> StepDecision:
         self.service.charge_user(input.email, input.customer_id, input.amount)
         order_status.set(context, "charged")
-        return go_to(self.ship, input)
+        return go_to(ShipStep, input)
 
 
 class ShipStep(Step[OrderRequest]):
@@ -79,7 +79,7 @@ class ShipStep(Step[OrderRequest]):
                 total_duration=timedelta(seconds=3),
             )
         ).on_execute_failure_proceed_to(
-            self.refund,
+            RefundStep,
             StepOptions(
                 execute_retry=RetryPolicy(
                     # total_duration=timedelta(hours=1),
@@ -102,7 +102,7 @@ class ShipStep(Step[OrderRequest]):
                 "Reminder: approve shipment",
                 "Please approve or provide a tracking number.",
             )
-            return go_to(self, input)
+            return go_to(ShipStep, input)
         self.service.ship_item(input.order_id, input.test_fail_at_shipping)
         order_status.set(context, "shipped")
         return graceful_complete(f"shipped:{input.order_id}")

--- a/examples/python/dex_examples/products/polling/polling_flow.py
+++ b/examples/python/dex_examples/products/polling/polling_flow.py
@@ -85,7 +85,7 @@ class Poll(Step[int]):
             self.task_c_completed.publish(context, None)
             return dead_end()
         self.current_polls.set(context, polls + 1)
-        return go_to(self, input)
+        return go_to(Poll, input)
 
 
 class Initialize(Step[int]):
@@ -102,8 +102,8 @@ class Initialize(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
         self.current_polls.set(context, 0)
         return go_to_multi(
-            StepMovement.of(self.poll, input),
-            StepMovement.of(self.wait_for_tasks, None),
+            StepMovement.of(Poll, input),
+            StepMovement.of(WaitForTasks, None),
         )
 
 

--- a/examples/python/dex_examples/products/shortlist-candidates/employer_opt_in_flow.py
+++ b/examples/python/dex_examples/products/shortlist-candidates/employer_opt_in_flow.py
@@ -89,5 +89,5 @@ class EmployerOptInFlow(Flow[EmployerOptInInput]):
         del context
         return RPCResult(
             None,
-            next_steps=(StepMovement.of(self.opt_out_step, None),),
+            next_steps=(StepMovement.of(OptOut, None),),
         )

--- a/examples/python/dex_examples/products/shortlist-candidates/shortlist_flow.py
+++ b/examples/python/dex_examples/products/shortlist-candidates/shortlist_flow.py
@@ -113,7 +113,7 @@ class Shortlist(Step[ShortlistInput]):
         self.employer_id.set(context, input.employer_id)
         self.candidate_id.set(context, input.candidate_id)
         self.email_sent_timestamp.set(context, 0)
-        return go_to(self.send_email, None)
+        return go_to(SendEmail, None)
 
 
 class ShortlistFlow(Flow[ShortlistInput]):

--- a/examples/python/dex_examples/products/signup/user_signup_flow.py
+++ b/examples/python/dex_examples/products/signup/user_signup_flow.py
@@ -64,7 +64,7 @@ class Verify(Step[None]):
             "reminder",
             "please verify your email",
         )
-        return go_to(self, None)
+        return go_to(Verify, None)
 
 
 class Submit(Step[SignupForm]):
@@ -84,7 +84,7 @@ class Submit(Step[SignupForm]):
         self.form.set(context, input)
         self.status.set(context, "waiting")
         self.service.send_email(input.email, "please verify the signup", "content")
-        return go_to(self.verify_step, None)
+        return go_to(Verify, None)
 
 
 class UserSignupFlow(Flow[SignupForm]):

--- a/examples/python/dex_examples/products/subscription/subscription_flow.py
+++ b/examples/python/dex_examples/products/subscription/subscription_flow.py
@@ -69,7 +69,7 @@ class ChargeCurrentBill(Step[None]):
             subscription_billing.send_subscription_over_email(customer, self.service)
             return force_complete("subscription ended")
         subscription_billing.charge_current_period(customer, self.service)
-        return go_to(self, None)
+        return go_to(ChargeCurrentBill, None)
 
 
 class Trial(Step[None]):
@@ -96,7 +96,7 @@ class Trial(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
         del input
         self.billing_period_number.set(context, 0)
-        return go_to(self.charge_current_bill, None)
+        return go_to(ChargeCurrentBill, None)
 
 
 class Cancel(Step[None]):
@@ -141,7 +141,7 @@ class UpdateChargeAmount(Step[None]):
         customer = self.customer_details.get(context)
         subscription_billing.apply_charge_amount(customer, amount)
         self.customer_details.set(context, customer)
-        return go_to(self, None)
+        return go_to(UpdateChargeAmount, None)
 
 
 class Initialize(Step[Customer]):
@@ -160,9 +160,9 @@ class Initialize(Step[Customer]):
     def execute(self, context: Context, input: Customer) -> StepDecision:
         self.customer_details.set(context, input)
         return go_to_multi(
-            StepMovement.of(self.trial, None),
-            StepMovement.of(self.cancel, None),
-            StepMovement.of(self.update_charge_amount, None),
+            StepMovement.of(Trial, None),
+            StepMovement.of(Cancel, None),
+            StepMovement.of(UpdateChargeAmount, None),
         )
 
 

--- a/examples/python/pyproject.toml
+++ b/examples/python/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "dex-python-sdk==0.2.0",
+    "dex-python-sdk==0.2.1",
     "flask>=3.0,<4",
     "openai>=1.66.2,<2",
     "openai-agents>=0.0.4,<0.0.5",

--- a/examples/python/sync-python/README.md
+++ b/examples/python/sync-python/README.md
@@ -3,7 +3,7 @@
 Showcase of the **sync** Dex Python SDK surface (`Client` / `Worker`) next to
 the primary async examples under `examples/python/`.
 
-Targets [`dex-python-sdk==0.2.0`](https://pypi.org/project/dex-python-sdk/0.2.0/).
+Targets [`dex-python-sdk==0.2.1`](https://pypi.org/project/dex-python-sdk/0.2.1/).
 Requires Python 3.11+.
 
 The samples use concrete SDK errors for missing, inactive, and duplicate Flows

--- a/examples/python/sync-python/sync_examples/patterns/parent_child/parent_child.py
+++ b/examples/python/sync-python/sync_examples/patterns/parent_child/parent_child.py
@@ -73,10 +73,8 @@ class AwaitChildWorkflowCompletion(Step[WaitForChildInput]):
     def __init__(
         self,
         client_provider: Callable[[], Client],
-        loop_for_next_task_provider: Callable[[], LoopForNextTask],
     ) -> None:
         self.client_provider = client_provider
-        self.loop_for_next_task_provider = loop_for_next_task_provider
 
     def wait_for(self, context: Context, input: WaitForChildInput) -> Wait:
         del context
@@ -91,13 +89,13 @@ class AwaitChildWorkflowCompletion(Step[WaitForChildInput]):
             )
         except LongPollTimeoutError:
             return go_to(
-                self,
+                AwaitChildWorkflowCompletion,
                 WaitForChildInput(
                     input.child_wf_id,
                     min(input.timer_seconds * 2, MAX_WAIT_SECONDS),
                 ),
             )
-        return go_to(self.loop_for_next_task_provider(), None)
+        return go_to(LoopForNextTask, None)
 
 
 class StartChildWorkflow(Step[int]):
@@ -123,7 +121,7 @@ class StartChildWorkflow(Step[int]):
         except FlowAlreadyStartedError:
             pass
         return go_to(
-            self.await_child_workflow_completion,
+            AwaitChildWorkflowCompletion,
             WaitForChildInput(child_workflow_id, 1),
         )
 
@@ -144,7 +142,7 @@ class LoopForNextTask(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
         del input
         request = self.task_queue.results(context)[0]
-        return go_to(self.start_child_workflow, request)
+        return go_to(StartChildWorkflow, request)
 
 
 class Init(Step[int]):
@@ -162,7 +160,7 @@ class Init(Step[int]):
 
         return go_to_multi(
             *(
-                StepMovement.of(self.loop_for_next_task, None)
+                StepMovement.of(LoopForNextTask, None)
                 for _ in range(CONCURRENCY_PER_PARENT_WORKFLOW)
             )
         )
@@ -180,7 +178,6 @@ class ParentFlowV2(Flow[int]):
     ) -> None:
         self.await_child_workflow_completion = AwaitChildWorkflowCompletion(
             client_provider,
-            lambda: self.loop_for_next_task,
         )
         self.start_child_workflow = StartChildWorkflow(
             client_provider,

--- a/examples/python/tests/integ/test_patterns.py
+++ b/examples/python/tests/integ/test_patterns.py
@@ -271,7 +271,7 @@ async def test_entity_store_profile_lifecycle(
     options = (
         StartFlowOptions(
             timeout=timedelta(hours=1),
-            config_override=FlowConfig(attribute_store_name=STORE_NAME),
+            config_override=FlowConfig(attribute_store_names=[STORE_NAME]),
         )
         .with_attribute(app.user_profile.display_name, profile.display_name)
         .with_attribute(app.user_profile.email, profile.email)

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -293,7 +293,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dex-python-sdk", specifier = "==0.2.0" },
+    { name = "dex-python-sdk", specifier = "==0.2.1" },
     { name = "flask", specifier = ">=3.0,<4" },
     { name = "openai", specifier = ">=1.66.2,<2" },
     { name = "openai-agents", specifier = ">=0.0.4,<0.0.5" },
@@ -312,20 +312,20 @@ dev = [
 
 [[package]]
 name = "dex-python-sdk"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "grpcio-status" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/5f/f61d7bc783c427c3e15d072c3bc3d6a8929f04c79fda51a2e2e881228caa/dex_python_sdk-0.2.0.tar.gz", hash = "sha256:02b7e809f045e3ded43919595374d55c32dda0127fdd19656e0235b63e8d6ce7", size = 148428, upload-time = "2026-08-21T23:40:37.817Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/45/ab295b8b44c0c9736322f259cbb18d9f92e1c511e931f93c3e41ff9eff7d/dex_python_sdk-0.2.1.tar.gz", hash = "sha256:890b6f3fa4817f966e6c7886bc09f290e6b7c4579e7d0877feaaa6ee354e0101", size = 148662, upload-time = "2026-08-27T04:30:35.736Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/c1/347db4eba695703277c481641cb044a39bda27c6de36d3a2cf75509f42aa/dex_python_sdk-0.2.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:26e56ef54e7ae5111bd4b997bd78f2f14109db4d8bcdc842e8409b57c9ad5499", size = 630526, upload-time = "2026-08-21T23:40:31.593Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/56/ba5f8a6130e1e9f4a8e74caa2e001de9029326ffc06fa39016e62fdb9a63/dex_python_sdk-0.2.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a1f9eb372f6592c585a9baaa832d0ffa10da66c79ccc1c3c572692790401c30", size = 609039, upload-time = "2026-08-21T23:40:32.829Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/b9/e31fc1381d10e1997d6b0b4f3f8979bcfb217b665c6e57967851fd4e14fb/dex_python_sdk-0.2.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40b921022f1201dc31ad6b3478183b313e115f83f197c052ae187f0098c8b09c", size = 671981, upload-time = "2026-08-21T23:40:34.163Z" },
-    { url = "https://files.pythonhosted.org/packages/df/83/42625cdf9c7ad4cf019938efe2c5ba85ee53cf915c0732e69fcf9c1b9ab0/dex_python_sdk-0.2.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1ce45c7c8e4bc89e5ffd436f9a6df9495f5ec483e7a84569fded31914f13362", size = 674281, upload-time = "2026-08-21T23:40:35.466Z" },
-    { url = "https://files.pythonhosted.org/packages/27/69/a2d41fa1c8254ebb9ef69e31fc2cb71d9e3e5cf0f93a99f7813648265a94/dex_python_sdk-0.2.0-cp311-abi3-win_amd64.whl", hash = "sha256:a336eee47e118894f792b63b350d23928547f3fc51939c33d2e4a32bb56ab1e2", size = 518157, upload-time = "2026-08-21T23:40:36.664Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/35/3b28865f25efca9ea36f8f24f9ffcba55a67f1f73de532bce560f14f5de2/dex_python_sdk-0.2.1-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f122489a2974756c2d10d7104de6206af96853c95dbdb4f6a6ffced31ff0b055", size = 630769, upload-time = "2026-08-27T04:30:28.112Z" },
+    { url = "https://files.pythonhosted.org/packages/32/17/1f355794e1e0386f5e4ea0ff649ed16a2825412f6b7bb8ee80b0d726a291/dex_python_sdk-0.2.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:c9d282567924dc6da24e09c6b076ac847037584bef7f4bb558af891e1599a60c", size = 609284, upload-time = "2026-08-27T04:30:29.678Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5f/bdf20f96528cb98358bf7c0f4c99b502dd5d1d59decff1c7079d8e6a4c14/dex_python_sdk-0.2.1-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4175bee17347756a801b530d60498eb001fa730984fc1abd2abf279f63e8206", size = 672220, upload-time = "2026-08-27T04:30:31.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/440201aba0e888ee1e333036078bc29bc8e08d2106885f2f9a5cc1cd9fda/dex_python_sdk-0.2.1-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1619adab399b6ec690b3eb5b993f5a81032daa5007a6e8d58ac19d541a0ef72", size = 674524, upload-time = "2026-08-27T04:30:32.891Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/42/0d7b70fe2c3e1b1bee4922149ab3f6ba45460b5b7ffab57edacd43d854ea/dex_python_sdk-0.2.1-cp311-abi3-win_amd64.whl", hash = "sha256:de882677f13013307ccd899dfe634b49cb93e601c41711e5c3e9030c0185d595", size = 518405, upload-time = "2026-08-27T04:30:34.527Z" },
 ]
 
 [[package]]

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "dex-blob-cache"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66a657b454ea2861ffc92f6cb6665e6e947c7fef403e30ff11d6f0a94884fcf"
+checksum = "f5bc228170f1340a23a4735ed51074fd5ff352a06f2148276902e4aa73b317b2"
 dependencies = [
  "crc32c",
  "sha2",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "dex-protocol"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ebc806f6d92d9994e7ef15ae519ae0064db1f56d6c8ce8a2cbf0e1a31d3857"
+checksum = "b310efbaa86ae68229b131791eb3d38c3fc7044bae530eab66bda69f5f19f1ea"
 dependencies = [
  "prost",
  "prost-types",
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "dex-sdk"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73adb58070fc9a5b67cac46046914dbacc421bdf7fe736980da937d667dccd0"
+checksum = "e93e6349bbce2c04d601b3781c850ab94de6b54fa4ca814c8330e95931d9ae0e"
 dependencies = [
  "dex-blob-cache",
  "dex-protocol",

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 rust-version = "1.97"
 
 [dependencies]
-dex-sdk = "=0.2.0"
+dex-sdk = "=0.2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 axum = "0.8"

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -1,7 +1,7 @@
 # Rust examples
 
 This application mirrors the examples shared by the Java, Python, and TypeScript
-applications. It intentionally depends on the published `dex-sdk = "=0.2.0"`
+applications. It intentionally depends on the published `dex-sdk = "=0.2.1"`
 crate without a repository path override.
 
 ## Layout

--- a/examples/rust/src/patterns/entity_store/flow.rs
+++ b/examples/rust/src/patterns/entity_store/flow.rs
@@ -49,7 +49,7 @@ pub struct UserProfileFlow;
 
 impl UserProfileFlow {
     pub fn flow_config() -> FlowConfig {
-        FlowConfig::new().attribute_store_name(STORE_NAME)
+        FlowConfig::new().attribute_store_names(vec![STORE_NAME.to_owned()])
     }
 
     pub fn start_options(profile: &UserProfile) -> StartFlowOptions {

--- a/examples/rust/src/primitives/attribute/flow.rs
+++ b/examples/rust/src/primitives/attribute/flow.rs
@@ -20,7 +20,7 @@ use dex_sdk::{
 const UPDATE_STATUS: Rpc<String, String> = Rpc::new("UpdateStatus");
 
 pub fn attribute_store_config() -> FlowConfig {
-    FlowConfig::new().attribute_store_name("profiles")
+    FlowConfig::new().attribute_store_names(vec!["profiles".to_owned()])
 }
 
 pub struct AttributeFlow {

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,6 +1,6 @@
 # Dex TypeScript examples
 
-These examples target [`@superdurable/dex@0.2.0`](https://www.npmjs.com/package/@superdurable/dex).
+These examples target [`@superdurable/dex@0.2.1`](https://www.npmjs.com/package/@superdurable/dex).
 
 The sample process hosts one gRPC Worker (default `127.0.0.1:8803`) and an HTTP
 controller on port `8080`. Step `execute` / `waitFor` / RPC handlers may

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@superdurable/dex-examples-typescript",
       "version": "0.0.0",
       "dependencies": {
-        "@superdurable/dex": "0.2.0",
+        "@superdurable/dex": "0.2.1",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -125,9 +125,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@superdurable/dex": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.2.0.tgz",
-      "integrity": "sha512-mX7TZz/ZLJyT3kMyxQl2X9yV50MWdxxX1mufIjvfcu6x5M7XgY528CYok+2bkidrG1CEIdeEguh9D/18xq065w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.2.1.tgz",
+      "integrity": "sha512-PrpYvTKhn4uxC0xA53qkYIQKo2wJmI7GVurRRlfQr31IfwaXKAxJMF4UwLvWwdbw5DDw7F3tzmjfjKe+yCtTtg==",
       "license": "LicenseRef-Super-Durable-1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.13.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -16,7 +16,7 @@
     "smoke": "npm run build && node --test --experimental-test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/e2e/flow-smoke.test.js'"
   },
   "dependencies": {
-    "@superdurable/dex": "0.2.0",
+    "@superdurable/dex": "0.2.1",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/examples/typescript/src/patterns/cron/cron-schedule-flow.ts
+++ b/examples/typescript/src/patterns/cron/cron-schedule-flow.ts
@@ -85,7 +85,7 @@ class Start implements Step<CronScheduleInput> {
     if (input.runCount <= 0 || input.interval.value <= 0) {
       return forceFail("interval value and run count must be positive");
     }
-    return goTo(this.schedule, {
+    return goTo(WaitForSchedule, {
       interval: input.interval,
       remainingRuns: input.runCount,
     });
@@ -124,7 +124,7 @@ class WaitForSchedule implements Step<ScheduleState> {
     if (state.remainingRuns === 1) {
       return gracefulComplete();
     }
-    return goTo(this, {
+    return goTo(WaitForSchedule, {
       interval: state.interval,
       remainingRuns: state.remainingRuns - 1,
     });
@@ -136,11 +136,11 @@ class WaitForSchedule implements Step<ScheduleState> {
       isFinal: state.remainingRuns === 1,
     };
     if (input.isFinal) {
-      return goTo(this.run, input);
+      return goTo(Run, input);
     }
     return goToMulti(
-      StepMovement.of(this.run, input),
-      StepMovement.of(this, {
+      StepMovement.of(Run, input),
+      StepMovement.of(WaitForSchedule, {
         interval: state.interval,
         remainingRuns: state.remainingRuns - 1,
       }),

--- a/examples/typescript/src/patterns/drain-channels/internal/drain-internal-channels-flow.ts
+++ b/examples/typescript/src/patterns/drain-channels/internal/drain-internal-channels-flow.ts
@@ -65,8 +65,8 @@ class Init implements Step<string> {
   public execute(context: Context, input: string): StepDecision {
     this.flow.processDataStateExecutionCounter.set(context, 0);
     return goToMulti(
-      StepMovement.of(this.flow.upsertMongoRecordStep, undefined),
-      StepMovement.of(this.flow.processDataStep, input),
+      StepMovement.of(UpsertMongoRecord, undefined),
+      StepMovement.of(ProcessData, input),
     );
   }
 }
@@ -98,7 +98,7 @@ class UpsertMongoRecord implements Step<void> {
     if (document.finalCommand) {
       return gracefulComplete();
     }
-    return goTo(this.flow.upsertMongoRecordStep, undefined);
+    return goTo(UpsertMongoRecord, undefined);
   }
 }
 
@@ -145,9 +145,9 @@ class ProcessData implements Step<string> {
     );
 
     if (executionCount <= 3) {
-      return goTo(this.flow.processDataStep, input);
+      return goTo(ProcessData, input);
     }
-    return goTo(this.flow.finalizeStep, undefined);
+    return goTo(Finalize, undefined);
   }
 }
 

--- a/examples/typescript/src/patterns/drain-channels/signal/drain-signal-channels-flow.ts
+++ b/examples/typescript/src/patterns/drain-channels/signal/drain-signal-channels-flow.ts
@@ -71,7 +71,7 @@ class ProcessSignal implements Step<string | undefined> {
 
     return forceCompleteIfChannelsEmpty(
       null,
-      StepMovement.of(this, undefined),
+      StepMovement.of(ProcessSignal, undefined),
       queueSignalChannel,
     );
   }

--- a/examples/typescript/src/patterns/entity-store/controller.ts
+++ b/examples/typescript/src/patterns/entity-store/controller.ts
@@ -49,7 +49,7 @@ export function createEntityStoreRouter(client: Client): Router {
         ),
         InitialAttribute.of(userProfileFlow.metadata, profile.metadata),
       ],
-      configOverride: { attributeStoreName: ENTITY_STORE_NAME },
+      configOverride: { attributeStoreNames: [ENTITY_STORE_NAME] },
     }));
     response.status(201).json({ flowID: userId, runID: runId, userId, ...profile });
   });

--- a/examples/typescript/src/patterns/interruptible/interruptible-execution-flow.ts
+++ b/examples/typescript/src/patterns/interruptible/interruptible-execution-flow.ts
@@ -46,8 +46,8 @@ class Init implements Step<void> {
   public execute(_context: Context, _input: void): StepDecision {
     const input: WorkJobParametersInput = { jobUpperBound: 15, progress: 1 };
     return goToMulti(
-      StepMovement.of(this.flow.workAExecutionStep, input),
-      StepMovement.of(this.flow.workNExecutionStep, input),
+      StepMovement.of(WorkAExecution, input),
+      StepMovement.of(WorkNExecution, input),
     );
   }
 }
@@ -79,7 +79,7 @@ class WorkAExecution implements Step<WorkJobParametersInput> {
       `[${context.flowId}][${context.stepExecutionId}]: Doing job ${input.progress}`,
     );
 
-    return goTo(this.flow.workAExecutionStep, {
+    return goTo(WorkAExecution, {
       jobUpperBound: input.jobUpperBound,
       progress: input.progress + 1,
     });
@@ -113,7 +113,7 @@ class WorkNExecution implements Step<WorkJobParametersInput> {
       `[${context.flowId}][${context.stepExecutionId}]: Processing job ${input.progress}`,
     );
 
-    return goTo(this.flow.workNExecutionStep, {
+    return goTo(WorkNExecution, {
       jobUpperBound: input.jobUpperBound,
       progress: input.progress + 1,
     });

--- a/examples/typescript/src/patterns/intervention/manual-intervention-flow.ts
+++ b/examples/typescript/src/patterns/intervention/manual-intervention-flow.ts
@@ -50,7 +50,7 @@ class Init implements Step<void> {
 
   public execute(context: Context, _input: void): StepDecision {
     this.flow.numberOfRetries.set(context, 0);
-    return goTo(this.flow.getDataStep, false);
+    return goTo(GetData, false);
   }
 }
 
@@ -76,9 +76,9 @@ class GetData implements Step<boolean> {
     try {
       this.pretendApiCall(context);
     } catch {
-      return goTo(this.flow.errorStep, undefined);
+      return goTo(ErrorStep, undefined);
     }
-    return goTo(this.flow.finalStep, undefined);
+    return goTo(Final, undefined);
   }
 
   private pretendApiCall(context: Context): void {
@@ -110,9 +110,9 @@ class ErrorStep implements Step<void> {
       `signal received: ${retry ? SIGNAL_CHANNEL_COMMAND_RETRY : SIGNAL_CHANNEL_COMMAND_SKIP}`,
     );
     if (retry) {
-      return goTo(this.flow.getDataStep, true);
+      return goTo(GetData, true);
     }
-    return goTo(this.flow.finalStep, undefined);
+    return goTo(Final, undefined);
   }
 }
 

--- a/examples/typescript/src/patterns/parallel/parallel-states-with-await-flow.ts
+++ b/examples/typescript/src/patterns/parallel/parallel-states-with-await-flow.ts
@@ -50,11 +50,11 @@ class Starting implements Step<number> {
 
   public execute(_context: Context, countOfJobSeekers: number): StepDecision {
     const movements: StepMovement<unknown>[] = [
-      StepMovement.of(this.flow.awaitAllUsersNotifiedStep, countOfJobSeekers),
+      StepMovement.of(AwaitAllUsersNotified, countOfJobSeekers),
     ];
     for (let index = 1; index <= countOfJobSeekers; index += 1) {
       movements.push(
-        StepMovement.of(this.flow.notifyUserStep, {
+        StepMovement.of(NotifyUser, {
           id: String(index),
           email: "jobseeker@indeed.com",
           phoneNumber: "0987654321",

--- a/examples/typescript/src/patterns/parallel/simple-parallel-states-flow.ts
+++ b/examples/typescript/src/patterns/parallel/simple-parallel-states-flow.ts
@@ -40,8 +40,8 @@ class Init implements Step<JobSeeker> {
 
   public execute(_context: Context, input: JobSeeker): StepDecision {
     return goToMulti(
-      StepMovement.of(this.flow.sendTextMessageStep, input.phoneNumber),
-      StepMovement.of(this.flow.sendEmailStep, input.email),
+      StepMovement.of(SendTextMessage, input.phoneNumber),
+      StepMovement.of(SendEmail, input.email),
     );
   }
 }

--- a/examples/typescript/src/patterns/parent-child/parent-flow-v2.ts
+++ b/examples/typescript/src/patterns/parent-child/parent-flow-v2.ts
@@ -60,7 +60,7 @@ class Init implements Step<number> {
 
     const movements: StepMovement<unknown>[] = [];
     for (let index = 0; index < CONCURRENCY_PER_PARENT_WORKFLOW; index += 1) {
-      movements.push(StepMovement.of(this.flow.loopForNextTaskStep, undefined));
+      movements.push(StepMovement.of(LoopForNextTask, undefined));
     }
     return goToMulti(...movements);
   }
@@ -82,7 +82,7 @@ class LoopForNextTask implements Step<void> {
     if (request === undefined) {
       throw new Error("No task found on queue");
     }
-    return goTo(this.flow.startChildWorkflowStep, request);
+    return goTo(StartChildWorkflow, request);
   }
 }
 
@@ -109,7 +109,7 @@ class StartChildWorkflow implements Step<number> {
         throw error;
       }
     }
-    return goTo(this.flow.awaitChildWorkflowCompletionStep, {
+    return goTo(AwaitChildWorkflowCompletion, {
       childWFId: childWorkflowId,
       timerSeconds: 1,
     });
@@ -138,14 +138,14 @@ class AwaitChildWorkflowCompletion implements Step<WaitForChildInput> {
       );
     } catch (error) {
       if (error instanceof LongPollTimeoutError) {
-        return goTo(this.flow.awaitChildWorkflowCompletionStep, {
+        return goTo(AwaitChildWorkflowCompletion, {
           childWFId: input.childWFId,
           timerSeconds: Math.min(input.timerSeconds * 2, 10),
         });
       }
       throw error;
     }
-    return goTo(this.flow.loopForNextTaskStep, undefined);
+    return goTo(LoopForNextTask, undefined);
   }
 }
 

--- a/examples/typescript/src/patterns/polling/backoff-polling-flow.ts
+++ b/examples/typescript/src/patterns/polling/backoff-polling-flow.ts
@@ -56,7 +56,7 @@ class ReadExternalDep implements Step<void> {
 
   public execute(_context: Context, _input: void): StepDecision {
     const result = this.service.attemptExternalApiCall("Read for BackoffPollingFlow");
-    return goTo(this.flow.pollingCompleteStep, result);
+    return goTo(PollingComplete, result);
   }
 }
 

--- a/examples/typescript/src/patterns/polling/simple-polling-flow.ts
+++ b/examples/typescript/src/patterns/polling/simple-polling-flow.ts
@@ -40,9 +40,9 @@ class SimplePolling implements Step<void> {
 
   public execute(_context: Context, _input: void): StepDecision {
     if (this.isSystemReady()) {
-      return goTo(this.flow.simplePollingCompleteStep, undefined);
+      return goTo(SimplePollingComplete, undefined);
     }
-    return goTo(this.flow.simplePollingStep, undefined);
+    return goTo(SimplePolling, undefined);
   }
 
   private isSystemReady(): boolean {

--- a/examples/typescript/src/patterns/recovery/failure-recovery-flow.ts
+++ b/examples/typescript/src/patterns/recovery/failure-recovery-flow.ts
@@ -82,7 +82,7 @@ class UpdateItemQuantity implements Step<FailureRecoveryWorkflowInput> {
 
   public getStepOptions(): StepOptions {
     return {
-      executeFailure: ExecuteFailure.proceedTo(this.flow.updateQuantityRecoveryStep, {
+      executeFailure: ExecuteFailure.proceedTo(UpdateQuantityRecovery, {
         executeRetry: { maximumAttempts: 5 },
       }),
       executeRetry: { maximumAttempts: 5 },
@@ -92,7 +92,7 @@ class UpdateItemQuantity implements Step<FailureRecoveryWorkflowInput> {
   public execute(context: Context, input: FailureRecoveryWorkflowInput): StepDecision {
     this.flow.workflowInput.set(context, input);
     this.database.reduceQuantity(input.itemName, input.requestedQuantity);
-    return goTo(this.flow.chargeForItemsStep, input.requestedQuantity);
+    return goTo(ChargeForItems, input.requestedQuantity);
   }
 }
 
@@ -111,7 +111,7 @@ class ChargeForItems implements Step<number> {
 
   public getStepOptions(): StepOptions {
     return {
-      executeFailure: ExecuteFailure.proceedTo(this.flow.voidPaymentRecoveryStep, {
+      executeFailure: ExecuteFailure.proceedTo(VoidPaymentRecovery, {
         executeRetry: { maximumAttempts: 5 },
       }),
       executeRetry: { maximumAttempts: 5 },
@@ -158,7 +158,7 @@ class VoidPaymentRecovery implements Step<number> {
     const itemValue = this.database.getItemPrice(workflow.itemName);
     const orderValue = workflow.requestedQuantity * itemValue;
     this.paymentProcessor.voidPayment(orderValue);
-    return goTo(this.flow.updateQuantityRecoveryStep, workflow);
+    return goTo(UpdateQuantityRecovery, workflow);
   }
 }
 

--- a/examples/typescript/src/patterns/reminders/reminder-flow.ts
+++ b/examples/typescript/src/patterns/reminders/reminder-flow.ts
@@ -59,8 +59,8 @@ class Init implements Step<void> {
   public execute(context: Context, _input: void): StepDecision {
     this.flow.status.set(context, "INITIATED");
     return goToMulti(
-      StepMovement.of(this.flow.processTimeoutStep, undefined),
-      StepMovement.of(this.flow.reminderStep, undefined),
+      StepMovement.of(ProcessTimeout, undefined),
+      StepMovement.of(Reminder, undefined),
     );
   }
 }
@@ -120,7 +120,7 @@ class Reminder implements Step<void> {
     }
 
     this.service.sendEmail("Reminder:xxx please respond", "Hello xxx, ...");
-    return goTo(this.flow.reminderStep, undefined);
+    return goTo(Reminder, undefined);
   }
 }
 

--- a/examples/typescript/src/patterns/resettable-timer/resettable-timer-flow.ts
+++ b/examples/typescript/src/patterns/resettable-timer/resettable-timer-flow.ts
@@ -51,9 +51,9 @@ class ResettableTimerStep implements Step<void> {
 
   public execute(context: Context, _input: void): StepDecision {
     if (context.hasTimerFired()) {
-      return goTo(this.flow.timerExpiredStep, undefined);
+      return goTo(TimerExpired, undefined);
     }
-    return goTo(this.flow.resettableTimerStep, undefined);
+    return goTo(ResettableTimerStep, undefined);
   }
 }
 

--- a/examples/typescript/src/patterns/scalable-parallel/parent-flow.ts
+++ b/examples/typescript/src/patterns/scalable-parallel/parent-flow.ts
@@ -72,7 +72,7 @@ class Init implements Step<BatchEnqueueRequest> {
     for (const uuid of initRequest.list) {
       taskQueue.publish(context, uuid);
     }
-    return goTo(this.flow.loopForNextMessageStep, undefined);
+    return goTo(LoopForNextMessage, undefined);
   }
 }
 
@@ -149,11 +149,11 @@ class LoopForNextMessage implements Step<void> {
     if (newWaitList.length === 0) {
       return forceCompleteIfChannelsEmpty(
         null,
-        StepMovement.of(this.flow.loopForNextMessageStep, undefined),
+        StepMovement.of(LoopForNextMessage, undefined),
         taskQueue,
       );
     }
-    return goTo(this.flow.loopForNextMessageStep, undefined);
+    return goTo(LoopForNextMessage, undefined);
   }
 }
 

--- a/examples/typescript/src/patterns/timeout/flow-graceful-timeout.ts
+++ b/examples/typescript/src/patterns/timeout/flow-graceful-timeout.ts
@@ -41,8 +41,8 @@ class Init implements Step<boolean> {
 
   public execute(_context: Context, workflowSuccessful: boolean): StepDecision {
     return goToMulti(
-      StepMovement.of(this.flow.timeoutStep, undefined),
-      StepMovement.of(this.flow.taskStep, workflowSuccessful),
+      StepMovement.of(Timeout, undefined),
+      StepMovement.of(Task, workflowSuccessful),
     );
   }
 }

--- a/examples/typescript/src/patterns/wait-for-state-completion/wait-for-state-completion-flow.ts
+++ b/examples/typescript/src/patterns/wait-for-state-completion/wait-for-state-completion-flow.ts
@@ -52,7 +52,7 @@ class PersistData implements Step<JobSeekerData> {
   public execute(context: Context, input: JobSeekerData): StepDecision {
     this.flow.mongoCollection.upsert(input);
     this.flow.jobSeekerData.set(context, input);
-    return goTo(this.flow.updateExternalSystemStep, input);
+    return goTo(UpdateExternalSystem, input);
   }
 }
 

--- a/examples/typescript/src/primitives/attribute/attribute-flow.ts
+++ b/examples/typescript/src/primitives/attribute/attribute-flow.ts
@@ -75,7 +75,7 @@ export class AttributeFlow implements Flow<string> {
   public readonly status = status;
   public readonly email = email;
   public readonly progress = progress;
-  public readonly attributeStoreConfig: FlowConfig = { attributeStoreName: "profiles" };
+  public readonly attributeStoreConfig: FlowConfig = { attributeStoreNames: ["profiles"] };
   private readonly start = new AttributeStep(this);
 
   public getFlowType(): string {

--- a/examples/typescript/src/primitives/durability/durability-flow.ts
+++ b/examples/typescript/src/primitives/durability/durability-flow.ts
@@ -40,9 +40,9 @@ class RouteDurabilityStep implements Step<string> {
 
   public execute(_context: Context, mode: string): StepDecision {
     if (mode === "async") {
-      return goTo(this.flow.asyncWorkStep, mode);
+      return goTo(AsyncWorkStep, mode);
     }
-    return goTo(this.flow.syncWorkStep, mode);
+    return goTo(SyncWorkStep, mode);
   }
 }
 
@@ -60,7 +60,7 @@ class SyncWorkStep implements Step<string> {
   }
 
   public execute(_context: Context, mode: string): StepDecision {
-    return goTo(this.flow.finishStep, `sync:${mode}`);
+    return goTo(FinishDurabilityStep, `sync:${mode}`);
   }
 }
 
@@ -78,7 +78,7 @@ class AsyncWorkStep implements Step<string> {
   }
 
   public execute(_context: Context, mode: string): StepDecision {
-    return goTo(this.flow.finishStep, `async:${mode}`);
+    return goTo(FinishDurabilityStep, `async:${mode}`);
   }
 }
 

--- a/examples/typescript/src/primitives/flow/example-flow.ts
+++ b/examples/typescript/src/primitives/flow/example-flow.ts
@@ -62,7 +62,7 @@ class ExampleStep implements Step<number> {
   }
 
   public execute(_context: Context, input: number): StepDecision {
-    return goTo(this.finish, input + 1);
+    return goTo(FinishStep, input + 1);
   }
 }
 

--- a/examples/typescript/src/primitives/options-override/options-override-flow.ts
+++ b/examples/typescript/src/primitives/options-override/options-override-flow.ts
@@ -44,7 +44,7 @@ class OverrideFirstStep implements Step<string> {
       waitForFailure: "proceed",
     };
     const payload = `${input}_state1`;
-    return goToMulti(StepMovement.of(this.flow.secondStep, payload, override));
+    return goToMulti(StepMovement.of(OverrideSecondStep, payload, override));
   }
 }
 

--- a/examples/typescript/src/primitives/proceed-on-wait-failure/proceed-on-wait-failure-flow.ts
+++ b/examples/typescript/src/primitives/proceed-on-wait-failure/proceed-on-wait-failure-flow.ts
@@ -63,7 +63,7 @@ class FailingWaitStep implements Step<string> {
     if (!context.waitForMethodFailed()) {
       throw new Error("waitFor failure was not reported");
     }
-    return goTo(this.finish, `${input}_recovered`);
+    return goTo(FinishStep, `${input}_recovered`);
   }
 }
 

--- a/examples/typescript/src/primitives/rpc/rpc-flow.ts
+++ b/examples/typescript/src/primitives/rpc/rpc-flow.ts
@@ -50,7 +50,7 @@ class RpcWait implements Step<number> {
   }
 
   public execute(_context: Context, _input: number): StepDecision {
-    return goTo(this.flow.completeStep, 0);
+    return goTo(RpcComplete, 0);
   }
 }
 
@@ -104,7 +104,7 @@ export class RpcFlow implements Flow<number> {
   public trigger(context: Context, input: string): RPCResult<string> {
     this.data.set(context, input);
     exampleCh.publish(context, undefined);
-    return { output: input, nextSteps: [StepMovement.of(this.exampleStep, input)] };
+    return { output: input, nextSteps: [StepMovement.of(ExampleStep, input)] };
   }
 }
 

--- a/examples/typescript/src/primitives/step-decision/step-decision-flow.ts
+++ b/examples/typescript/src/primitives/step-decision/step-decision-flow.ts
@@ -55,15 +55,15 @@ class RouteStep implements Step<string> {
     }
     if (mode === "dead-end") {
       return goToMulti(
-        StepMovement.of(this.flow.branchWorkerStep, "left"),
-        StepMovement.of(this.flow.branchWorkerStep, "right"),
+        StepMovement.of(BranchWorkerStep, "left"),
+        StepMovement.of(BranchWorkerStep, "right"),
       );
     }
     const quote: Quote = { carrier: "winner", price: 9 };
     return goToMulti(
-      StepMovement.of(this.flow.carrierAStep, { carrier: "A", price: 10 }),
-      StepMovement.of(this.flow.carrierBStep, { carrier: "B", price: 12 }),
-      StepMovement.of(this.flow.winnerStep, quote),
+      StepMovement.of(CarrierAStep, { carrier: "A", price: 10 }),
+      StepMovement.of(CarrierBStep, { carrier: "B", price: 12 }),
+      StepMovement.of(WinnerStep, quote),
     );
   }
 }
@@ -123,9 +123,9 @@ class WinnerStep implements Step<Quote> {
 
   public execute(_context: Context, quote: Quote): StepDecision {
     return withCancelingSteps(
-      goTo(this.flow.recordQuoteStep, quote),
-      this.flow.carrierAStep,
-      this.flow.carrierBStep,
+      goTo(RecordQuoteStep, quote),
+      CarrierAStep,
+      CarrierBStep,
     );
   }
 }

--- a/examples/typescript/src/primitives/step/step-flow.ts
+++ b/examples/typescript/src/primitives/step/step-flow.ts
@@ -45,7 +45,7 @@ class ExampleStep implements Step<number> {
   }
 
   public execute(_context: Context, input: number): StepDecision {
-    return goTo(this.flow.secondStep, input + 1);
+    return goTo(StepSecond, input + 1);
   }
 }
 

--- a/examples/typescript/src/products/engagement/engagement-flow.ts
+++ b/examples/typescript/src/products/engagement/engagement-flow.ts
@@ -117,7 +117,7 @@ export class EngagementFlow implements Flow<EngagementInput> {
     this.updateStatus(context, Status.DECLINED, note);
     return {
       output: Status.DECLINED,
-      nextSteps: [StepMovement.of(this.notifyExternalSystem, Status.DECLINED)],
+      nextSteps: [StepMovement.of(NotifyExternalSystem, Status.DECLINED)],
     };
   }
 
@@ -133,7 +133,7 @@ export class EngagementFlow implements Flow<EngagementInput> {
     completeProcess.publish(context, undefined);
     return {
       output: Status.ACCEPTED,
-      nextSteps: [StepMovement.of(this.notifyExternalSystem, Status.ACCEPTED)],
+      nextSteps: [StepMovement.of(NotifyExternalSystem, Status.ACCEPTED)],
     };
   }
 
@@ -171,9 +171,9 @@ class Initialize implements Step<EngagementInput> {
     this.flow.lastUpdateTimestamp.set(context, BigInt(Date.now()));
     this.flow.notes.set(context, input.notes);
     return goToMulti(
-      StepMovement.of(this.flow.processTimeout, undefined),
-      StepMovement.of(this.flow.reminder, undefined),
-      StepMovement.of(this.flow.notifyExternalSystem, Status.INITIATED),
+      StepMovement.of(ProcessTimeout, undefined),
+      StepMovement.of(Reminder, undefined),
+      StepMovement.of(NotifyExternalSystem, Status.INITIATED),
     );
   }
 }
@@ -231,7 +231,7 @@ class Reminder implements Step<void> {
       "Reminder: please respond",
       "Please respond to the engagement.",
     );
-    return goTo(this.flow.reminder, undefined);
+    return goTo(Reminder, undefined);
   }
 }
 

--- a/examples/typescript/src/products/job-post/job-post-flow.ts
+++ b/examples/typescript/src/products/job-post/job-post-flow.ts
@@ -87,7 +87,7 @@ export class JobPostFlow implements Flow {
     if (input.notes !== undefined && input.notes.length > 0) {
       this.notes.set(context, input.notes);
     }
-    return { output: undefined, nextSteps: [StepMovement.of(this.externalUpdate, undefined)] };
+    return { output: undefined, nextSteps: [StepMovement.of(ExternalUpdate, undefined)] };
   }
 
   private readJobInfo(context: Context): JobInfo {

--- a/examples/typescript/src/products/microservices/orchestration-flow.ts
+++ b/examples/typescript/src/products/microservices/orchestration-flow.ts
@@ -94,8 +94,8 @@ class CallAPI1 implements Step<string> {
     this.flow.service.callAPI1(input);
     this.flow.data.set(context, input);
     return goToMulti(
-      StepMovement.of(this.flow.callAPI2, undefined),
-      StepMovement.of(this.flow.callAPI3, undefined),
+      StepMovement.of(CallAPI2, undefined),
+      StepMovement.of(CallAPI3, undefined),
     );
   }
 }
@@ -128,7 +128,7 @@ class CallAPI3 implements Step<void> {
     const value = this.flow.data.get(context);
     this.flow.service.callAPI3(value);
     if (context.hasTimerFired()) {
-      return goTo(this.flow.callAPI4, undefined);
+      return goTo(CallAPI4, undefined);
     }
     return gracefulComplete(value);
   }

--- a/examples/typescript/src/products/money-transfer/money-transfer-flow.ts
+++ b/examples/typescript/src/products/money-transfer/money-transfer-flow.ts
@@ -66,7 +66,7 @@ export class MoneyTransferFlow implements Flow<TransferRequest> {
   public compensatedStepOptions(totalDurationMs: number): StepOptions {
     return {
       executeRetry: { totalDurationMs },
-      executeFailure: ExecuteFailure.proceedTo(this.compensate, {
+      executeFailure: ExecuteFailure.proceedTo(Compensate, {
         executeRetry: { totalDurationMs: DAY_MS },
       }),
     };
@@ -108,7 +108,7 @@ class CheckBalance implements Step<TransferRequest> {
     if (!this.flow.service.checkBalance(request.fromAccount, request.amount)) {
       return forceFail("insufficient funds");
     }
-    return goTo(this.flow.createDebitMemoStep, request);
+    return goTo(CreateDebitMemo, request);
   }
 }
 
@@ -125,7 +125,7 @@ class CreateDebitMemo implements Step<TransferRequest> {
 
   public execute(_context: Context, request: TransferRequest): StepDecision {
     this.flow.service.createDebitMemo(request.fromAccount, request.amount, request.notes);
-    return goTo(this.flow.debitStep, request);
+    return goTo(Debit, request);
   }
 }
 
@@ -142,7 +142,7 @@ class Debit implements Step<TransferRequest> {
 
   public execute(_context: Context, request: TransferRequest): StepDecision {
     this.flow.service.debit(request.fromAccount, request.amount);
-    return goTo(this.flow.createCreditMemoStep, request);
+    return goTo(CreateCreditMemo, request);
   }
 }
 
@@ -159,7 +159,7 @@ class CreateCreditMemo implements Step<TransferRequest> {
 
   public execute(_context: Context, request: TransferRequest): StepDecision {
     this.flow.service.createCreditMemo(request.toAccount, request.amount, request.notes);
-    return goTo(this.flow.creditStep, request);
+    return goTo(Credit, request);
   }
 }
 

--- a/examples/typescript/src/products/order-processing/order-processing-flow.ts
+++ b/examples/typescript/src/products/order-processing/order-processing-flow.ts
@@ -105,7 +105,7 @@ class ChargeStep implements Step<OrderRequest> {
   public execute(context: Context, input: OrderRequest): StepDecision {
     this.service.chargeUser(input.email, input.customerId, input.amount);
     orderStatus.set(context, "charged");
-    return goTo(this.ship, input);
+    return goTo(ShipStep, input);
   }
 }
 
@@ -127,7 +127,7 @@ class ShipStep implements Step<OrderRequest> {
         // totalDurationMs: 60 * 60 * 1000,
         totalDurationMs: 3_000,
       },
-      executeFailure: ExecuteFailure.proceedTo(this.refund, {
+      executeFailure: ExecuteFailure.proceedTo(RefundStep, {
         executeRetry: {
           // totalDurationMs: 60 * 60 * 1000,
           totalDurationMs: 3_000,
@@ -147,7 +147,7 @@ class ShipStep implements Step<OrderRequest> {
         "Reminder: approve shipment",
         "Please approve or provide a tracking number.",
       );
-      return goTo(this, input);
+      return goTo(ShipStep, input);
     }
     this.service.shipItem(input.orderId, input.testFailAtShipping);
     orderStatus.set(context, "shipped");

--- a/examples/typescript/src/products/polling/polling-flow.ts
+++ b/examples/typescript/src/products/polling/polling-flow.ts
@@ -86,8 +86,8 @@ class Initialize implements Step<number> {
   public execute(context: Context, maximumPolls: number): StepDecision {
     this.flow.currentPolls.set(context, 0);
     return goToMulti(
-      StepMovement.of(this.flow.poll, maximumPolls),
-      StepMovement.of(this.flow.waitForTasks, undefined),
+      StepMovement.of(Poll, maximumPolls),
+      StepMovement.of(WaitForTasks, undefined),
     );
   }
 }
@@ -133,7 +133,7 @@ class Poll implements Step<number> {
       return deadEnd();
     }
     this.flow.currentPolls.set(context, polls + 1);
-    return goTo(this.flow.poll, maximumPolls);
+    return goTo(Poll, maximumPolls);
   }
 }
 

--- a/examples/typescript/src/products/shortlist-candidates/employer-opt-in-flow.ts
+++ b/examples/typescript/src/products/shortlist-candidates/employer-opt-in-flow.ts
@@ -65,7 +65,7 @@ export class EmployerOptInFlow implements Flow<EmployerOptInInput> {
 
   @rpc()
   public optOut(_context: Context): RPCResult<void> {
-    return { output: undefined, nextSteps: [StepMovement.of(this.optOutStep, undefined)] };
+    return { output: undefined, nextSteps: [StepMovement.of(OptOut, undefined)] };
   }
 }
 

--- a/examples/typescript/src/products/shortlist-candidates/shortlist-flow.ts
+++ b/examples/typescript/src/products/shortlist-candidates/shortlist-flow.ts
@@ -98,7 +98,7 @@ class Shortlist implements Step<ShortlistInput> {
     this.flow.employerId.set(context, input.employerId);
     this.flow.candidateId.set(context, input.candidateId);
     this.flow.emailSentTimestamp.set(context, 0n);
-    return goTo(this.flow.sendEmail, undefined);
+    return goTo(SendEmail, undefined);
   }
 }
 

--- a/examples/typescript/src/products/signup/user-signup-flow.ts
+++ b/examples/typescript/src/products/signup/user-signup-flow.ts
@@ -89,7 +89,7 @@ class Submit implements Step<SignupForm> {
     this.flow.form.set(context, input);
     this.flow.status.set(context, "waiting");
     this.flow.service.sendEmail(input.email, "please verify the signup", "content");
-    return goTo(this.flow.verifyStep, undefined);
+    return goTo(Verify, undefined);
   }
 }
 
@@ -111,7 +111,7 @@ class Verify implements Step<void> {
       return gracefulComplete("done");
     }
     this.flow.service.sendEmail(signupForm.email, "reminder", "please verify your email");
-    return goTo(this.flow.verifyStep, undefined);
+    return goTo(Verify, undefined);
   }
 }
 

--- a/examples/typescript/src/products/subscription/subscription-flow.ts
+++ b/examples/typescript/src/products/subscription/subscription-flow.ts
@@ -102,9 +102,9 @@ class Initialize implements Step<Customer> {
   public execute(context: Context, customer: Customer): StepDecision {
     this.flow.customerDetails.set(context, customer);
     return goToMulti(
-      StepMovement.of(this.flow.trial, undefined),
-      StepMovement.of(this.flow.cancel, undefined),
-      StepMovement.of(this.flow.updateChargeAmountStep, undefined),
+      StepMovement.of(Trial, undefined),
+      StepMovement.of(Cancel, undefined),
+      StepMovement.of(UpdateChargeAmount, undefined),
     );
   }
 }
@@ -124,7 +124,7 @@ class Trial implements Step<void> {
 
   public execute(context: Context, _input: void): StepDecision {
     this.flow.billingPeriodNumber.set(context, 0);
-    return goTo(this.flow.chargeCurrentBill, undefined);
+    return goTo(ChargeCurrentBill, undefined);
   }
 }
 
@@ -155,7 +155,7 @@ class ChargeCurrentBill implements Step<void> {
       return forceComplete("subscription ended");
     }
     SubscriptionBilling.chargeCurrentPeriod(customer, this.flow.service);
-    return goTo(this.flow.chargeCurrentBill, undefined);
+    return goTo(ChargeCurrentBill, undefined);
   }
 }
 
@@ -194,7 +194,7 @@ class UpdateChargeAmount implements Step<void> {
     const customer = this.flow.customerDetails.get(context);
     SubscriptionBilling.applyChargeAmount(customer, amount);
     this.flow.customerDetails.set(context, customer);
-    return goTo(this.flow.updateChargeAmountStep, undefined);
+    return goTo(UpdateChargeAmount, undefined);
   }
 }
 


### PR DESCRIPTION
## Summary

- upgrade every root SDK example to the released v0.2.1 patch package
- use Step classes/types in Java, Python, and TypeScript navigation examples
- use the multi-attribute-store FlowConfig API across examples and English/Chinese documentation

## Rationale and user impact

The examples and product documentation now match the released SDK APIs, so developers can copy current Step movement and Attribute Store configuration patterns.

## Validation

- `./gradlew compileJava` (examples/java)
- `npm run typecheck && npm test` (examples/typescript)
- `GOWORK=off make unitTests` (examples/go)
- `cargo fmt --all -- --check && cargo test --all-targets --locked && cargo clippy --all-targets --locked -- -D warnings` (examples/rust)
- `UV_CACHE_DIR=/tmp/dex-uv-cache uv run python -m compileall -q dex_examples sync-python` and registry validation (examples/python)
- `npm run check` (docs)
- `make copyright-check`
