### PR TITLE
Update Java examples for SDK v0.2.2

### DIFF
--- a/docs/content/design-patterns/entity-store.mdx
+++ b/docs/content/design-patterns/entity-store.mdx
@@ -91,7 +91,7 @@ Attribute<String> displayName =
     Attribute.define("display_name", String.class).syncToAttributeStore();
 
 FlowConfig config = FlowConfig.newBuilder()
-    .attributeStoreNames(List.of("entityStore"))
+    .attributeStoreNames("entityStore")
     .build();
 ```
 

--- a/docs/content/primitives/attribute.mdx
+++ b/docs/content/primitives/attribute.mdx
@@ -598,7 +598,7 @@ _, err := client.StartFlow(ctx, flow, userID, nil, options)
 ```java
 final StartFlowOptions options = StartFlowOptions.newBuilder()
         .configOverride(FlowConfig.newBuilder()
-                .attributeStoreNames(List.of("entityStore"))
+                .attributeStoreNames("entityStore")
                 .build())
         .build();
 final String runId = client.startFlow(flow, userId, null, options);

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
@@ -598,7 +598,7 @@ _, err := client.StartFlow(ctx, flow, userID, nil, options)
 ```java
 final StartFlowOptions options = StartFlowOptions.newBuilder()
         .configOverride(FlowConfig.newBuilder()
-                .attributeStoreNames(List.of("entityStore"))
+                .attributeStoreNames("entityStore")
                 .build())
         .build();
 final String runId = client.startFlow(flow, userId, null, options);

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -1,6 +1,6 @@
 # Dex Java examples
 
-These examples target `io.superdurable:dex-sdk:0.2.1` (`io.superdurable.dex`).
+These examples target `io.superdurable:dex-sdk:0.2.2` (`io.superdurable.dex`).
 
 The sample process hosts one gRPC Worker on `127.0.0.1:8803` and an HTTP
 controller on port `8080`. One Registry and disk BlobCache are shared by its

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "io.superdurable:dex-sdk:0.2.1"
+    implementation "io.superdurable:dex-sdk:0.2.2"
 
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/entitystore/EntityStoreController.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/entitystore/EntityStoreController.java
@@ -19,7 +19,6 @@ package io.superdurable.dex.patterns.entitystore;
 import io.superdurable.dex.Client;
 import io.superdurable.dex.FlowConfig;
 import io.superdurable.dex.StartFlowOptions;
-import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,7 +53,7 @@ public class EntityStoreController {
                 .addAttribute(userProfileFlow.lastLoggedInTime, profile.lastLoggedInTime)
                 .addAttribute(userProfileFlow.metadata, profile.metadata)
                 .configOverride(FlowConfig.newBuilder()
-                        .attributeStoreNames(List.of(UserProfileFlow.STORE_NAME))
+                        .attributeStoreNames(UserProfileFlow.STORE_NAME)
                         .build())
                 .build();
         final String runId = client.startFlow(

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/attribute/AttributeFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/attribute/AttributeFlow.java
@@ -32,7 +32,6 @@ import io.superdurable.dex.StepDecision;
 import io.superdurable.dex.StepList;
 import io.superdurable.dex.StepOptions;
 import io.superdurable.dex.Wait;
-import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -50,7 +49,7 @@ public class AttributeFlow implements Flow<String> {
                     String.class,
                     new AttributeIndex(AttributeIndex.Type.KEYWORD, "OrderProgress"));
     private final FlowConfig attributeStoreConfig = FlowConfig.newBuilder()
-            .attributeStoreNames(List.of("profiles"))
+            .attributeStoreNames("profiles")
             .build();
     private final AttributeStep start = new AttributeStep();
 


### PR DESCRIPTION
## Summary

- update Java examples to `io.superdurable:dex-sdk:0.2.2`
- keep the Java Attribute Store examples on the concise `List.of(...)` form

## Validation

- `./gradlew compileJava --refresh-dependencies --no-daemon` (examples/java)
- verified `dex-sdk-0.2.2.pom` on Maven Central
