### PR TITLE
Add in-memory Stream Store backend

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -62,6 +62,9 @@ Choose another blob directory with:
 dexcli dev --blob-store-dir ./dex-blobs
 ```
 
+`dexcli dev` enables the in-memory Stream Store without Redis. Stream messages
+and their idempotency records are discarded when the CLI process stops.
+
 `--blob-store-dir` takes precedence over the directory derived from
 `--sqlite-db-filename`.
 

--- a/cli/internal/dev/supervisor.go
+++ b/cli/internal/dev/supervisor.go
@@ -262,6 +262,9 @@ func (s *supervisor) startDexRuntime(
 			OutputFile: s.cfg.dexServerLogPath(),
 		},
 		Api: config.ApiConfig{Port: s.cfg.DexPort},
+		StreamStore: config.StreamStoreConfig{
+			Backend: config.StreamStoreBackendMemory,
+		},
 		BlobStore: config.BlobStoreConfig{
 			Enabled:                ptr.Any(true),
 			LazyLoading:            ptr.Any(true),

--- a/cli/internal/dev/supervisor_integ_test.go
+++ b/cli/internal/dev/supervisor_integ_test.go
@@ -110,6 +110,35 @@ func TestLocalStackStartsAndReleasesPorts(t *testing.T) {
 		cancel()
 		t.Fatalf("unexpected CLI API response: %s", cliOutput.String())
 	}
+	cliOutput.Reset()
+	if err := cliApp.Execute(
+		context.Background(),
+		[]string{
+			"api", "call", "WriteStream",
+			"--data", `{"flowId":"cli-flow","flowType":"CliFlow","streamName":"progress","maxEstimatedBytes":"1048576","value":{"stringValue":"thinking"},"idempotencyKey":"cli-key"}`,
+			"--yes", "--server", dexAddress,
+		},
+	); err != nil {
+		cancel()
+		t.Fatalf("CLI Stream write failed: %v stderr=%s", err, cliErrors.String())
+	}
+	cliOutput.Reset()
+	if err := cliApp.Execute(
+		context.Background(),
+		[]string{
+			"api", "call", "ReadStream",
+			"--data", `{"flowId":"cli-flow","flowType":"CliFlow","streamName":"progress","waitTimeSeconds":1}`,
+			"--server", dexAddress,
+		},
+	); err != nil {
+		cancel()
+		t.Fatalf("CLI Stream read failed: %v stderr=%s", err, cliErrors.String())
+	}
+	if !bytes.Contains(cliOutput.Bytes(), []byte(`"stringValue":"thinking"`)) ||
+		!bytes.Contains(cliOutput.Bytes(), []byte(`"idempotencyKey":"cli-key"`)) {
+		cancel()
+		t.Fatalf("unexpected CLI Stream response: %s", cliOutput.String())
+	}
 
 	cancel()
 	select {

--- a/protos/dex.proto
+++ b/protos/dex.proto
@@ -47,7 +47,7 @@ option java_outer_classname = "DexProto";
 //                       WaitForStepCompletion, WaitForAttribute)
 //                       sub_status LONG_POLL_TIME_OUT
 //   Canceled          — caller canceled the RPC context
-//   Unavailable       — Temporal/Cadence backend or Stream Redis unavailable;
+//   Unavailable       — Temporal/Cadence backend or Stream Store backend unavailable;
 //                       never Dex application WorkerService
 //   Internal          — unexpected / violated trusted invariant
 //   Unimplemented     — Cadence: WaitForStepCompletion, WaitForAttribute,

--- a/sdk-python/dex/dexpb/dex_pb2_grpc.py
+++ b/sdk-python/dex/dexpb/dex_pb2_grpc.py
@@ -55,7 +55,7 @@ class FlowServiceStub:
     WaitForStepCompletion, WaitForAttribute)
     sub_status LONG_POLL_TIME_OUT
     Canceled          — caller canceled the RPC context
-    Unavailable       — Temporal/Cadence backend or Stream Redis unavailable;
+    Unavailable       — Temporal/Cadence backend or Stream Store backend unavailable;
     never Dex application WorkerService
     Internal          — unexpected / violated trusted invariant
     Unimplemented     — Cadence: WaitForStepCompletion, WaitForAttribute,
@@ -234,7 +234,7 @@ class FlowServiceServicer:
     WaitForStepCompletion, WaitForAttribute)
     sub_status LONG_POLL_TIME_OUT
     Canceled          — caller canceled the RPC context
-    Unavailable       — Temporal/Cadence backend or Stream Redis unavailable;
+    Unavailable       — Temporal/Cadence backend or Stream Store backend unavailable;
     never Dex application WorkerService
     Internal          — unexpected / violated trusted invariant
     Unimplemented     — Cadence: WaitForStepCompletion, WaitForAttribute,
@@ -554,7 +554,7 @@ class FlowService:
     WaitForStepCompletion, WaitForAttribute)
     sub_status LONG_POLL_TIME_OUT
     Canceled          — caller canceled the RPC context
-    Unavailable       — Temporal/Cadence backend or Stream Redis unavailable;
+    Unavailable       — Temporal/Cadence backend or Stream Store backend unavailable;
     never Dex application WorkerService
     Internal          — unexpected / violated trusted invariant
     Unimplemented     — Cadence: WaitForStepCompletion, WaitForAttribute,

--- a/server/README.md
+++ b/server/README.md
@@ -26,23 +26,28 @@ the [server operations guide](../docs/content/production/server-operations.mdx).
 Integration and replay test instructions are available in
 [integ/README.md](integ/README.md) and [replayTests/README.md](replayTests/README.md).
 
-The optional `streamStore` configuration enables Redis 7+ Standalone-backed
-resumable Streams. `redisURL` enables the feature. `maxMessageBytes` limits each
-serialized Value to 100 KiB by default. The remaining settings tune approximate
-per-message charging, trim watermarks, messages removed per atomic trim batch,
-and background trim concurrency. Redis is intentionally excluded from server
-readiness; only Stream RPCs fail when it is unavailable. Configure dedicated
+The optional `streamStore` configuration enables best-effort resumable Streams.
+`backend` accepts `memory` for one Dex Server process or `redis` for Redis 7+
+Standalone shared by multiple servers. It defaults to `disabled`. The memory
+backend loses messages and idempotency records when the process stops. The Redis
+backend requires `redisURL`; Redis is intentionally excluded from server
+readiness, so only Stream RPCs fail when it is unavailable. Configure dedicated
 Redis memory with `maxmemory` and `noeviction` so memory pressure becomes a
 visible write error.
 
-Capacity is not stored in Redis. Each write supplies the limit shared by all
-Flow instances with the same Flow type and Stream name. Charged bytes
-approximate the serialized Value, Flow ID, public and internal idempotency
-identities, and configured overhead. Client idempotency keys cannot contain
-`#`; Step SDKs use `<runID>#<stepExecutionID>`. Reaching the default 90% trigger
-starts singleton background FIFO trimming toward the 80% target. A write that
-would exceed 100% is not appended; it returns `ResourceExhausted` after
-scheduling trim and can be retried later.
+`maxMessageBytes` limits each serialized Value to 100 KiB by default. The
+remaining settings tune approximate per-message charging, trim watermarks,
+messages removed per trim batch, and background trim concurrency. Lease settings
+apply only to the Redis backend. The checked-in development config uses memory.
+
+Capacity is not persisted by either backend. Each write supplies the limit
+shared by all Flow instances with the same Flow type and Stream name. Charged
+bytes approximate the serialized Value, Flow ID, public and internal
+idempotency identities, and configured overhead. Client idempotency keys cannot
+contain `#`; Step SDKs use `<runID>#<stepExecutionID>`. Reaching the default 90%
+trigger starts singleton background FIFO trimming toward the 80% target. A
+write that would exceed 100% is not appended; it returns `ResourceExhausted`
+after scheduling trim and can be retried later.
 
 ## License
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -36,6 +36,12 @@ const (
 )
 
 const (
+	StreamStoreBackendDisabled StreamStoreBackend = "disabled"
+	StreamStoreBackendMemory   StreamStoreBackend = "memory"
+	StreamStoreBackendRedis    StreamStoreBackend = "redis"
+)
+
+const (
 	CleanupStrategyTypeAfterAllRunsDeleted CleanupStrategyType = "afterAllRunsDeleted"
 )
 
@@ -72,13 +78,13 @@ const (
 	DefaultAttributeIndexSyncTimeout = 2 * time.Minute
 	// DefaultStreamMaxMessageBytes limits each serialized Stream Value to 100 KiB.
 	DefaultStreamMaxMessageBytes int64 = 100 * 1024
-	// DefaultStreamEstimatedMessageOverheadBytes approximates Redis bookkeeping per message.
+	// DefaultStreamEstimatedMessageOverheadBytes approximates backend bookkeeping per message.
 	DefaultStreamEstimatedMessageOverheadBytes int64 = 512
 	// DefaultStreamTrimTriggerPercent starts asynchronous trimming at ninety percent of capacity.
 	DefaultStreamTrimTriggerPercent int32 = 90
 	// DefaultStreamTrimTargetPercent stops asynchronous trimming at eighty percent of capacity.
 	DefaultStreamTrimTargetPercent int32 = 80
-	// DefaultStreamBackgroundTrimBatchSize caps messages removed by one atomic Redis trim script.
+	// DefaultStreamBackgroundTrimBatchSize caps messages removed by one trim batch.
 	DefaultStreamBackgroundTrimBatchSize = 256
 	// DefaultStreamTrimLeaseTTL keeps a distributed trim lease alive for five seconds.
 	DefaultStreamTrimLeaseTTL = 5 * time.Second
@@ -154,12 +160,14 @@ type (
 		BlobStore BlobStoreConfig `yaml:"blobStore"`
 		// AttributeStore configures optional MySQL/Postgres Attribute synchronization. Default disabled when Stores is empty.
 		AttributeStore AttributeStoreConfig `yaml:"attributeStore"`
-		// StreamStore configures best-effort resumable Streams. Default disabled when RedisURL is empty.
+		// StreamStore configures best-effort resumable Streams. Default backend is disabled.
 		StreamStore StreamStoreConfig `yaml:"streamStore"`
 	}
 
 	StreamStoreConfig struct {
-		// RedisURL is a Redis 7+ Standalone URL. Default empty disables Streams. Immutable after startup.
+		// Backend selects disabled, memory, or redis storage. Default disabled. Immutable after startup.
+		Backend StreamStoreBackend `yaml:"backend"`
+		// RedisURL is a Redis 7+ Standalone URL. Default empty. Required only by the redis backend. Immutable after startup.
 		RedisURL string `yaml:"redisURL"`
 		// MaxMessageBytes limits each serialized Stream Value. Default 102400. Must be positive after defaults.
 		MaxMessageBytes int64 `yaml:"maxMessageBytes"`
@@ -169,17 +177,19 @@ type (
 		TrimTriggerPercent int32 `yaml:"trimTriggerPercent"`
 		// TrimTargetPercent stops asynchronous trimming at this capacity percentage. Default 80. Must be below TrimTriggerPercent.
 		TrimTargetPercent int32 `yaml:"trimTargetPercent"`
-		// BackgroundTrimBatchSize caps messages removed by one atomic Redis trim script. Default 256. Must be positive after defaults.
+		// BackgroundTrimBatchSize caps messages removed by one trim batch. Default 256. Must be positive after defaults.
 		BackgroundTrimBatchSize int `yaml:"backgroundTrimBatchSize"`
-		// TrimLeaseTTL controls the Redis lease lifetime for one active trimmer. Default 5s. Must be positive after defaults.
+		// TrimLeaseTTL controls the Redis lease lifetime for one active trimmer. Default 5s. Must be positive. Redis backend only.
 		TrimLeaseTTL time.Duration `yaml:"trimLeaseTTL"`
-		// TrimLeaseRetry controls how often a server retries a held trim lease. Default 100ms. Must be positive after defaults.
+		// TrimLeaseRetry controls how often a server retries a held trim lease. Default 100ms. Must be positive. Redis backend only.
 		TrimLeaseRetry time.Duration `yaml:"trimLeaseRetry"`
 		// TrimBatchYieldTime controls the pause between atomic trim batches. Default 1ms. Must be positive after defaults.
 		TrimBatchYieldTime time.Duration `yaml:"trimBatchYieldTime"`
 		// TrimWorkers bounds concurrent background trim jobs per server process. Default 4. Must be positive after defaults.
 		TrimWorkers int `yaml:"trimWorkers"`
 	}
+
+	StreamStoreBackend string
 
 	BlobStoreConfig struct {
 		// Enabled turns blob offload on or off. Default true when omitted.
@@ -499,6 +509,14 @@ func (c ApiConfig) EffectiveMaxWaitSeconds() int64 {
 	return c.MaxWaitSeconds
 }
 
+// EffectiveBackend returns the configured Stream Store backend or disabled.
+func (c StreamStoreConfig) EffectiveBackend() StreamStoreBackend {
+	if c.Backend == "" {
+		return StreamStoreBackendDisabled
+	}
+	return c.Backend
+}
+
 // EffectiveMaxMessageBytes returns the configured limit or 100-KiB default.
 func (c StreamStoreConfig) EffectiveMaxMessageBytes() int64 {
 	if c.MaxMessageBytes == 0 {
@@ -573,6 +591,22 @@ func (c StreamStoreConfig) EffectiveTrimWorkers() int {
 
 // Validate checks enabled Stream Store settings and trimming bounds.
 func (c StreamStoreConfig) Validate() error {
+	switch c.EffectiveBackend() {
+	case StreamStoreBackendDisabled:
+		if c.RedisURL != "" {
+			return fmt.Errorf("stream store redisURL requires redis backend")
+		}
+	case StreamStoreBackendMemory:
+		if c.RedisURL != "" {
+			return fmt.Errorf("stream store memory backend does not use redisURL")
+		}
+	case StreamStoreBackendRedis:
+		if c.RedisURL == "" {
+			return fmt.Errorf("stream store redis backend requires redisURL")
+		}
+	default:
+		return fmt.Errorf("unsupported stream store backend %q", c.Backend)
+	}
 	if c.EffectiveMaxMessageBytes() <= 0 {
 		return fmt.Errorf("stream store maxMessageBytes must be positive")
 	}

--- a/server/config/config_template.yaml
+++ b/server/config/config_template.yaml
@@ -52,8 +52,10 @@ blobStore:
       storageId: "local"
       storageType: "local"
       localDirectory: "/dex/dex-blobs"
-# Streams remain disabled until redisURL is configured.
+# Streams remain disabled until a backend is configured.
 # streamStore:
+#   # Use memory for one process. Redis supports multi-server deployments.
+#   backend: redis
 #   redisURL: redis://redis:6379/0
 #   maxMessageBytes: 102400
 #   estimatedMessageOverheadBytes: 512

--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -84,14 +84,5 @@ blobStore:
 #     maximumAttempts: 0
 #     totalDuration: 1h
 
-# streamStore:
-#   redisURL: redis://localhost:6379/0
-#   maxMessageBytes: 102400
-#   estimatedMessageOverheadBytes: 512
-#   trimTriggerPercent: 90
-#   trimTargetPercent: 80
-#   backgroundTrimBatchSize: 256
-#   trimLeaseTTL: 5s
-#   trimLeaseRetry: 100ms
-#   trimBatchYieldTime: 1ms
-#   trimWorkers: 4
+streamStore:
+  backend: memory

--- a/server/config/development_cadence.yaml
+++ b/server/config/development_cadence.yaml
@@ -43,3 +43,5 @@ blobStore:
       storageId: "local-cadence"
       storageType: "local"
       localDirectory: "./dex-blobs-cadence"
+streamStore:
+  backend: memory

--- a/server/integ/stream_test.go
+++ b/server/integ/stream_test.go
@@ -11,6 +11,7 @@ package integ
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -75,7 +76,7 @@ func TestStreamStoreGlobalFIFOResumeAndIdempotency(t *testing.T) {
 		streamTestFlowType,
 		"flow-a",
 		streamName,
-		flowAMessages[0].RedisID,
+		flowAMessages[0].MessageID,
 	)
 	require.NoError(t, err)
 	nextMessage := readOneMessage(t, store, "flow-a", streamName, firstToken)
@@ -89,7 +90,7 @@ func TestStreamStoreGlobalFIFOResumeAndIdempotency(t *testing.T) {
 		streamTestFlowType,
 		"flow-a",
 		streamName,
-		flowAMessages[2].RedisID,
+		flowAMessages[2].MessageID,
 	)
 	require.NoError(t, err)
 	retainedOriginal := readOneMessage(t, store, "flow-a", streamName, beforeLastToken)
@@ -113,7 +114,7 @@ func TestStreamStoreGlobalFIFOResumeAndIdempotency(t *testing.T) {
 		streamTestFlowType,
 		"flow-b",
 		streamName,
-		flowBMessages[0].RedisID,
+		flowBMessages[0].MessageID,
 	)
 	require.NoError(t, err)
 	readCtx, cancelRead := context.WithTimeout(context.Background(), time.Second)
@@ -171,7 +172,7 @@ func TestStreamStoreFlowTypesIsolateStreamScopes(t *testing.T) {
 		firstFlowType,
 		"shared-flow",
 		streamName,
-		firstMessage.RedisID,
+		firstMessage.MessageID,
 	)
 	require.NoError(t, err)
 	wrongTypeCtx, cancelWrongTypeRead := context.WithTimeout(context.Background(), time.Second)
@@ -316,6 +317,7 @@ func TestStreamStoreConcurrentTriggersUseSingletonTrimLease(t *testing.T) {
 
 func TestStreamStoreMessageSizeLimit(t *testing.T) {
 	store, redisClient := newStreamTestStoreWithConfig(t, config.StreamStoreConfig{
+		Backend:                       config.StreamStoreBackendRedis,
 		RedisURL:                      streamTestRedisURL,
 		MaxMessageBytes:               32,
 		EstimatedMessageOverheadBytes: 1,
@@ -349,6 +351,202 @@ func TestStreamStoreMessageSizeLimit(t *testing.T) {
 	require.Equal(t, int64(0), streamLength(t, redisClient, defaultStreamName))
 }
 
+func TestStreamStoreMemoryResumeIdempotencyAndBlockingRead(t *testing.T) {
+	store := newMemoryStreamTestStore(t)
+	streamName := "memory-resume-" + newRequestID()
+	firstInput := streamInput("flow-a", streamName, 0, "first")
+	firstInput.MaxEstimatedBytes = 1 << 20
+	require.NoError(t, store.Write(context.Background(), firstInput))
+
+	firstMessage := readOneMessage(t, store, "flow-a", streamName, "")
+	require.Equal(t, "first", firstMessage.Value.GetStringValue())
+	require.Equal(t, firstInput.PublicIdempotencyKey, firstMessage.IdempotencyKey)
+	firstToken, err := streamstore.EncodeResumeToken(
+		streamTestFlowType,
+		"flow-a",
+		streamName,
+		firstMessage.MessageID,
+	)
+	require.NoError(t, err)
+
+	duplicate := firstInput
+	duplicate.Value = stringValue("duplicate")
+	require.NoError(t, store.Write(context.Background(), duplicate))
+	require.Len(t, readAvailableMessages(t, store, "flow-a", streamName), 1)
+
+	readResult := make(chan *streamstore.Message, 1)
+	readErrors := make(chan error, 1)
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelRead()
+	go func() {
+		message, readErr := store.Read(readCtx, streamTestFlowType, "flow-a", streamName, firstToken)
+		if readErr != nil {
+			readErrors <- readErr
+			return
+		}
+		readResult <- message
+	}()
+	otherFlow := streamInput("flow-b", streamName, 1, "other-flow")
+	otherFlow.MaxEstimatedBytes = 1 << 20
+	require.NoError(t, store.Write(context.Background(), otherFlow))
+	require.Never(t, func() bool {
+		return len(readResult) != 0 || len(readErrors) != 0
+	}, 200*time.Millisecond, 10*time.Millisecond)
+	secondInput := streamInput("flow-a", streamName, 2, "second")
+	secondInput.MaxEstimatedBytes = 1 << 20
+	require.NoError(t, store.Write(context.Background(), secondInput))
+	select {
+	case readErr := <-readErrors:
+		require.NoError(t, readErr)
+	case message := <-readResult:
+		require.Equal(t, "second", message.Value.GetStringValue())
+	case <-readCtx.Done():
+		require.FailNow(t, "Memory Stream read did not resume", readCtx.Err())
+	}
+}
+
+func TestStreamStoreMemoryTrimWatermarks(t *testing.T) {
+	store := newMemoryStreamTestStore(t)
+	streamName := "memory-watermarks-" + newRequestID()
+	baseInput := streamInput("flow-a", streamName, 0, "payload-0000")
+	charge := estimatedCharge(baseInput, 1)
+	capacity := charge * 10
+	for index := 0; index < 8; index++ {
+		input := streamInput("flow-a", streamName, index, "payload-0000")
+		input.MaxEstimatedBytes = capacity
+		require.NoError(t, store.Write(context.Background(), input))
+	}
+	require.Len(t, readAvailableMessages(t, store, "flow-a", streamName), 8)
+
+	trigger := streamInput("flow-a", streamName, 8, "payload-0000")
+	trigger.MaxEstimatedBytes = capacity
+	require.NoError(t, store.Write(context.Background(), trigger))
+	require.Eventually(t, func() bool {
+		readCtx, cancelRead := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		message, readErr := store.Read(readCtx, streamTestFlowType, "flow-a", streamName, "")
+		cancelRead()
+		return readErr == nil && message.IdempotencyKey == "public-01"
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Equal(t, []string{
+		"public-01",
+		"public-02",
+		"public-03",
+		"public-04",
+		"public-05",
+		"public-06",
+		"public-07",
+		"public-08",
+	}, messageKeys(readAvailableMessages(t, store, "flow-a", streamName)))
+}
+
+func TestStreamStoreMemoryConcurrentCapacityTriggersDoNotOverTrim(t *testing.T) {
+	store := newMemoryStreamTestStore(t)
+	streamName := "memory-trim-" + newRequestID()
+	baseInput := streamInput("flow-a", streamName, 0, "payload-0000")
+	charge := estimatedCharge(baseInput, 1)
+	for index := 0; index < 80; index++ {
+		input := streamInput("flow-a", streamName, index, "payload-0000")
+		input.MaxEstimatedBytes = charge * 100
+		require.NoError(t, store.Write(context.Background(), input))
+	}
+
+	triggerStart := make(chan struct{})
+	triggerErrors := make(chan error, 20)
+	var writers sync.WaitGroup
+	for index := 80; index < 100; index++ {
+		writers.Add(1)
+		go func(messageIndex int) {
+			defer writers.Done()
+			<-triggerStart
+			input := streamInput("flow-a", streamName, messageIndex, "payload-0000")
+			input.MaxEstimatedBytes = charge * 10
+			triggerErrors <- store.Write(context.Background(), input)
+		}(index)
+	}
+	close(triggerStart)
+	writers.Wait()
+	close(triggerErrors)
+	rejectedWrites := 0
+	for writeErr := range triggerErrors {
+		if writeErr == nil {
+			continue
+		}
+		require.ErrorIs(t, writeErr, streamstore.ErrCapacityExceeded)
+		rejectedWrites++
+	}
+	require.Positive(t, rejectedWrites)
+	retained := waitForStreamMessageLimit(t, store, "flow-a", streamName, 9)
+	require.NotEmpty(t, retained)
+	require.GreaterOrEqual(t, len(retained), 8)
+	require.LessOrEqual(t, len(retained), 9)
+
+	lastToken, err := streamstore.EncodeResumeToken(
+		streamTestFlowType,
+		"flow-a",
+		streamName,
+		retained[len(retained)-1].MessageID,
+	)
+	require.NoError(t, err)
+	rewritten := baseInput
+	rewritten.Value = stringValue("rewritten")
+	rewritten.MaxEstimatedBytes = charge * 10
+	require.NoError(t, store.Write(context.Background(), rewritten))
+	rewrittenMessage := readOneMessage(t, store, "flow-a", streamName, lastToken)
+	require.Equal(t, "rewritten", rewrittenMessage.Value.GetStringValue())
+}
+
+func TestStreamStoreMemoryResumeTokenSurvivesProcessRestartBestEffort(t *testing.T) {
+	streamName := "memory-restart-" + newRequestID()
+	firstStore := newMemoryStreamTestStore(t)
+	firstInput := streamInput("flow-a", streamName, 0, "before-restart")
+	firstInput.MaxEstimatedBytes = 1 << 20
+	require.NoError(t, firstStore.Write(context.Background(), firstInput))
+	firstMessage := readOneMessage(t, firstStore, "flow-a", streamName, "")
+	resumeToken, err := streamstore.EncodeResumeToken(
+		streamTestFlowType,
+		"flow-a",
+		streamName,
+		firstMessage.MessageID,
+	)
+	require.NoError(t, err)
+	require.NoError(t, firstStore.Close())
+	require.Eventually(t, func() bool {
+		return time.Now().UnixMilli() > firstMessage.CreatedTime.UnixMilli()
+	}, time.Second, time.Millisecond)
+
+	secondStore := newMemoryStreamTestStore(t)
+	afterRestart := streamInput("flow-a", streamName, 1, "after-restart")
+	afterRestart.MaxEstimatedBytes = 1 << 20
+	require.NoError(t, secondStore.Write(context.Background(), afterRestart))
+	message := readOneMessage(t, secondStore, "flow-a", streamName, resumeToken)
+	require.Equal(t, "after-restart", message.Value.GetStringValue())
+}
+
+func TestStreamStoreBackendConfiguration(t *testing.T) {
+	disabledStore, err := streamstore.New(&config.StreamStoreConfig{}, log.NewNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, disabledStore.Close()) })
+	disabledInput := streamInput("flow-a", "disabled", 0, "value")
+	disabledInput.MaxEstimatedBytes = 1024
+	require.ErrorIs(t, disabledStore.Write(context.Background(), disabledInput), streamstore.ErrDisabled)
+
+	_, err = streamstore.New(&config.StreamStoreConfig{RedisURL: streamTestRedisURL}, log.NewNoop())
+	require.ErrorContains(t, err, "redisURL requires redis backend")
+	_, err = streamstore.New(&config.StreamStoreConfig{
+		Backend:  config.StreamStoreBackendMemory,
+		RedisURL: streamTestRedisURL,
+	}, log.NewNoop())
+	require.ErrorContains(t, err, "memory backend does not use redisURL")
+	_, err = streamstore.New(&config.StreamStoreConfig{
+		Backend: config.StreamStoreBackendRedis,
+	}, log.NewNoop())
+	require.ErrorContains(t, err, "redis backend requires redisURL")
+	_, err = streamstore.New(&config.StreamStoreConfig{
+		Backend: "unsupported",
+	}, log.NewNoop())
+	require.ErrorContains(t, err, "unsupported stream store backend")
+}
+
 func TestStreamAPITemporal(t *testing.T) {
 	if !*temporalIntegTest {
 		t.Skip()
@@ -359,6 +557,7 @@ func TestStreamAPITemporal(t *testing.T) {
 	runtime := startDexService(t, DexServiceTestConfig{
 		BackendType: service.BackendTypeTemporal,
 		StreamStore: config.StreamStoreConfig{
+			Backend:         config.StreamStoreBackendRedis,
 			RedisURL:        streamTestRedisURL,
 			MaxMessageBytes: 64,
 		},
@@ -506,7 +705,10 @@ func TestStreamFailureIsolationTemporal(t *testing.T) {
 	}
 	runtime := startDexService(t, DexServiceTestConfig{
 		BackendType: service.BackendTypeTemporal,
-		StreamStore: config.StreamStoreConfig{RedisURL: "redis://127.0.0.1:1/0"},
+		StreamStore: config.StreamStoreConfig{
+			Backend:  config.StreamStoreBackendRedis,
+			RedisURL: "redis://127.0.0.1:1/0",
+		},
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -546,6 +748,7 @@ func BenchmarkStreamStoreWrite(b *testing.B) {
 	for _, payloadBytes := range []int{128, 4096, 65536} {
 		b.Run(strconv.Itoa(payloadBytes), func(b *testing.B) {
 			store, err := streamstore.New(&config.StreamStoreConfig{
+				Backend:            config.StreamStoreBackendRedis,
 				RedisURL:           streamTestRedisURL,
 				TrimWorkers:        2,
 				TrimTriggerPercent: 90,
@@ -570,6 +773,7 @@ func BenchmarkStreamStoreWrite(b *testing.B) {
 func newStreamTestStore(t testing.TB) (*streamstore.Store, *redis.Client) {
 	t.Helper()
 	return newStreamTestStoreWithConfig(t, config.StreamStoreConfig{
+		Backend:                       config.StreamStoreBackendRedis,
 		RedisURL:                      streamTestRedisURL,
 		EstimatedMessageOverheadBytes: 1,
 		TrimTriggerPercent:            90,
@@ -580,6 +784,22 @@ func newStreamTestStore(t testing.TB) (*streamstore.Store, *redis.Client) {
 		TrimBatchYieldTime:            100 * time.Microsecond,
 		TrimWorkers:                   2,
 	})
+}
+
+func newMemoryStreamTestStore(t testing.TB) *streamstore.Store {
+	t.Helper()
+	store, err := streamstore.New(&config.StreamStoreConfig{
+		Backend:                       config.StreamStoreBackendMemory,
+		EstimatedMessageOverheadBytes: 1,
+		TrimTriggerPercent:            90,
+		TrimTargetPercent:             80,
+		BackgroundTrimBatchSize:       256,
+		TrimBatchYieldTime:            100 * time.Microsecond,
+		TrimWorkers:                   4,
+	}, log.NewNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	return store
 }
 
 func newStreamTestStoreWithConfig(
@@ -625,6 +845,16 @@ func readAvailableMessages(
 	streamName string,
 ) []*streamstore.Message {
 	t.Helper()
+	messages, err := availableStreamMessages(store, flowID, streamName)
+	require.NoError(t, err)
+	return messages
+}
+
+func availableStreamMessages(
+	store *streamstore.Store,
+	flowID string,
+	streamName string,
+) ([]*streamstore.Message, error) {
 	var messages []*streamstore.Message
 	resumeToken := ""
 	for {
@@ -632,17 +862,50 @@ func readAvailableMessages(
 		message, err := store.Read(readCtx, streamTestFlowType, flowID, streamName, resumeToken)
 		cancelRead()
 		if err != nil {
-			require.ErrorIs(t, err, streamstore.ErrWaitTimeout)
-			return messages
+			if errors.Is(err, streamstore.ErrWaitTimeout) {
+				return messages, nil
+			}
+			return nil, err
 		}
 		messages = append(messages, message)
 		resumeToken, err = streamstore.EncodeResumeToken(
 			streamTestFlowType,
 			flowID,
 			streamName,
-			message.RedisID,
+			message.MessageID,
 		)
-		require.NoError(t, err)
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+func waitForStreamMessageLimit(
+	t testing.TB,
+	store *streamstore.Store,
+	flowID string,
+	streamName string,
+	maximumCount int,
+) []*streamstore.Message {
+	t.Helper()
+	deadline := time.NewTimer(3 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	var messages []*streamstore.Message
+	var readErr error
+	for {
+		messages, readErr = availableStreamMessages(store, flowID, streamName)
+		if readErr == nil && len(messages) <= maximumCount {
+			return messages
+		}
+		select {
+		case <-deadline.C:
+			require.NoError(t, readErr)
+			require.LessOrEqual(t, len(messages), maximumCount)
+			return nil
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/server/service/api/service.go
+++ b/server/service/api/service.go
@@ -535,7 +535,7 @@ func (s *serviceImpl) ReadStream(
 		req.GetFlowType(),
 		req.GetFlowId(),
 		req.GetStreamName(),
-		message.RedisID,
+		message.MessageID,
 	)
 	if err != nil {
 		return nil, serviceerrors.Internal(err.Error()).ToGRPCError()

--- a/server/service/common/streamstore/memory.go
+++ b/server/service/common/streamstore/memory.go
@@ -1,0 +1,421 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package streamstore
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/superdurable/dex/config"
+	"github.com/superdurable/dex/gen/dexpb"
+	"google.golang.org/protobuf/proto"
+)
+
+type memoryBackend struct {
+	cfg *config.StreamStoreConfig
+
+	mutex   sync.Mutex
+	ready   *sync.Cond
+	scopes  map[streamScope]*memoryScope
+	pending map[streamScope]*memoryTrimState
+	closed  bool
+	stop    chan struct{}
+	wait    sync.WaitGroup
+}
+
+type memoryScope struct {
+	totalBytes       int64
+	fifo             []*memoryEntry
+	idempotency      map[string]*memoryEntry
+	instances        map[string]*memoryInstance
+	lastMilliseconds int64
+	lastSequence     uint64
+}
+
+type memoryInstance struct {
+	messages []*memoryEntry
+	notify   chan struct{}
+	waiters  int
+}
+
+type memoryEntry struct {
+	messageID    string
+	milliseconds int64
+	sequence     uint64
+	flowID       string
+	identity     string
+	publicKey    string
+	payload      []byte
+	chargedBytes int64
+}
+
+type memoryTrimState struct {
+	targetBytes int64
+	generation  uint64
+	isRunning   bool
+}
+
+type memoryTrimTask struct {
+	scope      streamScope
+	target     int64
+	generation uint64
+}
+
+func newMemoryBackend(cfg *config.StreamStoreConfig) *memoryBackend {
+	if cfg == nil {
+		panic("Memory Stream Store config must not be nil")
+	}
+	backend := &memoryBackend{
+		cfg:     cfg,
+		scopes:  make(map[streamScope]*memoryScope),
+		pending: make(map[streamScope]*memoryTrimState),
+		stop:    make(chan struct{}),
+	}
+	backend.ready = sync.NewCond(&backend.mutex)
+	for workerIndex := 0; workerIndex < cfg.EffectiveTrimWorkers(); workerIndex++ {
+		backend.wait.Add(1)
+		go backend.runTrimWorker()
+	}
+	return backend
+}
+
+func (b *memoryBackend) Close() error {
+	b.mutex.Lock()
+	if b.closed {
+		b.mutex.Unlock()
+		b.wait.Wait()
+		return nil
+	}
+	b.closed = true
+	for _, scope := range b.scopes {
+		for _, instance := range scope.instances {
+			close(instance.notify)
+		}
+	}
+	b.ready.Broadcast()
+	close(b.stop)
+	b.mutex.Unlock()
+	b.wait.Wait()
+	return nil
+}
+
+func (b *memoryBackend) Write(ctx context.Context, input backendWriteInput) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if b.closed {
+		return ErrUnavailable
+	}
+	scopeID := streamScope{
+		flowType:   input.input.FlowType,
+		streamName: input.input.StreamName,
+	}
+	scope := b.scopeLocked(scopeID)
+	if scope.idempotency[input.input.InternalIdentity] != nil {
+		return nil
+	}
+	if scope.totalBytes >= input.capacityBytes ||
+		input.chargedBytes > input.capacityBytes-scope.totalBytes {
+		b.scheduleTrimLocked(scopeID, input.baseTrimTargetBytes)
+		return ErrCapacityExceeded
+	}
+	entry := scope.append(
+		input.input.FlowID,
+		input.input.InternalIdentity,
+		input.input.PublicIdempotencyKey,
+		input.payload,
+		input.chargedBytes,
+	)
+	instance := scope.instance(input.input.FlowID)
+	instance.messages = append(instance.messages, entry)
+	close(instance.notify)
+	instance.notify = make(chan struct{})
+	if scope.totalBytes >= input.trimTriggerBytes {
+		b.scheduleTrimLocked(scopeID, input.messageTrimTargetBytes)
+	}
+	return nil
+}
+
+func (b *memoryBackend) Read(
+	ctx context.Context,
+	flowType string,
+	flowID string,
+	streamName string,
+	messageID string,
+) (*Message, error) {
+	cursorMilliseconds, cursorSequence, err := parseMessageID(messageID)
+	if err != nil {
+		panic("validated Stream message ID was not parseable")
+	}
+	for {
+		b.mutex.Lock()
+		if b.closed {
+			b.mutex.Unlock()
+			return nil, ErrUnavailable
+		}
+		scopeID := streamScope{flowType: flowType, streamName: streamName}
+		scope := b.scopeLocked(scopeID)
+		instance := scope.instance(flowID)
+		entry := instance.after(cursorMilliseconds, cursorSequence)
+		if entry != nil {
+			b.mutex.Unlock()
+			return entry.message()
+		}
+		notify := instance.notify
+		instance.waiters++
+		b.mutex.Unlock()
+		select {
+		case <-notify:
+			b.releaseReader(scopeID, flowID, scope, instance)
+		case <-ctx.Done():
+			b.releaseReader(scopeID, flowID, scope, instance)
+			if ctx.Err() == context.DeadlineExceeded {
+				return nil, ErrWaitTimeout
+			}
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (b *memoryBackend) runTrimWorker() {
+	defer b.wait.Done()
+	for {
+		task, ok := b.nextTrimTask()
+		if !ok {
+			return
+		}
+		b.trim(task)
+		b.finishTrimTask(task)
+	}
+}
+
+func (b *memoryBackend) nextTrimTask() (memoryTrimTask, bool) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	for {
+		if b.closed {
+			return memoryTrimTask{}, false
+		}
+		for scope, state := range b.pending {
+			if state.isRunning {
+				continue
+			}
+			state.isRunning = true
+			return memoryTrimTask{
+				scope:      scope,
+				target:     state.targetBytes,
+				generation: state.generation,
+			}, true
+		}
+		b.ready.Wait()
+	}
+}
+
+func (b *memoryBackend) trim(task memoryTrimTask) {
+	for {
+		b.mutex.Lock()
+		if b.closed {
+			b.mutex.Unlock()
+			return
+		}
+		scope := b.scopes[task.scope]
+		isComplete := scope == nil || scope.trim(task.target, b.cfg.EffectiveBackgroundTrimBatchSize())
+		if scope != nil && scope.isEmpty() {
+			delete(b.scopes, task.scope)
+		}
+		b.mutex.Unlock()
+		if isComplete || !b.waitForTrimBatch() {
+			return
+		}
+	}
+}
+
+func (b *memoryBackend) waitForTrimBatch() bool {
+	timer := time.NewTimer(b.cfg.EffectiveTrimBatchYieldTime())
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-b.stop:
+		return false
+	}
+}
+
+func (b *memoryBackend) finishTrimTask(task memoryTrimTask) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	state := b.pending[task.scope]
+	if state == nil {
+		return
+	}
+	if state.generation == task.generation {
+		delete(b.pending, task.scope)
+		return
+	}
+	state.isRunning = false
+	b.ready.Signal()
+}
+
+func (b *memoryBackend) releaseReader(
+	scopeID streamScope,
+	flowID string,
+	scope *memoryScope,
+	instance *memoryInstance,
+) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	instance.waiters--
+	if instance.waiters < 0 {
+		panic("Memory Stream Store reader count became negative")
+	}
+	if len(instance.messages) == 0 && instance.waiters == 0 && scope.instances[flowID] == instance {
+		delete(scope.instances, flowID)
+	}
+	if scope.isEmpty() && b.scopes[scopeID] == scope {
+		delete(b.scopes, scopeID)
+	}
+}
+
+func (b *memoryBackend) scopeLocked(scopeID streamScope) *memoryScope {
+	scope := b.scopes[scopeID]
+	if scope == nil {
+		scope = &memoryScope{
+			idempotency: make(map[string]*memoryEntry),
+			instances:   make(map[string]*memoryInstance),
+		}
+		b.scopes[scopeID] = scope
+	}
+	return scope
+}
+
+func (b *memoryBackend) scheduleTrimLocked(scopeID streamScope, targetBytes int64) {
+	state := b.pending[scopeID]
+	if state == nil {
+		state = &memoryTrimState{targetBytes: targetBytes}
+		b.pending[scopeID] = state
+	} else if targetBytes < state.targetBytes {
+		state.targetBytes = targetBytes
+	} else if !state.isRunning {
+		return
+	}
+	state.generation++
+	b.ready.Signal()
+}
+
+func (s *memoryScope) append(
+	flowID string,
+	identity string,
+	publicKey string,
+	payload []byte,
+	chargedBytes int64,
+) *memoryEntry {
+	milliseconds, sequence := s.nextMessageIdentity()
+	entry := &memoryEntry{
+		messageID:    fmt.Sprintf("%d-%d", milliseconds, sequence),
+		milliseconds: milliseconds,
+		sequence:     sequence,
+		flowID:       flowID,
+		identity:     identity,
+		publicKey:    publicKey,
+		payload:      payload,
+		chargedBytes: chargedBytes,
+	}
+	s.fifo = append(s.fifo, entry)
+	s.idempotency[identity] = entry
+	s.totalBytes += chargedBytes
+	return entry
+}
+
+func (s *memoryScope) nextMessageIdentity() (int64, uint64) {
+	milliseconds := time.Now().UnixMilli()
+	if milliseconds > s.lastMilliseconds {
+		s.lastMilliseconds = milliseconds
+		s.lastSequence = 0
+		return milliseconds, 0
+	}
+	if s.lastSequence == math.MaxUint64 {
+		s.lastMilliseconds++
+		s.lastSequence = 0
+		return s.lastMilliseconds, 0
+	}
+	s.lastSequence++
+	return s.lastMilliseconds, s.lastSequence
+}
+
+func (s *memoryScope) instance(flowID string) *memoryInstance {
+	instance := s.instances[flowID]
+	if instance == nil {
+		instance = &memoryInstance{notify: make(chan struct{})}
+		s.instances[flowID] = instance
+	}
+	return instance
+}
+
+func (s *memoryScope) trim(targetBytes int64, batchSize int) bool {
+	trimmedMessages := 0
+	for s.totalBytes > targetBytes && trimmedMessages < batchSize && len(s.fifo) > 0 {
+		entry := s.fifo[0]
+		s.fifo[0] = nil
+		s.fifo = s.fifo[1:]
+		instance := s.instances[entry.flowID]
+		if instance == nil || len(instance.messages) == 0 || instance.messages[0] != entry {
+			panic("Memory Stream Store instance FIFO is inconsistent")
+		}
+		instance.messages[0] = nil
+		instance.messages = instance.messages[1:]
+		if len(instance.messages) == 0 && instance.waiters == 0 {
+			delete(s.instances, entry.flowID)
+		}
+		delete(s.idempotency, entry.identity)
+		s.totalBytes -= entry.chargedBytes
+		if s.totalBytes < 0 {
+			panic("Memory Stream Store charged bytes became negative")
+		}
+		trimmedMessages++
+	}
+	return s.totalBytes <= targetBytes || len(s.fifo) == 0
+}
+
+func (s *memoryScope) isEmpty() bool {
+	return len(s.fifo) == 0 && len(s.idempotency) == 0 && len(s.instances) == 0
+}
+
+func (i *memoryInstance) after(milliseconds int64, sequence uint64) *memoryEntry {
+	index := sort.Search(len(i.messages), func(index int) bool {
+		entry := i.messages[index]
+		return entry.milliseconds > milliseconds ||
+			(entry.milliseconds == milliseconds && entry.sequence > sequence)
+	})
+	if index == len(i.messages) {
+		return nil
+	}
+	return i.messages[index]
+}
+
+func (e *memoryEntry) message() (*Message, error) {
+	value := &dexpb.Value{}
+	if err := proto.Unmarshal(e.payload, value); err != nil {
+		return nil, fmt.Errorf("unmarshal retained Stream Value: %w", err)
+	}
+	return &Message{
+		Value:          value,
+		MessageID:      e.messageID,
+		CreatedTime:    time.UnixMilli(e.milliseconds),
+		IdempotencyKey: e.publicKey,
+	}, nil
+}

--- a/server/service/common/streamstore/store.go
+++ b/server/service/common/streamstore/store.go
@@ -33,7 +33,7 @@ var (
 	ErrCapacityExceeded   = errors.New("Stream capacity is exhausted; retry after background trimming")
 	ErrWaitTimeout        = errors.New("Stream read timed out")
 	ErrInvalidResumeToken = errors.New("invalid Stream resume token")
-	ErrUnavailable        = errors.New("Stream Redis is unavailable")
+	ErrUnavailable        = errors.New("Stream Store backend is unavailable")
 )
 
 const resumeTokenVersion = 1
@@ -50,13 +50,33 @@ type WriteInput struct {
 
 type Message struct {
 	Value          *dexpb.Value
-	RedisID        string
+	MessageID      string
 	CreatedTime    time.Time
 	IdempotencyKey string
 }
 
 type Store struct {
-	cfg         *config.StreamStoreConfig
+	cfg     *config.StreamStoreConfig
+	backend backend
+}
+
+type backend interface {
+	Close() error
+	Write(context.Context, backendWriteInput) error
+	Read(context.Context, string, string, string, string) (*Message, error)
+}
+
+type backendWriteInput struct {
+	input                  WriteInput
+	payload                []byte
+	chargedBytes           int64
+	capacityBytes          int64
+	trimTriggerBytes       int64
+	baseTrimTargetBytes    int64
+	messageTrimTargetBytes int64
+}
+
+type redisBackend struct {
 	client      *redis.Client
 	coordinator *trimCoordinator
 }
@@ -66,7 +86,7 @@ type resumeToken struct {
 	FlowID     string `json:"f"`
 	FlowType   string `json:"t"`
 	StreamName string `json:"s"`
-	RedisID    string `json:"i"`
+	MessageID  string `json:"i"`
 }
 
 func New(cfg *config.StreamStoreConfig, logger log.Logger) (*Store, error) {
@@ -80,30 +100,36 @@ func New(cfg *config.StreamStoreConfig, logger log.Logger) (*Store, error) {
 		return nil, err
 	}
 	store := &Store{cfg: cfg}
-	if cfg.RedisURL == "" {
+	switch cfg.EffectiveBackend() {
+	case config.StreamStoreBackendDisabled:
 		return store, nil
+	case config.StreamStoreBackendMemory:
+		store.backend = newMemoryBackend(cfg)
+	case config.StreamStoreBackendRedis:
+		options, err := redis.ParseURL(cfg.RedisURL)
+		if err != nil {
+			return nil, fmt.Errorf("parse Stream Store Redis URL: %w", err)
+		}
+		client := redis.NewClient(options)
+		store.backend = &redisBackend{
+			client:      client,
+			coordinator: newTrimCoordinator(cfg, client, logger),
+		}
+	default:
+		panic("validated Stream Store backend was not handled")
 	}
-	options, err := redis.ParseURL(cfg.RedisURL)
-	if err != nil {
-		return nil, fmt.Errorf("parse Stream Store Redis URL: %w", err)
-	}
-	store.client = redis.NewClient(options)
-	store.coordinator = newTrimCoordinator(cfg, store.client, logger)
 	return store, nil
 }
 
 func (s *Store) Close() error {
-	if s.coordinator != nil {
-		s.coordinator.Close()
-	}
-	if s.client == nil {
+	if s.backend == nil {
 		return nil
 	}
-	return s.client.Close()
+	return s.backend.Close()
 }
 
 func (s *Store) Write(ctx context.Context, input WriteInput) error {
-	if s.client == nil {
+	if s.backend == nil {
 		return ErrDisabled
 	}
 	payload, err := proto.Marshal(input.Value)
@@ -123,10 +149,8 @@ func (s *Store) Write(ctx context.Context, input WriteInput) error {
 	if messageTrimTarget < chargedBytes {
 		messageTrimTarget = chargedBytes
 	}
-	scriptOutput, err := runWriteScript(ctx, s.client, writeScriptInput{
-		keys:                   streamKeys(input.FlowType, input.StreamName, input.FlowID),
-		internalIdentity:       input.InternalIdentity,
-		publicIdempotencyKey:   input.PublicIdempotencyKey,
+	return s.backend.Write(ctx, backendWriteInput{
+		input:                  input,
 		payload:                payload,
 		chargedBytes:           chargedBytes,
 		capacityBytes:          input.MaxEstimatedBytes,
@@ -134,11 +158,58 @@ func (s *Store) Write(ctx context.Context, input WriteInput) error {
 		baseTrimTargetBytes:    baseTrimTarget,
 		messageTrimTargetBytes: messageTrimTarget,
 	})
+}
+
+func (s *Store) Read(
+	ctx context.Context,
+	flowType string,
+	flowID string,
+	streamName string,
+	encodedResumeToken string,
+) (*Message, error) {
+	if s.backend == nil {
+		return nil, ErrDisabled
+	}
+	messageID, err := decodeResumeToken(encodedResumeToken, flowType, flowID, streamName)
+	if err != nil {
+		return nil, err
+	}
+	deadline, hasDeadline := ctx.Deadline()
+	if !hasDeadline {
+		panic("Stream read context requires a deadline")
+	}
+	if time.Until(deadline) <= 0 {
+		return nil, ErrWaitTimeout
+	}
+	return s.backend.Read(ctx, flowType, flowID, streamName, messageID)
+}
+
+func (b *redisBackend) Close() error {
+	b.coordinator.Close()
+	return b.client.Close()
+}
+
+func (b *redisBackend) Write(ctx context.Context, input backendWriteInput) error {
+	scriptOutput, err := runWriteScript(ctx, b.client, writeScriptInput{
+		keys:                   streamKeys(input.input.FlowType, input.input.StreamName, input.input.FlowID),
+		internalIdentity:       input.input.InternalIdentity,
+		publicIdempotencyKey:   input.input.PublicIdempotencyKey,
+		payload:                input.payload,
+		chargedBytes:           input.chargedBytes,
+		capacityBytes:          input.capacityBytes,
+		trimTriggerBytes:       input.trimTriggerBytes,
+		baseTrimTargetBytes:    input.baseTrimTargetBytes,
+		messageTrimTargetBytes: input.messageTrimTargetBytes,
+	})
 	if err != nil {
 		return err
 	}
 	if scriptOutput.needsTrim {
-		s.coordinator.Schedule(input.FlowType, input.StreamName, scriptOutput.trimTargetBytes)
+		b.coordinator.Schedule(
+			input.input.FlowType,
+			input.input.StreamName,
+			scriptOutput.trimTargetBytes,
+		)
 	}
 	switch scriptOutput.status {
 	case writeScriptStatusSucceeded:
@@ -150,32 +221,21 @@ func (s *Store) Write(ctx context.Context, input WriteInput) error {
 	}
 }
 
-func (s *Store) Read(
+func (b *redisBackend) Read(
 	ctx context.Context,
 	flowType string,
 	flowID string,
 	streamName string,
-	encodedResumeToken string,
+	messageID string,
 ) (*Message, error) {
-	if s.client == nil {
-		return nil, ErrDisabled
-	}
-	redisID, err := decodeResumeToken(encodedResumeToken, flowType, flowID, streamName)
-	if err != nil {
-		return nil, err
-	}
 	deadline, hasDeadline := ctx.Deadline()
 	if !hasDeadline {
 		panic("Stream read context requires a deadline")
 	}
-	blockDuration := time.Until(deadline)
-	if blockDuration <= 0 {
-		return nil, ErrWaitTimeout
-	}
-	result, err := s.client.XRead(ctx, &redis.XReadArgs{
-		Streams: []string{streamKeys(flowType, streamName, flowID).instance, redisID},
+	result, err := b.client.XRead(ctx, &redis.XReadArgs{
+		Streams: []string{streamKeys(flowType, streamName, flowID).instance, messageID},
 		Count:   1,
-		Block:   blockDuration,
+		Block:   time.Until(deadline),
 	}).Result()
 	if err != nil {
 		if errors.Is(err, redis.Nil) || errors.Is(err, context.DeadlineExceeded) {
@@ -202,20 +262,20 @@ func (s *Store) Read(
 	if err := proto.Unmarshal(payload, value); err != nil {
 		return nil, fmt.Errorf("unmarshal retained Stream Value: %w", err)
 	}
-	createdTime, err := createdTimeFromRedisID(redisMessage.ID)
+	createdTime, err := createdTimeFromMessageID(redisMessage.ID)
 	if err != nil {
 		return nil, err
 	}
 	return &Message{
 		Value:          value,
-		RedisID:        redisMessage.ID,
+		MessageID:      redisMessage.ID,
 		CreatedTime:    createdTime,
 		IdempotencyKey: publicKey,
 	}, nil
 }
 
-func EncodeResumeToken(flowType string, flowID string, streamName string, redisID string) (string, error) {
-	if _, err := createdTimeFromRedisID(redisID); err != nil {
+func EncodeResumeToken(flowType string, flowID string, streamName string, messageID string) (string, error) {
+	if _, _, err := parseMessageID(messageID); err != nil {
 		return "", err
 	}
 	payload, err := json.Marshal(resumeToken{
@@ -223,7 +283,7 @@ func EncodeResumeToken(flowType string, flowID string, streamName string, redisI
 		FlowID:     flowID,
 		FlowType:   flowType,
 		StreamName: streamName,
-		RedisID:    redisID,
+		MessageID:  messageID,
 	})
 	if err != nil {
 		return "", fmt.Errorf("marshal Stream resume token: %w", err)
@@ -272,25 +332,34 @@ func decodeResumeToken(encoded string, flowType string, flowID string, streamNam
 		token.StreamName != streamName {
 		return "", ErrInvalidResumeToken
 	}
-	if _, err := createdTimeFromRedisID(token.RedisID); err != nil {
+	if _, _, err := parseMessageID(token.MessageID); err != nil {
 		return "", ErrInvalidResumeToken
 	}
-	return token.RedisID, nil
+	return token.MessageID, nil
 }
 
-func createdTimeFromRedisID(redisID string) (time.Time, error) {
-	parts := strings.Split(redisID, "-")
+func createdTimeFromMessageID(messageID string) (time.Time, error) {
+	milliseconds, _, err := parseMessageID(messageID)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.UnixMilli(milliseconds), nil
+}
+
+func parseMessageID(messageID string) (int64, uint64, error) {
+	parts := strings.Split(messageID, "-")
 	if len(parts) != 2 {
-		return time.Time{}, fmt.Errorf("invalid Redis Stream ID")
+		return 0, 0, fmt.Errorf("invalid Stream message ID")
 	}
 	milliseconds, err := strconv.ParseInt(parts[0], 10, 64)
 	if err != nil || milliseconds < 0 {
-		return time.Time{}, fmt.Errorf("invalid Redis Stream ID")
+		return 0, 0, fmt.Errorf("invalid Stream message ID")
 	}
-	if _, err := strconv.ParseUint(parts[1], 10, 64); err != nil {
-		return time.Time{}, fmt.Errorf("invalid Redis Stream ID")
+	sequence, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid Stream message ID")
 	}
-	return time.UnixMilli(milliseconds), nil
+	return milliseconds, sequence, nil
 }
 
 type redisKeys struct {


### PR DESCRIPTION
## Summary

- add an in-process Stream Store backend with resumable reads, idempotent writes, blocking reads, and asynchronous FIFO trimming
- require an explicit `disabled`, `memory`, or `redis` Stream Store backend
- enable the memory backend by default for `dexcli dev` and checked-in local server configs
- preserve Redis behavior behind the shared Store interface and make resume message IDs backend-neutral internally

## Rationale

Local CLI and single-server deployments should be able to use best-effort Streams without operating Redis. Production multi-server deployments can continue using Redis, while the explicit backend prevents accidental in-memory fallback when Redis configuration is missing.

## User impact

- `dexcli dev` supports Stream RPCs without Redis; Stream data is discarded when the CLI process stops
- standalone servers can set `streamStore.backend: memory`
- Redis deployments must now set `streamStore.backend: redis` alongside `redisURL`
- the default backend remains disabled for ordinary server configurations

## Validation

- `make -C server unitTests`
- `make -C server streamIntegTests`
- `make -C server streamIntegTests integrationCoverageFlags=-race`
- `make -C cli test`
- `make -C cli integration-test`
- `make generated-code-check`
- `make copyright-check`
