### PR TITLE
Rename stream capacity SDK APIs

### DIFF
--- a/sdk-go/dex/client.go
+++ b/sdk-go/dex/client.go
@@ -1017,7 +1017,7 @@ func (client *Client) WriteStream(
 		FlowId:            flowID,
 		FlowType:          flow.flowType,
 		StreamName:        registered.definition.name,
-		MaxEstimatedBytes: registered.definition.maxEstimatedBytes,
+		MaxEstimatedBytes: registered.definition.streamCapacityBytes,
 		Value:             encoded,
 		IdempotencyKey:    idempotencyKey,
 	})

--- a/sdk-go/dex/invocation.go
+++ b/sdk-go/dex/invocation.go
@@ -141,7 +141,7 @@ func (invocation *invocationContext) writeStream(
 		FlowId:            invocation.flowID,
 		FlowType:          invocation.flow.flowType,
 		StreamName:        definition.name,
-		MaxEstimatedBytes: definition.maxEstimatedBytes,
+		MaxEstimatedBytes: definition.streamCapacityBytes,
 		Value:             encoded,
 		IdempotencyKey:    idempotencyKey,
 	})

--- a/sdk-go/dex/registration_test.go
+++ b/sdk-go/dex/registration_test.go
@@ -612,7 +612,7 @@ func TestRegistryValidatesPersistenceSchema(t *testing.T) {
 					Streams: []StreamDef{DefineStream[string]("stream", 0)},
 				},
 			}},
-			error: "max estimated bytes must be positive",
+			error: "capacity bytes must be positive",
 		},
 		{
 			name: "duplicate stream",

--- a/sdk-go/dex/stream.go
+++ b/sdk-go/dex/stream.go
@@ -16,7 +16,7 @@ import (
 // Stream defines one typed, best-effort resumable message stream.
 //
 // Register the Stream in exactly one Flow's PersistenceSchema. All Flow instances sharing that
-// Flow type and Stream name share maxEstimatedBytes. Stream writes are immediately visible and do
+// Flow type and Stream name share streamCapacityBytes. Stream writes are immediately visible and do
 // not roll back when a Step later fails.
 //
 //	var Thinking = dex.DefineStream[string]("thinking", 10<<20)
@@ -32,17 +32,17 @@ type Stream[T any] struct {
 }
 
 type streamDefinition struct {
-	name              string
-	maxEstimatedBytes int64
+	name                string
+	streamCapacityBytes int64
 }
 
 // DefineStream creates a typed Stream with a stable name and shared approximate byte budget.
 //
-// maxEstimatedBytes must be positive. Validation occurs when NewRegistry registers the Stream.
-func DefineStream[T any](name string, maxEstimatedBytes int64) Stream[T] {
+// streamCapacityBytes must be positive. Validation occurs when NewRegistry registers the Stream.
+func DefineStream[T any](name string, streamCapacityBytes int64) Stream[T] {
 	return Stream[T]{definition: &streamDefinition{
-		name:              name,
-		maxEstimatedBytes: maxEstimatedBytes,
+		name:                name,
+		streamCapacityBytes: streamCapacityBytes,
 	}}
 }
 
@@ -87,12 +87,12 @@ func (s Stream[T]) StreamName() string {
 	return s.definition.name
 }
 
-// MaxEstimatedBytes returns the approximate shared byte budget.
-func (s Stream[T]) MaxEstimatedBytes() int64 {
+// StreamCapacityBytes returns the approximate shared byte budget.
+func (s Stream[T]) StreamCapacityBytes() int64 {
 	if s.definition == nil {
 		return 0
 	}
-	return s.definition.maxEstimatedBytes
+	return s.definition.streamCapacityBytes
 }
 
 func (s Stream[T]) streamDefinition() *streamDefinition {
@@ -110,8 +110,8 @@ func validateStreamDefinition(definition *streamDefinition) error {
 	if definition.name == "" {
 		return fmt.Errorf("stream name must not be empty")
 	}
-	if definition.maxEstimatedBytes <= 0 {
-		return fmt.Errorf("stream %q max estimated bytes must be positive", definition.name)
+	if definition.streamCapacityBytes <= 0 {
+		return fmt.Errorf("stream %q capacity bytes must be positive", definition.name)
 	}
 	return nil
 }

--- a/sdk-java/src/main/java/io/superdurable/dex/Client.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Client.java
@@ -604,7 +604,7 @@ public final class Client implements AutoCloseable {
                 .setFlowId(Attribute.requireName(flowId))
                 .setFlowType(flow.getName())
                 .setStreamName(stream.getStreamName())
-                .setMaxEstimatedBytes(stream.getMaxEstimatedBytes())
+                .setMaxEstimatedBytes(stream.getStreamCapacityBytes())
                 .setValue(values.encode(value))
                 .setIdempotencyKey(key)
                 .build()));

--- a/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
@@ -182,7 +182,7 @@ final class InvocationContext implements Context {
                 .setFlowId(getFlowId())
                 .setFlowType(flow.getName())
                 .setStreamName(stream.getStreamName())
-                .setMaxEstimatedBytes(stream.getMaxEstimatedBytes())
+                .setMaxEstimatedBytes(stream.getStreamCapacityBytes())
                 .setValue(values.encode(value))
                 .setIdempotencyKey(getRunId() + "#" + getStepExecutionId())
                 .build());

--- a/sdk-java/src/main/java/io/superdurable/dex/Stream.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Stream.java
@@ -22,21 +22,21 @@ package io.superdurable.dex;
 public final class Stream<T> extends PersistenceDefinition {
     private final String name;
     private final Class<T> valueType;
-    private final long maxEstimatedBytes;
+    private final long streamCapacityBytes;
 
     private Stream(
             final String name,
             final Class<T> valueType,
-            final long maxEstimatedBytes) {
+            final long streamCapacityBytes) {
         this.name = Attribute.requireName(name);
         if (valueType == null) {
             throw new IllegalArgumentException("Stream value type is required");
         }
-        if (maxEstimatedBytes <= 0) {
-            throw new IllegalArgumentException("Stream maxEstimatedBytes must be positive");
+        if (streamCapacityBytes <= 0) {
+            throw new IllegalArgumentException("Stream streamCapacityBytes must be positive");
         }
         this.valueType = valueType;
-        this.maxEstimatedBytes = maxEstimatedBytes;
+        this.streamCapacityBytes = streamCapacityBytes;
     }
 
     /**
@@ -44,15 +44,15 @@ public final class Stream<T> extends PersistenceDefinition {
      *
      * @param name the nonblank logical name unique within its Flow
      * @param valueType the concrete message class used for decoding
-     * @param maxEstimatedBytes the positive approximate shared byte budget
+     * @param streamCapacityBytes the positive approximate shared byte budget
      * @param <T> the message type
      * @return an immutable Stream definition
      */
     public static <T> Stream<T> define(
             final String name,
             final Class<T> valueType,
-            final long maxEstimatedBytes) {
-        return new Stream<T>(name, valueType, maxEstimatedBytes);
+            final long streamCapacityBytes) {
+        return new Stream<T>(name, valueType, streamCapacityBytes);
     }
 
     /**
@@ -79,8 +79,8 @@ public final class Stream<T> extends PersistenceDefinition {
      *
      * @return the positive budget in bytes
      */
-    public long getMaxEstimatedBytes() {
-        return maxEstimatedBytes;
+    public long getStreamCapacityBytes() {
+        return streamCapacityBytes;
     }
 
     @Override

--- a/sdk-python/dex/_invocation_context.py
+++ b/sdk-python/dex/_invocation_context.py
@@ -175,7 +175,7 @@ class InvocationContext:
             flow_id=self.flow_id,
             flow_type=self._flow.name,
             stream_name=definition.name,
-            max_estimated_bytes=definition.max_estimated_bytes,
+            max_estimated_bytes=definition.stream_capacity_bytes,
             value=self._values.encode(
                 value,
                 self._values.codec(definition.value_type),

--- a/sdk-python/dex/async_client.py
+++ b/sdk-python/dex/async_client.py
@@ -535,7 +535,7 @@ class AsyncClient:
                 flow_id=require_name(flow_id),
                 flow_type=flow.name,
                 stream_name=stream.name,
-                max_estimated_bytes=stream.max_estimated_bytes,
+                max_estimated_bytes=stream.stream_capacity_bytes,
                 value=self._values.encode(
                     value,
                     self._values.codec(stream.value_type),

--- a/sdk-python/dex/client.py
+++ b/sdk-python/dex/client.py
@@ -536,7 +536,7 @@ class Client:
                 flow_id=require_name(flow_id),
                 flow_type=flow.name,
                 stream_name=stream.name,
-                max_estimated_bytes=stream.max_estimated_bytes,
+                max_estimated_bytes=stream.stream_capacity_bytes,
                 value=self._values.encode(
                     value,
                     self._values.codec(stream.value_type),

--- a/sdk-python/dex/stream.py
+++ b/sdk-python/dex/stream.py
@@ -27,12 +27,12 @@ class Stream(Generic[ValueT]):
     Attributes:
         name: Logical name unique within the Flow persistence schema.
         value_type: Python type encoded for every message.
-        max_estimated_bytes: Positive approximate budget shared by all Flow instances.
+        stream_capacity_bytes: Positive approximate budget shared by all Flow instances.
     """
 
     name: str
     value_type: type[ValueT]
-    max_estimated_bytes: int
+    stream_capacity_bytes: int
 
     def __post_init__(self) -> None:
         """Validate the Stream definition after dataclass construction.
@@ -42,10 +42,10 @@ class Stream(Generic[ValueT]):
             TypeError: If the byte budget is not an integer.
         """
         require_name(self.name)
-        if not isinstance(self.max_estimated_bytes, int):
-            raise TypeError("Stream max_estimated_bytes must be an integer")
-        if self.max_estimated_bytes <= 0:
-            raise ValueError("Stream max_estimated_bytes must be positive")
+        if not isinstance(self.stream_capacity_bytes, int):
+            raise TypeError("Stream stream_capacity_bytes must be an integer")
+        if self.stream_capacity_bytes <= 0:
+            raise ValueError("Stream stream_capacity_bytes must be positive")
 
     def write(self, context: Context, value: ValueT) -> Any:
         """Append one message immediately from the current Step execution.

--- a/sdk-rust/crates/dex-sdk/src/client.rs
+++ b/sdk-rust/crates/dex-sdk/src/client.rs
@@ -358,7 +358,7 @@ impl Client {
             flow_id: flow_id.to_string(),
             flow_type,
             stream_name: stream.name().to_string(),
-            max_estimated_bytes: stream.max_estimated_bytes(),
+            max_estimated_bytes: stream.stream_capacity_bytes(),
             value: Some(value_mapper::encode(&value)?),
             idempotency_key: idempotency_key.to_string(),
         };

--- a/sdk-rust/crates/dex-sdk/src/context.rs
+++ b/sdk-rust/crates/dex-sdk/src/context.rs
@@ -474,7 +474,7 @@ impl Context {
                     format!("Stream does not belong to Flow: {}", stream.name()),
                 )
             })?;
-        if definition.max_estimated_bytes != Some(stream.max_estimated_bytes()) {
+        if definition.stream_capacity_bytes != Some(stream.stream_capacity_bytes()) {
             return Err(HandlerError::new(
                 "dex_sdk::HandlerError",
                 format!(
@@ -496,7 +496,7 @@ impl Context {
             flow_id: self.flow_id().to_string(),
             flow_type: self.flow.name.to_string(),
             stream_name: stream.name().to_string(),
-            max_estimated_bytes: stream.max_estimated_bytes(),
+            max_estimated_bytes: stream.stream_capacity_bytes(),
             value: Some(value_mapper::encode_handler(&value)?),
             idempotency_key: format!("{}#{}", self.run_id(), self.step_execution_id()),
         };

--- a/sdk-rust/crates/dex-sdk/src/persistence.rs
+++ b/sdk-rust/crates/dex-sdk/src/persistence.rs
@@ -34,7 +34,7 @@ pub(crate) struct PersistenceDefinition {
     pub(crate) index: Option<AttributeIndex>,
     pub(crate) sync_to_attribute_store: bool,
     pub(crate) stream_identity: Option<usize>,
-    pub(crate) max_estimated_bytes: Option<i64>,
+    pub(crate) stream_capacity_bytes: Option<i64>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -112,7 +112,7 @@ impl PersistenceSchema {
             None,
             false,
             Some(stream.identity()),
-            Some(stream.max_estimated_bytes()),
+            Some(stream.stream_capacity_bytes()),
         );
         self
     }
@@ -128,7 +128,7 @@ impl PersistenceSchema {
         index: Option<AttributeIndex>,
         sync_to_attribute_store: bool,
         stream_identity: Option<usize>,
-        max_estimated_bytes: Option<i64>,
+        stream_capacity_bytes: Option<i64>,
     ) {
         self.definitions.push(PersistenceDefinition {
             name: name.to_string(),
@@ -136,7 +136,7 @@ impl PersistenceSchema {
             index,
             sync_to_attribute_store,
             stream_identity,
-            max_estimated_bytes,
+            stream_capacity_bytes,
         });
     }
 }
@@ -167,6 +167,6 @@ mod tests {
             schema.definitions[0].stream_identity,
             Some(stream.identity())
         );
-        assert_eq!(schema.definitions[0].max_estimated_bytes, Some(1_048_576));
+        assert_eq!(schema.definitions[0].stream_capacity_bytes, Some(1_048_576));
     }
 }

--- a/sdk-rust/crates/dex-sdk/src/stream.rs
+++ b/sdk-rust/crates/dex-sdk/src/stream.rs
@@ -15,7 +15,7 @@ use crate::{Context, HandlerResult, Value};
 #[derive(Debug)]
 struct StreamDefinition {
     name: String,
-    max_estimated_bytes: i64,
+    stream_capacity_bytes: i64,
 }
 
 /// Defines a typed best-effort resumable message Stream owned by one Flow type.
@@ -33,18 +33,18 @@ impl<T> Stream<T> {
     ///
     /// # Panics
     ///
-    /// Panics when `name` is empty or `max_estimated_bytes` is not positive.
-    pub fn new(name: impl Into<String>, max_estimated_bytes: i64) -> Self {
+    /// Panics when `name` is empty or `stream_capacity_bytes` is not positive.
+    pub fn new(name: impl Into<String>, stream_capacity_bytes: i64) -> Self {
         let name = name.into();
         assert!(!name.is_empty(), "Stream name must not be empty");
         assert!(
-            max_estimated_bytes > 0,
-            "Stream max_estimated_bytes must be positive"
+            stream_capacity_bytes > 0,
+            "Stream stream_capacity_bytes must be positive"
         );
         Self {
             definition: Arc::new(StreamDefinition {
                 name,
-                max_estimated_bytes,
+                stream_capacity_bytes,
             }),
             marker: PhantomData,
         }
@@ -56,8 +56,8 @@ impl<T> Stream<T> {
     }
 
     /// Returns the approximate shared byte budget.
-    pub fn max_estimated_bytes(&self) -> i64 {
-        self.definition.max_estimated_bytes
+    pub fn stream_capacity_bytes(&self) -> i64 {
+        self.definition.stream_capacity_bytes
     }
 
     /// Appends one message immediately from the current Step execution.

--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -526,7 +526,7 @@ export class Client {
         flowId: requireName(flowId),
         flowType: flow.name,
         streamName: stream.name,
-        maxEstimatedBytes: BigInt(stream.maxEstimatedBytes),
+        maxEstimatedBytes: BigInt(stream.streamCapacityBytes),
         value: encodeValue(stream.codec, value),
         idempotencyKey,
       }, callback),

--- a/sdk-typescript/src/invocation-context.ts
+++ b/sdk-typescript/src/invocation-context.ts
@@ -93,7 +93,7 @@ export class InvocationContext implements Context {
         flowId: this.flowId,
         flowType: this.flow.name,
         streamName: stream.name,
-        maxEstimatedBytes: BigInt(stream.maxEstimatedBytes),
+        maxEstimatedBytes: BigInt(stream.streamCapacityBytes),
         value: encodeValue(stream.codec, value),
         idempotencyKey: `${this.runId}#${this.stepExecutionId}`,
       });

--- a/sdk-typescript/src/stream.ts
+++ b/sdk-typescript/src/stream.ts
@@ -19,16 +19,16 @@ export class Stream<T> {
    * Creates a Stream definition for a PersistenceSchema.
    * @param name - Non-empty logical name unique within the Flow.
    * @param codec - Codec used for every Stream message.
-   * @param maxEstimatedBytes - Positive approximate byte budget shared by this Flow type's instances.
+   * @param streamCapacityBytes - Positive approximate byte budget shared by this Flow type's instances.
    */
   public constructor(
     public readonly name: string,
     public readonly codec: Codec<T>,
-    public readonly maxEstimatedBytes: number,
+    public readonly streamCapacityBytes: number,
   ) {
     requireName(name);
-    if (!Number.isSafeInteger(maxEstimatedBytes) || maxEstimatedBytes <= 0) {
-      throw new RangeError("Stream maxEstimatedBytes must be a positive safe integer");
+    if (!Number.isSafeInteger(streamCapacityBytes) || streamCapacityBytes <= 0) {
+      throw new RangeError("Stream streamCapacityBytes must be a positive safe integer");
     }
   }
 


### PR DESCRIPTION
## Summary

Rename the Stream byte-budget API across the Go, Java, Python, Rust, and TypeScript SDKs to StreamCapacityBytes and each language's idiomatic equivalent.

## Rationale

The new name describes the Stream retention capacity directly. The existing maxEstimatedBytes RPC and protobuf field remains unchanged, so the wire protocol is unaffected.

## User impact

Applications must update references to the renamed Stream SDK API. Examples and product documentation are intentionally unchanged in this PR.

## Validation

- `make -C sdk-go tests`
- `./gradlew test` in `sdk-java`
- `uv run pytest tests/test_contracts.py` in `sdk-python`
- `make test` in `sdk-rust`
- `npm test` in `sdk-typescript`
- `make copyright-check`
