### PR TITLE
Rename multi-step decision APIs to GoToMany

### DIFF
--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -114,7 +114,7 @@ func (executeOnlyStep) Execute(
 ) (*dex.StepDecision, error) {
 	first := dex.MovementOf(waitForCommand, input)
 	second := dex.MovementOf(executeOnly, input)
-	return dex.GoToMulti(first, second), nil
+	return dex.GoToMany(first, second), nil
 }
 
 var executeOnly = executeOnlyStep{}

--- a/sdk-go/dex/decision.go
+++ b/sdk-go/dex/decision.go
@@ -24,10 +24,10 @@ func GoTo[IN any](
 	input IN,
 	options ...StepMoveOption,
 ) *StepDecision {
-	return GoToMulti(MovementOf(step, input, options...))
+	return GoToMany(MovementOf(step, input, options...))
 }
 
-// MovementOf creates a typed Step movement for GoToMulti, RPCResult, or conditional completion.
+// MovementOf creates a typed Step movement for GoToMany, RPCResult, or conditional completion.
 func MovementOf[IN any](
 	step Step[IN],
 	input IN,
@@ -43,8 +43,8 @@ func MovementOf[IN any](
 	return movement
 }
 
-// GoToMulti moves to all targets, enabling concurrent active Steps.
-func GoToMulti(movements ...StepMovement) *StepDecision {
+// GoToMany moves to all targets, enabling concurrent active Steps.
+func GoToMany(movements ...StepMovement) *StepDecision {
 	return &StepDecision{
 		kind:      decisionNext,
 		movements: movements,

--- a/sdk-go/dex/proto_mapper.go
+++ b/sdk-go/dex/proto_mapper.go
@@ -704,7 +704,7 @@ func mapStepDecision(decision *StepDecision) (*dexpb.StepDecision, error) {
 	switch decision.kind {
 	case decisionNext:
 		if len(decision.movements) == 0 {
-			return nil, fmt.Errorf("dex: GoToMulti requires at least one movement")
+			return nil, fmt.Errorf("dex: GoToMany requires at least one movement")
 		}
 		movements, err := mapStepMovements(decision.movements)
 		if err != nil {

--- a/sdk-go/dex/proto_mapper_test.go
+++ b/sdk-go/dex/proto_mapper_test.go
@@ -152,7 +152,7 @@ func TestStepDecisionAndOptionsMapping(t *testing.T) {
 		mapped.NextSteps[0].StepOptions.ExecuteLockAttributeKeys,
 	)
 
-	_, err = mapStepDecision(GoToMulti())
+	_, err = mapStepDecision(GoToMany())
 	require.ErrorContains(t, err, "at least one")
 }
 

--- a/sdk-go/dex/step.go
+++ b/sdk-go/dex/step.go
@@ -111,7 +111,7 @@ type Step[IN any] interface {
 	//	       step-execution locals set in WaitFor
 	//	input  the same typed step input passed to WaitFor
 	//
-	// Return a non-nil StepDecision (GoTo, GoToMulti, DeadEnd, GracefulComplete,
+	// Return a non-nil StepDecision (GoTo, GoToMany, DeadEnd, GracefulComplete,
 	// ForceComplete, ForceFail, or a conditional close). Attribute / channel /
 	// event writes are allowed; they are accepted with the Execute response.
 	Execute(ctx Context, input IN) (*StepDecision, error)

--- a/sdk-go/dex/worker_mapping.go
+++ b/sdk-go/dex/worker_mapping.go
@@ -101,7 +101,7 @@ func mapRegisteredDecision(
 	switch decision.kind {
 	case decisionNext:
 		if len(decision.movements) == 0 {
-			return nil, fmt.Errorf("dex: GoToMulti requires at least one movement")
+			return nil, fmt.Errorf("dex: GoToMany requires at least one movement")
 		}
 		movements, err := mapRegisteredMovements(flow, decision.movements)
 		if err != nil {

--- a/sdk-go/integ/basic_test.go
+++ b/sdk-go/integ/basic_test.go
@@ -76,7 +76,7 @@ type multiOutputStartStep struct {
 }
 
 func (multiOutputStartStep) Execute(dex.Context, struct{}) (*dex.StepDecision, error) {
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(multiOutputStringStep{}, struct{}{}),
 		dex.MovementOf(multiOutputIntStep{}, struct{}{}),
 	), nil

--- a/sdk-go/integ/interstate_test.go
+++ b/sdk-go/integ/interstate_test.go
@@ -50,7 +50,7 @@ func (interStepStartStep) Execute(
 	dex.Context,
 	struct{},
 ) (*dex.StepDecision, error) {
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(interStepWaitStep{}, struct{}{}),
 		dex.MovementOf(interStepPublishStep{}, 2),
 	), nil

--- a/sdk-go/integ/step_cancellation_test.go
+++ b/sdk-go/integ/step_cancellation_test.go
@@ -112,17 +112,17 @@ func (cancellationStartStep) Execute(
 ) (*dex.StepDecision, error) {
 	switch scenario {
 	case cancelHeartbeatWaitFor:
-		return dex.GoToMulti(
+		return dex.GoToMany(
 			dex.MovementOf(cancellationBlockingWaitForStep{}, scenario),
 			dex.MovementOf(cancellationWinnerStep{}, scenario),
 		), nil
 	case cancelGlobalSelector, cancelSiblingSelector:
-		return dex.GoToMulti(
+		return dex.GoToMany(
 			dex.MovementOf(cancellationFirstParentStep{}, scenario),
 			dex.MovementOf(cancellationSecondParentStep{}, scenario),
 		), nil
 	default:
-		return dex.GoToMulti(
+		return dex.GoToMany(
 			dex.MovementOf(
 				cancellationBlockingExecuteStep{},
 				scenario,
@@ -311,7 +311,7 @@ func (cancellationFirstParentStep) Execute(
 	_ dex.Context,
 	scenario cancellationScenario,
 ) (*dex.StepDecision, error) {
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(cancellationSelectorWinnerStep{}, scenario),
 		dex.MovementOf(cancellationSelectorWaitingStep{}, "first"),
 	), nil

--- a/sdk-java/src/main/java/io/superdurable/dex/StepDecision.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StepDecision.java
@@ -86,7 +86,7 @@ public final class StepDecision {
     public static <I> StepDecision goTo(
             final Class<? extends Step<I>> stepClass,
             final I input) {
-        return goToMulti(StepMovement.of(stepClass, input));
+        return goToMany(StepMovement.of(stepClass, input));
     }
 
     /**
@@ -95,7 +95,7 @@ public final class StepDecision {
      * @param movements the movements to schedule
      * @return a multi-movement decision
      */
-    public static StepDecision goToMulti(final StepMovement<?>... movements) {
+    public static StepDecision goToMany(final StepMovement<?>... movements) {
         return new StepDecision(
                 Kind.NEXT,
                 Arrays.<StepMovement<?>>asList(movements.clone()),

--- a/sdk-java/src/main/java/io/superdurable/dex/StepMovement.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StepMovement.java
@@ -17,7 +17,7 @@ package io.superdurable.dex;
  * movement override the target Step's default options for that execution only.
  *
  * <pre>{@code
- * return StepDecision.goToMulti(
+ * return StepDecision.goToMany(
  *         StepMovement.of(ReserveInventory.class, order),
  *         StepMovement.of(AuthorizePayment.class, order, paymentOptions));
  * }</pre>

--- a/sdk-java/src/main/java/io/superdurable/dex/WorkerDispatcher.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/WorkerDispatcher.java
@@ -308,7 +308,7 @@ final class WorkerDispatcher {
             case NEXT:
                 if (decision.getMovements().isEmpty()) {
                     throw new InvalidStepResultException(
-                            source + " goToMulti requires a movement");
+                            source + " goToMany requires a movement");
                 }
                 mapped.addAllNextSteps(mapMovements(flow, decision.getMovements()));
                 break;

--- a/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
@@ -920,7 +920,7 @@ final class WorkerServiceIntegrationTest {
                 throw largeFailure();
             }
             if ("invalid".equals(input)) {
-                return StepDecision.goToMulti();
+                return StepDecision.goToMany();
             }
             if ("cancel".equals(input)) {
                 final StepDecision base = StepDecision.gracefulComplete(input);
@@ -968,7 +968,7 @@ final class WorkerServiceIntegrationTest {
         }
 
         private StepDecision heartbeatDecision(final Duration timeout) {
-            return StepDecision.goToMulti(StepMovement.of(
+            return StepDecision.goToMany(StepMovement.of(
                     BridgeOtherStep.class,
                     "next",
                     StepOptions.newBuilder().heartbeatTimeout(timeout).build()));

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/BasicImmutableStepOptionsWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/BasicImmutableStepOptionsWorkflow.java
@@ -44,7 +44,7 @@ final class BasicImmutableStepOptionsWorkflow implements Flow<Integer> {
                     .waitForRetry(RetryPolicy.newBuilder().maximumAttempts(1).build())
                     .waitForFailure(WaitForFailurePolicy.PROCEED)
                     .build();
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(FailingWaitStep.class, 1, override));
         }
     }

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/InternalChannelWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/InternalChannelWorkflow.java
@@ -53,7 +53,7 @@ final class InternalChannelWorkflow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
-            return StepDecision.goToMulti(
+        return StepDecision.goToMany(
                     StepMovement.of(ConsumeStep.class, input),
                     StepMovement.of(PublishStep.class, input));
         }

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/MultiOutputWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/MultiOutputWorkflow.java
@@ -48,7 +48,7 @@ final class MultiOutputWorkflow implements Flow<Void> {
 
         @Override
         public StepDecision execute(final Context context, final Void input) {
-            return StepDecision.goToMulti(
+        return StepDecision.goToMany(
                     StepMovement.of(MultiOutputStringStep.class, null),
                     StepMovement.of(MultiOutputIntegerStep.class, null));
         }

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsLockingWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsLockingWorkflow.java
@@ -60,7 +60,7 @@ final class StateOptionsLockingWorkflow implements Flow<Integer> {
                 movements[index] = StepMovement.of(LockedStep.class, index);
             }
             movements[parallelism] = StepMovement.of(CompleteStep.class, parallelism);
-            return StepDecision.goToMulti(movements);
+        return StepDecision.goToMany(movements);
         }
     }
 

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsOverrideWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StateOptionsOverrideWorkflow.java
@@ -53,7 +53,7 @@ final class StateOptionsOverrideWorkflow implements Flow<String> {
                     .waitForFailure(WaitForFailurePolicy.PROCEED)
                     .build();
             output += "_state1_decide";
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(CompleteStep.class, output, options));
         }
     }

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationWorkflow.java
@@ -195,16 +195,16 @@ final class StepCancellationWorkflow implements Flow<Void> {
         public StepDecision execute(final Context context, final Void input) {
             switch (scenario) {
                 case HEARTBEAT_WAIT_FOR:
-                    return StepDecision.goToMulti(
+                    return StepDecision.goToMany(
                             StepMovement.of(StepCancellationBlockingWaitForStep.class, null),
                             StepMovement.of(StepCancellationWinnerStep.class, null));
                 case GLOBAL_SELECTOR:
                 case SIBLING_SELECTOR:
-                    return StepDecision.goToMulti(
+                    return StepDecision.goToMany(
                             StepMovement.of(StepCancellationFirstParentStep.class, null),
                             StepMovement.of(StepCancellationSecondParentStep.class, null));
                 default:
-                    return StepDecision.goToMulti(
+                    return StepDecision.goToMany(
                             StepMovement.of(StepCancellationBlockingExecuteStep.class, null),
                             StepMovement.of(StepCancellationWinnerStep.class, null));
             }
@@ -368,7 +368,7 @@ final class StepCancellationWorkflow implements Flow<Void> {
 
         @Override
         public StepDecision execute(final Context context, final Void input) {
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(StepCancellationSelectorWinnerStep.class, null),
                     StepMovement.of(StepCancellationSelectorWaitingStep.class, "first"));
         }

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/WorkflowUncompletedEmptyDecisionWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/WorkflowUncompletedEmptyDecisionWorkflow.java
@@ -38,7 +38,7 @@ final class WorkflowUncompletedEmptyDecisionStep implements Step<Integer> {
 
     @Override
     public StepDecision execute(final Context context, final Integer input) {
-        return StepDecision.goToMulti();
+        return StepDecision.goToMany();
     }
 
     @Override

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/WorkflowUncompletedTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/WorkflowUncompletedTest.java
@@ -265,7 +265,7 @@ public final class WorkflowUncompletedTest {
             assertEquals(FlowStatus.FAILED, failure.getStatus());
             assertEquals(FlowErrorType.WORKER_API_FAILED, failure.getErrorType());
             assertTrue(
-                    failure.getErrorMessage().contains("goToMulti requires a movement"),
+                    failure.getErrorMessage().contains("goToMany requires a movement"),
                     failure.getErrorMessage());
             assertEquals(0, failure.getCompletions().size());
         }

--- a/sdk-python/dex/__init__.py
+++ b/sdk-python/dex/__init__.py
@@ -85,7 +85,7 @@ from dex.step import (
     force_complete_if_channels_empty,
     force_fail,
     go_to,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 from dex.step_execution import StepExecutionId, TimerId
@@ -181,7 +181,7 @@ __all__ = [
     "force_fail",
     "graceful_complete",
     "go_to",
-    "go_to_multi",
+    "go_to_many",
     "open_blob_cache",
     "rpc",
 ]

--- a/sdk-python/dex/_worker_dispatcher.py
+++ b/sdk-python/dex/_worker_dispatcher.py
@@ -476,7 +476,7 @@ class WorkerDispatcher:
         mapped = pb.StepDecision()
         if decision.kind is DecisionKind.NEXT:
             if not decision.movements:
-                raise ValueError("go_to_multi requires a movement")
+                raise ValueError("go_to_many requires a movement")
             mapped.next_steps.extend(self._map_movements(flow, decision.movements))
         elif decision.kind is DecisionKind.GRACEFUL_COMPLETE:
             mapped.close_decision.CopyFrom(

--- a/sdk-python/dex/step.py
+++ b/sdk-python/dex/step.py
@@ -416,10 +416,10 @@ def go_to(step: type[Step[InputT]], input: InputT) -> StepDecision:
     Returns:
         A next decision containing one StepMovement.
     """
-    return go_to_multi(StepMovement.of(step, input))
+    return go_to_many(StepMovement.of(step, input))
 
 
-def go_to_multi(*movements: StepMovement[Any]) -> StepDecision:
+def go_to_many(*movements: StepMovement[Any]) -> StepDecision:
     """Create a decision that schedules several next Steps.
 
     Args:

--- a/sdk-python/tests/integ/basic_internal_channel_flow.py
+++ b/sdk-python/tests/integ/basic_internal_channel_flow.py
@@ -21,7 +21,7 @@ from dex import (
     StepMovement,
     Wait,
     dead_end,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -62,7 +62,7 @@ class ForkStep(Step[int]):
 
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(ConsumeStep, input),
             StepMovement.of(PublishStep, input),
         )

--- a/sdk-python/tests/integ/empty_decision_flow.py
+++ b/sdk-python/tests/integ/empty_decision_flow.py
@@ -16,14 +16,14 @@ from dex import (
     StepDecision,
     StepList,
     StepOptions,
-    go_to_multi,
+    go_to_many,
 )
 
 
 class EmptyDecisionStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
         del context, input
-        return go_to_multi()
+        return go_to_many()
 
     def get_step_options(self) -> StepOptions:
         return StepOptions(execute_retry=RetryPolicy(maximum_attempts=1))

--- a/sdk-python/tests/integ/immutable_step_options_flow.py
+++ b/sdk-python/tests/integ/immutable_step_options_flow.py
@@ -22,7 +22,7 @@ from dex import (
     Wait,
     WaitForFailurePolicy,
     go_to,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -37,7 +37,7 @@ class ImmutableOptionsStartStep(Step[int]):
             wait_for_retry=RetryPolicy(maximum_attempts=1),
             wait_for_failure=WaitForFailurePolicy.PROCEED,
         )
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(ImmutableOptionsFailingWaitStep, 1, options=override)
         )
 

--- a/sdk-python/tests/integ/multi_output_flow.py
+++ b/sdk-python/tests/integ/multi_output_flow.py
@@ -15,7 +15,7 @@ from dex import (
     StepDecision,
     StepList,
     StepMovement,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -43,7 +43,7 @@ class MultiOutputStartStep(Step[None]):
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(MultiOutputStringStep, None),
             StepMovement.of(MultiOutputIntStep, None),
         )

--- a/sdk-python/tests/integ/state_options_override_flow.py
+++ b/sdk-python/tests/integ/state_options_override_flow.py
@@ -21,7 +21,7 @@ from dex import (
     StepOptions,
     Wait,
     WaitForFailurePolicy,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -43,7 +43,7 @@ class OverrideFirstStep(Step[str]):
             wait_for_retry=RetryPolicy(maximum_attempts=2),
             wait_for_failure=WaitForFailurePolicy.PROCEED,
         )
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(OverrideCompleteStep, self.output, options=options)
         )
 

--- a/sdk-python/tests/integ/step_cancellation_flow.py
+++ b/sdk-python/tests/integ/step_cancellation_flow.py
@@ -32,7 +32,7 @@ from dex import (
     dead_end,
     force_fail,
     go_to,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -55,7 +55,7 @@ class CancellationStart(Step[str]):
         del context, input
         scenario = self.flow.scenario
         if scenario is CancellationScenario.HEARTBEAT_WAIT_FOR:
-            return go_to_multi(
+            return go_to_many(
                 StepMovement.of(CancellationBlockingWaitFor, None),
                 StepMovement.of(CancellationWinner, None),
             )
@@ -63,11 +63,11 @@ class CancellationStart(Step[str]):
             CancellationScenario.GLOBAL_SELECTOR,
             CancellationScenario.SIBLING_SELECTOR,
         }:
-            return go_to_multi(
+            return go_to_many(
                 StepMovement.of(CancellationFirstParent, None),
                 StepMovement.of(CancellationSecondParent, None),
             )
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(CancellationBlockingExecute, None),
             StepMovement.of(CancellationWinner, None),
         )
@@ -206,7 +206,7 @@ class CancellationFirstParent(Step[None]):
 
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(CancellationSelectorWinner, None),
             StepMovement.of(CancellationSelectorWaiting, "first"),
         )

--- a/sdk-python/tests/integ/test_workflow_uncompleted_runtime.py
+++ b/sdk-python/tests/integ/test_workflow_uncompleted_runtime.py
@@ -220,7 +220,7 @@ def test_empty_decision_fails_flow() -> None:
         assert failure.status is FlowStatus.FAILED
         assert failure.error_type is FlowErrorType.WORKER_API_FAILED
         assert failure.error_message is not None
-        assert "go_to_multi requires a movement" in failure.error_message
+        assert "go_to_many requires a movement" in failure.error_message
         assert len(failure.completions) == 0
 
 


### PR DESCRIPTION
## Summary

Rename the multi-target StepDecision API to the clearer GoToMany form across the Go, Java, and Python SDKs. Rust already used go_to_many.

## Rationale

GoTo and GoToMany form a direct singular/plural pair and describe the operation more clearly than the Multi suffix.

## User impact

Applications must replace GoToMulti, goToMulti, and go_to_multi with GoToMany, goToMany, and go_to_many. Documentation and examples are intentionally unchanged in this PR.

## Validation

- `make -C sdk-go clientIntegTests workerIntegTests`
- `make -C sdk-go e2eTests`
- `./gradlew test` from `sdk-java`
- `uv run --frozen pytest tests/test_contracts.py tests/test_errors.py tests/test_flow_result.py tests/test_worker_startup.py` from `sdk-python`
- `./run-integration-tests.sh` from `sdk-python`
- `make copyright-check`
