### PR TITLE
Fix conditional close during channel execution

### DIFF
--- a/docs/content/design-patterns/draining-channel-for-external-publishing.mdx
+++ b/docs/content/design-patterns/draining-channel-for-external-publishing.mdx
@@ -10,7 +10,7 @@ Process externally published Channel messages, then close the short-lived Flow w
 
 Use this pattern when a Flow handles messages from outside the Worker with potential bursts. A Client can append directly through **PublishToChannel** or potentially use an RPC. The key requirement is to complete the Flow when the Channel is empty, so the Flow stays as short as possible. The Flow restarts when new messages arrive.
 
-The decision atomically checks the Channel while it records the next action. An empty Channel completes the Flow. A queued message takes the fallback movement back to **ProcessMessage**. After completion, the next request starts a new Flow execution with the same Flow ID and passes the message as the start input.
+The decision atomically checks the Channel while it records the next action. An empty Channel completes the Flow. A Channel with queued messages, or one with messages committed to a Step that has not finished processing **Execute**, takes the fallback movement back to **ProcessMessage**. After completion, the next request starts a new Flow execution with the same Flow ID and passes the message as the start input.
 
 Only one Step may consume a Channel checked by **ForceCompleteIfChannelsEmpty**.
 

--- a/docs/content/primitives/step/step-decision.mdx
+++ b/docs/content/primitives/step/step-decision.mdx
@@ -330,7 +330,7 @@ Ok(StepDecision::go_to(&RecordQuoteStep, quote)
 
 ## ForceCompleteIfChannelsEmpty {#forcecompleteifchannelsempty}
 
-**ForceCompleteIfChannelsEmpty** atomically checks if Channels are empty. If they are, it completes the Flow. Otherwise, it goes to other Steps.
+**ForceCompleteIfChannelsEmpty** atomically checks whether all named Channels are empty. A Channel with queued messages is non-empty. After a message is consumed and committed to a Step, that Channel remains non-empty until the Step finishes processing **Execute**. If every named Channel is empty, it completes the Flow. Otherwise, it goes to other Steps.
 
 Use it when you want to drain Channels and complete the Flow, so the Flow can stay short. See [Drain External Channel](/design-patterns/draining-channel-for-external-publishing) for the full example.
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/draining-channel-for-external-publishing.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/draining-channel-for-external-publishing.mdx
@@ -11,7 +11,7 @@ sidebar_label: Drain External Channel
 
 当一条 Flow 要处理 Worker 外部发来的消息，并且消息可能突发到来时，使用这个模式。Client 可以通过 **PublishToChannel** 直接追加消息，或者使用 RPC。关键要求是在 Channel 为空时完成 Flow，从而尽可能让 Flow 保持短生命周期。有新消息到来时，Flow 会重新启动。
 
-这个 decision 会在记录下一步动作时原子地检查 Channel。Channel 为空时完成 Flow；仍有消息时，Dex 会走 fallback movement 回到 **ProcessMessage**。前一次 execution 完成后，下一个请求会使用相同的 Flow ID 启动新的 Flow execution，并将消息作为启动输入。
+这个 decision 会在记录下一步动作时原子地检查 Channel。Channel 为空时完成 Flow；Channel 中还有排队消息，或有消息已从该 Channel 消费并提交给尚未完成 **Execute** 处理的 Step 时，Dex 会走 fallback movement 回到 **ProcessMessage**。前一次 execution 完成后，下一个请求会使用相同的 Flow ID 启动新的 Flow execution，并将消息作为启动输入。
 
 被 **ForceCompleteIfChannelsEmpty** 检查的 Channel 只能由一个 Step 消费。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
@@ -330,7 +330,7 @@ Ok(StepDecision::go_to(&RecordQuoteStep, quote)
 
 ## ForceCompleteIfChannelsEmpty {#forcecompleteifchannelsempty}
 
-**ForceCompleteIfChannelsEmpty** 原子检查 Channel 是否为空。若为空，它完成 Flow。否则，它转到其他 Step。
+**ForceCompleteIfChannelsEmpty** 原子检查所有指定的 Channel 是否为空。Channel 中有排队消息时，该 Channel 视为非空。消息从 Channel 消费并提交给 Step 后，在该 Step 完成 **Execute** 处理之前，该 Channel 也视为非空。若所有指定的 Channel 都为空，它完成 Flow；否则，它转到其他 Step。
 
 当你想 drain Channel 并完成 Flow，让 Flow 保持短小，使用它。完整例子见[排空外部 Channel](/design-patterns/draining-channel-for-external-publishing)。
 

--- a/protos/README.md
+++ b/protos/README.md
@@ -53,9 +53,11 @@ completion waits for other active steps; force completion and force failure end
 the flow immediately; dead end ends only the current step thread.
 
 `FORCE_COMPLETE_ON_CHANNELS_EMPTY` atomically completes when every named channel
-is empty. It requires unique, non-empty `conditional_channel_names` and at least
-one `next_steps` fallback. Other close types cannot include channel names or
-next steps. `FORCE_FAIL` accepts only a string `close_input`, and `DEAD_END`
+has neither queued messages nor messages committed to a Step that has not
+finished processing `Execute`. Otherwise, it schedules the `next_steps`
+fallback. It requires unique, non-empty `conditional_channel_names` and at
+least one `next_steps` fallback. Other close types cannot include channel names
+or next steps. `FORCE_FAIL` accepts only a string `close_input`, and `DEAD_END`
 accepts no input.
 
 ## Step execution cancellation

--- a/server/integ/conditional_close_committed_consumption_test.go
+++ b/server/integ/conditional_close_committed_consumption_test.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package integ
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superdurable/dex/gen/dexpb"
+	"github.com/superdurable/dex/integ/workflow/common"
+	"github.com/superdurable/dex/service"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	conditionalCloseCommittedFlowType        = "conditional-close-committed-consumption"
+	conditionalCloseCommittedRootStep        = "root"
+	conditionalCloseCommittedCheckerStep     = "checker"
+	conditionalCloseCommittedConsumerStep    = "consumer"
+	conditionalCloseCommittedOrElseStep      = "or-else"
+	conditionalCloseCommittedChannelName     = "messages"
+	conditionalCloseCommittedMessage         = "only"
+	conditionalCloseCommittedPrematureOutput = "premature"
+	conditionalCloseCommittedOrElseOutput    = "or-else"
+)
+
+type conditionalCloseCommittedHandler struct {
+	dexpb.UnimplementedWorkerServiceServer
+	allowCheckerOnce       sync.Once
+	releaseConsumerOnce    sync.Once
+	consumerExecuteOnce    sync.Once
+	allowChecker           chan struct{}
+	releaseConsumer        chan struct{}
+	consumerExecuteStarted chan *dexpb.InvokeExecuteMethodRequest
+}
+
+func newConditionalCloseCommittedHandler() *conditionalCloseCommittedHandler {
+	return &conditionalCloseCommittedHandler{
+		allowChecker:           make(chan struct{}),
+		releaseConsumer:        make(chan struct{}),
+		consumerExecuteStarted: make(chan *dexpb.InvokeExecuteMethodRequest, 1),
+	}
+}
+
+func (h *conditionalCloseCommittedHandler) allowCheckerDecision() {
+	h.allowCheckerOnce.Do(func() { close(h.allowChecker) })
+}
+
+func (h *conditionalCloseCommittedHandler) releaseConsumerExecute() {
+	h.releaseConsumerOnce.Do(func() { close(h.releaseConsumer) })
+}
+
+func (h *conditionalCloseCommittedHandler) releaseAll() {
+	h.allowCheckerDecision()
+	h.releaseConsumerExecute()
+}
+
+func TestForceCompleteIfChannelsEmptyCountsCommittedConsumptionTemporal(t *testing.T) {
+	if !*temporalIntegTest {
+		t.Skip()
+	}
+	for iteration := 0; iteration < *repeatIntegTest; iteration++ {
+		doTestForceCompleteIfChannelsEmptyCountsCommittedConsumption(
+			t,
+			service.BackendTypeTemporal,
+		)
+	}
+}
+
+func TestForceCompleteIfChannelsEmptyCountsCommittedConsumptionCadence(t *testing.T) {
+	if !*cadenceIntegTest {
+		t.Skip()
+	}
+	for iteration := 0; iteration < *repeatIntegTest; iteration++ {
+		doTestForceCompleteIfChannelsEmptyCountsCommittedConsumption(
+			t,
+			service.BackendTypeCadence,
+		)
+	}
+}
+
+func doTestForceCompleteIfChannelsEmptyCountsCommittedConsumption(
+	t *testing.T,
+	backendType service.BackendType,
+) {
+	t.Helper()
+	handler := newConditionalCloseCommittedHandler()
+	workerTarget := startWorker(t, handler)
+	runtime := startDexService(t, DexServiceTestConfig{BackendType: backendType})
+	t.Cleanup(handler.releaseAll)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	flowID := conditionalCloseCommittedFlowType + "-" + uuid.NewString()
+	_, err := runtime.FlowClient.StartFlow(ctx, &dexpb.StartFlowRequest{
+		RequestId:          newRequestID(),
+		FlowId:             flowID,
+		FlowType:           conditionalCloseCommittedFlowType,
+		FlowTimeoutSeconds: 30,
+		StartStepType:      conditionalCloseCommittedRootStep,
+		StepOptions:        &dexpb.StepOptions{SkipWaitFor: true},
+		FlowStartOptions:   withWorkerTarget(nil, workerTarget),
+	})
+	require.NoError(t, err)
+
+	_, err = runtime.FlowClient.PublishToChannel(ctx, &dexpb.PublishToChannelRequest{
+		FlowId: flowID,
+		Messages: []*dexpb.ChannelMessage{{
+			ChannelName: conditionalCloseCommittedChannelName,
+			Value:       stringValue(conditionalCloseCommittedMessage),
+		}},
+	})
+	require.NoError(t, err)
+
+	var consumerRequest *dexpb.InvokeExecuteMethodRequest
+	select {
+	case consumerRequest = <-handler.consumerExecuteStarted:
+	case <-ctx.Done():
+		require.FailNow(t, "consumer Execute did not start", ctx.Err())
+	}
+	channelResults := consumerRequest.GetConditionResults().GetChannelResults()
+	require.Len(t, channelResults, 1)
+	require.Equal(t, "message", channelResults[0].GetConditionId())
+	require.Equal(t, conditionalCloseCommittedChannelName, channelResults[0].GetChannelName())
+	require.Equal(
+		t,
+		dexpb.ConditionStatus_CONDITION_STATUS_COMPLETED,
+		channelResults[0].GetConditionStatus(),
+	)
+	require.Len(t, channelResults[0].GetValues(), 1)
+	require.Equal(
+		t,
+		conditionalCloseCommittedMessage,
+		channelResults[0].GetValues()[0].GetStringValue(),
+	)
+
+	handler.allowCheckerDecision()
+	response, err := runtime.FlowClient.WaitForFlow(ctx, &dexpb.WaitForFlowRequest{
+		FlowId:          flowID,
+		WaitTimeSeconds: 30,
+		NeedsResults:    true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, dexpb.FlowStatus_FLOW_STATUS_COMPLETED, response.GetFlowStatus())
+	require.Len(t, response.GetResults(), 1)
+	require.Equal(
+		t,
+		conditionalCloseCommittedOrElseStep,
+		response.GetResults()[0].GetCompletedStepType(),
+	)
+	require.Equal(
+		t,
+		conditionalCloseCommittedOrElseOutput,
+		response.GetResults()[0].GetCompletedStepOutput().GetStringValue(),
+	)
+}
+
+func (h *conditionalCloseCommittedHandler) InvokeWaitForMethod(
+	_ context.Context,
+	request *dexpb.InvokeWaitForMethodRequest,
+) (*dexpb.InvokeWaitForMethodResponse, error) {
+	if request.GetFlowType() != conditionalCloseCommittedFlowType ||
+		request.GetStepType() != conditionalCloseCommittedConsumerStep {
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"unexpected WaitFor %q/%q",
+			request.GetFlowType(),
+			request.GetStepType(),
+		)
+	}
+	return &dexpb.InvokeWaitForMethodResponse{
+		WaitingCondition: &dexpb.WaitingCondition{
+			WaitingConditionType: dexpb.WaitingConditionType_WAITING_CONDITION_TYPE_ALL_COMPLETED,
+			ChannelConditions: []*dexpb.ChannelCondition{{
+				ConditionId: "message",
+				ChannelName: conditionalCloseCommittedChannelName,
+			}},
+		},
+	}, nil
+}
+
+func (h *conditionalCloseCommittedHandler) InvokeExecuteMethod(
+	ctx context.Context,
+	request *dexpb.InvokeExecuteMethodRequest,
+) (*dexpb.InvokeExecuteMethodResponse, error) {
+	if request.GetFlowType() != conditionalCloseCommittedFlowType {
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"unexpected Execute Flow type %q",
+			request.GetFlowType(),
+		)
+	}
+	switch request.GetStepType() {
+	case conditionalCloseCommittedRootStep:
+		return conditionalCloseCommittedRootResponse(), nil
+	case conditionalCloseCommittedCheckerStep:
+		select {
+		case <-h.allowChecker:
+		case <-ctx.Done():
+			return nil, status.Error(codes.Canceled, "checker Execute canceled")
+		}
+		return conditionalCloseCommittedCheckerResponse(), nil
+	case conditionalCloseCommittedConsumerStep:
+		h.consumerExecuteOnce.Do(func() { h.consumerExecuteStarted <- request })
+		select {
+		case <-h.releaseConsumer:
+		case <-ctx.Done():
+			return nil, status.Error(codes.Canceled, "consumer Execute canceled")
+		}
+		return &dexpb.InvokeExecuteMethodResponse{
+			StepDecision: &dexpb.StepDecision{
+				CloseDecision: common.DeadEndDecision(),
+			},
+		}, nil
+	case conditionalCloseCommittedOrElseStep:
+		h.releaseConsumerExecute()
+		return &dexpb.InvokeExecuteMethodResponse{
+			StepDecision: &dexpb.StepDecision{
+				CloseDecision: common.GracefulCompleteDecision(
+					stringValue(conditionalCloseCommittedOrElseOutput),
+				),
+			},
+		}, nil
+	default:
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"unexpected Execute Step type %q",
+			request.GetStepType(),
+		)
+	}
+}
+
+func conditionalCloseCommittedRootResponse() *dexpb.InvokeExecuteMethodResponse {
+	return &dexpb.InvokeExecuteMethodResponse{
+		StepDecision: &dexpb.StepDecision{
+			NextSteps: []*dexpb.StepMovement{
+				{
+					StepType:    conditionalCloseCommittedCheckerStep,
+					StepOptions: &dexpb.StepOptions{SkipWaitFor: true},
+				},
+				{StepType: conditionalCloseCommittedConsumerStep},
+			},
+		},
+	}
+}
+
+func conditionalCloseCommittedCheckerResponse() *dexpb.InvokeExecuteMethodResponse {
+	return &dexpb.InvokeExecuteMethodResponse{
+		StepDecision: &dexpb.StepDecision{
+			NextSteps: []*dexpb.StepMovement{{
+				StepType:    conditionalCloseCommittedOrElseStep,
+				StepOptions: &dexpb.StepOptions{SkipWaitFor: true},
+			}},
+			CloseDecision: &dexpb.CloseDecision{
+				CloseDecisionType: dexpb.CloseDecisionType_CLOSE_DECISION_TYPE_FORCE_COMPLETE_ON_CHANNELS_EMPTY,
+				ConditionalChannelNames: []string{
+					conditionalCloseCommittedChannelName,
+				},
+				CloseInput: stringValue(conditionalCloseCommittedPrematureOutput),
+			},
+		},
+	}
+}

--- a/server/service/interpreter/channelStore.go
+++ b/server/service/interpreter/channelStore.go
@@ -19,11 +19,15 @@ import (
 
 // ChannelStore holds FIFO messages by channel.
 type ChannelStore struct {
-	channelMessages map[string][]*dexpb.Value
+	channelMessages           map[string][]*dexpb.Value
+	inFlightConsumptionCounts condition.ChannelAvailability
 }
 
 func NewChannelStore() *ChannelStore {
-	return &ChannelStore{channelMessages: map[string][]*dexpb.Value{}}
+	return &ChannelStore{
+		channelMessages:           map[string][]*dexpb.Value{},
+		inFlightConsumptionCounts: condition.ChannelAvailability{},
+	}
 }
 
 // RebuildChannelStore restores a snapshot.
@@ -34,7 +38,10 @@ func RebuildChannelStore(refill map[string]*dexpb.ChannelValues) *ChannelStore {
 			chMsgs[name] = channelValues.GetValues()
 		}
 	}
-	return &ChannelStore{channelMessages: chMsgs}
+	return &ChannelStore{
+		channelMessages:           chMsgs,
+		inFlightConsumptionCounts: condition.ChannelAvailability{},
+	}
 }
 
 // ProcessPublishing appends messages.
@@ -53,9 +60,10 @@ func (i *ChannelStore) Availability() condition.ChannelAvailability {
 	return availability
 }
 
-// HasData reports whether a channel has messages.
-func (i *ChannelStore) HasData(channelName string) bool {
-	return len(i.channelMessages[channelName]) > 0
+// HasPendingData reports queued messages or committed messages still executing.
+func (i *ChannelStore) HasPendingData(channelName string) bool {
+	return len(i.channelMessages[channelName]) > 0 ||
+		i.inFlightConsumptionCounts[channelName] > 0
 }
 
 // GetInfos returns channel sizes.
@@ -92,6 +100,7 @@ func (i *ChannelStore) CommitMatch(plan *condition.MatchPlan) map[int][]*dexpb.V
 		if consumption.Count > 0 {
 			consumed[consumption.ChannelConditionIndex] = values[:consumption.Count:consumption.Count]
 			values = values[consumption.Count:]
+			i.inFlightConsumptionCounts[consumption.ChannelName] += consumption.Count
 		} else {
 			consumed[consumption.ChannelConditionIndex] = nil
 		}
@@ -102,6 +111,30 @@ func (i *ChannelStore) CommitMatch(plan *condition.MatchPlan) map[int][]*dexpb.V
 		}
 	}
 	return consumed
+}
+
+// CompleteMatch releases messages after their consuming Execute returns.
+func (i *ChannelStore) CompleteMatch(plan *condition.MatchPlan) {
+	for _, consumption := range plan.Consumes {
+		if consumption.Count == 0 {
+			continue
+		}
+		inFlightCount := i.inFlightConsumptionCounts[consumption.ChannelName]
+		if inFlightCount < consumption.Count {
+			panic(fmt.Sprintf(
+				"channel %q has %d in-flight messages but completion releases %d",
+				consumption.ChannelName,
+				inFlightCount,
+				consumption.Count,
+			))
+		}
+		remainingCount := inFlightCount - consumption.Count
+		if remainingCount == 0 {
+			delete(i.inFlightConsumptionCounts, consumption.ChannelName)
+		} else {
+			i.inFlightConsumptionCounts[consumption.ChannelName] = remainingCount
+		}
+	}
 }
 
 func (i *ChannelStore) receive(channelName string, data *dexpb.Value) {

--- a/server/service/interpreter/workflowImpl.go
+++ b/server/service/interpreter/workflowImpl.go
@@ -765,7 +765,7 @@ func checkClosingWorkflow(
 
 		conditionMet := true
 		for _, channelName := range closeDecision.GetConditionalChannelNames() {
-			if channelStore.HasData(channelName) {
+			if channelStore.HasPendingData(channelName) {
 				conditionMet = false
 			}
 		}
@@ -1081,6 +1081,7 @@ func (i *Interpreter) processStepExecution(
 	}
 
 	consumed := channelStore.CommitMatch(matchPlan)
+	defer channelStore.CompleteMatch(matchPlan)
 	conditionResults := condition.BuildConditionResults(
 		waitingCondition,
 		completedTimerConditions,


### PR DESCRIPTION
## Summary

- track committed channel consumption as in-flight until the consuming Step finishes Execute
- treat queued or in-flight messages as non-empty for ForceCompleteIfChannelsEmpty
- cover the parallel consumer/checker race on Temporal and Cadence and document the behavior in both locales

## Rationale

A concurrent Step could consume the last queued message before another Step evaluated ForceCompleteIfChannelsEmpty. The channel then appeared empty even though that message was still being processed, allowing the Flow to complete prematurely instead of taking its fallback movement.

## User impact

ForceCompleteIfChannelsEmpty now takes its fallback movement while another Step is still processing a committed message from a checked Channel. Once that Execute call finishes, the message no longer keeps the Channel non-empty.

## Validation

- `make -C server unitTests`
- `make -C server temporalIntegTests`
- `make -C server cadenceIntegTests` (the new and existing conditional-close tests pass; the local full run encountered Cadence Elasticsearch `all shards failed` in unrelated persistence visibility tests)
- `make copyright-check`
- `make docs-prose-check`
