### PR TITLE
Refactor Rust schema definitions as lazy statics

### DIFF
--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -20,6 +20,12 @@ wrapper often injects `Co-authored-by: Cursor <cursoragent@cursor.com>`; strip
 it before pushing. After every commit run `git log -1 --format=%B`. Do not use
 `--no-verify`. See `.cursor/rules/git-commit.mdc`.
 
+## Agent Rule Synchronization
+
+Keep the Cursor (`.cursor/rules/`), Codex (`AGENTS.md`), and Claude
+(`CLAUDE.md`) coding-agent rules synchronized. Any addition or modification to
+one requires equivalent updates to all three in the same commit.
+
 ## Compatibility
 
 - The project has not launched. Remove dead config fields immediately.

--- a/.cursor/rules/rust-schema.mdc
+++ b/.cursor/rules/rust-schema.mdc
@@ -6,3 +6,5 @@ alwaysApply: true
 # Rust Workflow Schema Definitions
 
 In Rust examples and SDK tests under `sdk-rust/crates/dex-sdk/tests/integ/`, define every Attribute, Channel, and Stream as a module-level `static LazyLock<T>`. Do not use a function to construct or return one of these definitions. Reuse the static directly, or clone its initialized value only when an owned field is required.
+
+Codex and Claude mirrors: `AGENTS.md` and `CLAUDE.md`.

--- a/.cursor/rules/rust-schema.mdc
+++ b/.cursor/rules/rust-schema.mdc
@@ -1,0 +1,8 @@
+---
+description: Rust workflow schema definition rules
+alwaysApply: true
+---
+
+# Rust Workflow Schema Definitions
+
+In Rust examples and SDK tests under `sdk-rust/crates/dex-sdk/tests/integ/`, define every Attribute, Channel, and Stream as a module-level `static LazyLock<T>`. Do not use a function to construct or return one of these definitions. Reuse the static directly, or clone its initialized value only when an owned field is required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,12 @@ Before creating a feature branch, fetch and branch from `origin/main`. See
 (`script/branch_off_main_policy.py`; Codex requires `features.codex_hooks =
 true` in `~/.codex/config.toml`).
 
+### Agent Rule Synchronization
+
+Keep the Cursor (`.cursor/rules/`), Codex (`AGENTS.md`), and Claude
+(`CLAUDE.md`) coding-agent rules synchronized. Any addition or modification to
+one requires equivalent updates to all three in the same commit.
+
 ### Regenerate the Entire Repository After Proto Changes
 
 Whenever any `.proto` file changes, run `make generated-code` from the repository
@@ -105,6 +111,14 @@ Do not replace legacy headers. Editing a `legacy-only` file upgrades it to
 The project has **not launched**. Remove dead config fields immediately. Break
 APIs freely. Ask before adding any compat shim. Do not leave docs/comments that
 explain former behavior.
+
+### Rust Workflow Schema Definitions
+
+In Rust examples and SDK tests under `sdk-rust/crates/dex-sdk/tests/integ/`,
+define every Attribute, Channel, and Stream as a module-level `static
+LazyLock<T>`. Do not use a function to construct or return one of these
+definitions. Reuse the static directly, or clone its initialized value only
+when an owned field is required.
 
 ### Fluent SDK Call Sites
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,12 @@ wrapper often injects `Co-authored-by: Cursor <cursoragent@cursor.com>`; strip
 it before pushing. After every commit run `git log -1 --format=%B`. Do not use
 `--no-verify`. See `.cursor/rules/git-commit.mdc`.
 
+## Agent Rule Synchronization
+
+Keep the Cursor (`.cursor/rules/`), Codex (`AGENTS.md`), and Claude
+(`CLAUDE.md`) coding-agent rules synchronized. Any addition or modification to
+one requires equivalent updates to all three in the same commit.
+
 ## Compatibility
 
 - The project has not launched. Remove dead config fields immediately.
@@ -105,6 +111,14 @@ it before pushing. After every commit run `git log -1 --format=%B`. Do not use
   missing, add it. Or run `make copyright` from the repo root.
 - Use `make copyright` to add or upgrade headers and `make copyright-check` to
   verify classifications and normalized body hashes.
+
+# Rust Workflow Schema Definitions
+
+In Rust examples and SDK tests under `sdk-rust/crates/dex-sdk/tests/integ/`,
+define every Attribute, Channel, and Stream as a module-level `static
+LazyLock<T>`. Do not use a function to construct or return one of these
+definitions. Reuse the static directly, or clone its initialized value only
+when an owned field is required.
 
 # Server Go Conventions (`server/**/*.go`)
 

--- a/docs/content/intro/what-is-dex.mdx
+++ b/docs/content/intro/what-is-dex.mdx
@@ -593,12 +593,12 @@ impl OrderProcessingFlow {
     }
 
     fn approve(&self, context: &mut Context, _note: String) -> HandlerResult<RpcResult<String>> {
-        seller_ok().publish(context, "approved".to_string())?;
+        SELLER_OK.publish(context, "approved".to_string())?;
         Ok(RpcResult::new("ok".to_string()))
     }
 
     fn describe(&self, context: &mut Context) -> HandlerResult<RpcResult<String>> {
-        Ok(RpcResult::new(order_status().get_required(context)?))
+        Ok(RpcResult::new(ORDER_STATUS.get_required(context)?))
     }
 }
 
@@ -623,8 +623,8 @@ impl Flow for OrderProcessingFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&order_status())
-            .channel(&seller_ok())
+            .attribute(&ORDER_STATUS)
+            .channel(&SELLER_OK)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -656,7 +656,7 @@ impl Step for Charge {
         self.service
             .charge_user(&input.email, &input.customer_id, input.amount);
         context.record_event("charge", input.order_id.clone())?;
-        order_status().set(context, "charged".to_string())?;
+        ORDER_STATUS.set(context, "charged".to_string())?;
         Ok(StepDecision::go_to(&Ship::default(), input))
     }
 }
@@ -683,7 +683,7 @@ impl Step for Ship {
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            seller_ok().for_one(),
+            SELLER_OK.for_one(),
             Timer::by_duration(Duration::from_secs(24 * 60 * 60)),
         ]))
     }
@@ -700,7 +700,7 @@ impl Step for Ship {
         }
         self.service.ship_item(&input.order_id)?;
         context.record_event("ship", input.order_id.clone())?;
-        order_status().set(context, "shipped".to_string())?;
+        ORDER_STATUS.set(context, "shipped".to_string())?;
         Ok(StepDecision::graceful_complete(format!(
             "shipped:{}",
             input.order_id
@@ -730,7 +730,7 @@ impl Step for Refund {
         self.service
             .update_external_system(&format!("refund {}", input.order_id));
         context.record_event("refund", input.order_id.clone())?;
-        order_status().set(context, "refunded".to_string())?;
+        ORDER_STATUS.set(context, "refunded".to_string())?;
         Ok(StepDecision::graceful_complete(format!(
             "refunded:{}",
             input.order_id
@@ -738,13 +738,10 @@ impl Step for Refund {
     }
 }
 
-fn order_status() -> Attribute<String> {
-    Attribute::new("order-status").indexed(AttributeIndex::keyword())
-}
+static ORDER_STATUS: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("order-status").indexed(AttributeIndex::keyword()));
 
-fn seller_ok() -> Channel<String> {
-    Channel::new("seller-ok")
-}
+static SELLER_OK: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("seller-ok"));
 ```
 
 </SdkSnippet>

--- a/docs/content/primitives/attribute.mdx
+++ b/docs/content/primitives/attribute.mdx
@@ -543,9 +543,8 @@ public readonly displayName = new Attribute("display_name", stringCodec)
 <SdkSnippet lang="rust">
 
 ```rust
-fn display_name() -> Attribute<String> {
-    Attribute::new("display_name").sync_to_attribute_store()
-}
+static DISPLAY_NAME: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("display_name").sync_to_attribute_store());
 ```
 
 </SdkSnippet>

--- a/docs/content/primitives/channel.mdx
+++ b/docs/content/primitives/channel.mdx
@@ -220,9 +220,7 @@ export class ChannelFlow implements Flow<number> {
 ```rust
 pub const CHANNEL_APPROVE: Rpc<(), ()> = Rpc::new("ChannelApprove");
 
-fn approval() -> Channel<String> {
-    Channel::new("Approval")
-}
+static APPROVAL: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("Approval"));
 
 #[derive(Default)]
 pub struct ChannelFlow {
@@ -231,7 +229,7 @@ pub struct ChannelFlow {
 
 impl ChannelFlow {
     fn approve(&self, context: &mut Context) -> HandlerResult<()> {
-        approval().publish(context, "approved".to_string())
+        APPROVAL.publish(context, "approved".to_string())
     }
 }
 
@@ -243,7 +241,7 @@ impl Flow for ChannelFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&approval())
+        PersistenceSchema::new().channel(&APPROVAL)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -259,7 +257,7 @@ impl Step for ChannelWait {
 
     fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            approval().for_one(),
+            APPROVAL.for_one(),
             Timer::by_duration(Duration::from_secs(input.max(0) as u64)),
         ]))
     }
@@ -270,7 +268,7 @@ impl Step for ChannelWait {
                 "approval timed out".to_owned(),
             ));
         }
-        let approvals = approval().condition_results(context)?;
+        let approvals = APPROVAL.condition_results(context)?;
         Ok(StepDecision::graceful_complete(approvals[0].clone()))
     }
 }

--- a/docs/content/primitives/client/basic.mdx
+++ b/docs/content/primitives/client/basic.mdx
@@ -176,7 +176,7 @@ await client.publish("order-123", approval, "approved");
 <SdkSnippet lang="rust">
 
 ```rust
-client.publish("order-123", &approval(), "approved".to_owned())?;
+client.publish("order-123", &APPROVAL, "approved".to_owned())?;
 ```
 
 </SdkSnippet>

--- a/docs/content/primitives/step/basic.mdx
+++ b/docs/content/primitives/step/basic.mdx
@@ -173,9 +173,7 @@ class StepSecond implements Step<number> {
   <SdkSnippet lang="rust">
 
 ```rust
-fn approval() -> Channel<String> {
-    Channel::new("Approval")
-}
+static APPROVAL: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("Approval"));
 
 #[derive(Default)]
 struct ExampleStep;
@@ -184,7 +182,7 @@ impl Step for ExampleStep {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
-        Ok(Wait::until(approval().for_one()))
+        Ok(Wait::until(APPROVAL.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {

--- a/docs/content/primitives/step/waiting-condition.mdx
+++ b/docs/content/primitives/step/waiting-condition.mdx
@@ -138,9 +138,7 @@ const channelWaitStep = new ChannelWait();
   <SdkSnippet lang="rust">
 
 ```rust
-fn approval() -> Channel<String> {
-    Channel::new("Approval")
-}
+static APPROVAL: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("Approval"));
 
 #[derive(Default)]
 struct ChannelWait;
@@ -150,7 +148,7 @@ impl Step for ChannelWait {
 
     fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            approval().for_one(),
+            APPROVAL.for_one(),
             Timer::by_duration(Duration::from_secs(input.max(0) as u64)),
         ]))
     }
@@ -161,7 +159,7 @@ impl Step for ChannelWait {
                 "approval timed out".to_owned(),
             ));
         }
-        let approvals = approval().condition_results(context)?;
+        let approvals = APPROVAL.condition_results(context)?;
         Ok(StepDecision::graceful_complete(approvals[0].clone()))
     }
 }
@@ -424,7 +422,7 @@ public execute(context: Context, _input: number): StepDecision {
 ```rust
 fn wait_for(&self, context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
     context.set_step_execution_local("note", format!("approval:{input}"))?;
-    Ok(Wait::until(approval().for_one()))
+    Ok(Wait::until(APPROVAL.for_one()))
 }
 
 fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {

--- a/docs/content/primitives/stream.mdx
+++ b/docs/content/primitives/stream.mdx
@@ -157,12 +157,8 @@ export class StreamFlow implements Flow<string> {
 <SdkSnippet lang="rust">
 
 ```rust
-pub fn progress() -> Stream<String> {
-    static PROGRESS: OnceLock<Stream<String>> = OnceLock::new();
-    PROGRESS
-        .get_or_init(|| Stream::new("Progress", 10 * 1024 * 1024))
-        .clone()
-}
+pub static PROGRESS: LazyLock<Stream<String>> =
+    LazyLock::new(|| Stream::new("Progress", 10 * 1024 * 1024));
 
 #[derive(Default)]
 pub struct StreamFlow {
@@ -177,7 +173,7 @@ impl Flow for StreamFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().stream(&progress())
+        PersistenceSchema::new().stream(&PROGRESS)
     }
 }
 
@@ -192,7 +188,7 @@ impl Step for RenderPreview {
         context: &mut Context,
         input: Self::Input,
     ) -> HandlerResult<StepDecision> {
-        progress().write(context, format!("Rendering preview for {input}"))?;
+        PROGRESS.write(context, format!("Rendering preview for {input}"))?;
         Ok(StepDecision::graceful_complete(format!(
             "Rendered {input}"
         )))

--- a/docs/content/quick-start/index.mdx
+++ b/docs/content/quick-start/index.mdx
@@ -616,12 +616,12 @@ impl OrderProcessingFlow {
     }
 
     fn approve(&self, context: &mut Context, _note: String) -> HandlerResult<RpcResult<String>> {
-        seller_ok().publish(context, "approved".to_string())?;
+        SELLER_OK.publish(context, "approved".to_string())?;
         Ok(RpcResult::new("ok".to_string()))
     }
 
     fn describe(&self, context: &mut Context) -> HandlerResult<RpcResult<String>> {
-        Ok(RpcResult::new(order_status().get_required(context)?))
+        Ok(RpcResult::new(ORDER_STATUS.get_required(context)?))
     }
 }
 
@@ -646,8 +646,8 @@ impl Flow for OrderProcessingFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&order_status())
-            .channel(&seller_ok())
+            .attribute(&ORDER_STATUS)
+            .channel(&SELLER_OK)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -679,7 +679,7 @@ impl Step for Charge {
         self.service
             .charge_user(&input.email, &input.customer_id, input.amount);
         context.record_event("charge", input.order_id.clone())?;
-        order_status().set(context, "charged".to_string())?;
+        ORDER_STATUS.set(context, "charged".to_string())?;
         Ok(StepDecision::go_to(&Ship::default(), input))
     }
 }
@@ -706,7 +706,7 @@ impl Step for Ship {
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            seller_ok().for_one(),
+            SELLER_OK.for_one(),
             Timer::by_duration(Duration::from_secs(24 * 60 * 60)),
         ]))
     }
@@ -723,7 +723,7 @@ impl Step for Ship {
         }
         self.service.ship_item(&input.order_id)?;
         context.record_event("ship", input.order_id.clone())?;
-        order_status().set(context, "shipped".to_string())?;
+        ORDER_STATUS.set(context, "shipped".to_string())?;
         Ok(StepDecision::graceful_complete(format!(
             "shipped:{}",
             input.order_id
@@ -753,7 +753,7 @@ impl Step for Refund {
         self.service
             .update_external_system(&format!("refund {}", input.order_id));
         context.record_event("refund", input.order_id.clone())?;
-        order_status().set(context, "refunded".to_string())?;
+        ORDER_STATUS.set(context, "refunded".to_string())?;
         Ok(StepDecision::graceful_complete(format!(
             "refunded:{}",
             input.order_id
@@ -761,13 +761,10 @@ impl Step for Refund {
     }
 }
 
-fn order_status() -> Attribute<String> {
-    Attribute::new("order-status").indexed(AttributeIndex::keyword())
-}
+static ORDER_STATUS: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("order-status").indexed(AttributeIndex::keyword()));
 
-fn seller_ok() -> Channel<String> {
-    Channel::new("seller-ok")
-}
+static SELLER_OK: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("seller-ok"));
 ```
 
 </SdkSnippet>

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro/what-is-dex.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro/what-is-dex.mdx
@@ -593,12 +593,12 @@ impl OrderProcessingFlow {
     }
 
     fn approve(&self, context: &mut Context, _note: String) -> HandlerResult<RpcResult<String>> {
-        seller_ok().publish(context, "approved".to_string())?;
+        SELLER_OK.publish(context, "approved".to_string())?;
         Ok(RpcResult::new("ok".to_string()))
     }
 
     fn describe(&self, context: &mut Context) -> HandlerResult<RpcResult<String>> {
-        Ok(RpcResult::new(order_status().get_required(context)?))
+        Ok(RpcResult::new(ORDER_STATUS.get_required(context)?))
     }
 }
 
@@ -623,8 +623,8 @@ impl Flow for OrderProcessingFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&order_status())
-            .channel(&seller_ok())
+            .attribute(&ORDER_STATUS)
+            .channel(&SELLER_OK)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -656,7 +656,7 @@ impl Step for Charge {
         self.service
             .charge_user(&input.email, &input.customer_id, input.amount);
         context.record_event("charge", input.order_id.clone())?;
-        order_status().set(context, "charged".to_string())?;
+        ORDER_STATUS.set(context, "charged".to_string())?;
         Ok(StepDecision::go_to(&Ship::default(), input))
     }
 }
@@ -683,7 +683,7 @@ impl Step for Ship {
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            seller_ok().for_one(),
+            SELLER_OK.for_one(),
             Timer::by_duration(Duration::from_secs(24 * 60 * 60)),
         ]))
     }
@@ -700,7 +700,7 @@ impl Step for Ship {
         }
         self.service.ship_item(&input.order_id)?;
         context.record_event("ship", input.order_id.clone())?;
-        order_status().set(context, "shipped".to_string())?;
+        ORDER_STATUS.set(context, "shipped".to_string())?;
         Ok(StepDecision::graceful_complete(format!(
             "shipped:{}",
             input.order_id
@@ -730,7 +730,7 @@ impl Step for Refund {
         self.service
             .update_external_system(&format!("refund {}", input.order_id));
         context.record_event("refund", input.order_id.clone())?;
-        order_status().set(context, "refunded".to_string())?;
+        ORDER_STATUS.set(context, "refunded".to_string())?;
         Ok(StepDecision::graceful_complete(format!(
             "refunded:{}",
             input.order_id
@@ -738,13 +738,10 @@ impl Step for Refund {
     }
 }
 
-fn order_status() -> Attribute<String> {
-    Attribute::new("order-status").indexed(AttributeIndex::keyword())
-}
+static ORDER_STATUS: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("order-status").indexed(AttributeIndex::keyword()));
 
-fn seller_ok() -> Channel<String> {
-    Channel::new("seller-ok")
-}
+static SELLER_OK: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("seller-ok"));
 ```
 
 </SdkSnippet>

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/attribute.mdx
@@ -543,9 +543,8 @@ public readonly displayName = new Attribute("display_name", stringCodec)
 <SdkSnippet lang="rust">
 
 ```rust
-fn display_name() -> Attribute<String> {
-    Attribute::new("display_name").sync_to_attribute_store()
-}
+static DISPLAY_NAME: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("display_name").sync_to_attribute_store());
 ```
 
 </SdkSnippet>

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
@@ -221,9 +221,7 @@ export class ChannelFlow implements Flow<number> {
 ```rust
 pub const CHANNEL_APPROVE: Rpc<(), ()> = Rpc::new("ChannelApprove");
 
-fn approval() -> Channel<String> {
-    Channel::new("Approval")
-}
+static APPROVAL: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("Approval"));
 
 #[derive(Default)]
 pub struct ChannelFlow {
@@ -232,7 +230,7 @@ pub struct ChannelFlow {
 
 impl ChannelFlow {
     fn approve(&self, context: &mut Context) -> HandlerResult<()> {
-        approval().publish(context, "approved".to_string())
+        APPROVAL.publish(context, "approved".to_string())
     }
 }
 
@@ -244,7 +242,7 @@ impl Flow for ChannelFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&approval())
+        PersistenceSchema::new().channel(&APPROVAL)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -260,7 +258,7 @@ impl Step for ChannelWait {
 
     fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            approval().for_one(),
+            APPROVAL.for_one(),
             Timer::by_duration(Duration::from_secs(input.max(0) as u64)),
         ]))
     }
@@ -271,7 +269,7 @@ impl Step for ChannelWait {
                 "approval timed out".to_owned(),
             ));
         }
-        let approvals = approval().condition_results(context)?;
+        let approvals = APPROVAL.condition_results(context)?;
         Ok(StepDecision::graceful_complete(approvals[0].clone()))
     }
 }

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/client/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/client/basic.mdx
@@ -176,7 +176,7 @@ await client.publish("order-123", approval, "approved");
 <SdkSnippet lang="rust">
 
 ```rust
-client.publish("order-123", &approval(), "approved".to_owned())?;
+client.publish("order-123", &APPROVAL, "approved".to_owned())?;
 ```
 
 </SdkSnippet>

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
@@ -241,9 +241,7 @@ class StepSecond implements Step<number> {
   <SdkSnippet lang="rust">
 
 ```rust
-fn approval() -> Channel<String> {
-    Channel::new("Approval")
-}
+static APPROVAL: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("Approval"));
 
 #[derive(Default)]
 struct ExampleStep;
@@ -252,7 +250,7 @@ impl Step for ExampleStep {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
-        Ok(Wait::until(approval().for_one()))
+        Ok(Wait::until(APPROVAL.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/waiting-condition.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/waiting-condition.mdx
@@ -137,9 +137,7 @@ const channelWaitStep = new ChannelWait();
   <SdkSnippet lang="rust">
 
 ```rust
-fn approval() -> Channel<String> {
-    Channel::new("Approval")
-}
+static APPROVAL: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("Approval"));
 
 #[derive(Default)]
 struct ChannelWait;
@@ -149,7 +147,7 @@ impl Step for ChannelWait {
 
     fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            approval().for_one(),
+            APPROVAL.for_one(),
             Timer::by_duration(Duration::from_secs(input.max(0) as u64)),
         ]))
     }
@@ -160,7 +158,7 @@ impl Step for ChannelWait {
                 "approval timed out".to_owned(),
             ));
         }
-        let approvals = approval().condition_results(context)?;
+        let approvals = APPROVAL.condition_results(context)?;
         Ok(StepDecision::graceful_complete(approvals[0].clone()))
     }
 }
@@ -422,7 +420,7 @@ public execute(context: Context, _input: number): StepDecision {
 ```rust
 fn wait_for(&self, context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
     context.set_step_execution_local("note", format!("approval:{input}"))?;
-    Ok(Wait::until(approval().for_one()))
+    Ok(Wait::until(APPROVAL.for_one()))
 }
 
 fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/stream.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/stream.mdx
@@ -112,18 +112,14 @@ export class StreamFlow implements Flow<string> {
 <SdkSnippet lang="rust">
 
 ```rust
-pub fn progress() -> Stream<String> {
-    static PROGRESS: OnceLock<Stream<String>> = OnceLock::new();
-    PROGRESS
-        .get_or_init(|| Stream::new("Progress", 10 * 1024 * 1024))
-        .clone()
-}
+pub static PROGRESS: LazyLock<Stream<String>> =
+    LazyLock::new(|| Stream::new("Progress", 10 * 1024 * 1024));
 
 impl Flow for StreamFlow {
     type StartInput = String;
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().stream(&progress())
+        PersistenceSchema::new().stream(&PROGRESS)
     }
 }
 
@@ -135,7 +131,7 @@ impl Step for RenderPreview {
         context: &mut Context,
         input: Self::Input,
     ) -> HandlerResult<StepDecision> {
-        progress().write(context, format!("Rendering preview for {input}"))?;
+        PROGRESS.write(context, format!("Rendering preview for {input}"))?;
         Ok(StepDecision::graceful_complete(format!(
             "Rendered {input}"
         )))

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quick-start/index.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quick-start/index.mdx
@@ -612,12 +612,12 @@ impl OrderProcessingFlow {
     }
 
     fn approve(&self, context: &mut Context, _note: String) -> HandlerResult<RpcResult<String>> {
-        seller_ok().publish(context, "approved".to_string())?;
+        SELLER_OK.publish(context, "approved".to_string())?;
         Ok(RpcResult::new("ok".to_string()))
     }
 
     fn describe(&self, context: &mut Context) -> HandlerResult<RpcResult<String>> {
-        Ok(RpcResult::new(order_status().get_required(context)?))
+        Ok(RpcResult::new(ORDER_STATUS.get_required(context)?))
     }
 }
 
@@ -642,8 +642,8 @@ impl Flow for OrderProcessingFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&order_status())
-            .channel(&seller_ok())
+            .attribute(&ORDER_STATUS)
+            .channel(&SELLER_OK)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -675,7 +675,7 @@ impl Step for Charge {
         self.service
             .charge_user(&input.email, &input.customer_id, input.amount);
         context.record_event("charge", input.order_id.clone())?;
-        order_status().set(context, "charged".to_string())?;
+        ORDER_STATUS.set(context, "charged".to_string())?;
         Ok(StepDecision::go_to(&Ship::default(), input))
     }
 }
@@ -702,7 +702,7 @@ impl Step for Ship {
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            seller_ok().for_one(),
+            SELLER_OK.for_one(),
             Timer::by_duration(Duration::from_secs(24 * 60 * 60)),
         ]))
     }
@@ -719,7 +719,7 @@ impl Step for Ship {
         }
         self.service.ship_item(&input.order_id)?;
         context.record_event("ship", input.order_id.clone())?;
-        order_status().set(context, "shipped".to_string())?;
+        ORDER_STATUS.set(context, "shipped".to_string())?;
         Ok(StepDecision::graceful_complete(format!(
             "shipped:{}",
             input.order_id
@@ -749,7 +749,7 @@ impl Step for Refund {
         self.service
             .update_external_system(&format!("refund {}", input.order_id));
         context.record_event("refund", input.order_id.clone())?;
-        order_status().set(context, "refunded".to_string())?;
+        ORDER_STATUS.set(context, "refunded".to_string())?;
         Ok(StepDecision::graceful_complete(format!(
             "refunded:{}",
             input.order_id
@@ -757,13 +757,10 @@ impl Step for Refund {
     }
 }
 
-fn order_status() -> Attribute<String> {
-    Attribute::new("order-status").indexed(AttributeIndex::keyword())
-}
+static ORDER_STATUS: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("order-status").indexed(AttributeIndex::keyword()));
 
-fn seller_ok() -> Channel<String> {
-    Channel::new("seller-ok")
-}
+static SELLER_OK: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("seller-ok"));
 ```
 
 </SdkSnippet>

--- a/examples/rust/src/patterns/cron/flow.rs
+++ b/examples/rust/src/patterns/cron/flow.rs
@@ -14,6 +14,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision, StepList,
     StepMovement, Timer, Wait,
@@ -78,9 +80,7 @@ impl Flow for CronScheduleFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new()
-            .channel(&trigger())
-            .channel(&skip())
+        PersistenceSchema::new().channel(&TRIGGER).channel(&SKIP)
     }
 }
 
@@ -115,13 +115,13 @@ impl Step for WaitForSchedule {
     fn wait_for(&self, _context: &mut Context, state: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
             Timer::by_duration(state.interval.duration()),
-            trigger().for_one(),
-            skip().for_one(),
+            TRIGGER.for_one(),
+            SKIP.for_one(),
         ]))
     }
 
     fn execute(&self, context: &mut Context, state: Self::Input) -> HandlerResult<StepDecision> {
-        if !skip().condition_results(context)?.is_empty() {
+        if !SKIP.condition_results(context)?.is_empty() {
             return Ok(next_schedule(state));
         }
         let run_input = RunInput {
@@ -173,10 +173,6 @@ fn next_schedule(state: ScheduleState) -> StepDecision {
     )
 }
 
-pub fn trigger() -> Channel<()> {
-    Channel::new("cron-schedule-trigger")
-}
+pub static TRIGGER: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("cron-schedule-trigger"));
 
-pub fn skip() -> Channel<()> {
-    Channel::new("cron-schedule-skip")
-}
+pub static SKIP: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("cron-schedule-skip"));

--- a/examples/rust/src/patterns/drain_channels/controller.rs
+++ b/examples/rust/src/patterns/drain_channels/controller.rs
@@ -21,7 +21,7 @@ use axum::{
 use serde::Deserialize;
 
 use crate::patterns::drain_channels::flow::{
-    DrainInternalChannelFlow, DrainingExternalChannelFlow, external_queue,
+    DrainInternalChannelFlow, DrainingExternalChannelFlow, EXTERNAL_QUEUE,
 };
 use crate::server::helpers::{
     SharedClient, is_missing_or_inactive, map_sdk_error, new_flow_id, ok_text, run_blocking,
@@ -77,7 +77,7 @@ async fn start_or_publish(
         let flow = DrainingExternalChannelFlow::default();
         match client.publish(
             &flow_id,
-            &external_queue(),
+            &EXTERNAL_QUEUE,
             "message from start-or-publish endpoint".to_string(),
         ) {
             Ok(()) => Ok("Published to the Flow".to_string()),

--- a/examples/rust/src/patterns/drain_channels/flow.rs
+++ b/examples/rust/src/patterns/drain_channels/flow.rs
@@ -28,6 +28,8 @@
  * limitations under the License.
  */
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, RpcResult, Step,
     StepDecision, StepList, StepMovement, Wait,
@@ -53,7 +55,7 @@ impl Flow for DrainInternalChannelFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&side_step_data())
+        PersistenceSchema::new().channel(&SIDE_STEP_DATA)
     }
 }
 
@@ -79,7 +81,7 @@ impl Step for MainStep {
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
         for value in input {
-            side_step_data().publish(context, SideStepData::Message(value))?;
+            SIDE_STEP_DATA.publish(context, SideStepData::Message(value))?;
         }
         Ok(StepDecision::go_to(&Finalize, ()))
     }
@@ -92,11 +94,11 @@ impl Step for SideStep {
     type Input = ();
 
     fn wait_for(&self, _context: &mut Context, _input: ()) -> HandlerResult<Wait> {
-        Ok(Wait::until(side_step_data().for_one()))
+        Ok(Wait::until(SIDE_STEP_DATA.for_one()))
     }
 
     fn execute(&self, context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
-        let command = side_step_data()
+        let command = SIDE_STEP_DATA
             .condition_results(context)?
             .into_iter()
             .next()
@@ -125,7 +127,7 @@ impl Step for Finalize {
     type Input = ();
 
     fn execute(&self, context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
-        side_step_data().publish(context, SideStepData::Final)?;
+        SIDE_STEP_DATA.publish(context, SideStepData::Final)?;
         Ok(StepDecision::graceful_complete(()))
     }
 }
@@ -143,7 +145,7 @@ impl DrainingExternalChannelFlow {
         context: &mut Context,
         input: String,
     ) -> HandlerResult<RpcResult<String>> {
-        external_queue().publish(context, input.clone())?;
+        EXTERNAL_QUEUE.publish(context, input.clone())?;
         Ok(RpcResult::new(input))
     }
 }
@@ -156,7 +158,7 @@ impl Flow for DrainingExternalChannelFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&external_queue())
+        PersistenceSchema::new().channel(&EXTERNAL_QUEUE)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -172,14 +174,14 @@ impl Step for DrainChannel {
 
     fn wait_for(&self, _context: &mut Context, input: String) -> HandlerResult<Wait> {
         if input.is_empty() {
-            return Ok(Wait::until(external_queue().for_one()));
+            return Ok(Wait::until(EXTERNAL_QUEUE.for_one()));
         }
         Ok(Wait::skip_immediately())
     }
 
     fn execute(&self, context: &mut Context, input: String) -> HandlerResult<StepDecision> {
         let item = if input.is_empty() {
-            external_queue()
+            EXTERNAL_QUEUE
                 .condition_results(context)?
                 .into_iter()
                 .next()
@@ -191,15 +193,13 @@ impl Step for DrainChannel {
         Ok(StepDecision::force_complete_if_channels_empty(
             String::new(),
             StepMovement::to(&DrainChannel, String::new()),
-            [external_queue().when_empty()],
+            [EXTERNAL_QUEUE.when_empty()],
         ))
     }
 }
 
-fn side_step_data() -> Channel<SideStepData> {
-    Channel::new("SideStepData")
-}
+static SIDE_STEP_DATA: LazyLock<Channel<SideStepData>> =
+    LazyLock::new(|| Channel::new("SideStepData"));
 
-pub(crate) fn external_queue() -> Channel<String> {
-    Channel::new("drain-channel-queue")
-}
+pub(crate) static EXTERNAL_QUEUE: LazyLock<Channel<String>> =
+    LazyLock::new(|| Channel::new("drain-channel-queue"));

--- a/examples/rust/src/patterns/entity_store/flow.rs
+++ b/examples/rust/src/patterns/entity_store/flow.rs
@@ -14,6 +14,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Context, Flow, FlowConfig, HandlerError, HandlerResult, PersistenceSchema, Rpc,
     RpcList, RpcResult, StartFlowOptions, StepList,
@@ -56,46 +58,46 @@ impl UserProfileFlow {
         StartFlowOptions::new()
             .timeout(Duration::from_secs(3_600))
             .config_override(Self::flow_config())
-            .initial_attribute(&display_name(), profile.display_name.clone())
-            .initial_attribute(&email(), profile.email.clone())
-            .initial_attribute(&marketing_opt_in(), profile.marketing_opt_in)
-            .initial_attribute(&credits(), profile.credits)
-            .initial_attribute(&weight(), profile.weight)
-            .initial_attribute(&last_logged_in_time(), profile.last_logged_in_time.clone())
-            .initial_attribute(&metadata(), profile.metadata.clone())
+            .initial_attribute(&DISPLAY_NAME, profile.display_name.clone())
+            .initial_attribute(&EMAIL, profile.email.clone())
+            .initial_attribute(&MARKETING_OPT_IN, profile.marketing_opt_in)
+            .initial_attribute(&CREDITS, profile.credits)
+            .initial_attribute(&WEIGHT, profile.weight)
+            .initial_attribute(&LAST_LOGGED_IN_TIME, profile.last_logged_in_time.clone())
+            .initial_attribute(&METADATA, profile.metadata.clone())
     }
 
     fn read(&self, context: &mut Context) -> HandlerResult<RpcResult<UserProfile>> {
         Ok(RpcResult::new(UserProfile {
-            display_name: display_name().get_required(context)?,
-            email: email().get_required(context)?,
-            marketing_opt_in: marketing_opt_in().get_required(context)?,
-            credits: credits().get_required(context)?,
-            weight: weight().get_required(context)?,
-            last_logged_in_time: last_logged_in_time().get_required(context)?,
-            metadata: metadata().get_required(context)?,
+            display_name: DISPLAY_NAME.get_required(context)?,
+            email: EMAIL.get_required(context)?,
+            marketing_opt_in: MARKETING_OPT_IN.get_required(context)?,
+            credits: CREDITS.get_required(context)?,
+            weight: WEIGHT.get_required(context)?,
+            last_logged_in_time: LAST_LOGGED_IN_TIME.get_required(context)?,
+            metadata: METADATA.get_required(context)?,
         }))
     }
 
     fn update(&self, context: &mut Context, replacement: UserProfile) -> HandlerResult<()> {
         validate_profile(&replacement)?;
-        display_name().set(context, replacement.display_name)?;
-        email().set(context, replacement.email)?;
-        marketing_opt_in().set(context, replacement.marketing_opt_in)?;
-        credits().set(context, replacement.credits)?;
-        weight().set(context, replacement.weight)?;
-        last_logged_in_time().set(context, replacement.last_logged_in_time)?;
-        metadata().set(context, replacement.metadata)
+        DISPLAY_NAME.set(context, replacement.display_name)?;
+        EMAIL.set(context, replacement.email)?;
+        MARKETING_OPT_IN.set(context, replacement.marketing_opt_in)?;
+        CREDITS.set(context, replacement.credits)?;
+        WEIGHT.set(context, replacement.weight)?;
+        LAST_LOGGED_IN_TIME.set(context, replacement.last_logged_in_time)?;
+        METADATA.set(context, replacement.metadata)
     }
 
     fn clear(&self, context: &mut Context) -> HandlerResult<()> {
-        display_name().delete(context)?;
-        email().delete(context)?;
-        marketing_opt_in().delete(context)?;
-        credits().delete(context)?;
-        weight().delete(context)?;
-        last_logged_in_time().delete(context)?;
-        metadata().delete(context)
+        DISPLAY_NAME.delete(context)?;
+        EMAIL.delete(context)?;
+        MARKETING_OPT_IN.delete(context)?;
+        CREDITS.delete(context)?;
+        WEIGHT.delete(context)?;
+        LAST_LOGGED_IN_TIME.delete(context)?;
+        METADATA.delete(context)
     }
 }
 
@@ -108,13 +110,13 @@ impl Flow for UserProfileFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&display_name())
-            .attribute(&email())
-            .attribute(&marketing_opt_in())
-            .attribute(&credits())
-            .attribute(&weight())
-            .attribute(&last_logged_in_time())
-            .attribute(&metadata())
+            .attribute(&DISPLAY_NAME)
+            .attribute(&EMAIL)
+            .attribute(&MARKETING_OPT_IN)
+            .attribute(&CREDITS)
+            .attribute(&WEIGHT)
+            .attribute(&LAST_LOGGED_IN_TIME)
+            .attribute(&METADATA)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -147,30 +149,23 @@ fn validate_profile(profile: &UserProfile) -> HandlerResult<()> {
     Ok(())
 }
 
-fn display_name() -> Attribute<String> {
-    Attribute::new("display_name").sync_to_attribute_store()
-}
+static DISPLAY_NAME: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("display_name").sync_to_attribute_store());
 
-fn email() -> Attribute<String> {
-    Attribute::new("email").sync_to_attribute_store()
-}
+static EMAIL: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("email").sync_to_attribute_store());
 
-fn marketing_opt_in() -> Attribute<bool> {
-    Attribute::new("marketing_opt_in").sync_to_attribute_store()
-}
+static MARKETING_OPT_IN: LazyLock<Attribute<bool>> =
+    LazyLock::new(|| Attribute::new("marketing_opt_in").sync_to_attribute_store());
 
-fn credits() -> Attribute<i64> {
-    Attribute::new("credits").sync_to_attribute_store()
-}
+static CREDITS: LazyLock<Attribute<i64>> =
+    LazyLock::new(|| Attribute::new("credits").sync_to_attribute_store());
 
-fn weight() -> Attribute<f64> {
-    Attribute::new("weight").sync_to_attribute_store()
-}
+static WEIGHT: LazyLock<Attribute<f64>> =
+    LazyLock::new(|| Attribute::new("weight").sync_to_attribute_store());
 
-fn last_logged_in_time() -> Attribute<String> {
-    Attribute::new("last_logged_in_time").sync_to_attribute_store()
-}
+static LAST_LOGGED_IN_TIME: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("last_logged_in_time").sync_to_attribute_store());
 
-fn metadata() -> Attribute<UserProfileMetadata> {
-    Attribute::new("metadata").sync_to_attribute_store()
-}
+static METADATA: LazyLock<Attribute<UserProfileMetadata>> =
+    LazyLock::new(|| Attribute::new("metadata").sync_to_attribute_store());

--- a/examples/rust/src/patterns/interruptible/flow.rs
+++ b/examples/rust/src/patterns/interruptible/flow.rs
@@ -14,6 +14,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, Step, StepDecision,
     StepList, StepMovement, Timer, Wait,
@@ -37,7 +39,7 @@ pub struct InterruptibleFlow {
 
 impl InterruptibleFlow {
     fn interrupt(&self, context: &mut Context) -> HandlerResult<()> {
-        interrupt_signal().set(context, "cancel".to_string())
+        INTERRUPT_SIGNAL.set(context, "cancel".to_string())
     }
 }
 
@@ -51,7 +53,7 @@ impl Flow for InterruptibleFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().attribute(&interrupt_signal())
+        PersistenceSchema::new().attribute(&INTERRUPT_SIGNAL)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -88,7 +90,7 @@ impl Step for WorkAStep {
     }
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        if interrupt_signal().get(context)?.as_deref() == Some("cancel") {
+        if INTERRUPT_SIGNAL.get(context)?.as_deref() == Some("cancel") {
             println!("A: Interrupted!");
             return Ok(StepDecision::graceful_complete(()));
         }
@@ -123,7 +125,7 @@ impl Step for WorkBStep {
     }
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        if interrupt_signal().get(context)?.as_deref() == Some("cancel") {
+        if INTERRUPT_SIGNAL.get(context)?.as_deref() == Some("cancel") {
             println!("B: Interrupted!");
             return Ok(StepDecision::graceful_complete(()));
         }
@@ -147,6 +149,5 @@ impl Step for WorkBStep {
     }
 }
 
-fn interrupt_signal() -> Attribute<String> {
-    Attribute::new("interruptSignal")
-}
+static INTERRUPT_SIGNAL: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("interruptSignal"));

--- a/examples/rust/src/patterns/intervention/flow.rs
+++ b/examples/rust/src/patterns/intervention/flow.rs
@@ -28,6 +28,8 @@
  * limitations under the License.
  */
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerError, HandlerResult, PersistenceSchema, RetryPolicy, Step,
     StepDecision, StepList, StepOptions, Wait,
@@ -49,7 +51,7 @@ impl Flow for ManualRecoveryFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&retry()).channel(&skip())
+        PersistenceSchema::new().channel(&RETRY).channel(&SKIP)
     }
 }
 
@@ -92,21 +94,17 @@ impl Step for ManualStep {
     type Input = bool;
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
-        Ok(Wait::any_of([retry().for_one(), skip().for_one()]))
+        Ok(Wait::any_of([RETRY.for_one(), SKIP.for_one()]))
     }
 
     fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
-        if !retry().condition_results(context)?.is_empty() {
+        if !RETRY.condition_results(context)?.is_empty() {
             return Ok(StepDecision::go_to(&DoWorkStep, false));
         }
         Ok(StepDecision::force_fail("manual recovery skipped"))
     }
 }
 
-fn retry() -> Channel<()> {
-    Channel::new("manual-recovery-retry")
-}
+static RETRY: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("manual-recovery-retry"));
 
-fn skip() -> Channel<()> {
-    Channel::new("manual-recovery-skip")
-}
+static SKIP: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("manual-recovery-skip"));

--- a/examples/rust/src/patterns/parallel/flow.rs
+++ b/examples/rust/src/patterns/parallel/flow.rs
@@ -28,6 +28,8 @@
  * limitations under the License.
  */
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, Step, StepDecision,
     StepList, StepMovement, Wait,
@@ -98,11 +100,11 @@ pub struct ParallelStatesWithAwaitFlow {
 
 impl ParallelStatesWithAwaitFlow {
     fn release_one(&self, context: &mut Context) -> HandlerResult<()> {
-        release_one().publish(context, ())
+        RELEASE_ONE.publish(context, ())
     }
 
     fn release_two(&self, context: &mut Context) -> HandlerResult<()> {
-        release_two().publish(context, ())
+        RELEASE_TWO.publish(context, ())
     }
 }
 
@@ -117,8 +119,8 @@ impl Flow for ParallelStatesWithAwaitFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .channel(&release_one())
-            .channel(&release_two())
+            .channel(&RELEASE_ONE)
+            .channel(&RELEASE_TWO)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -149,7 +151,7 @@ impl Step for AwaitBranchOne {
     type Input = ();
 
     fn wait_for(&self, _context: &mut Context, _input: ()) -> HandlerResult<Wait> {
-        Ok(Wait::until(release_one().for_one()))
+        Ok(Wait::until(RELEASE_ONE.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
@@ -164,7 +166,7 @@ impl Step for AwaitBranchTwo {
     type Input = ();
 
     fn wait_for(&self, _context: &mut Context, _input: ()) -> HandlerResult<Wait> {
-        Ok(Wait::until(release_two().for_one()))
+        Ok(Wait::until(RELEASE_TWO.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
@@ -172,10 +174,6 @@ impl Step for AwaitBranchTwo {
     }
 }
 
-fn release_one() -> Channel<()> {
-    Channel::new("parallel-release-one")
-}
+static RELEASE_ONE: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("parallel-release-one"));
 
-fn release_two() -> Channel<()> {
-    Channel::new("parallel-release-two")
-}
+static RELEASE_TWO: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("parallel-release-two"));

--- a/examples/rust/src/patterns/parent_child/flow.rs
+++ b/examples/rust/src/patterns/parent_child/flow.rs
@@ -28,6 +28,8 @@
  * limitations under the License.
  */
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, Step,
     StepDecision, StepList, Wait,
@@ -43,7 +45,7 @@ pub struct ParentFlowV2 {
 
 impl ParentFlowV2 {
     fn child_completed(&self, context: &mut Context, output: String) -> HandlerResult<()> {
-        child_output().publish(context, output)
+        CHILD_OUTPUT.publish(context, output)
     }
 }
 
@@ -56,8 +58,8 @@ impl Flow for ParentFlowV2 {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&child_id())
-            .channel(&child_output())
+            .attribute(&CHILD_ID)
+            .channel(&CHILD_OUTPUT)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -72,7 +74,7 @@ impl Step for RecordChild {
     type Input = String;
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        child_id().set(context, input)?;
+        CHILD_ID.set(context, input)?;
         Ok(StepDecision::go_to(&AwaitChild, ()))
     }
 }
@@ -84,11 +86,11 @@ impl Step for AwaitChild {
     type Input = ();
 
     fn wait_for(&self, _context: &mut Context, _input: ()) -> HandlerResult<Wait> {
-        Ok(Wait::until(child_output().for_one()))
+        Ok(Wait::until(CHILD_OUTPUT.for_one()))
     }
 
     fn execute(&self, context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
-        let output = child_output()
+        let output = CHILD_OUTPUT
             .condition_results(context)?
             .into_iter()
             .next()
@@ -97,10 +99,8 @@ impl Step for AwaitChild {
     }
 }
 
-fn child_id() -> Attribute<String> {
-    Attribute::new("parent-v2-child-id")
-}
+static CHILD_ID: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("parent-v2-child-id"));
 
-fn child_output() -> Channel<String> {
-    Channel::new("parent-v2-child-output")
-}
+static CHILD_OUTPUT: LazyLock<Channel<String>> =
+    LazyLock::new(|| Channel::new("parent-v2-child-output"));

--- a/examples/rust/src/patterns/reminders/flow.rs
+++ b/examples/rust/src/patterns/reminders/flow.rs
@@ -30,6 +30,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, Step, StepDecision,
     StepList, StepMovement, Timer, Wait,
@@ -47,11 +49,11 @@ pub struct ReminderFlow {
 
 impl ReminderFlow {
     fn accept(&self, context: &mut Context) -> HandlerResult<()> {
-        resolution().publish(context, "accepted".to_string())
+        RESOLUTION.publish(context, "accepted".to_string())
     }
 
     fn opt_out(&self, context: &mut Context) -> HandlerResult<()> {
-        resolution().publish(context, "opted-out".to_string())
+        RESOLUTION.publish(context, "opted-out".to_string())
     }
 }
 
@@ -65,7 +67,7 @@ impl Flow for ReminderFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&resolution())
+        PersistenceSchema::new().channel(&RESOLUTION)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -97,13 +99,13 @@ impl Step for Remind {
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            resolution().for_one(),
+            RESOLUTION.for_one(),
             Timer::by_duration(Duration::from_secs(3_600)),
         ]))
     }
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        let resolutions = resolution().condition_results(context)?;
+        let resolutions = RESOLUTION.condition_results(context)?;
         if let Some(resolved) = resolutions.into_iter().next() {
             return Ok(StepDecision::force_complete(resolved));
         }
@@ -129,6 +131,5 @@ impl Step for Timeout {
     }
 }
 
-fn resolution() -> Channel<String> {
-    Channel::new("reminder-resolution")
-}
+static RESOLUTION: LazyLock<Channel<String>> =
+    LazyLock::new(|| Channel::new("reminder-resolution"));

--- a/examples/rust/src/patterns/resettable_timer/flow.rs
+++ b/examples/rust/src/patterns/resettable_timer/flow.rs
@@ -30,6 +30,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, Step, StepDecision,
     StepList, Timer, Wait,
@@ -44,7 +46,7 @@ pub struct ResettableTimerFlow {
 
 impl ResettableTimerFlow {
     fn reset(&self, context: &mut Context) -> HandlerResult<()> {
-        resets().publish(context, ())
+        RESETS.publish(context, ())
     }
 }
 
@@ -56,7 +58,7 @@ impl Flow for ResettableTimerFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&resets())
+        PersistenceSchema::new().channel(&RESETS)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -72,13 +74,13 @@ impl Step for WaitForInactivity {
 
     fn wait_for(&self, _context: &mut Context, seconds: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            resets().for_one(),
+            RESETS.for_one(),
             Timer::by_duration(Duration::from_secs(seconds.max(1))).with_id("inactivity"),
         ]))
     }
 
     fn execute(&self, context: &mut Context, seconds: Self::Input) -> HandlerResult<StepDecision> {
-        if resets().condition_results(context)?.is_empty() {
+        if RESETS.condition_results(context)?.is_empty() {
             Ok(StepDecision::graceful_complete("timer-fired".to_string()))
         } else {
             Ok(StepDecision::go_to(&WaitForInactivity, seconds))
@@ -86,6 +88,4 @@ impl Step for WaitForInactivity {
     }
 }
 
-fn resets() -> Channel<()> {
-    Channel::new("resettable-timer-resets")
-}
+static RESETS: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("resettable-timer-resets"));

--- a/examples/rust/src/patterns/scalable_parallel/flow.rs
+++ b/examples/rust/src/patterns/scalable_parallel/flow.rs
@@ -28,6 +28,8 @@
  * limitations under the License.
  */
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, RpcResult,
     Step, StepDecision, StepList, Wait,
@@ -71,8 +73,8 @@ impl ParentFlow {
         context: &mut Context,
         tasks: Vec<String>,
     ) -> HandlerResult<RpcResult<usize>> {
-        let capacity = capacity().get(context)?.unwrap_or(100);
-        let available = capacity.saturating_sub(parent_queue().size(context)?);
+        let capacity = CAPACITY.get(context)?.unwrap_or(100);
+        let available = capacity.saturating_sub(PARENT_QUEUE.size(context)?);
         if tasks.len() > available {
             return Err(dex_sdk::HandlerError::new(
                 "ScalableParallel",
@@ -80,7 +82,7 @@ impl ParentFlow {
             ));
         }
         for task in tasks {
-            parent_queue().publish(context, task)?;
+            PARENT_QUEUE.publish(context, task)?;
         }
         Ok(RpcResult::new(available))
     }
@@ -95,8 +97,8 @@ impl Flow for ParentFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&capacity())
-            .channel(&parent_queue())
+            .attribute(&CAPACITY)
+            .channel(&PARENT_QUEUE)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -111,12 +113,12 @@ impl Step for DrainParentQueue {
     type Input = usize;
 
     fn wait_for(&self, context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
-        capacity().set(context, input.max(1))?;
-        Ok(Wait::until(parent_queue().for_one()))
+        CAPACITY.set(context, input.max(1))?;
+        Ok(Wait::until(PARENT_QUEUE.for_one()))
     }
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        let task = parent_queue()
+        let task = PARENT_QUEUE
             .condition_results(context)?
             .into_iter()
             .next()
@@ -136,9 +138,9 @@ pub struct RequestReceiverFlow {
 impl RequestReceiverFlow {
     fn submit(&self, context: &mut Context, tasks: Vec<String>) -> HandlerResult<RpcResult<usize>> {
         for task in tasks {
-            request_buffer().publish(context, task)?;
+            REQUEST_BUFFER.publish(context, task)?;
         }
-        Ok(RpcResult::new(request_buffer().size(context)?))
+        Ok(RpcResult::new(REQUEST_BUFFER.size(context)?))
     }
 }
 
@@ -150,7 +152,7 @@ impl Flow for RequestReceiverFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&request_buffer())
+        PersistenceSchema::new().channel(&REQUEST_BUFFER)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -165,11 +167,11 @@ impl Step for ForwardRequests {
     type Input = ();
 
     fn wait_for(&self, _context: &mut Context, _input: ()) -> HandlerResult<Wait> {
-        Ok(Wait::until(request_buffer().for_one()))
+        Ok(Wait::until(REQUEST_BUFFER.for_one()))
     }
 
     fn execute(&self, context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
-        let request = request_buffer()
+        let request = REQUEST_BUFFER
             .condition_results(context)?
             .into_iter()
             .next()
@@ -179,14 +181,11 @@ impl Step for ForwardRequests {
     }
 }
 
-fn capacity() -> Attribute<usize> {
-    Attribute::new("scalable-parent-capacity")
-}
+static CAPACITY: LazyLock<Attribute<usize>> =
+    LazyLock::new(|| Attribute::new("scalable-parent-capacity"));
 
-fn parent_queue() -> Channel<String> {
-    Channel::new("scalable-parent-queue")
-}
+static PARENT_QUEUE: LazyLock<Channel<String>> =
+    LazyLock::new(|| Channel::new("scalable-parent-queue"));
 
-fn request_buffer() -> Channel<String> {
-    Channel::new("scalable-request-buffer")
-}
+static REQUEST_BUFFER: LazyLock<Channel<String>> =
+    LazyLock::new(|| Channel::new("scalable-request-buffer"));

--- a/examples/rust/src/patterns/wait_for_state_completion/flow.rs
+++ b/examples/rust/src/patterns/wait_for_state_completion/flow.rs
@@ -28,6 +28,8 @@
  * limitations under the License.
  */
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision,
     StepExecutionId, StepList, StepMovement,
@@ -60,7 +62,7 @@ impl Flow for WaitForStateCompletionFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().attribute(&record())
+        PersistenceSchema::new().attribute(&RECORD)
     }
 }
 
@@ -71,7 +73,7 @@ impl Step for PersistData {
     type Input = PersistRequest;
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        record().set(context, input.clone())?;
+        RECORD.set(context, input.clone())?;
         context.record_event("client-visible-persisted", input.record_id)?;
         Ok(StepDecision::go_to_many([StepMovement::to(
             &BackgroundWork,
@@ -92,6 +94,5 @@ impl Step for BackgroundWork {
     }
 }
 
-fn record() -> Attribute<PersistRequest> {
-    Attribute::new("wait-for-state-record")
-}
+static RECORD: LazyLock<Attribute<PersistRequest>> =
+    LazyLock::new(|| Attribute::new("wait-for-state-record"));

--- a/examples/rust/src/primitives/attribute/flow.rs
+++ b/examples/rust/src/primitives/attribute/flow.rs
@@ -12,12 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, AttributeIndex, AttributeMap, Context, Flow, FlowConfig, HandlerResult,
     PersistenceSchema, Rpc, RpcList, RpcResult, Step, StepDecision, StepList, StepOptions, Wait,
 };
 
 const UPDATE_STATUS: Rpc<String, String> = Rpc::new("UpdateStatus");
+
+static STATUS: LazyLock<Attribute<String>> = LazyLock::new(|| {
+    Attribute::new("primitive-attribute-status")
+        .indexed(AttributeIndex::keyword().with_key("OrderStatus"))
+});
+static EMAIL: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("primitive-attribute-email").sync_to_attribute_store());
 
 pub fn attribute_store_config() -> FlowConfig {
     FlowConfig::new().attribute_store_names(vec!["profiles".to_owned()])
@@ -32,9 +41,8 @@ pub struct AttributeFlow {
 
 impl Default for AttributeFlow {
     fn default() -> Self {
-        let status = Attribute::new("primitive-attribute-status")
-            .indexed(AttributeIndex::keyword().with_key("OrderStatus"));
-        let email = Attribute::new("primitive-attribute-email").sync_to_attribute_store();
+        let status = STATUS.clone();
+        let email = EMAIL.clone();
         let progress = AttributeMap::new("primitive-attribute-progress")
             .indexed(AttributeIndex::keyword().with_key("OrderProgress"));
         Self {

--- a/examples/rust/src/primitives/attribute/flow.rs
+++ b/examples/rust/src/primitives/attribute/flow.rs
@@ -33,25 +33,18 @@ pub fn attribute_store_config() -> FlowConfig {
 }
 
 pub struct AttributeFlow {
-    status: Attribute<String>,
-    email: Attribute<String>,
     progress: AttributeMap<String>,
     start: AttributeStep,
 }
 
 impl Default for AttributeFlow {
     fn default() -> Self {
-        let status = STATUS.clone();
-        let email = EMAIL.clone();
         let progress = AttributeMap::new("primitive-attribute-progress")
             .indexed(AttributeIndex::keyword().with_key("OrderProgress"));
         Self {
             start: AttributeStep {
-                status: status.clone(),
                 progress: progress.clone(),
             },
-            status,
-            email,
             progress,
         }
     }
@@ -66,15 +59,15 @@ impl Flow for AttributeFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&self.status)
-            .attribute(&self.email)
+            .attribute(&STATUS)
+            .attribute(&EMAIL)
             .attribute_map(&self.progress)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
         RpcList::new().function(
             UPDATE_STATUS
-                .lock(self.status.lock())
+                .lock(STATUS.lock())
                 .lock(self.progress.lock("payment")),
             Self::update_status,
         )
@@ -87,14 +80,13 @@ impl AttributeFlow {
         context: &mut Context,
         input: String,
     ) -> HandlerResult<RpcResult<String>> {
-        self.status.set(context, input.clone())?;
+        STATUS.set(context, input.clone())?;
         self.progress.set(context, "payment", input.clone())?;
         Ok(RpcResult::new(input))
     }
 }
 
 struct AttributeStep {
-    status: Attribute<String>,
     progress: AttributeMap<String>,
 }
 
@@ -103,21 +95,21 @@ impl Step for AttributeStep {
 
     fn options(&self) -> StepOptions<Self::Input> {
         StepOptions::new()
-            .wait_for_lock(self.status.lock())
+            .wait_for_lock(STATUS.lock())
             .wait_for_lock(self.progress.lock("payment"))
-            .execute_lock(self.status.lock())
+            .execute_lock(STATUS.lock())
             .execute_lock(self.progress.lock("payment"))
     }
 
     fn wait_for(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
-        self.status.set(context, "processing".to_owned())?;
+        STATUS.set(context, "processing".to_owned())?;
         self.progress
             .set(context, "payment", "authorized".to_owned())?;
         Ok(Wait::skip_immediately())
     }
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        self.status.set(context, "completed".to_owned())?;
+        STATUS.set(context, "completed".to_owned())?;
         Ok(StepDecision::graceful_complete(input))
     }
 }

--- a/examples/rust/src/primitives/channel/flow.rs
+++ b/examples/rust/src/primitives/channel/flow.rs
@@ -14,6 +14,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, Step, StepDecision,
     StepList, Timer, Wait,
@@ -21,9 +23,7 @@ use dex_sdk::{
 
 pub const CHANNEL_APPROVE: Rpc<(), ()> = Rpc::new("ChannelApprove");
 
-fn approval() -> Channel<String> {
-    Channel::new("Approval")
-}
+static APPROVAL: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("Approval"));
 
 #[derive(Default)]
 pub struct ChannelFlow {
@@ -32,7 +32,7 @@ pub struct ChannelFlow {
 
 impl ChannelFlow {
     fn approve(&self, context: &mut Context) -> HandlerResult<()> {
-        approval().publish(context, "approved".to_string())
+        APPROVAL.publish(context, "approved".to_string())
     }
 }
 
@@ -44,7 +44,7 @@ impl Flow for ChannelFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&approval())
+        PersistenceSchema::new().channel(&APPROVAL)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -60,7 +60,7 @@ impl Step for ChannelWait {
 
     fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            approval().for_one(),
+            APPROVAL.for_one(),
             Timer::by_duration(Duration::from_secs(input.max(0) as u64)),
         ]))
     }
@@ -71,7 +71,7 @@ impl Step for ChannelWait {
                 "approval timed out".to_owned(),
             ));
         }
-        let approvals = approval().condition_results(context)?;
+        let approvals = APPROVAL.condition_results(context)?;
         Ok(StepDecision::graceful_complete(approvals[0].clone()))
     }
 }

--- a/examples/rust/src/primitives/client_apis/flow.rs
+++ b/examples/rust/src/primitives/client_apis/flow.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, AttributeIndex, Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision,
     StepList,
@@ -19,9 +21,8 @@ use dex_sdk::{
 
 const KEYWORD_KEY: &str = "CustomKeywordField";
 
-fn keyword() -> Attribute<String> {
-    Attribute::new(KEYWORD_KEY).indexed(AttributeIndex::keyword())
-}
+static KEYWORD: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new(KEYWORD_KEY).indexed(AttributeIndex::keyword()));
 
 #[derive(Default)]
 pub struct ClientApisFlow {
@@ -36,7 +37,7 @@ impl Flow for ClientApisFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().attribute(&keyword())
+        PersistenceSchema::new().attribute(&KEYWORD)
     }
 }
 
@@ -47,7 +48,7 @@ impl Step for ClientApisStep {
     type Input = String;
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        keyword().set(context, input.clone())?;
+        KEYWORD.set(context, input.clone())?;
         Ok(StepDecision::graceful_complete(input))
     }
 }

--- a/examples/rust/src/primitives/flow/controller.rs
+++ b/examples/rust/src/primitives/flow/controller.rs
@@ -25,7 +25,7 @@ use dex_sdk::{
 use serde::Deserialize;
 use std::time::Duration;
 
-use crate::primitives::flow::flow::{ExampleFlow, status};
+use crate::primitives::flow::flow::{ExampleFlow, STATUS};
 use crate::server::helpers::{SharedClient, StartResponse, map_sdk_error, ok_json, run_blocking};
 
 #[derive(Deserialize)]
@@ -61,7 +61,7 @@ pub fn example_start_flow_options() -> StartFlowOptions {
                 .maximum_interval(Duration::from_secs(10 * 60))
                 .maximum_attempts(3),
         )
-        .initial_attribute(&status(), "queued".to_owned())
+        .initial_attribute(&STATUS, "queued".to_owned())
         .config_override(FlowConfig::new().step_durability(StepDurability::Sync))
         .ignore_already_started(true)
         .request_id("start-order-123")

--- a/examples/rust/src/primitives/flow/flow.rs
+++ b/examples/rust/src/primitives/flow/flow.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Channel, Context, Flow, FlowTimeoutHandler, HandlerResult, PersistenceSchema, Rpc,
     RpcList, RpcResult, Step, StepDecision, StepList, Wait,
@@ -19,13 +21,9 @@ use dex_sdk::{
 
 pub const DESCRIBE: Rpc<(), String> = Rpc::new("Describe");
 
-pub(crate) fn status() -> Attribute<String> {
-    Attribute::new("status")
-}
+pub(crate) static STATUS: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("status"));
 
-fn notify() -> Channel<()> {
-    Channel::new("notify")
-}
+static NOTIFY: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("notify"));
 
 #[derive(Default)]
 pub struct ExampleFlow {
@@ -35,12 +33,12 @@ pub struct ExampleFlow {
 
 impl ExampleFlow {
     fn describe(&self, context: &mut Context, _input: ()) -> HandlerResult<RpcResult<String>> {
-        let value = status().get(context)?.unwrap_or_default();
+        let value = STATUS.get(context)?.unwrap_or_default();
         Ok(RpcResult::new(value))
     }
 
     fn handle_timeout(&self, context: &mut Context) -> HandlerResult<StepDecision> {
-        status().set(context, "timed out".to_string())?;
+        STATUS.set(context, "timed out".to_string())?;
         Ok(StepDecision::force_fail("processing deadline reached"))
     }
 }
@@ -53,9 +51,7 @@ impl Flow for ExampleFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new()
-            .attribute(&status())
-            .channel(&notify())
+        PersistenceSchema::new().attribute(&STATUS).channel(&NOTIFY)
     }
 
     fn timeout_handler(&self) -> Option<FlowTimeoutHandler<Self>> {
@@ -74,7 +70,7 @@ impl Step for ExampleStep {
     type Input = i32;
 
     fn wait_for(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
-        status().set(context, "running".to_string())?;
+        STATUS.set(context, "running".to_string())?;
         Ok(Wait::skip_immediately())
     }
 
@@ -90,7 +86,7 @@ impl Step for FinishStep {
     type Input = i32;
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        status().set(context, "done".to_string())?;
+        STATUS.set(context, "done".to_string())?;
         Ok(StepDecision::graceful_complete(input + 1))
     }
 }

--- a/examples/rust/src/primitives/rpc/flow.rs
+++ b/examples/rust/src/primitives/rpc/flow.rs
@@ -14,6 +14,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, RpcResult,
     Step, StepDecision, StepList, StepMovement, Wait,
@@ -21,13 +23,9 @@ use dex_sdk::{
 
 pub const RPC_TRIGGER: Rpc<String, String> = Rpc::new("RpcTrigger");
 
-fn example_ch() -> Channel<()> {
-    Channel::new("rpc-internal")
-}
+static EXAMPLE_CH: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("rpc-internal"));
 
-fn data() -> Attribute<String> {
-    Attribute::new("rpc-data")
-}
+static DATA: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("rpc-data"));
 
 #[derive(Default)]
 pub struct RpcFlow {
@@ -38,8 +36,8 @@ pub struct RpcFlow {
 
 impl RpcFlow {
     fn trigger(&self, context: &mut Context, input: String) -> HandlerResult<RpcResult<String>> {
-        data().set(context, input.clone())?;
-        example_ch().publish(context, ())?;
+        DATA.set(context, input.clone())?;
+        EXAMPLE_CH.publish(context, ())?;
         Ok(RpcResult::new(input.clone()).then(StepMovement::to(&self.example_step, input)))
     }
 }
@@ -55,8 +53,8 @@ impl Flow for RpcFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&data())
-            .channel(&example_ch())
+            .attribute(&DATA)
+            .channel(&EXAMPLE_CH)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -71,7 +69,7 @@ impl Step for RpcWait {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
-        Ok(Wait::until(example_ch().for_one()))
+        Ok(Wait::until(EXAMPLE_CH.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {

--- a/examples/rust/src/primitives/step/flow.rs
+++ b/examples/rust/src/primitives/step/flow.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision, StepList, Wait,
 };
 
-fn approval() -> Channel<String> {
-    Channel::new("Approval")
-}
+static APPROVAL: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("Approval"));
 
 #[derive(Default)]
 pub struct StepFlow {
@@ -34,7 +34,7 @@ impl Flow for StepFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&approval())
+        PersistenceSchema::new().channel(&APPROVAL)
     }
 }
 
@@ -45,7 +45,7 @@ impl Step for ExampleStep {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
-        Ok(Wait::until(approval().for_one()))
+        Ok(Wait::until(APPROVAL.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {

--- a/examples/rust/src/primitives/step_execution_local/flow.rs
+++ b/examples/rust/src/primitives/step_execution_local/flow.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision, StepList, Wait,
 };
 
-fn approval() -> Channel<String> {
-    Channel::new("Approval")
-}
+static APPROVAL: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("Approval"));
 
 #[derive(Default)]
 pub struct StepExecutionLocalFlow {
@@ -33,7 +33,7 @@ impl Flow for StepExecutionLocalFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&approval())
+        PersistenceSchema::new().channel(&APPROVAL)
     }
 }
 
@@ -45,7 +45,7 @@ impl Step for NoteWaitStep {
 
     fn wait_for(&self, context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
         context.set_step_execution_local("note", format!("approval:{input}"))?;
-        Ok(Wait::until(approval().for_one()))
+        Ok(Wait::until(APPROVAL.for_one()))
     }
 
     fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {

--- a/examples/rust/src/primitives/stream/controller.rs
+++ b/examples/rust/src/primitives/stream/controller.rs
@@ -22,7 +22,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::primitives::stream::flow::{StreamFlow, progress};
+use crate::primitives::stream::flow::{PROGRESS, StreamFlow};
 use crate::server::helpers::{
     SharedClient, StartResponse, map_sdk_error, ok_json, ok_text, run_blocking,
 };
@@ -95,7 +95,7 @@ async fn write(
     match run_blocking(move || {
         client.write_stream(
             &query.workflow_id,
-            &progress(),
+            &PROGRESS,
             &query.idempotency_key,
             query.message,
         )
@@ -113,7 +113,7 @@ async fn read(
         client
             .read_stream_with_timeout(
                 &query.workflow_id,
-                &progress(),
+                &PROGRESS,
                 &query.resume_token,
                 Duration::from_secs(20),
             )

--- a/examples/rust/src/primitives/stream/flow.rs
+++ b/examples/rust/src/primitives/stream/flow.rs
@@ -12,18 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 use dex_sdk::{
     Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision, StepList, Stream,
 };
 
-pub fn progress() -> Stream<String> {
-    static PROGRESS: OnceLock<Stream<String>> = OnceLock::new();
-    PROGRESS
-        .get_or_init(|| Stream::new("Progress", 10 * 1024 * 1024))
-        .clone()
-}
+pub static PROGRESS: LazyLock<Stream<String>> =
+    LazyLock::new(|| Stream::new("Progress", 10 * 1024 * 1024));
 
 #[derive(Default)]
 pub struct StreamFlow {
@@ -38,7 +34,7 @@ impl Flow for StreamFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().stream(&progress())
+        PersistenceSchema::new().stream(&PROGRESS)
     }
 }
 
@@ -49,7 +45,7 @@ impl Step for RenderPreview {
     type Input = String;
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        progress().write(context, format!("Rendering preview for {input}"))?;
+        PROGRESS.write(context, format!("Rendering preview for {input}"))?;
         Ok(StepDecision::graceful_complete(format!("Rendered {input}")))
     }
 }

--- a/examples/rust/src/primitives/wait_types/flow.rs
+++ b/examples/rust/src/primitives/wait_types/flow.rs
@@ -14,6 +14,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, ConditionCombination, Context, Flow, HandlerError, HandlerResult, PersistenceSchema,
     Rpc, RpcList, Step, StepDecision, StepList, Timer, Wait,
@@ -23,13 +25,9 @@ use serde::{Deserialize, Serialize};
 pub const WAIT_TYPES_SIGNAL_A: Rpc<(), ()> = Rpc::new("WaitTypesSignalA");
 pub const WAIT_TYPES_SIGNAL_B: Rpc<(), ()> = Rpc::new("WaitTypesSignalB");
 
-fn signal_a_channel() -> Channel<String> {
-    Channel::new("SignalA")
-}
+static SIGNAL_A_CHANNEL: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("SignalA"));
 
-fn signal_b_channel() -> Channel<String> {
-    Channel::new("SignalB")
-}
+static SIGNAL_B_CHANNEL: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("SignalB"));
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct WaitTypesInput {
@@ -44,11 +42,11 @@ pub struct WaitTypesFlow {
 
 impl WaitTypesFlow {
     fn signal_a(&self, context: &mut Context) -> HandlerResult<()> {
-        signal_a_channel().publish(context, "signal-a".to_string())
+        SIGNAL_A_CHANNEL.publish(context, "signal-a".to_string())
     }
 
     fn signal_b(&self, context: &mut Context) -> HandlerResult<()> {
-        signal_b_channel().publish(context, "signal-b".to_string())
+        SIGNAL_B_CHANNEL.publish(context, "signal-b".to_string())
     }
 }
 
@@ -61,8 +59,8 @@ impl Flow for WaitTypesFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .channel(&signal_a_channel())
-            .channel(&signal_b_channel())
+            .channel(&SIGNAL_A_CHANNEL)
+            .channel(&SIGNAL_B_CHANNEL)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -82,19 +80,19 @@ impl Step for WaitTypesStep {
         let timeout = Duration::from_secs(input.timeout_seconds.max(0) as u64);
         match input.mode.as_str() {
             "any" => Ok(Wait::any_of([
-                signal_a_channel().for_one().with_id("signal"),
+                SIGNAL_A_CHANNEL.for_one().with_id("signal"),
                 Timer::by_duration(timeout).with_id("timeout"),
             ])),
             "all" => Ok(Wait::all_of([
-                signal_a_channel().for_one().with_id("signal-a"),
-                signal_b_channel().for_one().with_id("signal-b"),
+                SIGNAL_A_CHANNEL.for_one().with_id("signal-a"),
+                SIGNAL_B_CHANNEL.for_one().with_id("signal-b"),
             ])),
             "combo" => Ok(Wait::any_combination_of([
                 ConditionCombination::all_of([
-                    signal_a_channel().for_one().with_id("signal-a"),
+                    SIGNAL_A_CHANNEL.for_one().with_id("signal-a"),
                     Timer::by_duration(timeout).with_id("timeout"),
                 ]),
-                ConditionCombination::all_of([signal_b_channel().for_one().with_id("signal-b")]),
+                ConditionCombination::all_of([SIGNAL_B_CHANNEL.for_one().with_id("signal-b")]),
             ])),
             _ => Err(HandlerError::new(
                 "WaitTypes",

--- a/examples/rust/src/products/engagement/flow.rs
+++ b/examples/rust/src/products/engagement/flow.rs
@@ -30,6 +30,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, AttributeIndex, Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc,
     RpcList, RpcResult, Step, StepDecision, StepList, StepMovement, Timer, Wait,
@@ -62,11 +64,11 @@ pub struct EngagementFlow {
 
 impl EngagementFlow {
     fn describe(&self, context: &mut Context) -> HandlerResult<RpcResult<EngagementStatus>> {
-        Ok(RpcResult::new(status().get(context)?.unwrap_or_default()))
+        Ok(RpcResult::new(STATUS.get(context)?.unwrap_or_default()))
     }
 
     fn accept(&self, context: &mut Context, notes: String) -> HandlerResult<()> {
-        decision().publish(
+        DECISION.publish(
             context,
             EngagementStatus {
                 status: "accepted".into(),
@@ -76,7 +78,7 @@ impl EngagementFlow {
     }
 
     fn decline(&self, context: &mut Context, notes: String) -> HandlerResult<()> {
-        decision().publish(
+        DECISION.publish(
             context,
             EngagementStatus {
                 status: "declined".into(),
@@ -86,7 +88,7 @@ impl EngagementFlow {
     }
 
     fn opt_out(&self, context: &mut Context) -> HandlerResult<()> {
-        decision().publish(
+        DECISION.publish(
             context,
             EngagementStatus {
                 status: "opted-out".into(),
@@ -107,8 +109,8 @@ impl Flow for EngagementFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&status())
-            .channel(&decision())
+            .attribute(&STATUS)
+            .channel(&DECISION)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -127,7 +129,7 @@ impl Step for Start {
     type Input = EngagementRequest;
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        status().set(
+        STATUS.set(
             context,
             EngagementStatus {
                 status: "pending".into(),
@@ -152,13 +154,13 @@ impl Step for WaitForDecision {
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            decision().for_one(),
+            DECISION.for_one(),
             Timer::by_duration(Duration::from_secs(86_400)),
         ]))
     }
 
     fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
-        let resolved = decision()
+        let resolved = DECISION
             .condition_results(context)?
             .into_iter()
             .next()
@@ -166,7 +168,7 @@ impl Step for WaitForDecision {
                 status: "reminder-due".into(),
                 notes: String::new(),
             });
-        status().set(context, resolved.clone())?;
+        STATUS.set(context, resolved.clone())?;
         Ok(StepDecision::go_to(&NotifyExternalSystem, resolved.status))
     }
 }
@@ -183,10 +185,8 @@ impl Step for NotifyExternalSystem {
     }
 }
 
-fn status() -> Attribute<EngagementStatus> {
-    Attribute::new("engagement-status").indexed(AttributeIndex::keyword())
-}
+static STATUS: LazyLock<Attribute<EngagementStatus>> =
+    LazyLock::new(|| Attribute::new("engagement-status").indexed(AttributeIndex::keyword()));
 
-fn decision() -> Channel<EngagementStatus> {
-    Channel::new("engagement-decision")
-}
+static DECISION: LazyLock<Channel<EngagementStatus>> =
+    LazyLock::new(|| Channel::new("engagement-decision"));

--- a/examples/rust/src/products/job_post/flow.rs
+++ b/examples/rust/src/products/job_post/flow.rs
@@ -28,6 +28,8 @@
  * limitations under the License.
  */
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, AttributeIndex, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList,
     RpcResult, Step, StepDecision, StepList,
@@ -53,7 +55,7 @@ pub struct JobPostFlow {
 
 impl JobPostFlow {
     fn read(&self, context: &mut Context) -> HandlerResult<RpcResult<JobPost>> {
-        Ok(RpcResult::new(post().get_required(context)?))
+        Ok(RpcResult::new(POST.get_required(context)?))
     }
 
     fn update(
@@ -61,17 +63,17 @@ impl JobPostFlow {
         context: &mut Context,
         replacement: JobPost,
     ) -> HandlerResult<RpcResult<JobPost>> {
-        post().set(context, replacement.clone())?;
-        title().set(context, replacement.title.clone())?;
-        description().set(context, replacement.description.clone())?;
+        POST.set(context, replacement.clone())?;
+        TITLE.set(context, replacement.title.clone())?;
+        DESCRIPTION.set(context, replacement.description.clone())?;
         Ok(RpcResult::new(replacement))
     }
 
     fn delete(&self, context: &mut Context, notes: String) -> HandlerResult<()> {
-        let mut current = post().get_required(context)?;
+        let mut current = POST.get_required(context)?;
         current.deleted = true;
         current.notes = notes;
-        post().set(context, current)
+        POST.set(context, current)
     }
 }
 
@@ -84,9 +86,9 @@ impl Flow for JobPostFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&post())
-            .attribute(&title())
-            .attribute(&description())
+            .attribute(&POST)
+            .attribute(&TITLE)
+            .attribute(&DESCRIPTION)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -104,21 +106,17 @@ impl Step for Create {
     type Input = JobPost;
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        post().set(context, input.clone())?;
-        title().set(context, input.title)?;
-        description().set(context, input.description)?;
+        POST.set(context, input.clone())?;
+        TITLE.set(context, input.title)?;
+        DESCRIPTION.set(context, input.description)?;
         Ok(StepDecision::dead_end())
     }
 }
 
-fn post() -> Attribute<JobPost> {
-    Attribute::new("job-post")
-}
+static POST: LazyLock<Attribute<JobPost>> = LazyLock::new(|| Attribute::new("job-post"));
 
-fn title() -> Attribute<String> {
-    Attribute::new("job-post-title").indexed(AttributeIndex::full_text())
-}
+static TITLE: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("job-post-title").indexed(AttributeIndex::full_text()));
 
-fn description() -> Attribute<String> {
-    Attribute::new("job-post-description").indexed(AttributeIndex::full_text())
-}
+static DESCRIPTION: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("job-post-description").indexed(AttributeIndex::full_text()));

--- a/examples/rust/src/products/order_processing/flow.rs
+++ b/examples/rust/src/products/order_processing/flow.rs
@@ -14,6 +14,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, AttributeIndex, Channel, Context, Flow, HandlerResult, PersistenceSchema,
     RetryPolicy, Rpc, RpcList, RpcResult, Step, StepDecision, StepList, StepOptions, Timer, Wait,
@@ -56,12 +58,12 @@ impl OrderProcessingFlow {
     }
 
     fn approve(&self, context: &mut Context, _note: String) -> HandlerResult<RpcResult<String>> {
-        seller_ok().publish(context, "approved".to_string())?;
+        SELLER_OK.publish(context, "approved".to_string())?;
         Ok(RpcResult::new("ok".to_string()))
     }
 
     fn describe(&self, context: &mut Context) -> HandlerResult<RpcResult<String>> {
-        Ok(RpcResult::new(order_status().get_required(context)?))
+        Ok(RpcResult::new(ORDER_STATUS.get_required(context)?))
     }
 }
 
@@ -86,8 +88,8 @@ impl Flow for OrderProcessingFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&order_status())
-            .channel(&seller_ok())
+            .attribute(&ORDER_STATUS)
+            .channel(&SELLER_OK)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -121,7 +123,7 @@ impl Step for Charge {
         self.service
             .charge_user(&input.email, &input.customer_id, input.amount);
         context.record_event("charge", input.order_id.clone())?;
-        order_status().set(context, "charged".to_string())?;
+        ORDER_STATUS.set(context, "charged".to_string())?;
         Ok(StepDecision::go_to(&Ship::default(), input))
     }
 }
@@ -150,7 +152,7 @@ impl Step for Ship {
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            seller_ok().for_one(),
+            SELLER_OK.for_one(),
             Timer::by_duration(Duration::from_secs(24 * 60 * 60)),
         ]))
     }
@@ -168,7 +170,7 @@ impl Step for Ship {
         self.service
             .ship_item(&input.order_id, input.test_fail_at_shipping)?;
         context.record_event("ship", input.order_id.clone())?;
-        order_status().set(context, "shipped".to_string())?;
+        ORDER_STATUS.set(context, "shipped".to_string())?;
         Ok(StepDecision::graceful_complete(format!(
             "shipped:{}",
             input.order_id
@@ -200,7 +202,7 @@ impl Step for Refund {
         self.service
             .update_external_system(&format!("refund {}", input.order_id));
         context.record_event("refund", input.order_id.clone())?;
-        order_status().set(context, "refunded".to_string())?;
+        ORDER_STATUS.set(context, "refunded".to_string())?;
         Ok(StepDecision::graceful_complete(format!(
             "refunded:{}",
             input.order_id
@@ -208,10 +210,7 @@ impl Step for Refund {
     }
 }
 
-fn order_status() -> Attribute<String> {
-    Attribute::new("order-status").indexed(AttributeIndex::keyword())
-}
+static ORDER_STATUS: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("order-status").indexed(AttributeIndex::keyword()));
 
-fn seller_ok() -> Channel<String> {
-    Channel::new("seller-ok")
-}
+static SELLER_OK: LazyLock<Channel<String>> = LazyLock::new(|| Channel::new("seller-ok"));

--- a/examples/rust/src/products/polling/flow.rs
+++ b/examples/rust/src/products/polling/flow.rs
@@ -30,6 +30,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, Step, StepDecision,
     StepList, StepMovement, Timer, Wait,
@@ -48,8 +50,8 @@ pub struct PollingFlow {
 impl PollingFlow {
     fn complete_task(&self, context: &mut Context, task: String) -> HandlerResult<()> {
         match task.as_str() {
-            "a" => task_a().publish(context, ()),
-            "b" => task_b().publish(context, ()),
+            "a" => TASK_A.publish(context, ()),
+            "b" => TASK_B.publish(context, ()),
             _ => Err(dex_sdk::HandlerError::new("Polling", "task must be a or b")),
         }
     }
@@ -66,9 +68,7 @@ impl Flow for PollingFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new()
-            .channel(&task_a())
-            .channel(&task_b())
+        PersistenceSchema::new().channel(&TASK_A).channel(&TASK_B)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -102,7 +102,7 @@ impl Step for WaitForTaskA {
     type Input = ();
 
     fn wait_for(&self, _context: &mut Context, _input: ()) -> HandlerResult<Wait> {
-        Ok(Wait::until(task_a().for_one()))
+        Ok(Wait::until(TASK_A.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
@@ -117,7 +117,7 @@ impl Step for WaitForTaskB {
     type Input = ();
 
     fn wait_for(&self, _context: &mut Context, _input: ()) -> HandlerResult<Wait> {
-        Ok(Wait::until(task_b().for_one()))
+        Ok(Wait::until(TASK_B.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
@@ -145,10 +145,6 @@ impl Step for PollTaskC {
     }
 }
 
-fn task_a() -> Channel<()> {
-    Channel::new("polling-task-a-completed")
-}
+static TASK_A: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("polling-task-a-completed"));
 
-fn task_b() -> Channel<()> {
-    Channel::new("polling-task-b-completed")
-}
+static TASK_B: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("polling-task-b-completed"));

--- a/examples/rust/src/products/shortlist_candidates/flow.rs
+++ b/examples/rust/src/products/shortlist_candidates/flow.rs
@@ -30,6 +30,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, RpcResult,
     Step, StepDecision, StepList, Timer, Wait,
@@ -57,7 +59,7 @@ pub struct EmployerOptInFlow {
 
 impl EmployerOptInFlow {
     fn opt_out(&self, context: &mut Context) -> HandlerResult<()> {
-        opt_out().publish(context, ())
+        OPT_OUT.publish(context, ())
     }
 
     fn is_opted_in(&self, _context: &mut Context) -> HandlerResult<RpcResult<bool>> {
@@ -74,8 +76,8 @@ impl Flow for EmployerOptInFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&employer())
-            .channel(&opt_out())
+            .attribute(&EMPLOYER)
+            .channel(&OPT_OUT)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -92,7 +94,7 @@ impl Step for OptIn {
     type Input = String;
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        employer().set(context, input)?;
+        EMPLOYER.set(context, input)?;
         Ok(StepDecision::go_to(&AwaitOptOut, ()))
     }
 }
@@ -104,7 +106,7 @@ impl Step for AwaitOptOut {
     type Input = ();
 
     fn wait_for(&self, _context: &mut Context, _input: ()) -> HandlerResult<Wait> {
-        Ok(Wait::until(opt_out().for_one()))
+        Ok(Wait::until(OPT_OUT.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
@@ -125,11 +127,11 @@ pub struct ShortlistFlow {
 
 impl ShortlistFlow {
     fn revoke(&self, context: &mut Context) -> HandlerResult<()> {
-        revoked().publish(context, ())
+        REVOKED.publish(context, ())
     }
 
     fn email_sent_timestamp(&self, context: &mut Context) -> HandlerResult<RpcResult<i64>> {
-        Ok(RpcResult::new(email_sent().get(context)?.unwrap_or(0)))
+        Ok(RpcResult::new(EMAIL_SENT.get(context)?.unwrap_or(0)))
     }
 }
 
@@ -142,8 +144,8 @@ impl Flow for ShortlistFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&email_sent())
-            .channel(&revoked())
+            .attribute(&EMAIL_SENT)
+            .channel(&REVOKED)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -161,18 +163,18 @@ impl Step for ScheduleContact {
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            revoked().for_one(),
+            REVOKED.for_one(),
             Timer::by_duration(Duration::from_secs(86_400)),
         ]))
     }
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        if revoked().condition_results(context)?.is_empty() {
+        if REVOKED.condition_results(context)?.is_empty() {
             let timestamp = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|duration| duration.as_millis() as i64)
                 .unwrap_or(0);
-            email_sent().set(context, timestamp)?;
+            EMAIL_SENT.set(context, timestamp)?;
             context.record_event("candidate-contact", input.candidate_id)?;
             Ok(StepDecision::graceful_complete("contacted".to_string()))
         } else {
@@ -181,18 +183,11 @@ impl Step for ScheduleContact {
     }
 }
 
-fn employer() -> Attribute<String> {
-    Attribute::new("employer-opt-in")
-}
+static EMPLOYER: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("employer-opt-in"));
 
-fn opt_out() -> Channel<()> {
-    Channel::new("employer-opt-out")
-}
+static OPT_OUT: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("employer-opt-out"));
 
-fn email_sent() -> Attribute<i64> {
-    Attribute::new("SHORTLIST_EmailSentTimestamp")
-}
+static EMAIL_SENT: LazyLock<Attribute<i64>> =
+    LazyLock::new(|| Attribute::new("SHORTLIST_EmailSentTimestamp"));
 
-fn revoked() -> Channel<()> {
-    Channel::new("shortlist-revoked")
-}
+static REVOKED: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("shortlist-revoked"));

--- a/examples/rust/src/products/signup/flow.rs
+++ b/examples/rust/src/products/signup/flow.rs
@@ -30,6 +30,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, Step, StepDecision,
     StepList, Timer, Wait,
@@ -45,7 +47,7 @@ pub struct UserSignupFlow {
 
 impl UserSignupFlow {
     fn verify(&self, context: &mut Context) -> HandlerResult<()> {
-        verified().publish(context, ())
+        VERIFIED.publish(context, ())
     }
 }
 
@@ -57,7 +59,7 @@ impl Flow for UserSignupFlow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&verified())
+        PersistenceSchema::new().channel(&VERIFIED)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -85,13 +87,13 @@ impl Step for AwaitVerification {
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            verified().for_one(),
+            VERIFIED.for_one(),
             Timer::by_duration(Duration::from_secs(86_400)),
         ]))
     }
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        if !verified().condition_results(context)?.is_empty() {
+        if !VERIFIED.condition_results(context)?.is_empty() {
             return Ok(StepDecision::graceful_complete(input.0));
         }
         context.record_event("verification-reminder", input.0.clone())?;
@@ -102,6 +104,4 @@ impl Step for AwaitVerification {
     }
 }
 
-fn verified() -> Channel<()> {
-    Channel::new("signup-verified")
-}
+static VERIFIED: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("signup-verified"));

--- a/examples/rust/src/products/subscription/flow.rs
+++ b/examples/rust/src/products/subscription/flow.rs
@@ -30,6 +30,8 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, RpcResult,
     Step, StepDecision, StepList, StepMovement, Timer, Wait,
@@ -63,15 +65,15 @@ pub struct SubscriptionFlow {
 
 impl SubscriptionFlow {
     fn describe(&self, context: &mut Context) -> HandlerResult<RpcResult<SubscriptionState>> {
-        Ok(RpcResult::new(state().get(context)?.unwrap_or_default()))
+        Ok(RpcResult::new(STATE.get(context)?.unwrap_or_default()))
     }
 
     fn update_charge(&self, context: &mut Context, amount: i64) -> HandlerResult<()> {
-        commands().publish(context, SubscriptionCommand::Charge(amount))
+        COMMANDS.publish(context, SubscriptionCommand::Charge(amount))
     }
 
     fn cancel(&self, context: &mut Context) -> HandlerResult<()> {
-        commands().publish(context, SubscriptionCommand::Cancel)
+        COMMANDS.publish(context, SubscriptionCommand::Cancel)
     }
 }
 
@@ -86,8 +88,8 @@ impl Flow for SubscriptionFlow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&state())
-            .channel(&commands())
+            .attribute(&STATE)
+            .channel(&COMMANDS)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -111,7 +113,7 @@ impl Step for Welcome {
     type Input = SubscriptionRequest;
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
-        state().set(
+        STATE.set(
             context,
             SubscriptionState {
                 charge_cents: input.charge_cents,
@@ -142,12 +144,12 @@ impl Step for Billing {
         context: &mut Context,
         remaining: Self::Input,
     ) -> HandlerResult<StepDecision> {
-        let mut current = state().get_required(context)?;
+        let mut current = STATE.get_required(context)?;
         if current.cancelled || remaining == 0 {
             return Ok(StepDecision::graceful_complete(current));
         }
         current.periods_charged += 1;
-        state().set(context, current)?;
+        STATE.set(context, current)?;
         Ok(StepDecision::go_to(&Billing, remaining - 1))
     }
 }
@@ -159,18 +161,18 @@ impl Step for Control {
     type Input = ();
 
     fn wait_for(&self, _context: &mut Context, _input: Self::Input) -> HandlerResult<Wait> {
-        Ok(Wait::until(commands().for_one()))
+        Ok(Wait::until(COMMANDS.for_one()))
     }
 
     fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
-        let mut current = state().get_required(context)?;
-        for command in commands().condition_results(context)? {
+        let mut current = STATE.get_required(context)?;
+        for command in COMMANDS.condition_results(context)? {
             match command {
                 SubscriptionCommand::Charge(amount) => current.charge_cents = amount,
                 SubscriptionCommand::Cancel => current.cancelled = true,
             }
         }
-        state().set(context, current.clone())?;
+        STATE.set(context, current.clone())?;
         if current.cancelled {
             Ok(StepDecision::force_complete(current))
         } else {
@@ -179,10 +181,8 @@ impl Step for Control {
     }
 }
 
-fn state() -> Attribute<SubscriptionState> {
-    Attribute::new("subscription-state")
-}
+static STATE: LazyLock<Attribute<SubscriptionState>> =
+    LazyLock::new(|| Attribute::new("subscription-state"));
 
-fn commands() -> Channel<SubscriptionCommand> {
-    Channel::new("subscription-commands")
-}
+static COMMANDS: LazyLock<Channel<SubscriptionCommand>> =
+    LazyLock::new(|| Channel::new("subscription-commands"));

--- a/examples/rust/tests/dex_integration.rs
+++ b/examples/rust/tests/dex_integration.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use dex_examples_rust::create_example_registry;
 use dex_examples_rust::patterns::recovery::FailureRecoveryFlow;
-use dex_examples_rust::primitives::stream::flow::{StreamFlow, progress};
+use dex_examples_rust::primitives::stream::flow::{PROGRESS, StreamFlow};
 use dex_examples_rust::products::engagement::{
     ENGAGEMENT_ACCEPT, ENGAGEMENT_DESCRIBE, EngagementFlow, EngagementRequest, EngagementStatus,
 };
@@ -190,7 +190,7 @@ fn stream_resumes_after_step_and_client_writes() {
 
     let step_message = environment
         .client
-        .read_stream_with_timeout(&flow_id, &progress(), "", Duration::from_secs(20))
+        .read_stream_with_timeout(&flow_id, &PROGRESS, "", Duration::from_secs(20))
         .expect("read Rust Step Stream message");
     assert_eq!(step_message.value, "Rendering preview for invoice");
     assert!(!step_message.resume_token.is_empty());
@@ -199,7 +199,7 @@ fn stream_resumes_after_step_and_client_writes() {
         .client
         .write_stream(
             &flow_id,
-            &progress(),
+            &PROGRESS,
             "browser/complete",
             "Preview displayed".to_string(),
         )
@@ -208,7 +208,7 @@ fn stream_resumes_after_step_and_client_writes() {
         .client
         .read_stream_with_timeout(
             &flow_id,
-            &progress(),
+            &PROGRESS,
             &step_message.resume_token,
             Duration::from_secs(20),
         )

--- a/sdk-rust/crates/dex-sdk/tests/integ/any_command_combination_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/any_command_combination_workflow.rs
@@ -8,10 +8,16 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerError, HandlerResult, PersistenceSchema, RetryPolicy, Step,
     StepDecision, StepList, StepOptions, Wait,
 };
+
+static FIRST: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("test-signal-1"));
+static SECOND: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("test-signal-2"));
+static THIRD: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("test-signal-3"));
 
 pub(crate) struct AnyCommandCombinationWorkflow {
     first: Channel<i32>,
@@ -23,9 +29,9 @@ pub(crate) struct AnyCommandCombinationWorkflow {
 impl AnyCommandCombinationWorkflow {
     pub(crate) fn new() -> Self {
         Self {
-            first: Channel::new("test-signal-1"),
-            second: Channel::new("test-signal-2"),
-            third: Channel::new("test-signal-3"),
+            first: FIRST.clone(),
+            second: SECOND.clone(),
+            third: THIRD.clone(),
             start: AnyCommandCombinationStep,
         }
     }

--- a/sdk-rust/crates/dex-sdk/tests/integ/any_command_combination_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/any_command_combination_workflow.rs
@@ -20,18 +20,12 @@ static SECOND: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("test-sign
 static THIRD: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("test-signal-3"));
 
 pub(crate) struct AnyCommandCombinationWorkflow {
-    first: Channel<i32>,
-    second: Channel<i32>,
-    third: Channel<i32>,
     start: AnyCommandCombinationStep,
 }
 
 impl AnyCommandCombinationWorkflow {
     pub(crate) fn new() -> Self {
         Self {
-            first: FIRST.clone(),
-            second: SECOND.clone(),
-            third: THIRD.clone(),
             start: AnyCommandCombinationStep,
         }
     }
@@ -46,9 +40,9 @@ impl Flow for AnyCommandCombinationWorkflow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .channel(&self.first)
-            .channel(&self.second)
-            .channel(&self.third)
+            .channel(&FIRST)
+            .channel(&SECOND)
+            .channel(&THIRD)
     }
 }
 

--- a/sdk-rust/crates/dex-sdk/tests/integ/conditional_complete_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/conditional_complete_test.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use dex_sdk::{Client, Registry, SdkResult};
 
-use crate::conditional_complete_workflow::ConditionalCompleteWorkflow;
+use crate::conditional_complete_workflow::{ConditionalCompleteWorkflow, SIGNAL};
 use crate::support::{DexDevTestEnvironment, flow_id};
 
 #[test]
@@ -28,7 +28,7 @@ fn test_signal_channel() {
         .expect("start conditional signal Flow");
     environment
         .client
-        .publish_many(&flow_id, &workflow.signal, [(), (), ()])
+        .publish_many(&flow_id, &SIGNAL, [(), (), ()])
         .expect("publish signal messages");
     assert_eq!(
         3,
@@ -73,7 +73,7 @@ fn test_internal_channel() {
 fn compile_conditional_complete(client: &Client) -> SdkResult<()> {
     let workflow = ConditionalCompleteWorkflow::new();
     client.start_flow(&workflow, "conditional-signal", true)?;
-    client.publish_many("conditional-signal", &workflow.signal, [(), (), ()])?;
+    client.publish_many("conditional-signal", &SIGNAL, [(), (), ()])?;
     let _: i32 = client
         .wait_for_flow("conditional-signal")?
         .single_output()?;

--- a/sdk-rust/crates/dex-sdk/tests/integ/conditional_complete_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/conditional_complete_workflow.rs
@@ -15,14 +15,12 @@ use dex_sdk::{
     StepDecision, StepList, StepMovement, Wait,
 };
 
-static SIGNAL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("test-signal-channel"));
+pub(crate) static SIGNAL: LazyLock<Channel<()>> =
+    LazyLock::new(|| Channel::new("test-signal-channel"));
 static INTERNAL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("test-internal-channel"));
 static COUNTER: LazyLock<Attribute<i32>> = LazyLock::new(|| Attribute::new("counter"));
 
 pub(crate) struct ConditionalCompleteWorkflow {
-    pub(crate) signal: Channel<()>,
-    internal: Channel<()>,
-    counter: Attribute<i32>,
     start: ConditionalCompleteStep,
 }
 
@@ -30,24 +28,14 @@ impl ConditionalCompleteWorkflow {
     pub(crate) const PUBLISH_TO_INTERNAL: Rpc<i32, ()> = Rpc::new("publish_to_internal_channel");
 
     pub(crate) fn new() -> Self {
-        let signal = SIGNAL.clone();
-        let internal = INTERNAL.clone();
-        let counter = COUNTER.clone();
         Self {
-            start: ConditionalCompleteStep {
-                signal: signal.clone(),
-                internal: internal.clone(),
-                counter: counter.clone(),
-            },
-            signal,
-            internal,
-            counter,
+            start: ConditionalCompleteStep,
         }
     }
 
     fn publish_to_internal_channel(&self, context: &mut Context, count: i32) -> HandlerResult<()> {
         for _ in 0..count {
-            self.internal.publish(context, ())?;
+            INTERNAL.publish(context, ())?;
         }
         Ok(())
     }
@@ -62,9 +50,9 @@ impl Flow for ConditionalCompleteWorkflow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&self.counter)
-            .channel(&self.signal)
-            .channel(&self.internal)
+            .attribute(&COUNTER)
+            .channel(&SIGNAL)
+            .channel(&INTERNAL)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -72,31 +60,23 @@ impl Flow for ConditionalCompleteWorkflow {
     }
 }
 
-struct ConditionalCompleteStep {
-    signal: Channel<()>,
-    internal: Channel<()>,
-    counter: Attribute<i32>,
-}
+struct ConditionalCompleteStep;
 
 impl Step for ConditionalCompleteStep {
     type Input = bool;
 
     fn wait_for(&self, _context: &mut Context, use_signal: bool) -> HandlerResult<Wait> {
         Ok(Wait::until(if use_signal {
-            self.signal.for_one()
+            SIGNAL.for_one()
         } else {
-            self.internal.for_one()
+            INTERNAL.for_one()
         }))
     }
 
     fn execute(&self, context: &mut Context, use_signal: bool) -> HandlerResult<StepDecision> {
-        let next = self.counter.get(context)?.unwrap_or_default() + 1;
-        self.counter.set(context, next)?;
-        let selected = if use_signal {
-            &self.signal
-        } else {
-            &self.internal
-        };
+        let next = COUNTER.get(context)?.unwrap_or_default() + 1;
+        COUNTER.set(context, next)?;
+        let selected = if use_signal { &*SIGNAL } else { &*INTERNAL };
         Ok(StepDecision::force_complete_if_channels_empty(
             next,
             StepMovement::to(self, use_signal),

--- a/sdk-rust/crates/dex-sdk/tests/integ/conditional_complete_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/conditional_complete_workflow.rs
@@ -8,10 +8,16 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, Step,
     StepDecision, StepList, StepMovement, Wait,
 };
+
+static SIGNAL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("test-signal-channel"));
+static INTERNAL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("test-internal-channel"));
+static COUNTER: LazyLock<Attribute<i32>> = LazyLock::new(|| Attribute::new("counter"));
 
 pub(crate) struct ConditionalCompleteWorkflow {
     pub(crate) signal: Channel<()>,
@@ -24,9 +30,9 @@ impl ConditionalCompleteWorkflow {
     pub(crate) const PUBLISH_TO_INTERNAL: Rpc<i32, ()> = Rpc::new("publish_to_internal_channel");
 
     pub(crate) fn new() -> Self {
-        let signal = Channel::new("test-signal-channel");
-        let internal = Channel::new("test-internal-channel");
-        let counter = Attribute::new("counter");
+        let signal = SIGNAL.clone();
+        let internal = INTERNAL.clone();
+        let counter = COUNTER.clone();
         Self {
             start: ConditionalCompleteStep {
                 signal: signal.clone(),

--- a/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_test.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use dex_sdk::{Client, Registry, SdkResult};
 
-use crate::internal_channel_waiting_workflow::InternalChannelWaitingWorkflow;
+use crate::internal_channel_waiting_workflow::{CHANNEL, InternalChannelWaitingWorkflow};
 use crate::internal_channel_workflow::InternalChannelWorkflow;
 use crate::support::{DexDevTestEnvironment, flow_id};
 
@@ -51,7 +51,7 @@ fn test_waiting_internal_channel() {
         .expect("start waiting-channel Flow");
     environment
         .client
-        .publish_many(&flow_id, &workflow.channel, [2, 3])
+        .publish_many(&flow_id, &CHANNEL, [2, 3])
         .expect("publish waiting-channel messages");
     assert_eq!(
         6,
@@ -69,7 +69,7 @@ fn compile_internal_channels(client: &Client) -> SdkResult<()> {
     let _: i32 = client.wait_for_flow("basic-internal")?.single_output()?;
     let workflow = InternalChannelWaitingWorkflow::new();
     client.start_flow(&workflow, "waiting-internal", 1)?;
-    client.publish_many("waiting-internal", &workflow.channel, [2, 3])?;
+    client.publish_many("waiting-internal", &CHANNEL, [2, 3])?;
     let _: i32 = client.wait_for_flow("waiting-internal")?.single_output()?;
     Ok(())
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_waiting_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_waiting_workflow.rs
@@ -8,9 +8,13 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision, StepList, Wait,
 };
+
+static CHANNEL: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("waiting-channel"));
 
 pub(crate) struct InternalChannelWaitingWorkflow {
     pub(crate) channel: Channel<i32>,
@@ -19,7 +23,7 @@ pub(crate) struct InternalChannelWaitingWorkflow {
 
 impl InternalChannelWaitingWorkflow {
     pub(crate) fn new() -> Self {
-        let channel = Channel::new("waiting-channel");
+        let channel = CHANNEL.clone();
         Self {
             start: WaitingStep {
                 channel: channel.clone(),

--- a/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_waiting_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_waiting_workflow.rs
@@ -14,22 +14,16 @@ use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision, StepList, Wait,
 };
 
-static CHANNEL: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("waiting-channel"));
+pub(crate) static CHANNEL: LazyLock<Channel<i32>> =
+    LazyLock::new(|| Channel::new("waiting-channel"));
 
 pub(crate) struct InternalChannelWaitingWorkflow {
-    pub(crate) channel: Channel<i32>,
     start: WaitingStep,
 }
 
 impl InternalChannelWaitingWorkflow {
     pub(crate) fn new() -> Self {
-        let channel = CHANNEL.clone();
-        Self {
-            start: WaitingStep {
-                channel: channel.clone(),
-            },
-            channel,
-        }
+        Self { start: WaitingStep }
     }
 }
 
@@ -41,24 +35,21 @@ impl Flow for InternalChannelWaitingWorkflow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().channel(&self.channel)
+        PersistenceSchema::new().channel(&CHANNEL)
     }
 }
 
-struct WaitingStep {
-    channel: Channel<i32>,
-}
+struct WaitingStep;
 
 impl Step for WaitingStep {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, _input: i32) -> HandlerResult<Wait> {
-        Ok(Wait::until(self.channel.for_n(2)))
+        Ok(Wait::until(CHANNEL.for_n(2)))
     }
 
     fn execute(&self, context: &mut Context, input: i32) -> HandlerResult<StepDecision> {
-        let output = self
-            .channel
+        let output = CHANNEL
             .condition_results(context)?
             .into_iter()
             .fold(input, i32::saturating_add);

--- a/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_workflow.rs
@@ -21,8 +21,6 @@ static SECOND_CHANNEL: LazyLock<Channel<i32>> =
     LazyLock::new(|| Channel::new("test-inter-state-channel-2"));
 
 pub(crate) struct InternalChannelWorkflow {
-    first_channel: Channel<i32>,
-    second_channel: Channel<i32>,
     channel_map: ChannelMap<i32>,
     start: ForkStep,
     consumer: ConsumeStep,
@@ -31,22 +29,15 @@ pub(crate) struct InternalChannelWorkflow {
 
 impl InternalChannelWorkflow {
     pub(crate) fn new() -> Self {
-        let first_channel = FIRST_CHANNEL.clone();
-        let second_channel = SECOND_CHANNEL.clone();
         let channel_map = ChannelMap::new("test-inter-state-channel-map");
         Self {
             start: ForkStep,
             consumer: ConsumeStep {
-                first_channel: first_channel.clone(),
-                second_channel: second_channel.clone(),
                 channel_map: channel_map.clone(),
             },
             publisher: PublishStep {
-                first_channel: first_channel.clone(),
                 channel_map: channel_map.clone(),
             },
-            first_channel,
-            second_channel,
             channel_map,
         }
     }
@@ -63,8 +54,8 @@ impl Flow for InternalChannelWorkflow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .channel(&self.first_channel)
-            .channel(&self.second_channel)
+            .channel(&FIRST_CHANNEL)
+            .channel(&SECOND_CHANNEL)
             .channel_map(&self.channel_map)
     }
 }
@@ -78,15 +69,12 @@ impl Step for ForkStep {
         Ok(StepDecision::go_to_many([
             StepMovement::to(
                 &ConsumeStep {
-                    first_channel: FIRST_CHANNEL.clone(),
-                    second_channel: SECOND_CHANNEL.clone(),
                     channel_map: ChannelMap::new("test-inter-state-channel-map"),
                 },
                 input,
             ),
             StepMovement::to(
                 &PublishStep {
-                    first_channel: FIRST_CHANNEL.clone(),
                     channel_map: ChannelMap::new("test-inter-state-channel-map"),
                 },
                 input,
@@ -96,8 +84,6 @@ impl Step for ForkStep {
 }
 
 struct ConsumeStep {
-    first_channel: Channel<i32>,
-    second_channel: Channel<i32>,
     channel_map: ChannelMap<i32>,
 }
 
@@ -107,21 +93,21 @@ impl Step for ConsumeStep {
     fn wait_for(&self, _context: &mut Context, _input: i32) -> HandlerResult<Wait> {
         Ok(Wait::any_combination_of([
             ConditionCombination::all_of([
-                self.first_channel.for_one().with_id("first"),
+                FIRST_CHANNEL.for_one().with_id("first"),
                 self.channel_map.for_one("one").with_id("mapped"),
             ]),
-            ConditionCombination::all_of([self.second_channel.for_one().with_id("second")]),
+            ConditionCombination::all_of([SECOND_CHANNEL.for_one().with_id("second")]),
         ]))
     }
 
     fn execute(&self, context: &mut Context, input: i32) -> HandlerResult<StepDecision> {
-        if !self.second_channel.condition_results(context)?.is_empty() {
+        if !SECOND_CHANNEL.condition_results(context)?.is_empty() {
             return Err(HandlerError::new(
                 "InternalChannelFailure",
                 "second channel should still be waiting",
             ));
         }
-        let first = self.first_channel.condition_results(context)?[0];
+        let first = FIRST_CHANNEL.condition_results(context)?[0];
         let mapped = self.channel_map.condition_results(context, "one")?[0];
         if mapped != 3 {
             return Err(HandlerError::new(
@@ -134,7 +120,6 @@ impl Step for ConsumeStep {
 }
 
 struct PublishStep {
-    first_channel: Channel<i32>,
     channel_map: ChannelMap<i32>,
 }
 
@@ -142,7 +127,7 @@ impl Step for PublishStep {
     type Input = i32;
 
     fn execute(&self, context: &mut Context, _input: i32) -> HandlerResult<StepDecision> {
-        self.first_channel.publish(context, 2)?;
+        FIRST_CHANNEL.publish(context, 2)?;
         self.channel_map.publish(context, "one", 3)?;
         Ok(StepDecision::dead_end())
     }

--- a/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/internal_channel_workflow.rs
@@ -8,10 +8,17 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, ChannelMap, ConditionCombination, Context, Flow, HandlerError, HandlerResult,
     PersistenceSchema, Step, StepDecision, StepList, StepMovement, Wait,
 };
+
+static FIRST_CHANNEL: LazyLock<Channel<i32>> =
+    LazyLock::new(|| Channel::new("test-inter-state-channel-1"));
+static SECOND_CHANNEL: LazyLock<Channel<i32>> =
+    LazyLock::new(|| Channel::new("test-inter-state-channel-2"));
 
 pub(crate) struct InternalChannelWorkflow {
     first_channel: Channel<i32>,
@@ -24,8 +31,8 @@ pub(crate) struct InternalChannelWorkflow {
 
 impl InternalChannelWorkflow {
     pub(crate) fn new() -> Self {
-        let first_channel = Channel::new("test-inter-state-channel-1");
-        let second_channel = Channel::new("test-inter-state-channel-2");
+        let first_channel = FIRST_CHANNEL.clone();
+        let second_channel = SECOND_CHANNEL.clone();
         let channel_map = ChannelMap::new("test-inter-state-channel-map");
         Self {
             start: ForkStep,
@@ -71,15 +78,15 @@ impl Step for ForkStep {
         Ok(StepDecision::go_to_many([
             StepMovement::to(
                 &ConsumeStep {
-                    first_channel: Channel::new("test-inter-state-channel-1"),
-                    second_channel: Channel::new("test-inter-state-channel-2"),
+                    first_channel: FIRST_CHANNEL.clone(),
+                    second_channel: SECOND_CHANNEL.clone(),
                     channel_map: ChannelMap::new("test-inter-state-channel-map"),
                 },
                 input,
             ),
             StepMovement::to(
                 &PublishStep {
-                    first_channel: Channel::new("test-inter-state-channel-1"),
+                    first_channel: FIRST_CHANNEL.clone(),
                     channel_map: ChannelMap::new("test-inter-state-channel-map"),
                 },
                 input,

--- a/sdk-rust/crates/dex-sdk/tests/integ/no_start_state_dead_end_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/no_start_state_dead_end_workflow.rs
@@ -15,12 +15,11 @@ use dex_sdk::{
     RpcResult, Step, StepDecision, StepList, StepMovement,
 };
 
-static IDLE_SIGNAL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("idle-signal"));
+pub(crate) static IDLE_SIGNAL: LazyLock<Channel<()>> =
+    LazyLock::new(|| Channel::new("idle-signal"));
 static IDLE_INTERNAL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("idle-internal"));
 
 pub(crate) struct NoStartStateDeadEndWorkflow {
-    pub(crate) idle_signal: Channel<()>,
-    idle_internal: Channel<()>,
     start: DeadEndStep,
     complete: CompleteStep,
 }
@@ -32,20 +31,18 @@ impl NoStartStateDeadEndWorkflow {
 
     pub(crate) fn new() -> Self {
         Self {
-            idle_signal: IDLE_SIGNAL.clone(),
-            idle_internal: IDLE_INTERNAL.clone(),
             start: DeadEndStep,
             complete: CompleteStep,
         }
     }
 
     fn signal_size(&self, context: &mut Context) -> HandlerResult<RpcResult<usize>> {
-        Ok(RpcResult::new(self.idle_signal.size(context)?))
+        Ok(RpcResult::new(IDLE_SIGNAL.size(context)?))
     }
 
     fn publish_internal(&self, context: &mut Context) -> HandlerResult<RpcResult<usize>> {
-        self.idle_internal.publish(context, ())?;
-        Ok(RpcResult::new(self.idle_internal.size(context)?))
+        IDLE_INTERNAL.publish(context, ())?;
+        Ok(RpcResult::new(IDLE_INTERNAL.size(context)?))
     }
 
     fn invoke(&self, context: &mut Context, _input: String) -> HandlerResult<RpcResult<i64>> {
@@ -68,8 +65,8 @@ impl Flow for NoStartStateDeadEndWorkflow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .channel(&self.idle_signal)
-            .channel(&self.idle_internal)
+            .channel(&IDLE_SIGNAL)
+            .channel(&IDLE_INTERNAL)
     }
 
     fn rpcs(&self) -> RpcList<Self> {

--- a/sdk-rust/crates/dex-sdk/tests/integ/no_start_state_dead_end_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/no_start_state_dead_end_workflow.rs
@@ -8,10 +8,15 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, Context, Flow, HandlerError, HandlerResult, PersistenceSchema, Rpc, RpcList,
     RpcResult, Step, StepDecision, StepList, StepMovement,
 };
+
+static IDLE_SIGNAL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("idle-signal"));
+static IDLE_INTERNAL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("idle-internal"));
 
 pub(crate) struct NoStartStateDeadEndWorkflow {
     pub(crate) idle_signal: Channel<()>,
@@ -27,8 +32,8 @@ impl NoStartStateDeadEndWorkflow {
 
     pub(crate) fn new() -> Self {
         Self {
-            idle_signal: Channel::new("idle-signal"),
-            idle_internal: Channel::new("idle-internal"),
+            idle_signal: IDLE_SIGNAL.clone(),
+            idle_internal: IDLE_INTERNAL.clone(),
             start: DeadEndStep,
             complete: CompleteStep,
         }

--- a/sdk-rust/crates/dex-sdk/tests/integ/persistence_set_attributes_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/persistence_set_attributes_workflow.rs
@@ -19,58 +19,36 @@ use dex_sdk::{
 
 use crate::persistence_workflow::PersistenceModel;
 
-static DATA: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("data"));
-static MODEL: LazyLock<Attribute<PersistenceModel>> =
+pub(crate) static DATA: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("data"));
+pub(crate) static MODEL: LazyLock<Attribute<PersistenceModel>> =
     LazyLock::new(|| Attribute::new("data-model"));
-static KEYWORD: LazyLock<Attribute<String>> =
+pub(crate) static KEYWORD: LazyLock<Attribute<String>> =
     LazyLock::new(|| Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword()));
-static FULL_TEXT: LazyLock<Attribute<String>> =
+pub(crate) static FULL_TEXT: LazyLock<Attribute<String>> =
     LazyLock::new(|| Attribute::new("CustomTextField").indexed(AttributeIndex::full_text()));
-static DECIMAL: LazyLock<Attribute<f64>> =
+pub(crate) static DECIMAL: LazyLock<Attribute<f64>> =
     LazyLock::new(|| Attribute::new("CustomDoubleField").indexed(AttributeIndex::double()));
-static INTEGER: LazyLock<Attribute<i32>> =
+pub(crate) static INTEGER: LazyLock<Attribute<i32>> =
     LazyLock::new(|| Attribute::new("CustomIntField").indexed(AttributeIndex::int()));
-static BOOLEAN: LazyLock<Attribute<bool>> =
+pub(crate) static BOOLEAN: LazyLock<Attribute<bool>> =
     LazyLock::new(|| Attribute::new("CustomBoolField").indexed(AttributeIndex::bool()));
-static KEYWORDS: LazyLock<Attribute<Vec<String>>> = LazyLock::new(|| {
+pub(crate) static KEYWORDS: LazyLock<Attribute<Vec<String>>> = LazyLock::new(|| {
     Attribute::new("CustomKeywordArrayField").indexed(AttributeIndex::keyword_array())
 });
-static DATETIME: LazyLock<Attribute<SystemTime>> =
+pub(crate) static DATETIME: LazyLock<Attribute<SystemTime>> =
     LazyLock::new(|| Attribute::new("CustomDatetimeField").indexed(AttributeIndex::date_time()));
-static PROCEED: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("proceed"));
+pub(crate) static PROCEED: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("proceed"));
 
 pub(crate) struct PersistenceSetAttributesWorkflow {
-    pub(crate) data: Attribute<String>,
     pub(crate) data_map: AttributeMap<String>,
-    pub(crate) model: Attribute<PersistenceModel>,
-    pub(crate) keyword: Attribute<String>,
-    pub(crate) full_text: Attribute<String>,
-    pub(crate) decimal: Attribute<f64>,
-    pub(crate) integer: Attribute<i32>,
-    pub(crate) boolean: Attribute<bool>,
-    pub(crate) keywords: Attribute<Vec<String>>,
-    pub(crate) datetime: Attribute<SystemTime>,
-    pub(crate) proceed: Channel<()>,
     start: SetAttributesStep,
 }
 
 impl PersistenceSetAttributesWorkflow {
     pub(crate) fn new() -> Self {
         Self {
-            data: DATA.clone(),
             data_map: AttributeMap::new("data-map"),
-            model: MODEL.clone(),
-            keyword: KEYWORD.clone(),
-            full_text: FULL_TEXT.clone(),
-            decimal: DECIMAL.clone(),
-            integer: INTEGER.clone(),
-            boolean: BOOLEAN.clone(),
-            keywords: KEYWORDS.clone(),
-            datetime: DATETIME.clone(),
-            proceed: PROCEED.clone(),
-            start: SetAttributesStep {
-                proceed: PROCEED.clone(),
-            },
+            start: SetAttributesStep,
         }
     }
 }
@@ -84,29 +62,27 @@ impl Flow for PersistenceSetAttributesWorkflow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&self.data)
+            .attribute(&DATA)
             .attribute_map(&self.data_map)
-            .attribute(&self.model)
-            .attribute(&self.keyword)
-            .attribute(&self.full_text)
-            .attribute(&self.decimal)
-            .attribute(&self.integer)
-            .attribute(&self.boolean)
-            .attribute(&self.keywords)
-            .attribute(&self.datetime)
-            .channel(&self.proceed)
+            .attribute(&MODEL)
+            .attribute(&KEYWORD)
+            .attribute(&FULL_TEXT)
+            .attribute(&DECIMAL)
+            .attribute(&INTEGER)
+            .attribute(&BOOLEAN)
+            .attribute(&KEYWORDS)
+            .attribute(&DATETIME)
+            .channel(&PROCEED)
     }
 }
 
-struct SetAttributesStep {
-    proceed: Channel<()>,
-}
+struct SetAttributesStep;
 
 impl Step for SetAttributesStep {
     type Input = String;
 
     fn wait_for(&self, _context: &mut Context, _input: String) -> HandlerResult<Wait> {
-        Ok(Wait::until(self.proceed.for_one()))
+        Ok(Wait::until(PROCEED.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, _input: String) -> HandlerResult<StepDecision> {

--- a/sdk-rust/crates/dex-sdk/tests/integ/persistence_set_attributes_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/persistence_set_attributes_workflow.rs
@@ -10,12 +10,34 @@
 
 use std::time::SystemTime;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, AttributeIndex, AttributeMap, Channel, Context, Flow, HandlerResult,
     PersistenceSchema, Step, StepDecision, StepList, Wait,
 };
 
 use crate::persistence_workflow::PersistenceModel;
+
+static DATA: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("data"));
+static MODEL: LazyLock<Attribute<PersistenceModel>> =
+    LazyLock::new(|| Attribute::new("data-model"));
+static KEYWORD: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword()));
+static FULL_TEXT: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("CustomTextField").indexed(AttributeIndex::full_text()));
+static DECIMAL: LazyLock<Attribute<f64>> =
+    LazyLock::new(|| Attribute::new("CustomDoubleField").indexed(AttributeIndex::double()));
+static INTEGER: LazyLock<Attribute<i32>> =
+    LazyLock::new(|| Attribute::new("CustomIntField").indexed(AttributeIndex::int()));
+static BOOLEAN: LazyLock<Attribute<bool>> =
+    LazyLock::new(|| Attribute::new("CustomBoolField").indexed(AttributeIndex::bool()));
+static KEYWORDS: LazyLock<Attribute<Vec<String>>> = LazyLock::new(|| {
+    Attribute::new("CustomKeywordArrayField").indexed(AttributeIndex::keyword_array())
+});
+static DATETIME: LazyLock<Attribute<SystemTime>> =
+    LazyLock::new(|| Attribute::new("CustomDatetimeField").indexed(AttributeIndex::date_time()));
+static PROCEED: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("proceed"));
 
 pub(crate) struct PersistenceSetAttributesWorkflow {
     pub(crate) data: Attribute<String>,
@@ -35,20 +57,19 @@ pub(crate) struct PersistenceSetAttributesWorkflow {
 impl PersistenceSetAttributesWorkflow {
     pub(crate) fn new() -> Self {
         Self {
-            data: Attribute::new("data"),
+            data: DATA.clone(),
             data_map: AttributeMap::new("data-map"),
-            model: Attribute::new("data-model"),
-            keyword: Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword()),
-            full_text: Attribute::new("CustomTextField").indexed(AttributeIndex::full_text()),
-            decimal: Attribute::new("CustomDoubleField").indexed(AttributeIndex::double()),
-            integer: Attribute::new("CustomIntField").indexed(AttributeIndex::int()),
-            boolean: Attribute::new("CustomBoolField").indexed(AttributeIndex::bool()),
-            keywords: Attribute::new("CustomKeywordArrayField")
-                .indexed(AttributeIndex::keyword_array()),
-            datetime: Attribute::new("CustomDatetimeField").indexed(AttributeIndex::date_time()),
-            proceed: Channel::new("proceed"),
+            model: MODEL.clone(),
+            keyword: KEYWORD.clone(),
+            full_text: FULL_TEXT.clone(),
+            decimal: DECIMAL.clone(),
+            integer: INTEGER.clone(),
+            boolean: BOOLEAN.clone(),
+            keywords: KEYWORDS.clone(),
+            datetime: DATETIME.clone(),
+            proceed: PROCEED.clone(),
             start: SetAttributesStep {
-                proceed: Channel::new("proceed"),
+                proceed: PROCEED.clone(),
             },
         }
     }

--- a/sdk-rust/crates/dex-sdk/tests/integ/persistence_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/persistence_test.rs
@@ -12,8 +12,10 @@ use std::time::{Duration, SystemTime};
 
 use dex_sdk::{Attribute, Client, Registry, SdkError, SdkResult, StartFlowOptions};
 
-use crate::persistence_set_attributes_workflow::PersistenceSetAttributesWorkflow;
-use crate::persistence_workflow::{PersistenceModel, PersistenceWorkflow};
+use crate::persistence_set_attributes_workflow::{
+    self as set_attributes, PersistenceSetAttributesWorkflow,
+};
+use crate::persistence_workflow::{self as persistence, PersistenceModel, PersistenceWorkflow};
 use crate::support::{DexDevTestEnvironment, flow_id};
 
 #[test]
@@ -25,12 +27,12 @@ fn test_persistence_reads() {
     assert!(matches!(
         environment
             .client
-            .get_attribute(&flow_id("missing"), &workflow.data),
+            .get_attribute(&flow_id("missing"), &persistence::DATA),
         Err(SdkError::FlowNotFound { .. })
     ));
     let flow_id = flow_id("persistence");
     let options = StartFlowOptions::new()
-        .initial_attribute(&workflow.initial, "initial".to_string())
+        .initial_attribute(&persistence::INITIAL, "initial".to_string())
         .initial_attribute_map(&workflow.data_map, "one", "initial".to_string());
     environment
         .client
@@ -48,14 +50,14 @@ fn test_persistence_reads() {
         Some("input".to_string()),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.data)
+            .get_attribute(&flow_id, &persistence::DATA)
             .expect("get data Attribute")
     );
     assert_eq!(
         Some("initial".to_string()),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.initial)
+            .get_attribute(&flow_id, &persistence::INITIAL)
             .expect("get initial Attribute")
     );
     assert_eq!(
@@ -69,34 +71,34 @@ fn test_persistence_reads() {
         Some("input".to_string()),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.keyword)
+            .get_attribute(&flow_id, &persistence::KEYWORD)
             .expect("get keyword Attribute")
     );
     assert_eq!(
         Some(1),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.integer)
+            .get_attribute(&flow_id, &persistence::INTEGER)
             .expect("get integer Attribute")
     );
     assert_eq!(
         Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_681_766_269)),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.datetime)
+            .get_attribute(&flow_id, &persistence::DATETIME)
             .expect("get datetime Attribute")
     );
     assert_eq!(
         Some(PersistenceModel { value: 0 }),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.model)
+            .get_attribute(&flow_id, &persistence::MODEL)
             .expect("get model Attribute")
     );
     assert!(matches!(
         environment
             .client
-            .set_attribute(&flow_id, &workflow.data, "closed".to_string()),
+            .set_attribute(&flow_id, &persistence::DATA, "closed".to_string()),
         Err(SdkError::FlowNotActive { .. })
     ));
 }
@@ -117,35 +119,35 @@ fn test_set_indexed_attributes() {
         .expect("start set-indexed-attributes Flow");
     environment
         .client
-        .set_attribute(&flow_id, &workflow.keyword, "keyword-1".to_string())
+        .set_attribute(&flow_id, &set_attributes::KEYWORD, "keyword-1".to_string())
         .expect("set keyword Attribute");
     environment
         .client
-        .set_attribute(&flow_id, &workflow.full_text, "text-1".to_string())
+        .set_attribute(&flow_id, &set_attributes::FULL_TEXT, "text-1".to_string())
         .expect("set full-text Attribute");
     environment
         .client
-        .set_attribute(&flow_id, &workflow.decimal, 1.0)
+        .set_attribute(&flow_id, &set_attributes::DECIMAL, 1.0)
         .expect("set double Attribute");
     environment
         .client
-        .set_attribute(&flow_id, &workflow.integer, 1)
+        .set_attribute(&flow_id, &set_attributes::INTEGER, 1)
         .expect("set integer Attribute");
     environment
         .client
-        .set_attribute(&flow_id, &workflow.boolean, true)
+        .set_attribute(&flow_id, &set_attributes::BOOLEAN, true)
         .expect("set boolean Attribute");
     environment
         .client
-        .set_attribute(&flow_id, &workflow.keywords, keywords.clone())
+        .set_attribute(&flow_id, &set_attributes::KEYWORDS, keywords.clone())
         .expect("set keyword-array Attribute");
     environment
         .client
-        .set_attribute(&flow_id, &workflow.datetime, datetime)
+        .set_attribute(&flow_id, &set_attributes::DATETIME, datetime)
         .expect("set datetime Attribute");
     environment
         .client
-        .publish(&flow_id, &workflow.proceed, ())
+        .publish(&flow_id, &set_attributes::PROCEED, ())
         .expect("publish proceed message");
     assert_eq!(
         "test-result",
@@ -159,49 +161,49 @@ fn test_set_indexed_attributes() {
         Some("keyword-1".to_string()),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.keyword)
+            .get_attribute(&flow_id, &set_attributes::KEYWORD)
             .expect("get keyword Attribute")
     );
     assert_eq!(
         Some("text-1".to_string()),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.full_text)
+            .get_attribute(&flow_id, &set_attributes::FULL_TEXT)
             .expect("get full-text Attribute")
     );
     assert_eq!(
         Some(1.0),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.decimal)
+            .get_attribute(&flow_id, &set_attributes::DECIMAL)
             .expect("get double Attribute")
     );
     assert_eq!(
         Some(1),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.integer)
+            .get_attribute(&flow_id, &set_attributes::INTEGER)
             .expect("get integer Attribute")
     );
     assert_eq!(
         Some(true),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.boolean)
+            .get_attribute(&flow_id, &set_attributes::BOOLEAN)
             .expect("get boolean Attribute")
     );
     assert_eq!(
         Some(keywords),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.keywords)
+            .get_attribute(&flow_id, &set_attributes::KEYWORDS)
             .expect("get keyword-array Attribute")
     );
     assert_eq!(
         Some(datetime),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.datetime)
+            .get_attribute(&flow_id, &set_attributes::DATETIME)
             .expect("get datetime Attribute")
     );
 }
@@ -221,7 +223,7 @@ fn test_set_data_attributes() {
     assert!(matches!(
         environment.client.wait_for_attribute_equal(
             &flow_id,
-            &workflow.data,
+            &set_attributes::DATA,
             "never".to_string(),
             Duration::from_secs(1),
         ),
@@ -231,14 +233,14 @@ fn test_set_data_attributes() {
         let waiting = scope.spawn(|| {
             environment.client.wait_for_attribute_equal(
                 &flow_id,
-                &workflow.data,
+                &set_attributes::DATA,
                 "query-start".to_string(),
                 Duration::from_secs(30),
             )
         });
         environment
             .client
-            .set_attribute(&flow_id, &workflow.data, "query-start".to_string())
+            .set_attribute(&flow_id, &set_attributes::DATA, "query-start".to_string())
             .expect("set data Attribute");
         waiting
             .join()
@@ -272,7 +274,7 @@ fn test_set_data_attributes() {
     assert!(matches!(
         environment.client.wait_for_attribute_equal(
             &flow_id,
-            &workflow.model,
+            &set_attributes::MODEL,
             PersistenceModel { value: 8 },
             Duration::from_secs(30),
         ),
@@ -307,11 +309,15 @@ fn test_set_data_attributes() {
         .expect("set AttributeMap entry");
     environment
         .client
-        .set_attribute(&flow_id, &workflow.model, PersistenceModel { value: 7 })
+        .set_attribute(
+            &flow_id,
+            &set_attributes::MODEL,
+            PersistenceModel { value: 7 },
+        )
         .expect("set model Attribute");
     environment
         .client
-        .publish(&flow_id, &workflow.proceed, ())
+        .publish(&flow_id, &set_attributes::PROCEED, ())
         .expect("publish proceed message");
     assert_eq!(
         "test-result",
@@ -325,7 +331,7 @@ fn test_set_data_attributes() {
         Some("query-start".to_string()),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.data)
+            .get_attribute(&flow_id, &set_attributes::DATA)
             .expect("get data Attribute")
     );
     assert_eq!(
@@ -339,7 +345,7 @@ fn test_set_data_attributes() {
         Some(PersistenceModel { value: 7 }),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.model)
+            .get_attribute(&flow_id, &set_attributes::MODEL)
             .expect("get model Attribute")
     );
 }
@@ -348,14 +354,14 @@ fn test_set_data_attributes() {
 fn compile_persistence_reads(client: &Client) -> SdkResult<()> {
     let workflow = PersistenceWorkflow::new();
     let options = StartFlowOptions::new()
-        .initial_attribute(&workflow.initial, "initial".to_string())
+        .initial_attribute(&persistence::INITIAL, "initial".to_string())
         .initial_attribute_map(&workflow.data_map, "one", "initial".to_string());
     client.start_flow_with_options(&workflow, "persistence", "input".to_string(), options)?;
-    let _: Option<String> = client.get_attribute("persistence", &workflow.data)?;
+    let _: Option<String> = client.get_attribute("persistence", &persistence::DATA)?;
     let _: Option<String> =
         client.get_attribute_map_instance("persistence", &workflow.data_map, "one")?;
-    let _: Option<i32> = client.get_attribute("persistence", &workflow.integer)?;
-    let _: Option<SystemTime> = client.get_attribute("persistence", &workflow.datetime)?;
+    let _: Option<i32> = client.get_attribute("persistence", &persistence::INTEGER)?;
+    let _: Option<SystemTime> = client.get_attribute("persistence", &persistence::DATETIME)?;
     Ok(())
 }
 
@@ -363,25 +369,29 @@ fn compile_persistence_reads(client: &Client) -> SdkResult<()> {
 fn compile_persistence_writes(client: &Client) -> SdkResult<()> {
     let workflow = PersistenceSetAttributesWorkflow::new();
     client.start_flow(&workflow, "set-attributes", "input".to_string())?;
-    client.set_attribute("set-attributes", &workflow.data, "value".to_string())?;
+    client.set_attribute("set-attributes", &set_attributes::DATA, "value".to_string())?;
     client.set_attribute_map_instance(
         "set-attributes",
         &workflow.data_map,
         "one",
         "value".to_string(),
     )?;
-    client.set_attribute("set-attributes", &workflow.keyword, "keyword".to_string())?;
-    client.set_attribute("set-attributes", &workflow.decimal, 1.5)?;
-    client.set_attribute("set-attributes", &workflow.integer, 1)?;
-    client.set_attribute("set-attributes", &workflow.boolean, true)?;
     client.set_attribute(
         "set-attributes",
-        &workflow.keywords,
+        &set_attributes::KEYWORD,
+        "keyword".to_string(),
+    )?;
+    client.set_attribute("set-attributes", &set_attributes::DECIMAL, 1.5)?;
+    client.set_attribute("set-attributes", &set_attributes::INTEGER, 1)?;
+    client.set_attribute("set-attributes", &set_attributes::BOOLEAN, true)?;
+    client.set_attribute(
+        "set-attributes",
+        &set_attributes::KEYWORDS,
         vec!["one".to_string(), "two".to_string()],
     )?;
     client.wait_for_attribute_equal(
         "set-attributes",
-        &workflow.data,
+        &set_attributes::DATA,
         "value".to_string(),
         Duration::from_secs(30),
     )?;

--- a/sdk-rust/crates/dex-sdk/tests/integ/persistence_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/persistence_workflow.rs
@@ -17,15 +17,17 @@ use dex_sdk::{
     PersistenceSchema, Step, StepDecision, StepList, Wait,
 };
 
-static INITIAL: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("data-obj-0"));
-static DATA: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("data-obj-1"));
-static MODEL: LazyLock<Attribute<PersistenceModel>> =
+pub(crate) static INITIAL: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("data-obj-0"));
+pub(crate) static DATA: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("data-obj-1"));
+pub(crate) static MODEL: LazyLock<Attribute<PersistenceModel>> =
     LazyLock::new(|| Attribute::new("data-obj-2"));
-static KEYWORD: LazyLock<Attribute<String>> =
+pub(crate) static KEYWORD: LazyLock<Attribute<String>> =
     LazyLock::new(|| Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword()));
-static INTEGER: LazyLock<Attribute<i32>> =
+pub(crate) static INTEGER: LazyLock<Attribute<i32>> =
     LazyLock::new(|| Attribute::new("CustomIntField").indexed(AttributeIndex::int()));
-static DATETIME: LazyLock<Attribute<SystemTime>> =
+pub(crate) static DATETIME: LazyLock<Attribute<SystemTime>> =
     LazyLock::new(|| Attribute::new("CustomDatetimeField").indexed(AttributeIndex::date_time()));
 
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -34,40 +36,18 @@ pub(crate) struct PersistenceModel {
 }
 
 pub(crate) struct PersistenceWorkflow {
-    pub(crate) initial: Attribute<String>,
-    pub(crate) data: Attribute<String>,
-    pub(crate) model: Attribute<PersistenceModel>,
     pub(crate) data_map: AttributeMap<String>,
-    pub(crate) keyword: Attribute<String>,
-    pub(crate) integer: Attribute<i32>,
-    pub(crate) datetime: Attribute<SystemTime>,
     start: PersistenceStep,
 }
 
 impl PersistenceWorkflow {
     pub(crate) fn new() -> Self {
-        let data = DATA.clone();
-        let model = MODEL.clone();
         let data_map = AttributeMap::new("data-map");
-        let keyword = KEYWORD.clone();
-        let integer = INTEGER.clone();
-        let datetime = DATETIME.clone();
         Self {
-            initial: INITIAL.clone(),
             start: PersistenceStep {
-                data: data.clone(),
-                model: model.clone(),
                 data_map: data_map.clone(),
-                keyword: keyword.clone(),
-                integer: integer.clone(),
-                datetime: datetime.clone(),
             },
-            data,
-            model,
             data_map,
-            keyword,
-            integer,
-            datetime,
         }
     }
 }
@@ -81,30 +61,25 @@ impl Flow for PersistenceWorkflow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&self.initial)
-            .attribute(&self.data)
-            .attribute(&self.model)
+            .attribute(&INITIAL)
+            .attribute(&DATA)
+            .attribute(&MODEL)
             .attribute_map(&self.data_map)
-            .attribute(&self.keyword)
-            .attribute(&self.integer)
-            .attribute(&self.datetime)
+            .attribute(&KEYWORD)
+            .attribute(&INTEGER)
+            .attribute(&DATETIME)
     }
 }
 
 struct PersistenceStep {
-    data: Attribute<String>,
-    model: Attribute<PersistenceModel>,
     data_map: AttributeMap<String>,
-    keyword: Attribute<String>,
-    integer: Attribute<i32>,
-    datetime: Attribute<SystemTime>,
 }
 
 impl Step for PersistenceStep {
     type Input = String;
 
     fn wait_for(&self, context: &mut Context, input: String) -> HandlerResult<Wait> {
-        self.data.set(context, input.clone())?;
+        DATA.set(context, input.clone())?;
         self.data_map.set(context, "one", input.clone())?;
         context.set_step_execution_local("local", input.clone())?;
         context.record_event("written", input)?;
@@ -119,16 +94,14 @@ impl Step for PersistenceStep {
                 "step execution local did not round trip",
             ));
         }
-        self.keyword.set(context, input)?;
-        self.integer.set(context, 1)?;
-        self.datetime.set(
+        KEYWORD.set(context, input)?;
+        INTEGER.set(context, 1)?;
+        DATETIME.set(
             context,
             SystemTime::UNIX_EPOCH + Duration::from_secs(1_681_766_269),
         )?;
-        self.model.set(context, PersistenceModel { value: 0 })?;
+        MODEL.set(context, PersistenceModel { value: 0 })?;
         self.data_map.delete(context, "one")?;
-        Ok(StepDecision::graceful_complete(
-            self.data.get_required(context)?,
-        ))
+        Ok(StepDecision::graceful_complete(DATA.get_required(context)?))
     }
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/persistence_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/persistence_workflow.rs
@@ -10,10 +10,23 @@
 
 use std::time::{Duration, SystemTime};
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, AttributeIndex, AttributeMap, Context, Flow, HandlerError, HandlerResult,
     PersistenceSchema, Step, StepDecision, StepList, Wait,
 };
+
+static INITIAL: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("data-obj-0"));
+static DATA: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("data-obj-1"));
+static MODEL: LazyLock<Attribute<PersistenceModel>> =
+    LazyLock::new(|| Attribute::new("data-obj-2"));
+static KEYWORD: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword()));
+static INTEGER: LazyLock<Attribute<i32>> =
+    LazyLock::new(|| Attribute::new("CustomIntField").indexed(AttributeIndex::int()));
+static DATETIME: LazyLock<Attribute<SystemTime>> =
+    LazyLock::new(|| Attribute::new("CustomDatetimeField").indexed(AttributeIndex::date_time()));
 
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub(crate) struct PersistenceModel {
@@ -33,14 +46,14 @@ pub(crate) struct PersistenceWorkflow {
 
 impl PersistenceWorkflow {
     pub(crate) fn new() -> Self {
-        let data = Attribute::new("data-obj-1");
-        let model = Attribute::new("data-obj-2");
+        let data = DATA.clone();
+        let model = MODEL.clone();
         let data_map = AttributeMap::new("data-map");
-        let keyword = Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword());
-        let integer = Attribute::new("CustomIntField").indexed(AttributeIndex::int());
-        let datetime = Attribute::new("CustomDatetimeField").indexed(AttributeIndex::date_time());
+        let keyword = KEYWORD.clone();
+        let integer = INTEGER.clone();
+        let datetime = DATETIME.clone();
         Self {
-            initial: Attribute::new("data-obj-0"),
+            initial: INITIAL.clone(),
             start: PersistenceStep {
                 data: data.clone(),
                 model: model.clone(),

--- a/sdk-rust/crates/dex-sdk/tests/integ/reset_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/reset_test.rs
@@ -15,7 +15,7 @@ use dex_sdk::{
     TimeTravelStepMethod,
 };
 
-use crate::reset_workflow::ResetWorkflow;
+use crate::reset_workflow::{COUNTER, DATA, EXECUTION_COUNT, KEYWORD, ResetWorkflow};
 use crate::support::{DexDevTestEnvironment, flow_id};
 
 #[test]
@@ -129,28 +129,28 @@ fn assert_completed_with_attributes(
         Some(ResetWorkflow::EXPECTED_VALUE.to_string()),
         environment
             .client
-            .get_attribute(flow_id, &workflow.data)
+            .get_attribute(flow_id, &DATA)
             .expect("get reset data Attribute")
     );
     assert_eq!(
         Some(ResetWorkflow::EXPECTED_VALUE.to_string()),
         environment
             .client
-            .get_attribute(flow_id, &workflow.keyword)
+            .get_attribute(flow_id, &KEYWORD)
             .expect("get reset keyword Attribute")
     );
     assert_eq!(
         Some(100),
         environment
             .client
-            .get_attribute(flow_id, &workflow.counter)
+            .get_attribute(flow_id, &COUNTER)
             .expect("get reset counter Attribute")
     );
     assert_eq!(
         Some(2),
         environment
             .client
-            .get_attribute(flow_id, &workflow.execution_count)
+            .get_attribute(flow_id, &EXECUTION_COUNT)
             .expect("get reset execution-count Attribute")
     );
     let item = environment
@@ -180,28 +180,28 @@ fn assert_reset_times_out_without_attributes(
         None,
         environment
             .client
-            .get_attribute(flow_id, &workflow.data)
+            .get_attribute(flow_id, &DATA)
             .expect("get cleared reset data Attribute")
     );
     assert_eq!(
         None,
         environment
             .client
-            .get_attribute(flow_id, &workflow.keyword)
+            .get_attribute(flow_id, &KEYWORD)
             .expect("get cleared reset keyword Attribute")
     );
     assert_eq!(
         None,
         environment
             .client
-            .get_attribute(flow_id, &workflow.counter)
+            .get_attribute(flow_id, &COUNTER)
             .expect("get cleared reset counter Attribute")
     );
     assert_eq!(
         None,
         environment
             .client
-            .get_attribute(flow_id, &workflow.execution_count)
+            .get_attribute(flow_id, &EXECUTION_COUNT)
             .expect("get cleared reset execution-count Attribute")
     );
     assert_eq!(

--- a/sdk-rust/crates/dex-sdk/tests/integ/reset_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/reset_workflow.rs
@@ -16,22 +16,18 @@ use dex_sdk::{
     StepOptions, Wait,
 };
 
-static EXECUTION_COUNT: LazyLock<Attribute<i32>> =
+pub(crate) static EXECUTION_COUNT: LazyLock<Attribute<i32>> =
     LazyLock::new(|| Attribute::new("reset-execution-count"));
-static CHANNEL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("rpc-channel"));
-static DATA: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("rpc-lock-data"));
-static KEYWORD: LazyLock<Attribute<String>> =
+pub(crate) static CHANNEL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("rpc-channel"));
+pub(crate) static DATA: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("rpc-lock-data"));
+pub(crate) static KEYWORD: LazyLock<Attribute<String>> =
     LazyLock::new(|| Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword()));
-static COUNTER: LazyLock<Attribute<i32>> =
+pub(crate) static COUNTER: LazyLock<Attribute<i32>> =
     LazyLock::new(|| Attribute::new("CustomIntField").indexed(AttributeIndex::int()));
 
 pub(crate) struct ResetWorkflow {
-    channel: Channel<()>,
-    pub(crate) data: Attribute<String>,
-    pub(crate) keyword: Attribute<String>,
-    pub(crate) counter: Attribute<i32>,
     pub(crate) items: AttributeMap<String>,
-    pub(crate) execution_count: Attribute<i32>,
     pub(crate) first: LockWaitStep,
     second: LockCompleteStep,
 }
@@ -43,31 +39,17 @@ impl ResetWorkflow {
     pub(crate) const WITHOUT_LOCKING: Rpc<(), ()> = Rpc::new("without_locking");
 
     pub(crate) fn new() -> Self {
-        let channel = CHANNEL.clone();
-        let data = DATA.clone();
-        let keyword = KEYWORD.clone();
-        let counter = COUNTER.clone();
         let items = AttributeMap::new("rpc-lock-items");
-        let execution_count = EXECUTION_COUNT.clone();
         Self {
-            first: LockWaitStep {
-                channel: channel.clone(),
-            },
-            second: LockCompleteStep {
-                execution_count: execution_count.clone(),
-            },
-            channel,
-            data,
-            keyword,
-            counter,
+            first: LockWaitStep,
+            second: LockCompleteStep,
             items,
-            execution_count,
         }
     }
 
     fn with_locking(&self, context: &mut Context) -> HandlerResult<RpcResult<()>> {
         self.write_attributes(context)?;
-        self.channel.publish(context, ())?;
+        CHANNEL.publish(context, ())?;
         Ok(RpcResult::new(()).then(StepMovement::to(&self.second, ())))
     }
 
@@ -77,15 +59,14 @@ impl ResetWorkflow {
 
     fn without_locking(&self, context: &mut Context) -> HandlerResult<RpcResult<()>> {
         self.write_attributes(context)?;
-        self.channel.publish(context, ())?;
+        CHANNEL.publish(context, ())?;
         Ok(RpcResult::new(()).then(StepMovement::to(&self.second, ())))
     }
 
     fn write_attributes(&self, context: &mut Context) -> HandlerResult<()> {
-        self.data.set(context, Self::EXPECTED_VALUE.to_string())?;
-        self.keyword
-            .set(context, Self::EXPECTED_VALUE.to_string())?;
-        self.counter.set(context, 100)
+        DATA.set(context, Self::EXPECTED_VALUE.to_string())?;
+        KEYWORD.set(context, Self::EXPECTED_VALUE.to_string())?;
+        COUNTER.set(context, 100)
     }
 }
 
@@ -98,21 +79,21 @@ impl Flow for ResetWorkflow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&self.data)
-            .attribute(&self.keyword)
-            .attribute(&self.counter)
+            .attribute(&DATA)
+            .attribute(&KEYWORD)
+            .attribute(&COUNTER)
             .attribute_map(&self.items)
-            .attribute(&self.execution_count)
-            .channel(&self.channel)
+            .attribute(&EXECUTION_COUNT)
+            .channel(&CHANNEL)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
         RpcList::new()
             .function_without_input(
                 Self::WITH_LOCKING
-                    .lock(self.data.lock())
-                    .lock(self.keyword.lock())
-                    .lock(self.counter.lock()),
+                    .lock(DATA.lock())
+                    .lock(KEYWORD.lock())
+                    .lock(COUNTER.lock()),
                 Self::with_locking,
             )
             .procedure_without_input(
@@ -123,41 +104,32 @@ impl Flow for ResetWorkflow {
     }
 }
 
-pub(crate) struct LockWaitStep {
-    channel: Channel<()>,
-}
+pub(crate) struct LockWaitStep;
 
 impl Step for LockWaitStep {
     type Input = ();
 
     fn wait_for(&self, _context: &mut Context, (): ()) -> HandlerResult<Wait> {
-        Ok(Wait::until(self.channel.for_one()))
+        Ok(Wait::until(CHANNEL.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, (): ()) -> HandlerResult<StepDecision> {
-        Ok(StepDecision::go_to(
-            &LockCompleteStep {
-                execution_count: EXECUTION_COUNT.clone(),
-            },
-            (),
-        ))
+        Ok(StepDecision::go_to(&LockCompleteStep, ()))
     }
 }
 
-struct LockCompleteStep {
-    execution_count: Attribute<i32>,
-}
+struct LockCompleteStep;
 
 impl Step for LockCompleteStep {
     type Input = ();
 
     fn execute(&self, context: &mut Context, (): ()) -> HandlerResult<StepDecision> {
-        let next = self.execution_count.get(context)?.unwrap_or_default() + 1;
-        self.execution_count.set(context, next)?;
+        let next = EXECUTION_COUNT.get(context)?.unwrap_or_default() + 1;
+        EXECUTION_COUNT.set(context, next)?;
         Ok(StepDecision::graceful_complete(next))
     }
 
     fn options(&self) -> StepOptions<Self::Input> {
-        StepOptions::new().execute_lock(self.execution_count.lock())
+        StepOptions::new().execute_lock(EXECUTION_COUNT.lock())
     }
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/reset_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/reset_workflow.rs
@@ -8,11 +8,22 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, AttributeIndex, AttributeMap, Channel, Context, Flow, HandlerResult,
     PersistenceSchema, Rpc, RpcList, RpcResult, Step, StepDecision, StepList, StepMovement,
     StepOptions, Wait,
 };
+
+static EXECUTION_COUNT: LazyLock<Attribute<i32>> =
+    LazyLock::new(|| Attribute::new("reset-execution-count"));
+static CHANNEL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("rpc-channel"));
+static DATA: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("rpc-lock-data"));
+static KEYWORD: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword()));
+static COUNTER: LazyLock<Attribute<i32>> =
+    LazyLock::new(|| Attribute::new("CustomIntField").indexed(AttributeIndex::int()));
 
 pub(crate) struct ResetWorkflow {
     channel: Channel<()>,
@@ -32,12 +43,12 @@ impl ResetWorkflow {
     pub(crate) const WITHOUT_LOCKING: Rpc<(), ()> = Rpc::new("without_locking");
 
     pub(crate) fn new() -> Self {
-        let channel = Channel::new("rpc-channel");
-        let data = Attribute::new("rpc-lock-data");
-        let keyword = Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword());
-        let counter = Attribute::new("CustomIntField").indexed(AttributeIndex::int());
+        let channel = CHANNEL.clone();
+        let data = DATA.clone();
+        let keyword = KEYWORD.clone();
+        let counter = COUNTER.clone();
         let items = AttributeMap::new("rpc-lock-items");
-        let execution_count = Attribute::new("reset-execution-count");
+        let execution_count = EXECUTION_COUNT.clone();
         Self {
             first: LockWaitStep {
                 channel: channel.clone(),
@@ -126,7 +137,7 @@ impl Step for LockWaitStep {
     fn execute(&self, _context: &mut Context, (): ()) -> HandlerResult<StepDecision> {
         Ok(StepDecision::go_to(
             &LockCompleteStep {
-                execution_count: Attribute::new("reset-execution-count"),
+                execution_count: EXECUTION_COUNT.clone(),
             },
             (),
         ))

--- a/sdk-rust/crates/dex-sdk/tests/integ/rpc_no_state_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/rpc_no_state_workflow.rs
@@ -19,9 +19,7 @@ use crate::rpc_workflow::RpcWorkflow;
 
 static COUNTER: LazyLock<Attribute<i32>> = LazyLock::new(|| Attribute::new("counter"));
 
-pub(crate) struct RpcNoStateWorkflow {
-    counter: Attribute<i32>,
-}
+pub(crate) struct RpcNoStateWorkflow {}
 
 impl RpcNoStateWorkflow {
     pub(crate) const RPC_OUTPUT: i64 = 100;
@@ -31,19 +29,17 @@ impl RpcNoStateWorkflow {
     pub(crate) const INVOKE: Rpc<String, i64> = Rpc::new("invoke");
 
     pub(crate) fn new() -> Self {
-        Self {
-            counter: COUNTER.clone(),
-        }
+        Self {}
     }
 
     fn increase_counter(&self, context: &mut Context) -> HandlerResult<RpcResult<i32>> {
-        let next = self.counter.get(context)?.unwrap_or_default() + 1;
-        self.counter.set(context, next)?;
+        let next = COUNTER.get(context)?.unwrap_or_default() + 1;
+        COUNTER.set(context, next)?;
         Ok(RpcResult::new(next))
     }
 
     fn get_counter(&self, context: &mut Context) -> HandlerResult<RpcResult<Option<i32>>> {
-        Ok(RpcResult::new(self.counter.get(context)?))
+        Ok(RpcResult::new(COUNTER.get(context)?))
     }
 
     fn fail(&self, _context: &mut Context, input: String) -> HandlerResult<RpcResult<i64>> {
@@ -65,13 +61,13 @@ impl Flow for RpcNoStateWorkflow {
     type StartInput = ();
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().attribute(&self.counter)
+        PersistenceSchema::new().attribute(&COUNTER)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
         RpcList::new()
             .function_without_input(
-                Self::INCREASE_COUNTER.lock(self.counter.lock()),
+                Self::INCREASE_COUNTER.lock(COUNTER.lock()),
                 Self::increase_counter,
             )
             .function_without_input(Self::GET_COUNTER, Self::get_counter)

--- a/sdk-rust/crates/dex-sdk/tests/integ/rpc_no_state_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/rpc_no_state_workflow.rs
@@ -8,12 +8,16 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Context, Flow, HandlerError, HandlerResult, PersistenceSchema, Rpc, RpcList,
     RpcResult,
 };
 
 use crate::rpc_workflow::RpcWorkflow;
+
+static COUNTER: LazyLock<Attribute<i32>> = LazyLock::new(|| Attribute::new("counter"));
 
 pub(crate) struct RpcNoStateWorkflow {
     counter: Attribute<i32>,
@@ -28,7 +32,7 @@ impl RpcNoStateWorkflow {
 
     pub(crate) fn new() -> Self {
         Self {
-            counter: Attribute::new("counter"),
+            counter: COUNTER.clone(),
         }
     }
 

--- a/sdk-rust/crates/dex-sdk/tests/integ/rpc_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/rpc_test.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use dex_sdk::{Client, GrpcCode, Registry, SdkError, SdkResult, StopFlowOptions};
 
-use crate::no_start_state_dead_end_workflow::NoStartStateDeadEndWorkflow;
+use crate::no_start_state_dead_end_workflow::{IDLE_SIGNAL, NoStartStateDeadEndWorkflow};
 use crate::rpc_no_state_workflow::RpcNoStateWorkflow;
 use crate::rpc_workflow::RpcWorkflow;
 use crate::support::{DexDevTestEnvironment, flow_id};
@@ -236,7 +236,7 @@ fn test_signal_channel_size_info() {
     );
     environment
         .client
-        .publish_many(&flow_id, &workflow.idle_signal, [(), (), ()])
+        .publish_many(&flow_id, &IDLE_SIGNAL, [(), (), ()])
         .expect("publish external messages");
     assert_eq!(
         3,

--- a/sdk-rust/crates/dex-sdk/tests/integ/rpc_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/rpc_test.rs
@@ -15,7 +15,7 @@ use dex_sdk::{Client, GrpcCode, Registry, SdkError, SdkResult, StopFlowOptions};
 
 use crate::no_start_state_dead_end_workflow::{IDLE_SIGNAL, NoStartStateDeadEndWorkflow};
 use crate::rpc_no_state_workflow::RpcNoStateWorkflow;
-use crate::rpc_workflow::RpcWorkflow;
+use crate::rpc_workflow::{DATA, INTEGER, KEYWORD, RpcWorkflow};
 use crate::support::{DexDevTestEnvironment, flow_id};
 
 #[test]
@@ -319,7 +319,7 @@ pub(crate) fn verify_optional_rpc_attributes(environment: &DexDevTestEnvironment
 
 pub(crate) fn assert_rpc_completion(
     environment: &DexDevTestEnvironment,
-    workflow: &RpcWorkflow,
+    _workflow: &RpcWorkflow,
     flow_id: &str,
     expected_value: &str,
 ) {
@@ -335,21 +335,21 @@ pub(crate) fn assert_rpc_completion(
         Some(expected_value.to_string()),
         environment
             .client
-            .get_attribute(flow_id, &workflow.data)
+            .get_attribute(flow_id, &DATA)
             .expect("get data Attribute")
     );
     assert_eq!(
         Some(expected_value.to_string()),
         environment
             .client
-            .get_attribute(flow_id, &workflow.keyword)
+            .get_attribute(flow_id, &KEYWORD)
             .expect("get keyword Attribute")
     );
     assert_eq!(
         Some(RpcWorkflow::RPC_OUTPUT as i32),
         environment
             .client
-            .get_attribute(flow_id, &workflow.integer)
+            .get_attribute(flow_id, &INTEGER)
             .expect("get integer Attribute")
     );
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/rpc_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/rpc_workflow.rs
@@ -8,10 +8,19 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, AttributeIndex, AttributeMap, Channel, Context, Flow, HandlerError, HandlerResult,
     PersistenceSchema, Rpc, RpcList, RpcResult, Step, StepDecision, StepList, Wait,
 };
+
+static DATA: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("rpc-data"));
+static KEYWORD: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword()));
+static INTEGER: LazyLock<Attribute<i32>> =
+    LazyLock::new(|| Attribute::new("CustomIntField").indexed(AttributeIndex::int()));
+static INTERNAL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("rpc-internal"));
 
 pub(crate) struct RpcWorkflow {
     internal: Channel<()>,
@@ -39,16 +48,16 @@ impl RpcWorkflow {
     pub(crate) const GET_KEYWORD: Rpc<(), Option<String>> = Rpc::new("get_keyword");
 
     pub(crate) fn new() -> Self {
-        let internal = Channel::new("rpc-internal");
+        let internal = INTERNAL.clone();
         Self {
             first: FirstStep {
                 internal: internal.clone(),
             },
             output: OutputStep,
             internal,
-            data: Attribute::new("rpc-data"),
-            keyword: Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword()),
-            integer: Attribute::new("CustomIntField").indexed(AttributeIndex::int()),
+            data: DATA.clone(),
+            keyword: KEYWORD.clone(),
+            integer: INTEGER.clone(),
             map: AttributeMap::new("rpc-map"),
         }
     }

--- a/sdk-rust/crates/dex-sdk/tests/integ/rpc_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/rpc_workflow.rs
@@ -15,18 +15,14 @@ use dex_sdk::{
     PersistenceSchema, Rpc, RpcList, RpcResult, Step, StepDecision, StepList, Wait,
 };
 
-static DATA: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("rpc-data"));
-static KEYWORD: LazyLock<Attribute<String>> =
+pub(crate) static DATA: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("rpc-data"));
+pub(crate) static KEYWORD: LazyLock<Attribute<String>> =
     LazyLock::new(|| Attribute::new("CustomKeywordField").indexed(AttributeIndex::keyword()));
-static INTEGER: LazyLock<Attribute<i32>> =
+pub(crate) static INTEGER: LazyLock<Attribute<i32>> =
     LazyLock::new(|| Attribute::new("CustomIntField").indexed(AttributeIndex::int()));
-static INTERNAL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("rpc-internal"));
+pub(crate) static INTERNAL: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("rpc-internal"));
 
 pub(crate) struct RpcWorkflow {
-    internal: Channel<()>,
-    pub(crate) data: Attribute<String>,
-    pub(crate) keyword: Attribute<String>,
-    pub(crate) integer: Attribute<i32>,
     map: AttributeMap<String>,
     first: FirstStep,
     output: OutputStep,
@@ -48,58 +44,51 @@ impl RpcWorkflow {
     pub(crate) const GET_KEYWORD: Rpc<(), Option<String>> = Rpc::new("get_keyword");
 
     pub(crate) fn new() -> Self {
-        let internal = INTERNAL.clone();
         Self {
-            first: FirstStep {
-                internal: internal.clone(),
-            },
+            first: FirstStep,
             output: OutputStep,
-            internal,
-            data: DATA.clone(),
-            keyword: KEYWORD.clone(),
-            integer: INTEGER.clone(),
             map: AttributeMap::new("rpc-map"),
         }
     }
 
     fn publish_without_attribute_access(&self, context: &mut Context) -> HandlerResult<()> {
         Self::require_context(context)?;
-        self.internal.publish(context, ())
+        INTERNAL.publish(context, ())
     }
 
     fn function_one(&self, context: &mut Context, input: String) -> HandlerResult<RpcResult<i64>> {
         Self::require_context(context)?;
-        self.data.delete(context)?;
-        self.data.set(context, input.clone())?;
-        self.keyword.set(context, input)?;
-        self.integer.set(context, Self::RPC_OUTPUT as i32)?;
-        self.internal.publish(context, ())?;
+        DATA.delete(context)?;
+        DATA.set(context, input.clone())?;
+        KEYWORD.set(context, input)?;
+        INTEGER.set(context, Self::RPC_OUTPUT as i32)?;
+        INTERNAL.publish(context, ())?;
         Ok(RpcResult::new(Self::RPC_OUTPUT))
     }
 
     fn function_zero(&self, context: &mut Context) -> HandlerResult<RpcResult<i64>> {
         Self::require_context(context)?;
-        self.data.set(context, Self::HARDCODED_VALUE.into())?;
-        self.keyword.set(context, Self::HARDCODED_VALUE.into())?;
-        self.integer.set(context, Self::RPC_OUTPUT as i32)?;
-        self.internal.publish(context, ())?;
+        DATA.set(context, Self::HARDCODED_VALUE.into())?;
+        KEYWORD.set(context, Self::HARDCODED_VALUE.into())?;
+        INTEGER.set(context, Self::RPC_OUTPUT as i32)?;
+        INTERNAL.publish(context, ())?;
         Ok(RpcResult::new(Self::RPC_OUTPUT))
     }
 
     fn procedure_one(&self, context: &mut Context, input: String) -> HandlerResult<()> {
         Self::require_context(context)?;
-        self.data.set(context, input.clone())?;
-        self.keyword.set(context, input)?;
-        self.integer.set(context, Self::RPC_OUTPUT as i32)?;
-        self.internal.publish(context, ())
+        DATA.set(context, input.clone())?;
+        KEYWORD.set(context, input)?;
+        INTEGER.set(context, Self::RPC_OUTPUT as i32)?;
+        INTERNAL.publish(context, ())
     }
 
     fn procedure_zero(&self, context: &mut Context) -> HandlerResult<()> {
         Self::require_context(context)?;
-        self.data.set(context, Self::HARDCODED_VALUE.into())?;
-        self.keyword.set(context, Self::HARDCODED_VALUE.into())?;
-        self.integer.set(context, Self::RPC_OUTPUT as i32)?;
-        self.internal.publish(context, ())
+        DATA.set(context, Self::HARDCODED_VALUE.into())?;
+        KEYWORD.set(context, Self::HARDCODED_VALUE.into())?;
+        INTEGER.set(context, Self::RPC_OUTPUT as i32)?;
+        INTERNAL.publish(context, ())
     }
 
     fn read_only(&self, context: &mut Context, _input: String) -> HandlerResult<RpcResult<i64>> {
@@ -108,19 +97,19 @@ impl RpcWorkflow {
     }
 
     fn set_data(&self, context: &mut Context, input: Option<String>) -> HandlerResult<()> {
-        Self::set_optional(context, &self.data, input)
+        Self::set_optional(context, &DATA, input)
     }
 
     fn get_data(&self, context: &mut Context) -> HandlerResult<RpcResult<Option<String>>> {
-        Ok(RpcResult::new(self.data.get(context)?))
+        Ok(RpcResult::new(DATA.get(context)?))
     }
 
     fn set_keyword(&self, context: &mut Context, input: Option<String>) -> HandlerResult<()> {
-        Self::set_optional(context, &self.keyword, input)
+        Self::set_optional(context, &KEYWORD, input)
     }
 
     fn get_keyword(&self, context: &mut Context) -> HandlerResult<RpcResult<Option<String>>> {
-        Ok(RpcResult::new(self.keyword.get(context)?))
+        Ok(RpcResult::new(KEYWORD.get(context)?))
     }
 
     fn set_optional(
@@ -151,11 +140,11 @@ impl Flow for RpcWorkflow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&self.data)
-            .attribute(&self.keyword)
-            .attribute(&self.integer)
+            .attribute(&DATA)
+            .attribute(&KEYWORD)
+            .attribute(&INTEGER)
             .attribute_map(&self.map)
-            .channel(&self.internal)
+            .channel(&INTERNAL)
     }
 
     fn rpcs(&self) -> RpcList<Self> {
@@ -176,15 +165,13 @@ impl Flow for RpcWorkflow {
     }
 }
 
-struct FirstStep {
-    internal: Channel<()>,
-}
+struct FirstStep;
 
 impl Step for FirstStep {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, _input: i32) -> HandlerResult<Wait> {
-        Ok(Wait::until(self.internal.for_one()))
+        Ok(Wait::until(INTERNAL.for_one()))
     }
 
     fn execute(&self, _context: &mut Context, _input: i32) -> HandlerResult<StepDecision> {

--- a/sdk-rust/crates/dex-sdk/tests/integ/search_flows_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/search_flows_workflow.rs
@@ -8,10 +8,16 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, AttributeIndex, Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision,
     StepList,
 };
+
+static KEYWORD: LazyLock<Attribute<String>> = LazyLock::new(|| {
+    Attribute::new(SearchFlowsWorkflow::KEYWORD_KEY).indexed(AttributeIndex::keyword())
+});
 
 pub(crate) struct SearchFlowsWorkflow {
     keyword: Attribute<String>,
@@ -22,7 +28,7 @@ impl SearchFlowsWorkflow {
     pub(crate) const KEYWORD_KEY: &str = "CustomKeywordField";
 
     pub(crate) fn new() -> Self {
-        let keyword = Attribute::new(Self::KEYWORD_KEY).indexed(AttributeIndex::keyword());
+        let keyword = KEYWORD.clone();
         Self {
             start: IndexStep {
                 keyword: keyword.clone(),

--- a/sdk-rust/crates/dex-sdk/tests/integ/search_flows_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/search_flows_workflow.rs
@@ -20,7 +20,6 @@ static KEYWORD: LazyLock<Attribute<String>> = LazyLock::new(|| {
 });
 
 pub(crate) struct SearchFlowsWorkflow {
-    keyword: Attribute<String>,
     start: IndexStep,
 }
 
@@ -28,13 +27,7 @@ impl SearchFlowsWorkflow {
     pub(crate) const KEYWORD_KEY: &str = "CustomKeywordField";
 
     pub(crate) fn new() -> Self {
-        let keyword = KEYWORD.clone();
-        Self {
-            start: IndexStep {
-                keyword: keyword.clone(),
-            },
-            keyword,
-        }
+        Self { start: IndexStep }
     }
 }
 
@@ -46,19 +39,17 @@ impl Flow for SearchFlowsWorkflow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().attribute(&self.keyword)
+        PersistenceSchema::new().attribute(&KEYWORD)
     }
 }
 
-struct IndexStep {
-    keyword: Attribute<String>,
-}
+struct IndexStep;
 
 impl Step for IndexStep {
     type Input = String;
 
     fn execute(&self, context: &mut Context, input: String) -> HandlerResult<StepDecision> {
-        self.keyword.set(context, input.clone())?;
+        KEYWORD.set(context, input.clone())?;
         Ok(StepDecision::graceful_complete(input))
     }
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/signal_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/signal_test.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use dex_sdk::{Client, GrpcCode, Registry, SdkError, SdkResult, StepExecutionId, TimerId};
 
-use crate::signal_workflow::SignalWorkflow;
+use crate::signal_workflow::{FIRST, SignalWorkflow, THIRD};
 use crate::support::{DexDevTestEnvironment, flow_id};
 
 #[test]
@@ -27,11 +27,11 @@ fn test_basic_signal_workflow() {
         .expect("start signal Flow");
     environment
         .client
-        .publish_many(&flow_id, &workflow.first, [2, 3, 5])
+        .publish_many(&flow_id, &FIRST, [2, 3, 5])
         .expect("publish first signals");
     environment
         .client
-        .publish(&flow_id, &workflow.third, ())
+        .publish(&flow_id, &THIRD, ())
         .expect("publish null signal");
     environment
         .client
@@ -55,7 +55,7 @@ fn test_basic_signal_workflow() {
     );
     match environment
         .client
-        .publish(&flow_id, &workflow.first, 8)
+        .publish(&flow_id, &FIRST, 8)
         .expect_err("publishing to a closed Flow must fail")
     {
         SdkError::FlowNotActive { service } => {
@@ -69,8 +69,8 @@ fn test_basic_signal_workflow() {
 fn compile_signals_and_timer_skip(client: &Client) -> SdkResult<()> {
     let workflow = SignalWorkflow::new();
     client.start_flow(&workflow, "signal", 1)?;
-    client.publish_many("signal", &workflow.first, [2, 3, 5])?;
-    client.publish("signal", &workflow.third, ())?;
+    client.publish_many("signal", &FIRST, [2, 3, 5])?;
+    client.publish("signal", &THIRD, ())?;
     client.publish_map("signal", &workflow.signal_map, "one", [4])?;
     client.skip_timer(
         "signal",

--- a/sdk-rust/crates/dex-sdk/tests/integ/signal_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/signal_workflow.rs
@@ -17,14 +17,11 @@ use dex_sdk::{
     PersistenceSchema, Step, StepDecision, StepList, Timer, Wait,
 };
 
-static SECOND: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("signal-2"));
-static THIRD: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("signal-3"));
-static FIRST: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("signal-1"));
+pub(crate) static SECOND: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("signal-2"));
+pub(crate) static THIRD: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("signal-3"));
+pub(crate) static FIRST: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("signal-1"));
 
 pub(crate) struct SignalWorkflow {
-    pub(crate) first: Channel<i32>,
-    pub(crate) second: Channel<i32>,
-    pub(crate) third: Channel<()>,
     pub(crate) signal_map: ChannelMap<i32>,
     start: FirstStep,
     pub(crate) combination: CombinationStep,
@@ -32,24 +29,12 @@ pub(crate) struct SignalWorkflow {
 
 impl SignalWorkflow {
     pub(crate) fn new() -> Self {
-        let first = FIRST.clone();
-        let second = SECOND.clone();
-        let third = THIRD.clone();
         let signal_map = ChannelMap::new("signal-map");
         Self {
-            start: FirstStep {
-                first: first.clone(),
-                second: second.clone(),
-            },
+            start: FirstStep,
             combination: CombinationStep {
-                first: first.clone(),
-                second: second.clone(),
-                third: third.clone(),
                 signal_map: signal_map.clone(),
             },
-            first,
-            second,
-            third,
             signal_map,
         }
     }
@@ -64,41 +49,35 @@ impl Flow for SignalWorkflow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .channel(&self.first)
-            .channel(&self.second)
-            .channel(&self.third)
+            .channel(&FIRST)
+            .channel(&SECOND)
+            .channel(&THIRD)
             .channel_map(&self.signal_map)
     }
 }
 
-struct FirstStep {
-    first: Channel<i32>,
-    second: Channel<i32>,
-}
+struct FirstStep;
 
 impl Step for FirstStep {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, _input: i32) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
-            self.first.for_one().with_id("test-signal-id-1"),
-            self.second.for_one().with_id("test-signal-id-2"),
+            FIRST.for_one().with_id("test-signal-id-1"),
+            SECOND.for_one().with_id("test-signal-id-2"),
         ]))
     }
 
     fn execute(&self, context: &mut Context, input: i32) -> HandlerResult<StepDecision> {
-        if !self.second.condition_results(context)?.is_empty() {
+        if !SECOND.condition_results(context)?.is_empty() {
             return Err(HandlerError::new(
                 "SignalFailure",
                 "second signal should still be waiting",
             ));
         }
-        let value = self.first.condition_results(context)?[0];
+        let value = FIRST.condition_results(context)?[0];
         Ok(StepDecision::go_to(
             &CombinationStep {
-                first: self.first.clone(),
-                second: SECOND.clone(),
-                third: THIRD.clone(),
                 signal_map: ChannelMap::new("signal-map"),
             },
             input + value,
@@ -107,9 +86,6 @@ impl Step for FirstStep {
 }
 
 pub(crate) struct CombinationStep {
-    first: Channel<i32>,
-    second: Channel<i32>,
-    third: Channel<()>,
     signal_map: ChannelMap<i32>,
 }
 
@@ -118,21 +94,21 @@ impl Step for CombinationStep {
 
     fn wait_for(&self, _context: &mut Context, _input: i32) -> HandlerResult<Wait> {
         Ok(Wait::any_combination_of([ConditionCombination::all_of([
-            self.first.for_one().with_id("signal-1"),
-            self.third.for_one().with_id("signal-3"),
+            FIRST.for_one().with_id("signal-1"),
+            THIRD.for_one().with_id("signal-3"),
             self.signal_map.for_one("one").with_id("signal-map"),
             Timer::by_duration(Duration::from_secs(365 * 24 * 60 * 60)).with_id("test-timer-id"),
         ])]))
     }
 
     fn execute(&self, context: &mut Context, input: i32) -> HandlerResult<StepDecision> {
-        if !self.second.condition_results(context)?.is_empty() {
+        if !SECOND.condition_results(context)?.is_empty() {
             return Err(HandlerError::new(
                 "SignalFailure",
                 "second signal should still be waiting",
             ));
         }
-        if self.third.condition_results(context)?.len() != 1 {
+        if THIRD.condition_results(context)?.len() != 1 {
             return Err(HandlerError::new(
                 "SignalFailure",
                 "null signal was not received",
@@ -148,7 +124,7 @@ impl Step for CombinationStep {
             return Err(HandlerError::new("SignalFailure", "timer was not fired"));
         }
         Ok(StepDecision::graceful_complete(
-            input + self.first.condition_results(context)?[0],
+            input + FIRST.condition_results(context)?[0],
         ))
     }
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/signal_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/signal_workflow.rs
@@ -10,10 +10,16 @@
 
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Channel, ChannelMap, ConditionCombination, Context, Flow, HandlerError, HandlerResult,
     PersistenceSchema, Step, StepDecision, StepList, Timer, Wait,
 };
+
+static SECOND: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("signal-2"));
+static THIRD: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("signal-3"));
+static FIRST: LazyLock<Channel<i32>> = LazyLock::new(|| Channel::new("signal-1"));
 
 pub(crate) struct SignalWorkflow {
     pub(crate) first: Channel<i32>,
@@ -26,9 +32,9 @@ pub(crate) struct SignalWorkflow {
 
 impl SignalWorkflow {
     pub(crate) fn new() -> Self {
-        let first = Channel::new("signal-1");
-        let second = Channel::new("signal-2");
-        let third = Channel::new("signal-3");
+        let first = FIRST.clone();
+        let second = SECOND.clone();
+        let third = THIRD.clone();
         let signal_map = ChannelMap::new("signal-map");
         Self {
             start: FirstStep {
@@ -91,8 +97,8 @@ impl Step for FirstStep {
         Ok(StepDecision::go_to(
             &CombinationStep {
                 first: self.first.clone(),
-                second: Channel::new("signal-2"),
-                third: Channel::new("signal-3"),
+                second: SECOND.clone(),
+                third: THIRD.clone(),
                 signal_map: ChannelMap::new("signal-map"),
             },
             input + value,

--- a/sdk-rust/crates/dex-sdk/tests/integ/state_options_locking_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/state_options_locking_workflow.rs
@@ -15,16 +15,13 @@ use dex_sdk::{
     StepDecision, StepList, StepMovement, StepOptions, Wait,
 };
 
-static WAIT_FOR_COUNT: LazyLock<Attribute<i32>> =
+pub(crate) static WAIT_FOR_COUNT: LazyLock<Attribute<i32>> =
     LazyLock::new(|| Attribute::new("step-lock-wait-for-count"));
-static EXECUTE_COUNT: LazyLock<Attribute<i32>> =
+pub(crate) static EXECUTE_COUNT: LazyLock<Attribute<i32>> =
     LazyLock::new(|| Attribute::new("step-lock-execute-count"));
 static COMPLETED: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("step-lock-completed"));
 
 pub(crate) struct StateOptionsLockingWorkflow {
-    pub(crate) wait_for_count: Attribute<i32>,
-    pub(crate) execute_count: Attribute<i32>,
-    completed: Channel<()>,
     start: StartStep,
     locked: LockedStep,
     complete: CompleteStep,
@@ -32,24 +29,10 @@ pub(crate) struct StateOptionsLockingWorkflow {
 
 impl StateOptionsLockingWorkflow {
     pub(crate) fn new() -> Self {
-        let wait_for_count = WAIT_FOR_COUNT.clone();
-        let execute_count = EXECUTE_COUNT.clone();
-        let completed = COMPLETED.clone();
         Self {
             start: StartStep,
-            locked: LockedStep {
-                wait_for_count: wait_for_count.clone(),
-                execute_count: execute_count.clone(),
-                completed: completed.clone(),
-            },
-            complete: CompleteStep {
-                wait_for_count: wait_for_count.clone(),
-                execute_count: execute_count.clone(),
-                completed: completed.clone(),
-            },
-            wait_for_count,
-            execute_count,
-            completed,
+            locked: LockedStep,
+            complete: CompleteStep,
         }
     }
 }
@@ -65,9 +48,9 @@ impl Flow for StateOptionsLockingWorkflow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&self.wait_for_count)
-            .attribute(&self.execute_count)
-            .channel(&self.completed)
+            .attribute(&WAIT_FOR_COUNT)
+            .attribute(&EXECUTE_COUNT)
+            .channel(&COMPLETED)
     }
 }
 
@@ -78,73 +61,49 @@ impl Step for StartStep {
 
     fn execute(&self, _context: &mut Context, parallelism: i32) -> HandlerResult<StepDecision> {
         let mut movements = (0..parallelism)
-            .map(|index| {
-                StepMovement::to(
-                    &LockedStep {
-                        wait_for_count: WAIT_FOR_COUNT.clone(),
-                        execute_count: EXECUTE_COUNT.clone(),
-                        completed: COMPLETED.clone(),
-                    },
-                    index,
-                )
-            })
+            .map(|index| StepMovement::to(&LockedStep, index))
             .collect::<Vec<_>>();
-        movements.push(StepMovement::to(
-            &CompleteStep {
-                wait_for_count: WAIT_FOR_COUNT.clone(),
-                execute_count: EXECUTE_COUNT.clone(),
-                completed: COMPLETED.clone(),
-            },
-            parallelism,
-        ));
+        movements.push(StepMovement::to(&CompleteStep, parallelism));
         Ok(StepDecision::go_to_many(movements))
     }
 }
 
-struct LockedStep {
-    wait_for_count: Attribute<i32>,
-    execute_count: Attribute<i32>,
-    completed: Channel<()>,
-}
+struct LockedStep;
 
 impl Step for LockedStep {
     type Input = i32;
 
     fn wait_for(&self, context: &mut Context, _input: i32) -> HandlerResult<Wait> {
-        let next = self.wait_for_count.get(context)?.unwrap_or_default() + 1;
-        self.wait_for_count.set(context, next)?;
+        let next = WAIT_FOR_COUNT.get(context)?.unwrap_or_default() + 1;
+        WAIT_FOR_COUNT.set(context, next)?;
         Ok(Wait::skip_immediately())
     }
 
     fn execute(&self, context: &mut Context, _input: i32) -> HandlerResult<StepDecision> {
-        let next = self.execute_count.get(context)?.unwrap_or_default() + 1;
-        self.execute_count.set(context, next)?;
-        self.completed.publish(context, ())?;
+        let next = EXECUTE_COUNT.get(context)?.unwrap_or_default() + 1;
+        EXECUTE_COUNT.set(context, next)?;
+        COMPLETED.publish(context, ())?;
         Ok(StepDecision::dead_end())
     }
 
     fn options(&self) -> StepOptions<Self::Input> {
         StepOptions::new()
-            .wait_for_lock(self.wait_for_count.lock())
-            .execute_lock(self.execute_count.lock())
+            .wait_for_lock(WAIT_FOR_COUNT.lock())
+            .execute_lock(EXECUTE_COUNT.lock())
     }
 }
 
-struct CompleteStep {
-    wait_for_count: Attribute<i32>,
-    execute_count: Attribute<i32>,
-    completed: Channel<()>,
-}
+struct CompleteStep;
 
 impl Step for CompleteStep {
     type Input = i32;
 
     fn wait_for(&self, _context: &mut Context, parallelism: i32) -> HandlerResult<Wait> {
-        Ok(Wait::until(self.completed.for_n(parallelism as usize)))
+        Ok(Wait::until(COMPLETED.for_n(parallelism as usize)))
     }
 
     fn execute(&self, context: &mut Context, parallelism: i32) -> HandlerResult<StepDecision> {
-        if self.completed.condition_results(context)?.len() != parallelism as usize {
+        if COMPLETED.condition_results(context)?.len() != parallelism as usize {
             return Err(HandlerError::new(
                 "StateOptionsLockingFailure",
                 "not all locked Steps completed",
@@ -152,8 +111,8 @@ impl Step for CompleteStep {
         }
         Ok(StepDecision::graceful_complete(format!(
             "{}:{}",
-            self.wait_for_count.get_required(context)?,
-            self.execute_count.get_required(context)?
+            WAIT_FOR_COUNT.get_required(context)?,
+            EXECUTE_COUNT.get_required(context)?
         )))
     }
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/state_options_locking_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/state_options_locking_workflow.rs
@@ -8,10 +8,18 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Channel, Context, Flow, HandlerError, HandlerResult, PersistenceSchema, Step,
     StepDecision, StepList, StepMovement, StepOptions, Wait,
 };
+
+static WAIT_FOR_COUNT: LazyLock<Attribute<i32>> =
+    LazyLock::new(|| Attribute::new("step-lock-wait-for-count"));
+static EXECUTE_COUNT: LazyLock<Attribute<i32>> =
+    LazyLock::new(|| Attribute::new("step-lock-execute-count"));
+static COMPLETED: LazyLock<Channel<()>> = LazyLock::new(|| Channel::new("step-lock-completed"));
 
 pub(crate) struct StateOptionsLockingWorkflow {
     pub(crate) wait_for_count: Attribute<i32>,
@@ -24,9 +32,9 @@ pub(crate) struct StateOptionsLockingWorkflow {
 
 impl StateOptionsLockingWorkflow {
     pub(crate) fn new() -> Self {
-        let wait_for_count = Attribute::new("step-lock-wait-for-count");
-        let execute_count = Attribute::new("step-lock-execute-count");
-        let completed = Channel::new("step-lock-completed");
+        let wait_for_count = WAIT_FOR_COUNT.clone();
+        let execute_count = EXECUTE_COUNT.clone();
+        let completed = COMPLETED.clone();
         Self {
             start: StartStep,
             locked: LockedStep {
@@ -73,9 +81,9 @@ impl Step for StartStep {
             .map(|index| {
                 StepMovement::to(
                     &LockedStep {
-                        wait_for_count: Attribute::new("step-lock-wait-for-count"),
-                        execute_count: Attribute::new("step-lock-execute-count"),
-                        completed: Channel::new("step-lock-completed"),
+                        wait_for_count: WAIT_FOR_COUNT.clone(),
+                        execute_count: EXECUTE_COUNT.clone(),
+                        completed: COMPLETED.clone(),
                     },
                     index,
                 )
@@ -83,9 +91,9 @@ impl Step for StartStep {
             .collect::<Vec<_>>();
         movements.push(StepMovement::to(
             &CompleteStep {
-                wait_for_count: Attribute::new("step-lock-wait-for-count"),
-                execute_count: Attribute::new("step-lock-execute-count"),
-                completed: Channel::new("step-lock-completed"),
+                wait_for_count: WAIT_FOR_COUNT.clone(),
+                execute_count: EXECUTE_COUNT.clone(),
+                completed: COMPLETED.clone(),
             },
             parallelism,
         ));

--- a/sdk-rust/crates/dex-sdk/tests/integ/state_options_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/state_options_test.rs
@@ -12,7 +12,9 @@ use std::time::Duration;
 
 use dex_sdk::{Client, Registry, SdkResult};
 
-use crate::state_options_locking_workflow::StateOptionsLockingWorkflow;
+use crate::state_options_locking_workflow::{
+    EXECUTE_COUNT, StateOptionsLockingWorkflow, WAIT_FOR_COUNT,
+};
 use crate::state_options_workflow::StateOptionsWorkflow;
 use crate::support::{DexDevTestEnvironment, flow_id};
 
@@ -61,14 +63,14 @@ fn test_wait_for_and_execute_locks_serialize_parallel_steps() {
         Some(parallelism),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.wait_for_count)
+            .get_attribute(&flow_id, &WAIT_FOR_COUNT)
             .expect("read waitFor count")
     );
     assert_eq!(
         Some(parallelism),
         environment
             .client
-            .get_attribute(&flow_id, &workflow.execute_count)
+            .get_attribute(&flow_id, &EXECUTE_COUNT)
             .expect("read execute count")
     );
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/state_options_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/state_options_workflow.rs
@@ -8,10 +8,16 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Context, Flow, HandlerError, HandlerResult, PersistenceSchema, Step, StepDecision,
     StepList, StepOptions, Wait,
 };
+
+static WAIT_VALUE: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("DA_WAIT_UNTIL"));
+static EXECUTE_VALUE: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("DA_EXECUTE"));
+static BOTH_VALUE: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("DA_BOTH"));
 
 pub(crate) struct StateOptionsWorkflow {
     pub(crate) wait_value: Attribute<String>,
@@ -24,9 +30,9 @@ pub(crate) struct StateOptionsWorkflow {
 
 impl StateOptionsWorkflow {
     pub(crate) fn new() -> Self {
-        let wait_value = Attribute::new("DA_WAIT_UNTIL");
-        let execute_value = Attribute::new("DA_EXECUTE");
-        let both_value = Attribute::new("DA_BOTH");
+        let wait_value = WAIT_VALUE.clone();
+        let execute_value = EXECUTE_VALUE.clone();
+        let both_value = BOTH_VALUE.clone();
         Self {
             first: OptionsFirstStep {
                 wait_value: wait_value.clone(),

--- a/sdk-rust/crates/dex-sdk/tests/integ/state_options_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/state_options_workflow.rs
@@ -20,9 +20,6 @@ static EXECUTE_VALUE: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::
 static BOTH_VALUE: LazyLock<Attribute<String>> = LazyLock::new(|| Attribute::new("DA_BOTH"));
 
 pub(crate) struct StateOptionsWorkflow {
-    pub(crate) wait_value: Attribute<String>,
-    pub(crate) execute_value: Attribute<String>,
-    pub(crate) both_value: Attribute<String>,
     first: OptionsFirstStep,
     second: OptionsSecondStep,
     third: OptionsThirdStep,
@@ -30,26 +27,10 @@ pub(crate) struct StateOptionsWorkflow {
 
 impl StateOptionsWorkflow {
     pub(crate) fn new() -> Self {
-        let wait_value = WAIT_VALUE.clone();
-        let execute_value = EXECUTE_VALUE.clone();
-        let both_value = BOTH_VALUE.clone();
         Self {
-            first: OptionsFirstStep {
-                wait_value: wait_value.clone(),
-                execute_value: execute_value.clone(),
-                both_value: both_value.clone(),
-            },
-            second: OptionsSecondStep {
-                wait_value: wait_value.clone(),
-                execute_value: execute_value.clone(),
-                both_value: both_value.clone(),
-            },
-            third: OptionsThirdStep {
-                both_value: both_value.clone(),
-            },
-            wait_value,
-            execute_value,
-            both_value,
+            first: OptionsFirstStep,
+            second: OptionsSecondStep,
+            third: OptionsThirdStep,
         }
     }
 }
@@ -65,92 +46,70 @@ impl Flow for StateOptionsWorkflow {
 
     fn persistence(&self) -> PersistenceSchema {
         PersistenceSchema::new()
-            .attribute(&self.wait_value)
-            .attribute(&self.execute_value)
-            .attribute(&self.both_value)
+            .attribute(&WAIT_VALUE)
+            .attribute(&EXECUTE_VALUE)
+            .attribute(&BOTH_VALUE)
     }
 }
 
-struct OptionsFirstStep {
-    wait_value: Attribute<String>,
-    execute_value: Attribute<String>,
-    both_value: Attribute<String>,
-}
+struct OptionsFirstStep;
 
 impl Step for OptionsFirstStep {
     type Input = ();
 
     fn execute(&self, context: &mut Context, (): ()) -> HandlerResult<StepDecision> {
-        self.execute_value.set(context, "execute".into())?;
-        self.wait_value.set(context, "wait_until".into())?;
-        self.both_value.set(context, "both".into())?;
-        Ok(StepDecision::go_to(
-            &OptionsSecondStep {
-                wait_value: self.wait_value.clone(),
-                execute_value: self.execute_value.clone(),
-                both_value: self.both_value.clone(),
-            },
-            (),
-        ))
+        EXECUTE_VALUE.set(context, "execute".into())?;
+        WAIT_VALUE.set(context, "wait_until".into())?;
+        BOTH_VALUE.set(context, "both".into())?;
+        Ok(StepDecision::go_to(&OptionsSecondStep, ()))
     }
 }
 
-struct OptionsSecondStep {
-    wait_value: Attribute<String>,
-    execute_value: Attribute<String>,
-    both_value: Attribute<String>,
-}
+struct OptionsSecondStep;
 
 impl Step for OptionsSecondStep {
     type Input = ();
 
     fn wait_for(&self, context: &mut Context, (): ()) -> HandlerResult<Wait> {
-        require_attribute(context, &self.wait_value, "wait_until")?;
-        require_attribute(context, &self.execute_value, "execute")?;
-        require_attribute(context, &self.both_value, "both")?;
+        require_attribute(context, &WAIT_VALUE, "wait_until")?;
+        require_attribute(context, &EXECUTE_VALUE, "execute")?;
+        require_attribute(context, &BOTH_VALUE, "both")?;
         Ok(Wait::skip_immediately())
     }
 
     fn execute(&self, context: &mut Context, (): ()) -> HandlerResult<StepDecision> {
-        require_attribute(context, &self.execute_value, "execute")?;
-        require_attribute(context, &self.wait_value, "wait_until")?;
-        require_attribute(context, &self.both_value, "both")?;
-        Ok(StepDecision::go_to(
-            &OptionsThirdStep {
-                both_value: self.both_value.clone(),
-            },
-            (),
-        ))
+        require_attribute(context, &EXECUTE_VALUE, "execute")?;
+        require_attribute(context, &WAIT_VALUE, "wait_until")?;
+        require_attribute(context, &BOTH_VALUE, "both")?;
+        Ok(StepDecision::go_to(&OptionsThirdStep, ()))
     }
 
     fn options(&self) -> StepOptions<Self::Input> {
         StepOptions::new()
-            .wait_for_lock(self.wait_value.lock())
-            .execute_lock(self.execute_value.lock())
+            .wait_for_lock(WAIT_VALUE.lock())
+            .execute_lock(EXECUTE_VALUE.lock())
     }
 }
 
-struct OptionsThirdStep {
-    both_value: Attribute<String>,
-}
+struct OptionsThirdStep;
 
 impl Step for OptionsThirdStep {
     type Input = ();
 
     fn wait_for(&self, context: &mut Context, (): ()) -> HandlerResult<Wait> {
-        require_attribute(context, &self.both_value, "both")?;
+        require_attribute(context, &BOTH_VALUE, "both")?;
         Ok(Wait::skip_immediately())
     }
 
     fn execute(&self, context: &mut Context, (): ()) -> HandlerResult<StepDecision> {
-        require_attribute(context, &self.both_value, "both")?;
+        require_attribute(context, &BOTH_VALUE, "both")?;
         Ok(StepDecision::graceful_complete("success".to_string()))
     }
 
     fn options(&self) -> StepOptions<Self::Input> {
         StepOptions::new()
-            .wait_for_lock(self.both_value.lock())
-            .execute_lock(self.both_value.lock())
+            .wait_for_lock(BOTH_VALUE.lock())
+            .execute_lock(BOTH_VALUE.lock())
     }
 }
 

--- a/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_test.rs
@@ -16,7 +16,7 @@ use dex_sdk::{Registry, StepExecutionId};
 
 use crate::step_cancellation_workflow::{
     CancellationBlockingExecute, CancellationBlockingWaitFor, CancellationScenario,
-    CancellationState, StepCancellationWorkflow,
+    CancellationState, LATE_WRITE, StepCancellationWorkflow,
 };
 use crate::support::{DexDevTestEnvironment, flow_id};
 
@@ -31,7 +31,6 @@ fn test_step_cancellation() {
 fn run_scenario(scenario: CancellationScenario) {
     let state = CancellationState::new(scenario);
     let workflow = StepCancellationWorkflow::new(Arc::clone(&state));
-    let late_write = workflow.late_write.clone();
     let environment = DexDevTestEnvironment::start(Registry::new().register(workflow));
     let client_workflow = StepCancellationWorkflow::new(Arc::clone(&state));
     let flow_id = flow_id(&format!("rust-cancellation-{}", scenario.name()));
@@ -61,7 +60,6 @@ fn run_scenario(scenario: CancellationScenario) {
                     &flow_id,
                     StepExecutionId::of(&CancellationBlockingExecute {
                         state: Arc::clone(&state),
-                        late_write: late_write.clone(),
                     }),
                     Duration::from_secs(30),
                 )
@@ -106,7 +104,7 @@ fn run_scenario(scenario: CancellationScenario) {
         None,
         environment
             .client
-            .get_attribute::<String>(&flow_id, &late_write)
+            .get_attribute::<String>(&flow_id, &LATE_WRITE)
             .expect("read late Attribute")
     );
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_workflow.rs
@@ -20,7 +20,7 @@ use dex_sdk::{
     StepList, StepMovement, StepOptions, Timer, Wait, WaitForFailurePolicy,
 };
 
-static LATE_WRITE: LazyLock<Attribute<String>> =
+pub(crate) static LATE_WRITE: LazyLock<Attribute<String>> =
     LazyLock::new(|| Attribute::new("rust-cancellation-late-write"));
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -119,7 +119,6 @@ impl CancellationState {
 }
 
 pub(crate) struct StepCancellationWorkflow {
-    pub(crate) late_write: Attribute<String>,
     start: CancellationStart,
     blocking_execute: CancellationBlockingExecute,
     blocking_wait_for: CancellationBlockingWaitFor,
@@ -134,12 +133,10 @@ pub(crate) struct StepCancellationWorkflow {
 
 impl StepCancellationWorkflow {
     pub(crate) fn new(state: Arc<CancellationState>) -> Self {
-        let late_write = LATE_WRITE.clone();
         Self {
             start: CancellationStart(Arc::clone(&state)),
             blocking_execute: CancellationBlockingExecute {
                 state: Arc::clone(&state),
-                late_write: late_write.clone(),
             },
             blocking_wait_for: CancellationBlockingWaitFor(Arc::clone(&state)),
             winner: CancellationWinner(Arc::clone(&state)),
@@ -149,7 +146,6 @@ impl StepCancellationWorkflow {
             second_parent: CancellationSecondParent(Arc::clone(&state)),
             selector_winner: CancellationSelectorWinner(Arc::clone(&state)),
             selector_waiting: CancellationSelectorWaiting(Arc::clone(&state)),
-            late_write,
         }
     }
 }
@@ -171,7 +167,7 @@ impl Flow for StepCancellationWorkflow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().attribute(&self.late_write)
+        PersistenceSchema::new().attribute(&LATE_WRITE)
     }
 }
 
@@ -197,7 +193,6 @@ impl Step for CancellationStart {
                 StepMovement::to(
                     &CancellationBlockingExecute {
                         state: Arc::clone(&state),
-                        late_write: LATE_WRITE.clone(),
                     },
                     (),
                 ),
@@ -210,7 +205,6 @@ impl Step for CancellationStart {
 
 pub(crate) struct CancellationBlockingExecute {
     pub(crate) state: Arc<CancellationState>,
-    pub(crate) late_write: Attribute<String>,
 }
 
 impl Step for CancellationBlockingExecute {
@@ -231,7 +225,7 @@ impl Step for CancellationBlockingExecute {
                 .store(context.is_cancelled(), Ordering::SeqCst);
             self.state.cancellation_observed.set();
         }
-        self.late_write.set(context, "late".to_string())?;
+        LATE_WRITE.set(context, "late".to_string())?;
         self.state.late_handler_returned.set();
         Ok(StepDecision::go_to(
             &CancellationRecovery(Arc::clone(&self.state)),
@@ -322,7 +316,6 @@ impl Step for CancellationWinner {
         }
         Ok(decision.cancel_step(&CancellationBlockingExecute {
             state: Arc::clone(&self.0),
-            late_write: LATE_WRITE.clone(),
         }))
     }
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_workflow.rs
@@ -13,10 +13,15 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Attribute, Context, Flow, HandlerError, HandlerResult, PersistenceSchema, Step, StepDecision,
     StepList, StepMovement, StepOptions, Timer, Wait, WaitForFailurePolicy,
 };
+
+static LATE_WRITE: LazyLock<Attribute<String>> =
+    LazyLock::new(|| Attribute::new("rust-cancellation-late-write"));
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum CancellationScenario {
@@ -129,7 +134,7 @@ pub(crate) struct StepCancellationWorkflow {
 
 impl StepCancellationWorkflow {
     pub(crate) fn new(state: Arc<CancellationState>) -> Self {
-        let late_write = Attribute::new("rust-cancellation-late-write");
+        let late_write = LATE_WRITE.clone();
         Self {
             start: CancellationStart(Arc::clone(&state)),
             blocking_execute: CancellationBlockingExecute {
@@ -192,7 +197,7 @@ impl Step for CancellationStart {
                 StepMovement::to(
                     &CancellationBlockingExecute {
                         state: Arc::clone(&state),
-                        late_write: Attribute::new("rust-cancellation-late-write"),
+                        late_write: LATE_WRITE.clone(),
                     },
                     (),
                 ),
@@ -317,7 +322,7 @@ impl Step for CancellationWinner {
         }
         Ok(decision.cancel_step(&CancellationBlockingExecute {
             state: Arc::clone(&self.0),
-            late_write: Attribute::new("rust-cancellation-late-write"),
+            late_write: LATE_WRITE.clone(),
         }))
     }
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/stream_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/stream_test.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, SystemTime};
 
 use dex_sdk::Registry;
 
-use crate::stream_workflow::StreamTestWorkflow;
+use crate::stream_workflow::{PROGRESS, StreamTestWorkflow};
 use crate::support::{DexDevTestEnvironment, flow_id};
 
 #[test]
@@ -34,7 +34,7 @@ fn test_stream_round_trip() {
         .client
         .write_stream(
             &flow_id,
-            &workflow.progress,
+            &PROGRESS,
             "client-write",
             "client-progress".to_string(),
         )
@@ -43,7 +43,7 @@ fn test_stream_round_trip() {
         .client
         .write_stream(
             &flow_id,
-            &workflow.progress,
+            &PROGRESS,
             "client-write",
             "duplicate-ignored".to_string(),
         )
@@ -51,7 +51,7 @@ fn test_stream_round_trip() {
 
     let step = environment
         .client
-        .read_stream_with_timeout(&flow_id, &workflow.progress, "", Duration::from_secs(30))
+        .read_stream_with_timeout(&flow_id, &PROGRESS, "", Duration::from_secs(30))
         .expect("read Step Stream message");
     assert_eq!("step-progress", step.value);
     assert!(!step.resume_token.is_empty());
@@ -62,7 +62,7 @@ fn test_stream_round_trip() {
         .client
         .read_stream_with_timeout(
             &flow_id,
-            &workflow.progress,
+            &PROGRESS,
             &step.resume_token,
             Duration::from_secs(30),
         )

--- a/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
@@ -8,9 +8,14 @@
 // Third-Party Materials remain under the Apache License, Version 2.0.
 // See LICENSE and LEGACY_NOTICES.md.
 
+use std::sync::LazyLock;
+
 use dex_sdk::{
     Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision, StepList, Stream,
 };
+
+static PROGRESS: LazyLock<Stream<String>> =
+    LazyLock::new(|| Stream::new("stream-test-progress", 1 << 20));
 
 #[derive(Clone)]
 pub(crate) struct StreamTestWorkflow {
@@ -20,7 +25,7 @@ pub(crate) struct StreamTestWorkflow {
 
 impl StreamTestWorkflow {
     pub(crate) fn new() -> Self {
-        let progress = Stream::new("stream-test-progress", 1 << 20);
+        let progress = PROGRESS.clone();
         Self {
             progress: progress.clone(),
             start: StreamTestStep { progress },

--- a/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
@@ -14,21 +14,18 @@ use dex_sdk::{
     Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision, StepList, Stream,
 };
 
-static PROGRESS: LazyLock<Stream<String>> =
+pub(crate) static PROGRESS: LazyLock<Stream<String>> =
     LazyLock::new(|| Stream::new("stream-test-progress", 1 << 20));
 
 #[derive(Clone)]
 pub(crate) struct StreamTestWorkflow {
-    pub(crate) progress: Stream<String>,
     start: StreamTestStep,
 }
 
 impl StreamTestWorkflow {
     pub(crate) fn new() -> Self {
-        let progress = PROGRESS.clone();
         Self {
-            progress: progress.clone(),
-            start: StreamTestStep { progress },
+            start: StreamTestStep,
         }
     }
 }
@@ -41,20 +38,18 @@ impl Flow for StreamTestWorkflow {
     }
 
     fn persistence(&self) -> PersistenceSchema {
-        PersistenceSchema::new().stream(&self.progress)
+        PersistenceSchema::new().stream(&PROGRESS)
     }
 }
 
 #[derive(Clone)]
-struct StreamTestStep {
-    progress: Stream<String>,
-}
+struct StreamTestStep;
 
 impl Step for StreamTestStep {
     type Input = ();
 
     fn execute(&self, context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
-        self.progress.write(context, "step-progress".to_string())?;
+        PROGRESS.write(context, "step-progress".to_string())?;
         Ok(StepDecision::graceful_complete(()))
     }
 }


### PR DESCRIPTION
## Summary

- Define Rust example and SDK integration-test Attributes, Channels, and Streams with module-level `LazyLock` statics.
- Replace schema factory functions and dynamic construction with references to the shared definitions.
- Add a repository rule that keeps this convention in Rust examples and SDK integration tests.

## Rationale

Schema definitions are stable workflow identities. Named lazy statics make that identity explicit and remove repetitive factory functions.

## User impact

Rust examples and integration tests now demonstrate the recommended schema-definition pattern. No public SDK behavior changes.

## Validation

- `cargo test --manifest-path sdk-rust/Cargo.toml -p dex-sdk --test integ --no-run`
- `cargo check --manifest-path examples/rust/Cargo.toml --all-targets`
