### PR TITLE
Update stream capacity docs and examples

### DIFF
--- a/docs/content/design-patterns/parallel.mdx
+++ b/docs/content/design-patterns/parallel.mdx
@@ -44,7 +44,7 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+ (async waitFor/execute/RPC OK).
+// @superdurable/dex ^0.2.3+ (async waitFor/execute/RPC OK).
 // See examples/typescript/src/patterns/parallel/
 ```
 

--- a/docs/content/design-patterns/polling.mdx
+++ b/docs/content/design-patterns/polling.mdx
@@ -43,7 +43,7 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+ (async waitFor/execute/RPC OK).
+// @superdurable/dex ^0.2.3+ (async waitFor/execute/RPC OK).
 // See examples/typescript/src/patterns/polling/
 ```
 

--- a/docs/content/design-patterns/reminders.mdx
+++ b/docs/content/design-patterns/reminders.mdx
@@ -48,7 +48,7 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+ (async waitFor/execute/RPC OK).
+// @superdurable/dex ^0.2.3+ (async waitFor/execute/RPC OK).
 // See examples/typescript/src/patterns/reminders/
 ```
 

--- a/docs/content/design-patterns/resettable-timer.mdx
+++ b/docs/content/design-patterns/resettable-timer.mdx
@@ -41,7 +41,7 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+ (async waitFor/execute/RPC OK).
+// @superdurable/dex ^0.2.3+ (async waitFor/execute/RPC OK).
 // See examples/typescript/src/patterns/resettable-timer/
 ```
 

--- a/docs/content/design-patterns/scalable-parallel.mdx
+++ b/docs/content/design-patterns/scalable-parallel.mdx
@@ -71,7 +71,7 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
 
 ```typescript
 // Parent Step starts children with await getClient().startFlow(...)
-// on the same Worker (@superdurable/dex ^0.1.3+). No sync sidecar.
+// on the same Worker (@superdurable/dex ^0.2.3+). No sync sidecar.
 
 async execute(context: Context, _input: void): Promise<StepDecision> {
   const request = taskQueue.results(context)[0];

--- a/docs/content/design-patterns/timeout.mdx
+++ b/docs/content/design-patterns/timeout.mdx
@@ -65,7 +65,7 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+ (async waitFor/execute/RPC OK).
+// @superdurable/dex ^0.2.3+ (async waitFor/execute/RPC OK).
 // See examples/typescript/src/patterns/timeout/
 ```
 

--- a/docs/content/design-patterns/wait-for-step-completion.mdx
+++ b/docs/content/design-patterns/wait-for-step-completion.mdx
@@ -40,7 +40,7 @@ Full runnable samples live under examples/go, examples/java, examples/python, ex
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+ (async waitFor/execute/RPC OK).
+// @superdurable/dex ^0.2.3+ (async waitFor/execute/RPC OK).
 // See examples/typescript/src/patterns/wait-for-state-completion/
 ```
 

--- a/docs/content/primitives/stream.mdx
+++ b/docs/content/primitives/stream.mdx
@@ -17,7 +17,7 @@ A Stream provides best-effort durability only, using an in-memory store such as 
 
 ## Define and register a Stream
 
-A Stream has a stable name, a message type, and **maxEstimatedBytes**. maxEstimatedBytes is an approximate capacity shared by all Flow executions with the same Flow type and Stream name. It is not a per-Flow-ID limit.
+A Stream has a stable name, a message type, and **streamCapacityBytes**. streamCapacityBytes is an approximate capacity shared by all Flow executions with the same Flow type and Stream name. It is not a per-Flow-ID limit.
 
 This example writes a progress message before its Step returns. The write becomes visible as soon as Dex accepts it; the Client does not wait for the Step to complete.
 
@@ -230,11 +230,11 @@ Resume is best effort. A slow reader can miss messages trimmed before its next r
 
 ### Approximate capacity
 
-**maxEstimatedBytes** is an approximate capacity shared by all Flow executions with the same Flow type and Stream name. It is not a per-Flow-ID limit.
+**streamCapacityBytes** is an approximate capacity shared by all Flow executions with the same Flow type and Stream name. It is not a per-Flow-ID limit.
 
 The Dex server calculates the estimated size from each message's serialized value, identity bytes, and configured per-message overhead.
 
-When usage reaches the trim trigger threshold, one background trimmer removes the oldest messages across all instances until usage reaches the trim target threshold. In rare cases, if trimming is too slow and usage reaches the capacity limit (**maxEstimatedBytes**), the write request is rejected.
+When usage reaches the trim trigger threshold, one background trimmer removes the oldest messages across all instances until usage reaches the trim target threshold. In rare cases, if trimming is too slow and usage reaches the capacity limit (**streamCapacityBytes**), the write request is rejected.
 
 The server also limits the size of each Stream message. The default is 100 KiB.
 

--- a/docs/content/use-cases/dataset-deal.mdx
+++ b/docs/content/use-cases/dataset-deal.mdx
@@ -52,7 +52,7 @@ make bins
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+; Client methods are async (await).
+// @superdurable/dex ^0.2.3+; Client methods are async (await).
 // Browse examples/go/products/dataset-deal (Go-only sample; own UI, not on the playground)
 ```
 

--- a/docs/content/use-cases/engagement.mdx
+++ b/docs/content/use-cases/engagement.mdx
@@ -39,7 +39,7 @@ Long-running backend processes need durable waits, retries, and external interac
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+; Client methods are async (await).
+// @superdurable/dex ^0.2.3+; Client methods are async (await).
 // Browse examples/typescript/src/products/engagement/ (TypeScript tree under examples/typescript)
 ```
 

--- a/docs/content/use-cases/job-post.mdx
+++ b/docs/content/use-cases/job-post.mdx
@@ -39,7 +39,7 @@ Long-running backend processes need durable waits, retries, and external interac
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+; Client methods are async (await).
+// @superdurable/dex ^0.2.3+; Client methods are async (await).
 // Browse examples/typescript/src/products/job-post/ (TypeScript tree under examples/typescript)
 ```
 

--- a/docs/content/use-cases/microservice-orchestration.mdx
+++ b/docs/content/use-cases/microservice-orchestration.mdx
@@ -45,7 +45,7 @@ See archived microservice orchestration case study under **docs/archive/** for n
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+; Client methods are async (await).
+// @superdurable/dex ^0.2.3+; Client methods are async (await).
 // Browse examples/typescript/src/products/microservices/ (TypeScript tree under examples/typescript)
 ```
 

--- a/docs/content/use-cases/money-transfer.mdx
+++ b/docs/content/use-cases/money-transfer.mdx
@@ -39,7 +39,7 @@ Long-running backend processes need durable waits, retries, and external interac
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+; Client methods are async (await).
+// @superdurable/dex ^0.2.3+; Client methods are async (await).
 // Browse examples/typescript/src/products/money-transfer/ (TypeScript tree under examples/typescript)
 ```
 

--- a/docs/content/use-cases/polling.mdx
+++ b/docs/content/use-cases/polling.mdx
@@ -39,7 +39,7 @@ Long-running backend processes need durable waits, retries, and external interac
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+; Client methods are async (await).
+// @superdurable/dex ^0.2.3+; Client methods are async (await).
 // Browse examples/typescript/src/products/polling/ (TypeScript tree under examples/typescript)
 ```
 

--- a/docs/content/use-cases/shortlist-candidates.mdx
+++ b/docs/content/use-cases/shortlist-candidates.mdx
@@ -39,7 +39,7 @@ Long-running backend processes need durable waits, retries, and external interac
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+; Client methods are async (await).
+// @superdurable/dex ^0.2.3+; Client methods are async (await).
 // Browse examples/typescript/src/products/shortlist-candidates/ (TypeScript tree under examples/typescript)
 ```
 

--- a/docs/content/use-cases/signup.mdx
+++ b/docs/content/use-cases/signup.mdx
@@ -45,7 +45,7 @@ See also archived case study notes under **docs/archive/** (legacy iWF wording) 
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+; Client methods are async (await).
+// @superdurable/dex ^0.2.3+; Client methods are async (await).
 // Browse examples/typescript/src/products/signup/ (TypeScript tree under examples/typescript)
 ```
 

--- a/docs/content/use-cases/subscription.mdx
+++ b/docs/content/use-cases/subscription.mdx
@@ -39,7 +39,7 @@ Long-running backend processes need durable waits, retries, and external interac
   <SdkSnippet lang="typescript">
 
 ```typescript
-// @superdurable/dex ^0.1.3+; Client methods are async (await).
+// @superdurable/dex ^0.2.3+; Client methods are async (await).
 // Browse examples/typescript/src/products/subscription/ (TypeScript tree under examples/typescript)
 ```
 

--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -781,7 +781,7 @@ Execute never receive or synthesize channel sizes.
 ### Streams
 
 `DefineStream[T]` creates an immutable definition with a name and positive
-`maxEstimatedBytes`. The Registry requires exact definition identity, unique
+`streamCapacityBytes`. The Registry requires exact definition identity, unique
 persistence names within a Flow, and ownership by exactly one Flow. This lets
 different Flow types use the same Stream name with separate capacity scopes.
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/stream.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/stream.mdx
@@ -17,7 +17,7 @@ Stream 只提供 best-effort durability，底层使用 Redis 等内存存储。�
 
 ## 定义并注册 Stream
 
-Stream 包含稳定名称、消息类型和 **maxEstimatedBytes**。maxEstimatedBytes 是相同 Flow type 和 Stream name 下所有 Flow execution 共享的近似容量，不是每个 Flow ID 独立的 limit。
+Stream 包含稳定名称、消息类型和 **streamCapacityBytes**。streamCapacityBytes 是相同 Flow type 和 Stream name 下所有 Flow execution 共享的近似容量，不是每个 Flow ID 独立的 limit。
 
 下面的 Step 在返回之前写入一条 progress message。Dex 接受写入后，Client 立刻就能读取；不需要等待 Step 完成。
 
@@ -173,11 +173,11 @@ Step 直接写入 Stream 时：
 
 ### 近似容量
 
-**maxEstimatedBytes** 是相同 Flow type 和 Stream name 下所有 Flow execution 共享的近似容量，不是每个 Flow ID 独立的 limit。
+**streamCapacityBytes** 是相同 Flow type 和 Stream name 下所有 Flow execution 共享的近似容量，不是每个 Flow ID 独立的 limit。
 
 Dex server 根据每条消息的 serialized value、identity bytes 和可配置的 per-message overhead 计算估算大小。
 
-当 usage 达到 trim trigger threshold 时，全局只有一个 background trimmer 会删除所有 instance 中最旧的消息，直到 usage 降至 trim target threshold。极少数情况下，如果 trimming 太慢，usage 达到 capacity limit（**maxEstimatedBytes**），write request 会被拒绝。
+当 usage 达到 trim trigger threshold 时，全局只有一个 background trimmer 会删除所有 instance 中最旧的消息，直到 usage 降至 trim target threshold。极少数情况下，如果 trimming 太慢，usage 达到 capacity limit（**streamCapacityBytes**），write request 会被拒绝。
 
 Server 还会限制单条 Stream message 的大小，默认上限为 100 KiB。
 

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -1,6 +1,6 @@
 # Dex Go examples
 
-These examples target `github.com/superdurable/dex/sdk-go v0.2.3`.
+These examples target `github.com/superdurable/dex/sdk-go v0.2.4`.
 
 `dex.None` marks a nil-only Step, RPC, or Channel payload. Calls pass `nil`.
 

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/stretchr/testify v1.11.1
 	github.com/superdurable/dex/blob-cache-go v0.1.0
-	github.com/superdurable/dex/sdk-go v0.2.3
+	github.com/superdurable/dex/sdk-go v0.2.4
 )
 
 require (

--- a/examples/go/go.sum
+++ b/examples/go/go.sum
@@ -92,6 +92,8 @@ github.com/superdurable/dex/blob-cache-go v0.1.0 h1:+c3H5YBWG3DlICOHbgT9IUM5vTlf
 github.com/superdurable/dex/blob-cache-go v0.1.0/go.mod h1:Atepb7+sztvDCztVKmlvEKCSKFCkHKtDhoFYjaFmtEw=
 github.com/superdurable/dex/sdk-go v0.2.3 h1:ZgtvPOyFok1zdtiAkNWuta8PT6NAxqJ902xWgRxg1IM=
 github.com/superdurable/dex/sdk-go v0.2.3/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
+github.com/superdurable/dex/sdk-go v0.2.4 h1:M5GWxCRAK4hNAxL6svGjzSSZH2VXYpv0/xkL75A//QA=
+github.com/superdurable/dex/sdk-go v0.2.4/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -1,6 +1,6 @@
 # Dex Java examples
 
-These examples target `io.superdurable:dex-sdk:0.2.3` (`io.superdurable.dex`).
+These examples target `io.superdurable:dex-sdk:0.2.4` (`io.superdurable.dex`).
 
 The sample process hosts one gRPC Worker on `127.0.0.1:8803` and an HTTP
 controller on port `8080`. One Registry and disk BlobCache are shared by its

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "io.superdurable:dex-sdk:0.2.3"
+    implementation "io.superdurable:dex-sdk:0.2.4"
 
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,6 +1,6 @@
 # Dex Python examples
 
-These examples target [`dex-python-sdk==0.2.2`](https://pypi.org/project/dex-python-sdk/0.2.2/)
+These examples target [`dex-python-sdk==0.2.3`](https://pypi.org/project/dex-python-sdk/0.2.3/)
 (`import dex`). Requires Python 3.11+.
 
 The primary sample process hosts one asyncio `AsyncWorker` on `127.0.0.1:8803` and a

--- a/examples/python/pyproject.toml
+++ b/examples/python/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "dex-python-sdk==0.2.2",
+    "dex-python-sdk==0.2.3",
     "flask>=3.0,<4",
     "openai>=1.66.2,<2",
     "openai-agents>=0.0.4,<0.0.5",

--- a/examples/python/sync-python/README.md
+++ b/examples/python/sync-python/README.md
@@ -3,7 +3,7 @@
 Showcase of the **sync** Dex Python SDK surface (`Client` / `Worker`) next to
 the primary async examples under `examples/python/`.
 
-Targets [`dex-python-sdk==0.2.2`](https://pypi.org/project/dex-python-sdk/0.2.2/).
+Targets [`dex-python-sdk==0.2.3`](https://pypi.org/project/dex-python-sdk/0.2.3/).
 Requires Python 3.11+.
 
 The samples use concrete SDK errors for missing, inactive, and duplicate Flows

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -293,7 +293,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dex-python-sdk", specifier = "==0.2.2" },
+    { name = "dex-python-sdk", specifier = "==0.2.3" },
     { name = "flask", specifier = ">=3.0,<4" },
     { name = "openai", specifier = ">=1.66.2,<2" },
     { name = "openai-agents", specifier = ">=0.0.4,<0.0.5" },
@@ -312,20 +312,20 @@ dev = [
 
 [[package]]
 name = "dex-python-sdk"
-version = "0.2.2"
+version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "grpcio-status" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/83/9d1450e621df9df85a9bdbdf8d9d2efa2090f596f5161dce163da6c43fdd/dex_python_sdk-0.2.2.tar.gz", hash = "sha256:f15379bea44166b2ed1bd1dae45fc3a39f41075d19fbaeaddcbd1ce7b1f108a8", size = 152733, upload-time = "2026-08-27T22:43:28.065Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/35/216f227f2ff512e70813fc689aa05f85e1387399ed582a4bc8eb76c13938/dex_python_sdk-0.2.3.tar.gz", hash = "sha256:71caa465a0c5893e444fe983440986da234ad573f210a9fdecc8f8ecc3d488d0", size = 152748, upload-time = "2026-08-28T17:16:11.387Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/40/5b6c3caf1ec795a03e8235c070600b28e6b114ea7a938992facba7713c27/dex_python_sdk-0.2.2-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f01bdfc76909eab29d7ed7fe20a923ac050cf39b1b9817a9fbfafe75b221bf6c", size = 635409, upload-time = "2026-08-27T22:43:20.738Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/f8/c2f382f3b77128df46656685f7cfc0fa106ecd079e32d47ae89939b032a0/dex_python_sdk-0.2.2-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0e643b4cac345428639173248c757ce66adcbb40b45a9c72dab9aa4d11f6fed", size = 613919, upload-time = "2026-08-27T22:43:22.197Z" },
-    { url = "https://files.pythonhosted.org/packages/98/03/989f159bb970bf0284d0edb634adf7c52cf4b792b29f7844e29398a20b1a/dex_python_sdk-0.2.2-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33ca8cda63ab5291aad4136906a50d36904ed321b5f3cc664ab5a904f4fd76b2", size = 676861, upload-time = "2026-08-27T22:43:24.427Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/f7/fb5decc71bdd3abbd1a588b2728deb20053d154f2ce77175a66fd866dc01/dex_python_sdk-0.2.2-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b824ae12257dd8eb3a0ca993266797175e8bd75eedd0df1541f980d3ba93c1c", size = 679160, upload-time = "2026-08-27T22:43:25.63Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/35/fad8ea1e2e5f3fb69d4908c6ef494bcfce7aa37ebaa57b880506b5e773f3/dex_python_sdk-0.2.2-cp311-abi3-win_amd64.whl", hash = "sha256:4df680f37ebf6e27d685301580d3bf985bf413f32b31aaf205cc14e2a1f9cb95", size = 523080, upload-time = "2026-08-27T22:43:26.8Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ae/313a650fe199fe20f68af110407bb5d661a78485a2771f5dd2c0a0bcb1e4/dex_python_sdk-0.2.3-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:fc25eeac08a307886fb95446da2db352548e82a290f6e67acac77cc951679c77", size = 635434, upload-time = "2026-08-28T17:16:06.169Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/54/ab5b96a82ea72ab2158ed43b6a23e78da44ec71dc230d46745069190cee5/dex_python_sdk-0.2.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:641f97d0f41b2361dffb3f37e7b30383fa85cd8d1dad32b07d9f7dd72b3c4fc9", size = 613900, upload-time = "2026-08-28T17:16:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ca/8da97bd31b271fa4ca82632074d39b7664592120a938927f9907f0bc8903/dex_python_sdk-0.2.3-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:829e029d76736fb635db509fa07a4c39a73b3a086b79be86506f9895e2f40a7d", size = 676848, upload-time = "2026-08-28T17:16:08.413Z" },
+    { url = "https://files.pythonhosted.org/packages/18/9f/51e7ca151d766226b24b48bce22a4609b80351b39d1afd8f793a29505def/dex_python_sdk-0.2.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6ad752f1cdd30acea9408c8ab0ac4aad755984ca8851dbd4bd03b471eb26683", size = 679164, upload-time = "2026-08-28T17:16:09.494Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/42e34b911df4814c1399333c5f0e85f29d09a1591333276fd7f4bc999003/dex_python_sdk-0.2.3-cp311-abi3-win_amd64.whl", hash = "sha256:1ebae38d2dd2109489e0722dc430e21897cae98741160a692debbe446f046e12", size = 523095, upload-time = "2026-08-28T17:16:10.462Z" },
 ]
 
 [[package]]

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "dex-blob-cache"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30757c5cda3fcef7f7468c2ae59c663bd4de10f1df8cfdb508627fc5abe1327"
+checksum = "4ac304c9bc3e8174796f19a8a5d385dd36bcae031cebbc93cf90dce7f4b297f4"
 dependencies = [
  "crc32c",
  "sha2",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "dex-protocol"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e872fb906e1906ef6210bdd5b941e5234d2299fe3f0f9ffe9aa0f553c4e9f3"
+checksum = "bd3bb22b31fafec56944de7278f33bc309c05c0de12ce91101c532cf04e86db0"
 dependencies = [
  "prost",
  "prost-types",
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "dex-sdk"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61261202bb7b3b07944b44ba2b1aad204f5b0ffec99334d861b980b98f2603dd"
+checksum = "842458d48044d1f9bd7362cc07566814c6c191fbb66b2b9c7b313b056f45ad6a"
 dependencies = [
  "dex-blob-cache",
  "dex-protocol",

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 rust-version = "1.97"
 
 [dependencies]
-dex-sdk = "=0.2.2"
+dex-sdk = "=0.2.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 axum = "0.8"

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -1,7 +1,7 @@
 # Rust examples
 
 This application mirrors the examples shared by the Java, Python, and TypeScript
-applications. It intentionally depends on the published `dex-sdk = "=0.2.2"`
+applications. It intentionally depends on the published `dex-sdk = "=0.2.3"`
 crate without a repository path override.
 
 ## Layout

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,6 +1,6 @@
 # Dex TypeScript examples
 
-These examples target [`@superdurable/dex@0.2.2`](https://www.npmjs.com/package/@superdurable/dex).
+These examples target [`@superdurable/dex@0.2.3`](https://www.npmjs.com/package/@superdurable/dex).
 
 The sample process hosts one gRPC Worker (default `127.0.0.1:8803`) and an HTTP
 controller on port `8080`. Step `execute` / `waitFor` / RPC handlers may

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@superdurable/dex-examples-typescript",
       "version": "0.0.0",
       "dependencies": {
-        "@superdurable/dex": "0.2.2",
+        "@superdurable/dex": "0.2.3",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -125,9 +125,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@superdurable/dex": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.2.2.tgz",
-      "integrity": "sha512-zi+rfsZVtAxlf3v6RLtMbublL0fFZl6sx/B41Di2IGNmBLHvIb66tBP+GqHZYWhYiDcs4cBFammaXv6CdiiZ/g==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.2.3.tgz",
+      "integrity": "sha512-424ESbcQKlj3oXeWZq9maqjoI+ramCAcZnpD+l8/MNDyowxcbqxvwloqiXo9zwgrqqmZF7lJjyaHMCn3SswZfw==",
       "license": "LicenseRef-Super-Durable-1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.13.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -16,7 +16,7 @@
     "smoke": "npm run build && node --test --experimental-test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/e2e/flow-smoke.test.js'"
   },
   "dependencies": {
-    "@superdurable/dex": "0.2.2",
+    "@superdurable/dex": "0.2.3",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/protos/README.md
+++ b/protos/README.md
@@ -27,7 +27,7 @@ change the target for subsequent WorkerService calls while the flow is running.
 ## Resumable Streams
 
 `WriteStream` appends one best-effort message to the Stream instance identified
-by `flow_id` and `stream_name`. Every write carries `max_estimated_bytes` and a
+by `flow_id` and `stream_name`. Every write carries `stream_capacity_bytes` and a
 single `idempotency_key`. Client keys cannot contain `#`; Step SDKs compose the
 key as `<runID>#<stepExecutionID>`. The server scopes the key to the Flow and
 uses it for first-write-wins idempotency.


### PR DESCRIPTION
## Summary

- Rename the Stream capacity field in English and Simplified Chinese product documentation.
- Update the Go SDK design document and protocol README to use the new names.
- Pin every example project to its newly published SDK version and refresh its lockfile.
- Refresh TypeScript SDK version guidance in product documentation.

## Rationale

The documentation and examples now match the published stream-capacity API rename and package releases.

## User impact

Examples consume released dependencies: Go and Java v0.2.4; Python, TypeScript, and Rust v0.2.3.

## Validation

- `npm run check` (docs)
- `GOWORK=off make bins unitTests` (examples/go)
- `./gradlew test --tests 'io.superdurable.dex.products.*' --refresh-dependencies -PjavaVersion=25` (examples/java)
- `uv sync --locked && make unitTests` (examples/python)
- `make fmt-check clippy test` (examples/rust)
- `npm ci && npm test` (examples/typescript)
