### PR TITLE
Add Stream tab to Flow details

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -72,7 +72,7 @@ saved queries, configurable columns, Indexed Attributes, and timezone
 preferences.
 
 The Run page opens on Step graph and also provides Overview (Live Flow State beside
-Selected event, then Run input beside Identity), Timeline, attributes, timers, queued
+Selected event, then Run input beside Identity), Timeline, Streams, attributes, timers, queued
 steps, channels, completed outputs, stop, and time travel. Timeline and Step graph keep
 Selected event in the sidebar, where the critical-action **Review time travel**
 entry opens the operation with that Step execution and its WaitFor or Execute
@@ -100,6 +100,9 @@ Timeline and Step graph share structured event details for flow, step method, RP
 and channel events. A Raw JSON tab preserves the complete server payload.
 Successful Temporal RPC Updates appear as the same RPC events as result signals.
 Blob-backed RPC input and output hydrate through the existing selected-event loader.
+The Streams tab accepts a Stream name, reads its retained messages from the beginning,
+and then continuously long-polls for the next message. Each message displays its creation
+time and idempotency key. Stream retention is best effort, so older messages can be trimmed.
 External attribute writes appear as Attributes updated events, with a
 SetAttributes type label and the changed values in the event details.
 Raw JSON shows hydrated values; missing retained data is labeled unavailable.

--- a/web/api/handlers.go
+++ b/web/api/handlers.go
@@ -45,6 +45,7 @@ func RegisterHandlers(mux *http.ServeMux, client dexpb.FlowServiceClient) {
 	mux.HandleFunc("GET /api/flows/history", handler.getHistoryEvents)
 	mux.HandleFunc("GET /api/flows/state", handler.getFlowState)
 	mux.HandleFunc("GET /api/flows/wait", handler.waitForHistoryEvent)
+	mux.HandleFunc("GET /api/flows/stream", handler.readStream)
 	mux.HandleFunc("POST /api/flows/time-travel", handler.timeTravelFlow)
 	mux.HandleFunc("POST /api/flows/stop", handler.stopFlow)
 	mux.HandleFunc("POST /api/blobs/load", handler.loadBlobs)
@@ -211,6 +212,31 @@ func (h *handler) waitForHistoryEvent(response http.ResponseWriter, request *htt
 		return
 	}
 	writeJSON(response, http.StatusOK, mapped)
+}
+
+func (h *handler) readStream(response http.ResponseWriter, request *http.Request) {
+	flowID := request.URL.Query().Get("flowId")
+	flowType := request.URL.Query().Get("flowType")
+	streamName := strings.TrimSpace(request.URL.Query().Get("streamName"))
+	if flowID == "" || flowType == "" || streamName == "" {
+		WriteError(response, http.StatusBadRequest, "flowId, flowType, and streamName are required", nil)
+		return
+	}
+	result, err := h.client.ReadStream(request.Context(), &dexpb.ReadStreamRequest{
+		FlowId:      flowID,
+		FlowType:    flowType,
+		StreamName:  streamName,
+		ResumeToken: request.URL.Query().Get("resumeToken"),
+	})
+	if err != nil {
+		writeGRPCError(response, err, "ReadStream")
+		return
+	}
+	if result.GetMessage() == nil {
+		WriteError(response, http.StatusBadGateway, "ReadStream returned no message", nil)
+		return
+	}
+	writeJSON(response, http.StatusOK, mapStreamMessage(result.GetMessage()))
 }
 
 func (h *handler) timeTravelFlow(response http.ResponseWriter, request *http.Request) {

--- a/web/api/mapping.go
+++ b/web/api/mapping.go
@@ -49,6 +49,15 @@ func mapSummary(summary *dexpb.GetFlowSummaryResponse) flowSummary {
 	}
 }
 
+func mapStreamMessage(message *dexpb.StreamMessage) streamMessage {
+	return streamMessage{
+		Value:          dexValue(message.GetValue()),
+		ResumeToken:    message.GetResumeToken(),
+		CreatedTime:    timestamp(message.GetCreatedTime()),
+		IdempotencyKey: message.GetIdempotencyKey(),
+	}
+}
+
 func mapHistoryEvent(event *dexpb.FlowHistoryEvent) (historyEvent, error) {
 	var (
 		eventType string

--- a/web/api/types.go
+++ b/web/api/types.go
@@ -87,6 +87,13 @@ type flowState struct {
 	CompletedSteps         []interface{}          `json:"completedSteps"`
 }
 
+type streamMessage struct {
+	Value          interface{} `json:"value"`
+	ResumeToken    string      `json:"resumeToken"`
+	CreatedTime    *string     `json:"createdTime"`
+	IdempotencyKey string      `json:"idempotencyKey"`
+}
+
 type activeStepExecution struct {
 	StepExecutionID     string                 `json:"stepExecutionId"`
 	FromStepExecutionID string                 `json:"fromStepExecutionId"`

--- a/web/app/flows/RunDetailsPage.tsx
+++ b/web/app/flows/RunDetailsPage.tsx
@@ -30,9 +30,10 @@ import { FlowStatePanel } from './details/FlowStatePanel';
 import { TimeTravelDialog } from './details/TimeTravelDialog';
 import { StopFlowDialog } from './details/StopFlowDialog';
 import { StepGraph } from './details/StepGraph';
+import { StreamPanel } from './details/StreamPanel';
 import { Timeline } from './details/Timeline';
 
-type RunTab = 'overview' | 'steps' | 'timeline';
+type RunTab = 'overview' | 'steps' | 'timeline' | 'stream';
 
 interface SelectedEventConnector {
   height: number;
@@ -310,6 +311,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
     ['overview', 'Overview'],
     ['steps', 'Step graph'],
     ['timeline', 'Timeline'],
+    ['stream', 'Streams'],
   ];
   const latestEvent = history.at(-1);
   const selectedRaw = selectedEvent ?? latestEvent ?? null;
@@ -511,7 +513,10 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
               onSelectEvent={setSelectedEvent}
             />
           )}
-          {nextPageToken && (
+          {tab === 'stream' && summary && (
+            <StreamPanel flowId={flowId} flowType={summary.flowType} />
+          )}
+          {tab !== 'stream' && nextPageToken && (
             <div className="load-more">
               <button
                 className="button ghost"
@@ -529,7 +534,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
             </div>
           )}
         </section>
-        {tab !== 'overview' && (
+        {(tab === 'steps' || tab === 'timeline') && (
           <aside className="run-sidebar">
             <button
               type="button"

--- a/web/app/flows/details/StreamPanel.test.tsx
+++ b/web/app/flows/details/StreamPanel.test.tsx
@@ -21,7 +21,7 @@ describe('StreamPanel', () => {
 
     expect(markup).toContain('Resumable stream');
     expect(markup).toContain('Stream name');
-    expect(markup).toContain('placeholder="thinking"');
+    expect(markup).toContain('placeholder="a defined stream name"');
     expect(markup).toContain('Start listening');
     expect(markup).toContain('best effort');
   });

--- a/web/app/flows/details/StreamPanel.test.tsx
+++ b/web/app/flows/details/StreamPanel.test.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { PreferencesProvider } from '@/app/providers';
+import { listenToStream, StreamPanel } from './StreamPanel';
+
+describe('StreamPanel', () => {
+  it('shows one Stream name control before it starts listening', () => {
+    const markup = renderToStaticMarkup(
+      <PreferencesProvider>
+        <StreamPanel flowId="checkout-1" flowType="CheckoutFlow" />
+      </PreferencesProvider>,
+    );
+
+    expect(markup).toContain('Resumable stream');
+    expect(markup).toContain('Stream name');
+    expect(markup).toContain('placeholder="thinking"');
+    expect(markup).toContain('Start listening');
+    expect(markup).toContain('best effort');
+  });
+
+  it('continues after a long-poll timeout and resumes after each message', async () => {
+    const controller = new AbortController();
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      void input;
+      if (fetcher.mock.calls.length === 3) controller.abort();
+      if (fetcher.mock.calls.length === 1) {
+        return new Response(JSON.stringify({
+          value: 'first token',
+          resumeToken: 'token-1',
+          createdTime: '2026-08-27T12:34:56Z',
+          idempotencyKey: 'run-1#Step-1',
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: 'Stream read timed out' }), { status: 408 });
+    });
+    const messages: string[] = [];
+
+    await listenToStream({
+      flowId: 'checkout-1',
+      flowType: 'CheckoutFlow',
+      streamName: 'thinking',
+      signal: controller.signal,
+      fetcher: fetcher as typeof fetch,
+      onMessage: async (message) => {
+        messages.push(message.resumeToken);
+      },
+    });
+
+    expect(messages).toEqual(['token-1']);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(String(fetcher.mock.calls[2][0])).toContain('resumeToken=token-1');
+  });
+});

--- a/web/app/flows/details/StreamPanel.tsx
+++ b/web/app/flows/details/StreamPanel.tsx
@@ -141,7 +141,7 @@ export function StreamPanel({ flowId, flowType }: StreamPanelProps) {
             id="stream-name"
             name="streamName"
             onChange={(event) => setStreamName(event.target.value)}
-            placeholder="thinking"
+            placeholder="a defined stream name"
             value={streamName}
           />
           <button className="button primary" type="submit">

--- a/web/app/flows/details/StreamPanel.tsx
+++ b/web/app/flows/details/StreamPanel.tsx
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+import { useEffect, useRef, useState } from 'react';
+import type { FormEvent } from 'react';
+import { hydrateBlobs } from '@/lib/blobs';
+import { formatDate } from '@/lib/format';
+import { readResponseJSON } from '@/lib/http';
+import type { StreamMessage } from '@/lib/types';
+import { StructuredValue } from '../../components/StructuredValue';
+import { usePreferences } from '../../providers';
+
+interface StreamPanelProps {
+  flowId: string;
+  flowType: string;
+}
+
+interface StreamListenerOptions {
+  flowId: string;
+  flowType: string;
+  streamName: string;
+  signal: AbortSignal;
+  onMessage: (message: StreamMessage) => Promise<void>;
+  fetcher?: typeof fetch;
+}
+
+export async function listenToStream({
+  flowId,
+  flowType,
+  streamName,
+  signal,
+  onMessage,
+  fetcher = fetch,
+}: StreamListenerOptions): Promise<void> {
+  let resumeToken = '';
+  while (!signal.aborted) {
+    const params = new URLSearchParams({
+      flowId,
+      flowType,
+      streamName,
+      resumeToken,
+    });
+    const response = await fetcher(`/api/flows/stream?${params}`, {
+      cache: 'no-store',
+      signal,
+    });
+    if (response.status === 408) {
+      await response.text();
+      continue;
+    }
+    const rawMessage = await readResponseJSON<StreamMessage>(response);
+    resumeToken = rawMessage.resumeToken;
+    await onMessage(rawMessage);
+  }
+}
+
+export function StreamPanel({ flowId, flowType }: StreamPanelProps) {
+  const { timezone } = usePreferences();
+  const [streamName, setStreamName] = useState('');
+  const [activeStreamName, setActiveStreamName] = useState('');
+  const [messages, setMessages] = useState<StreamMessage[]>([]);
+  const [isListening, setIsListening] = useState(false);
+  const [error, setError] = useState('');
+  const [blobWarning, setBlobWarning] = useState('');
+  const [session, setSession] = useState(0);
+  const blobCache = useRef(new Map<string, unknown>());
+
+  useEffect(() => {
+    if (!activeStreamName) return;
+    const controller = new AbortController();
+    let isActive = true;
+
+    const read = async () => {
+      setIsListening(true);
+      try {
+        await listenToStream({
+          flowId,
+          flowType,
+          streamName: activeStreamName,
+          signal: controller.signal,
+          onMessage: async (rawMessage) => {
+            const hydrated = await hydrateBlobs(rawMessage.value, blobCache.current, controller.signal);
+            if (!isActive) return;
+            setMessages((current) => [...current, { ...rawMessage, value: hydrated.value }]);
+            if (hydrated.error) setBlobWarning(hydrated.error);
+          },
+        });
+      } catch (readError) {
+        if (controller.signal.aborted) return;
+        setError(readError instanceof Error ? readError.message : 'Stream read failed');
+        setIsListening(false);
+      }
+    };
+    void read();
+    return () => {
+      isActive = false;
+      controller.abort();
+    };
+  }, [activeStreamName, flowId, flowType, session]);
+
+  const startListening = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextStreamName = streamName.trim();
+    if (!nextStreamName) {
+      setError('Enter a Stream name.');
+      return;
+    }
+    blobCache.current.clear();
+    setMessages([]);
+    setError('');
+    setBlobWarning('');
+    setActiveStreamName(nextStreamName);
+    setSession((current) => current + 1);
+  };
+
+  return (
+    <section className="stream-panel">
+      <div className="stream-panel-header">
+        <div>
+          <p className="eyebrow">Resumable stream</p>
+          <h2>Stream messages</h2>
+          <p>Messages are best effort and may be trimmed as the Stream reaches its configured capacity.</p>
+        </div>
+        {activeStreamName && (
+          <span className="stream-listening-status" aria-live="polite">
+            <span className={isListening ? 'stream-listening-dot' : ''} />
+            {isListening ? 'Listening' : 'Stopped'}
+          </span>
+        )}
+      </div>
+
+      <form className="stream-form" onSubmit={startListening}>
+        <label htmlFor="stream-name">Stream name</label>
+        <div>
+          <input
+            id="stream-name"
+            name="streamName"
+            onChange={(event) => setStreamName(event.target.value)}
+            placeholder="thinking"
+            value={streamName}
+          />
+          <button className="button primary" type="submit">
+            {activeStreamName ? 'Restart listening' : 'Start listening'}
+          </button>
+        </div>
+      </form>
+
+      {error && <div className="error-banner">{error}</div>}
+      {blobWarning && <div className="warning-banner">{blobWarning}</div>}
+
+      {activeStreamName && messages.length === 0 && !error && (
+        <p className="stream-empty">Listening for messages in <code>{activeStreamName}</code>…</p>
+      )}
+      {messages.length > 0 && (
+        <div className="stream-message-list" aria-live="polite">
+          {messages.map((message) => (
+            <article className="stream-message" key={message.resumeToken}>
+              <div className="stream-message-meta">
+                <span>{formatDate(message.createdTime, timezone)}</span>
+                {message.idempotencyKey && <code>{message.idempotencyKey}</code>}
+              </div>
+              <StructuredValue value={message.value} />
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -887,6 +887,126 @@ pre {
   min-width: 0;
 }
 
+.stream-panel {
+  display: grid;
+  gap: 18px;
+  max-width: 960px;
+  padding: 4px 0 28px;
+}
+
+.stream-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.stream-panel-header h2 {
+  margin: 3px 0 6px;
+  font-size: 20px;
+}
+
+.stream-panel-header p:not(.eyebrow) {
+  max-width: 660px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.stream-listening-status {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  background: white;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.stream-listening-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--brand);
+  box-shadow: 0 0 0 3px var(--brand-soft);
+}
+
+.stream-form {
+  display: grid;
+  gap: 7px;
+  max-width: 560px;
+}
+
+.stream-form > label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.stream-form > div {
+  display: flex;
+  gap: 8px;
+}
+
+.stream-form input {
+  min-width: 0;
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: white;
+}
+
+.stream-empty {
+  margin: 4px 0 0;
+  padding: 22px;
+  border: 1px dashed #bdcfb4;
+  border-radius: 12px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.stream-message-list {
+  display: grid;
+  gap: 10px;
+  max-height: min(60vh, 720px);
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.stream-message {
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: white;
+  box-shadow: 0 3px 12px rgba(45, 79, 42, 0.04);
+}
+
+.stream-message-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.stream-message-meta code {
+  overflow: hidden;
+  max-width: 70%;
+  padding: 2px 5px;
+  border-radius: 4px;
+  color: var(--ink);
+  background: var(--canvas);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .run-sidebar {
   position: relative;
   min-width: 0;
@@ -2724,6 +2844,16 @@ pre {
 
   .run-tabs button {
     flex: none;
+  }
+
+  .stream-panel-header,
+  .stream-form > div {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .stream-listening-status {
+    align-self: flex-start;
   }
 
   .metric-grid {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -78,6 +78,13 @@ export interface HistoryPage {
   nextInternalEventId: number;
 }
 
+export interface StreamMessage {
+  value: unknown;
+  resumeToken: string;
+  createdTime: string | null;
+  idempotencyKey: string;
+}
+
 export interface ActiveStepExecution {
   stepExecutionId: string;
   fromStepExecutionId: string;

--- a/web/server_integ_test.go
+++ b/web/server_integ_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type flowService struct {
@@ -38,6 +39,7 @@ type flowService struct {
 	searchRequests     chan *dexpb.SearchFlowsRequest
 	loadBlobsRequests  chan *dexpb.LoadBlobsRequest
 	loadBlobsError     error
+	streamRequests     chan *dexpb.ReadStreamRequest
 	stopRequests       chan *dexpb.StopFlowRequest
 	timeTravelRequests chan *dexpb.ResetFlowRequest
 }
@@ -131,6 +133,56 @@ func TestWebServerMapsGRPCErrors(t *testing.T) {
 	}
 	if result.GRPCCode != int32(codes.NotFound) {
 		t.Fatalf("missing summary gRPC code = %d", result.GRPCCode)
+	}
+}
+
+func TestWebServerReadsStream(t *testing.T) {
+	service := &flowService{streamRequests: make(chan *dexpb.ReadStreamRequest, 2)}
+	harness := newHarness(t, service)
+
+	response := get(
+		t,
+		harness.http.URL+"/api/flows/stream?flowId=checkout-1&flowType=CheckoutFlow&streamName=thinking&resumeToken=previous-token",
+	)
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("read stream status = %d body=%q", response.StatusCode, readBody(t, response))
+	}
+	var result struct {
+		Value          string `json:"value"`
+		ResumeToken    string `json:"resumeToken"`
+		CreatedTime    string `json:"createdTime"`
+		IdempotencyKey string `json:"idempotencyKey"`
+	}
+	decodeResponse(t, response, &result)
+	if result.Value != "reasoning token" ||
+		result.ResumeToken != "next-token" ||
+		result.CreatedTime != "2026-08-27T12:34:56Z" ||
+		result.IdempotencyKey != "run-1#Step-1" {
+		t.Fatalf("unexpected Stream message: %+v", result)
+	}
+	streamRequest := <-service.streamRequests
+	if streamRequest.GetFlowId() != "checkout-1" ||
+		streamRequest.GetFlowType() != "CheckoutFlow" ||
+		streamRequest.GetStreamName() != "thinking" ||
+		streamRequest.GetResumeToken() != "previous-token" ||
+		streamRequest.GetWaitTimeSeconds() != 0 {
+		t.Fatalf("unexpected ReadStream request: %+v", streamRequest)
+	}
+
+	timeoutResponse := get(
+		t,
+		harness.http.URL+"/api/flows/stream?flowId=checkout-1&flowType=CheckoutFlow&streamName=timeout",
+	)
+	defer timeoutResponse.Body.Close()
+	if timeoutResponse.StatusCode != http.StatusRequestTimeout {
+		t.Fatalf("stream timeout status = %d body=%q", timeoutResponse.StatusCode, readBody(t, timeoutResponse))
+	}
+
+	missingInput := get(t, harness.http.URL+"/api/flows/stream?flowId=checkout-1&flowType=CheckoutFlow")
+	defer missingInput.Body.Close()
+	if missingInput.StatusCode != http.StatusBadRequest {
+		t.Fatalf("missing Stream name status = %d", missingInput.StatusCode)
 	}
 }
 
@@ -340,6 +392,24 @@ func (s *flowService) GetFlowSummary(
 		)
 	}
 	return nil, status.Error(codes.InvalidArgument, "invalid flow")
+}
+
+func (s *flowService) ReadStream(
+	_ context.Context,
+	request *dexpb.ReadStreamRequest,
+) (*dexpb.ReadStreamResponse, error) {
+	if s.streamRequests != nil {
+		s.streamRequests <- request
+	}
+	if request.GetStreamName() == "timeout" {
+		return nil, status.Error(codes.DeadlineExceeded, "stream read timed out")
+	}
+	return &dexpb.ReadStreamResponse{Message: &dexpb.StreamMessage{
+		Value:          &dexpb.Value{Kind: &dexpb.Value_StringValue{StringValue: "reasoning token"}},
+		ResumeToken:    "next-token",
+		CreatedTime:    timestamppb.New(time.Date(2026, time.August, 27, 12, 34, 56, 0, time.UTC)),
+		IdempotencyKey: "run-1#Step-1",
+	}}, nil
 }
 
 func (s *flowService) LoadBlobs(


### PR DESCRIPTION
## Summary

- add a Streams tab to Flow details with a Stream name input and retained-message display
- proxy ReadStream through the same-origin Web API, including creation time and idempotency key
- continue long-polling after every message and after server long-poll timeouts

## Rationale

Stream messages make best-effort Agent and LLM progress visible while a Flow is running. The tab reads from the retained head first, then resumes with each returned token.

## User impact

Operators can open a Flow, enter a defined Stream name, and watch messages arrive without manually managing resume tokens. Blob-backed values use the existing hydration path.

## Validation

- `cd web && npm run check`
- `cd web && npm run build`
- `cd web && GOWORK=off go test ./...`
