### PR TITLE
Simplify attribute store configuration

### DIFF
--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -2497,7 +2497,7 @@ const (
 
 type FlowConfig struct {
 	ActiveStepSearchMode       *ActiveStepSearchMode
-	AttributeStoreNames        *[]string
+	AttributeStoreNames        []string
 	ContinueAsNewThreshold     *int32
 	ContinueAsNewPageSizeBytes *int32
 	StepDurability             *StepDurability
@@ -2630,11 +2630,9 @@ type TimeTravelOptions struct {
 ```
 
 Pointer fields in `FlowConfig` preserve proto presence for partial overrides.
-`AttributeStoreNames == nil` omits the target override, while a pointer to an
-empty slice disables synchronization for future enabled writes. Every enabled
-Attribute write is projected to every selected Store. Use
-`AttributeStoreNames("profiles")` to create the present pointer value; calling
-it with no names disables future projections.
+`AttributeStoreNames == nil` omits the target override, while an empty non-nil
+slice disables synchronization for future enabled writes. Every enabled Attribute
+write is projected to every selected Store.
 `WorkerTarget` is configured through `FlowConfig`, not as a separate StartFlow
 argument. Phase 5 adds `ClientOptions.WorkerTarget` as the default inserted into
 that FlowConfig.

--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -2632,7 +2632,9 @@ type TimeTravelOptions struct {
 Pointer fields in `FlowConfig` preserve proto presence for partial overrides.
 `AttributeStoreNames == nil` omits the target override, while a pointer to an
 empty slice disables synchronization for future enabled writes. Every enabled
-Attribute write is projected to every selected Store.
+Attribute write is projected to every selected Store. Use
+`AttributeStoreNames("profiles")` to create the present pointer value; calling
+it with no names disables future projections.
 `WorkerTarget` is configured through `FlowConfig`, not as a separate StartFlow
 argument. Phase 5 adds `ClientOptions.WorkerTarget` as the default inserted into
 that FlowConfig.

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -248,15 +248,15 @@ var CustomerEmail = dex.DefineAttribute[string](
 )
 
 config := &dex.FlowConfig{
-	AttributeStoreNames: dex.AttributeStoreNames("profiles", "audit"),
+	AttributeStoreNames: []string{"profiles", "audit"},
 }
 ```
 
 Store updates are asynchronous. Every enabled Attribute write is sent to every
 selected Store. Deleting an opted-in Attribute writes SQL `NULL`, and a Store
 failure does not roll back the Flow Attribute. A `nil` `AttributeStoreNames`
-preserves current targets; a pointer to an empty slice disables future
-synchronization while preserving protocol presence.
+preserves current targets; an empty non-nil slice disables future synchronization
+while preserving protocol presence.
 
 `DefineStep` and `DefineStartStep` retain the step input type behind a private
 `typedStepDef` that implements the sealed `StepDef` interface. Runtime

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -248,7 +248,7 @@ var CustomerEmail = dex.DefineAttribute[string](
 )
 
 config := &dex.FlowConfig{
-	AttributeStoreNames: ptr.Any([]string{"profiles", "audit"}),
+	AttributeStoreNames: dex.AttributeStoreNames("profiles", "audit"),
 }
 ```
 

--- a/sdk-go/dex/client_integration_test.go
+++ b/sdk-go/dex/client_integration_test.go
@@ -670,7 +670,7 @@ func TestClientRPCResultsAndAdministrativeTransport(t *testing.T) {
 
 	require.NoError(t, client.UpdateFlowConfig(ctx, "order-1", FlowConfig{
 		ContinueAsNewThreshold: ptr.Any(int32(100)),
-		AttributeStoreNames:    ptr.Any([]string{"reporting", "audit"}),
+		AttributeStoreNames:    []string{"reporting", "audit"},
 	}))
 	require.Nil(t, service.updateConfigRequest.FlowConfig.WorkerTarget)
 	require.Equal(t, []string{"reporting", "audit"}, service.updateConfigRequest.FlowConfig.GetAttributeStoreNames().GetNames())

--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -194,6 +194,7 @@ func TestPublicContractsCompile(t *testing.T) {
 		ActiveStepSearchMode:   &mode,
 		ContinueAsNewThreshold: ptr.Any(int32(100)),
 		StepDurability:         &durability,
+		AttributeStoreNames:    dex.AttributeStoreNames("profiles"),
 	}
 	options := dex.StartFlowOptions{
 		Timeout:        ptr.Any(time.Minute),
@@ -205,6 +206,12 @@ func TestPublicContractsCompile(t *testing.T) {
 		options.StartDelay == nil ||
 		len(options.Attributes) != 2 {
 		t.Fatal("start flow options are missing")
+	}
+	if config.AttributeStoreNames == nil || len(*config.AttributeStoreNames) != 1 {
+		t.Fatal("attribute store names are missing")
+	}
+	if disabled := dex.AttributeStoreNames(); disabled == nil || len(*disabled) != 0 {
+		t.Fatal("empty attribute store names must preserve an explicit empty override")
 	}
 
 	registry, err := dex.NewRegistry([]dex.Flow{flow})

--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -194,7 +194,7 @@ func TestPublicContractsCompile(t *testing.T) {
 		ActiveStepSearchMode:   &mode,
 		ContinueAsNewThreshold: ptr.Any(int32(100)),
 		StepDurability:         &durability,
-		AttributeStoreNames:    dex.AttributeStoreNames("profiles"),
+		AttributeStoreNames:    []string{"profiles"},
 	}
 	options := dex.StartFlowOptions{
 		Timeout:        ptr.Any(time.Minute),
@@ -207,10 +207,11 @@ func TestPublicContractsCompile(t *testing.T) {
 		len(options.Attributes) != 2 {
 		t.Fatal("start flow options are missing")
 	}
-	if config.AttributeStoreNames == nil || len(*config.AttributeStoreNames) != 1 {
+	if config.AttributeStoreNames == nil || len(config.AttributeStoreNames) != 1 {
 		t.Fatal("attribute store names are missing")
 	}
-	if disabled := dex.AttributeStoreNames(); disabled == nil || len(*disabled) != 0 {
+	disabledConfig := dex.FlowConfig{AttributeStoreNames: []string{}}
+	if disabledConfig.AttributeStoreNames == nil || len(disabledConfig.AttributeStoreNames) != 0 {
 		t.Fatal("empty attribute store names must preserve an explicit empty override")
 	}
 

--- a/sdk-go/dex/options.go
+++ b/sdk-go/dex/options.go
@@ -10,11 +10,7 @@
 
 package dex
 
-import (
-	"time"
-
-	"github.com/superdurable/dex/sdk-go/dex/ptr"
-)
+import "time"
 
 // RetryPolicy overrides retry timing for a Step's WaitFor or Execute method.
 // Zero fields preserve server defaults; MaximumAttempts counts the initial attempt.
@@ -140,21 +136,8 @@ type FlowConfig struct {
 	// WorkerTarget routes future Step and RPC invocations.
 	WorkerTarget *WorkerTarget
 	// AttributeStoreNames selects Server-configured Attribute Stores for opted-in writes.
-	// Nil preserves the current targets; an empty slice disables future asynchronous projections.
-	AttributeStoreNames *[]string
-}
-
-// AttributeStoreNames returns a present Attribute Store override for FlowConfig.
-//
-// Pass the Server-configured stores that should receive opted-in Attribute writes. Calling
-// AttributeStoreNames with no arguments explicitly disables future projections, while a nil
-// FlowConfig.AttributeStoreNames field leaves the current or server-selected stores unchanged.
-//
-//	config := dex.FlowConfig{AttributeStoreNames: dex.AttributeStoreNames("profiles")}
-//
-// The returned pointer owns the supplied slice and is intended for FlowConfig.AttributeStoreNames.
-func AttributeStoreNames(names ...string) *[]string {
-	return ptr.Any(names)
+	// A nil slice preserves the current targets; an empty non-nil slice disables future projections.
+	AttributeStoreNames []string
 }
 
 // StartFlowOptions configures a new Flow execution.

--- a/sdk-go/dex/options.go
+++ b/sdk-go/dex/options.go
@@ -10,7 +10,11 @@
 
 package dex
 
-import "time"
+import (
+	"time"
+
+	"github.com/superdurable/dex/sdk-go/dex/ptr"
+)
 
 // RetryPolicy overrides retry timing for a Step's WaitFor or Execute method.
 // Zero fields preserve server defaults; MaximumAttempts counts the initial attempt.
@@ -138,6 +142,19 @@ type FlowConfig struct {
 	// AttributeStoreNames selects Server-configured Attribute Stores for opted-in writes.
 	// Nil preserves the current targets; an empty slice disables future asynchronous projections.
 	AttributeStoreNames *[]string
+}
+
+// AttributeStoreNames returns a present Attribute Store override for FlowConfig.
+//
+// Pass the Server-configured stores that should receive opted-in Attribute writes. Calling
+// AttributeStoreNames with no arguments explicitly disables future projections, while a nil
+// FlowConfig.AttributeStoreNames field leaves the current or server-selected stores unchanged.
+//
+//	config := dex.FlowConfig{AttributeStoreNames: dex.AttributeStoreNames("profiles")}
+//
+// The returned pointer owns the supplied slice and is intended for FlowConfig.AttributeStoreNames.
+func AttributeStoreNames(names ...string) *[]string {
+	return ptr.Any(names)
 }
 
 // StartFlowOptions configures a new Flow execution.

--- a/sdk-go/dex/proto_mapper.go
+++ b/sdk-go/dex/proto_mapper.go
@@ -359,7 +359,7 @@ func mapFlowConfig(config *FlowConfig) (*dexpb.FlowConfig, error) {
 	}
 	var attributeStoreNames *dexpb.AttributeStoreNames
 	if config.AttributeStoreNames != nil {
-		attributeStoreNames = &dexpb.AttributeStoreNames{Names: *config.AttributeStoreNames}
+		attributeStoreNames = &dexpb.AttributeStoreNames{Names: config.AttributeStoreNames}
 	}
 	return &dexpb.FlowConfig{
 		ActiveStepSearchMode:         searchMode,

--- a/sdk-go/dex/proto_mapper_test.go
+++ b/sdk-go/dex/proto_mapper_test.go
@@ -194,8 +194,6 @@ func TestStartAndFlowConfigMappingPreservesPresence(t *testing.T) {
 	attributeMap := DefineAttributeMap[string]("status-by-tenant", SyncToAttributeStore())
 	initialMap, err := InitialAttributeMapValue(attributeMap, "tenant-1", "ready")
 	require.NoError(t, err)
-	storeNames := []string{"reporting", "audit"}
-
 	flowTimeout, timeoutPolicy, options, err := mapStartFlowOptions(StartFlowOptions{
 		Timeout:       &timeout,
 		TimeoutPolicy: TimeoutFail,
@@ -204,7 +202,7 @@ func TestStartAndFlowConfigMappingPreservesPresence(t *testing.T) {
 		ConfigOverride: &FlowConfig{
 			ActiveStepSearchMode: &searchMode,
 			StepDurability:       &durability,
-			AttributeStoreNames:  &storeNames,
+			AttributeStoreNames:  []string{"reporting", "audit"},
 			WorkerTarget: &WorkerTarget{
 				Address:  "worker:7233",
 				Headless: true,
@@ -224,9 +222,8 @@ func TestStartAndFlowConfigMappingPreservesPresence(t *testing.T) {
 	require.Equal(t, []string{"reporting", "audit"}, options.FlowConfigOverride.GetAttributeStoreNames().GetNames())
 	require.NotNil(t, options.FlowConfigOverride.AttributeStoreNames)
 
-	disabled := []string{}
 	_, _, disabledOptions, err := mapStartFlowOptions(StartFlowOptions{
-		ConfigOverride: &FlowConfig{AttributeStoreNames: &disabled},
+		ConfigOverride: &FlowConfig{AttributeStoreNames: []string{}},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, disabledOptions.FlowConfigOverride.AttributeStoreNames)

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -383,14 +383,14 @@ Attribute Store synchronization is definition-level and immutable:
 Attribute<String> email = Attribute.define("customer-email", String.class)
         .syncToAttributeStore();
 FlowConfig config = FlowConfig.newBuilder()
-        .attributeStoreNames(Arrays.asList("profiles", "audit"))
+        .attributeStoreNames("profiles", "audit")
         .build();
 ```
 
 Stores are asynchronous latest-state projections. Every enabled Attribute write
 is sent to every selected Store. Deletion writes SQL `NULL`, and projection
 failures do not roll back Flow Attributes. Omitting `attributeStoreNames`
-preserves current targets; `attributeStoreNames(Collections.emptyList())` disables future
+preserves current targets; `attributeStoreNames()` disables future
 synchronization with protocol presence.
 
 The IWF integration inventory is implemented as real Dex E2E tests under

--- a/sdk-java/src/main/java/io/superdurable/dex/FlowConfig.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/FlowConfig.java
@@ -11,6 +11,7 @@
 package io.superdurable.dex;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -172,6 +173,27 @@ public final class FlowConfig {
                     ? null
                     : Collections.unmodifiableList(new ArrayList<>(value));
             return this;
+        }
+
+        /**
+         * Selects Server-configured Attribute Stores for enabled Attribute writes.
+         *
+         * <p>This overload is convenient when a Flow uses one or a few stores. Each enabled
+         * Attribute write is projected to every supplied store. Calling this method with no names
+         * explicitly disables future projections; omitting it leaves the current or server-selected
+         * values unchanged. Already queued projections retain their original targets.
+         *
+         * <pre>{@code
+         * FlowConfig config = FlowConfig.newBuilder()
+         *         .attributeStoreNames("profiles")
+         *         .build();
+         * }</pre>
+         *
+         * @param values the Attribute Store names; no names disables future projections
+         * @return this builder
+         */
+        public Builder attributeStoreNames(final String... values) {
+            return attributeStoreNames(values == null ? null : Arrays.asList(values));
         }
 
         /**

--- a/sdk-java/src/test/java/io/superdurable/dex/AttributeStoreSyncTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/AttributeStoreSyncTest.java
@@ -43,12 +43,17 @@ final class AttributeStoreSyncTest {
             assertFalse(absent.hasAttributeStoreNames());
 
             final io.superdurable.gen.FlowConfig selected = client.mapFlowConfig(
-                    FlowConfig.newBuilder().attributeStoreNames(Arrays.asList("reporting", "audit")).build());
+                    FlowConfig.newBuilder().attributeStoreNames("reporting", "audit").build());
             assertTrue(selected.hasAttributeStoreNames());
             assertEquals(Arrays.asList("reporting", "audit"), selected.getAttributeStoreNames().getNamesList());
 
+            final io.superdurable.gen.FlowConfig selectedSingle = client.mapFlowConfig(
+                    FlowConfig.newBuilder().attributeStoreNames("reporting").build());
+            assertTrue(selectedSingle.hasAttributeStoreNames());
+            assertEquals(Collections.singletonList("reporting"), selectedSingle.getAttributeStoreNames().getNamesList());
+
             final io.superdurable.gen.FlowConfig disabled = client.mapFlowConfig(
-                    FlowConfig.newBuilder().attributeStoreNames(Collections.<String>emptyList()).build());
+                    FlowConfig.newBuilder().attributeStoreNames().build());
             assertTrue(disabled.hasAttributeStoreNames());
             assertEquals(Collections.emptyList(), disabled.getAttributeStoreNames().getNamesList());
 


### PR DESCRIPTION
## Summary

- make Go **FlowConfig.AttributeStoreNames** a direct string slice
- add Java **FlowConfig.Builder.attributeStoreNames(String... names)** for concise one-Store and multi-Store calls
- document and test omitted, selected, and explicitly empty Attribute Store targets

## Rationale and user impact

Most Flows select one Attribute Store. Go applications can now write
`AttributeStoreNames: []string{"profiles"}`, while Java applications can write
`.attributeStoreNames("profiles")`. In Go, a nil slice leaves the current or
server-selected targets unchanged, and an empty non-nil slice explicitly disables
future projections.

## Validation

- `make unitTests` (sdk-go)
- `./gradlew test --no-daemon` (sdk-java)
- `make copyright-check`
