### PR TITLE
Rename TypeScript multi-step decision API

### DIFF
--- a/sdk-typescript/src/step.ts
+++ b/sdk-typescript/src/step.ts
@@ -300,14 +300,14 @@ export type StepDecision = (
  * @returns A next decision containing one movement.
  */
 export const goTo = <Input>(step: StepClass<Input>, input: Input): StepDecision =>
-  goToMulti(StepMovement.of(step, input));
+  goToMany(StepMovement.of(step, input));
 
 /**
  * Creates a decision scheduling several next Steps.
  * @param movements - Typed movements applied in argument order.
  * @returns A next decision containing every movement.
  */
-export const goToMulti = (...movements: readonly StepMovement<unknown>[]): StepDecision => ({
+export const goToMany = (...movements: readonly StepMovement<unknown>[]): StepDecision => ({
   kind: "next",
   movements,
 });

--- a/sdk-typescript/src/worker-dispatcher.ts
+++ b/sdk-typescript/src/worker-dispatcher.ts
@@ -391,7 +391,7 @@ function mapDecision(flow: RegisteredFlow, decision: StepDecision | undefined): 
   }
   if (decision.kind === "next") {
     if (decision.movements.length === 0) {
-      throw new TypeError("goToMulti requires a movement");
+      throw new TypeError("goToMany requires a movement");
     }
     return withCancellationSelection(
       flow,

--- a/sdk-typescript/test/integ/basic_internal_channel_flow.ts
+++ b/sdk-typescript/test/integ/basic_internal_channel_flow.ts
@@ -17,7 +17,7 @@ import {
   Wait,
   deadEnd,
   doubleCodec,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   type Context,
   type Flow,
@@ -82,7 +82,7 @@ class ForkStep implements Step<number> {
   }
 
   public execute(_context: Context, input: number): StepDecision {
-    return goToMulti(
+    return goToMany(
       StepMovement.of(ConsumeStep, input),
       StepMovement.of(PublishStep, input),
     );

--- a/sdk-typescript/test/integ/empty_decision_flow.ts
+++ b/sdk-typescript/test/integ/empty_decision_flow.ts
@@ -11,7 +11,7 @@
 import {
   StepList,
   doubleCodec,
-  goToMulti,
+  goToMany,
   type Context,
   type Flow,
   type Step,
@@ -27,7 +27,7 @@ class EmptyDecisionStep implements Step<number> {
   }
 
   public execute(_context: Context, _input: number): StepDecision {
-    return goToMulti();
+    return goToMany();
   }
 
   public getStepOptions(): StepOptions {

--- a/sdk-typescript/test/integ/immutable_step_options_flow.ts
+++ b/sdk-typescript/test/integ/immutable_step_options_flow.ts
@@ -14,7 +14,7 @@ import {
   Wait,
   doubleCodec,
   goTo,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   type Context,
   type Flow,
@@ -57,7 +57,7 @@ class ImmutableStartStep implements Step<number> {
   }
 
   public execute(_context: Context, _input: number): StepDecision {
-    return goToMulti(
+    return goToMany(
       StepMovement.of(ImmutableFailingWaitStep, 1, {
         waitForRetry: { maximumAttempts: 1 },
         waitForFailure: "proceed",

--- a/sdk-typescript/test/integ/multi_output_flow.ts
+++ b/sdk-typescript/test/integ/multi_output_flow.ts
@@ -11,7 +11,7 @@
 import {
   StepList,
   StepMovement,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   voidCodec,
   type Context,
@@ -57,7 +57,7 @@ class MultiOutputStartStep implements Step<void> {
   }
 
   public execute(_context: Context, _input: void): StepDecision {
-    return goToMulti(
+    return goToMany(
       StepMovement.of(MultiOutputStringStep, undefined),
       StepMovement.of(MultiOutputNumberStep, undefined),
     );

--- a/sdk-typescript/test/integ/state_options_override_flow.ts
+++ b/sdk-typescript/test/integ/state_options_override_flow.ts
@@ -12,7 +12,7 @@ import {
   StepList,
   StepMovement,
   Wait,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   stringCodec,
   type Context,
@@ -68,7 +68,7 @@ class OverrideFirstStep implements Step<string> {
 
   public execute(_context: Context, _input: string): StepDecision {
     this.output += "_state1_decide";
-    return goToMulti(
+    return goToMany(
       StepMovement.of(CompleteStep, this.output, {
         waitForRetry: { maximumAttempts: 2 },
         waitForFailure: "proceed",

--- a/sdk-typescript/test/integ/step_cancellation_flow.ts
+++ b/sdk-typescript/test/integ/step_cancellation_flow.ts
@@ -18,7 +18,7 @@ import {
   deadEnd,
   forceFail,
   goTo,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   stringCodec,
   voidCodec,
@@ -62,18 +62,18 @@ class CancellationStart implements Step<string> {
 
   public execute(_context: Context, _input: string): StepDecision {
     if (this.flow.scenario === "heartbeat-wait-for") {
-      return goToMulti(
+      return goToMany(
         StepMovement.of(CancellationBlockingWaitFor, undefined),
         StepMovement.of(CancellationWinner, undefined),
       );
     }
     if (this.flow.scenario === "global-selector" || this.flow.scenario === "sibling-selector") {
-      return goToMulti(
+      return goToMany(
         StepMovement.of(CancellationFirstParent, undefined),
         StepMovement.of(CancellationSecondParent, undefined),
       );
     }
-    return goToMulti(
+    return goToMany(
       StepMovement.of(CancellationBlockingExecute, undefined),
       StepMovement.of(CancellationWinner, undefined),
     );
@@ -238,7 +238,7 @@ class CancellationFirstParent implements Step<void> {
   }
 
   public execute(_context: Context, _input: void): StepDecision {
-    return goToMulti(
+    return goToMany(
       StepMovement.of(CancellationSelectorWinner, undefined),
       StepMovement.of(CancellationSelectorWaiting, "first"),
     );

--- a/sdk-typescript/test/integ/workflow-uncompleted.integration.test.ts
+++ b/sdk-typescript/test/integ/workflow-uncompleted.integration.test.ts
@@ -177,7 +177,7 @@ test("Worker method timeout fails the Flow", async () => {
   });
 });
 
-test("empty goToMulti decision fails the Flow", async () => {
+test("empty goToMany decision fails the Flow", async () => {
   const flow = new EmptyDecisionFlow();
   await withEnvironment([flow], async ({ client }) => {
     const id = flowId("empty-decision");
@@ -185,7 +185,7 @@ test("empty goToMulti decision fails the Flow", async () => {
     const failure = await waitForFailure(client, id);
     assert.equal(failure.status, "failed");
     assert.equal(failure.errorType, FlowErrorType.WORKER_API_FAILED);
-    assert.match(failure.errorMessage ?? "", /goToMulti requires a movement/);
+    assert.match(failure.errorMessage ?? "", /goToMany requires a movement/);
     assert.equal(failure.completions.length, 0);
   });
 });


### PR DESCRIPTION
## Summary

Rename the TypeScript multi-target StepDecision API from goToMulti to goToMany.

## Rationale

This completes the singular/plural API normalization already merged for the other SDKs: goTo and goToMany.

## User impact

TypeScript applications must replace goToMulti with goToMany. The renamed worker error and all integration fixtures use the new name.

## Validation

- `npm test` from `sdk-typescript`
- `npm run coverage:integration` from `sdk-typescript`
- `npm run docs:check` from `sdk-typescript`
- `make copyright-check`
