### PR TITLE
Update examples and docs for GoToMany

### DIFF
--- a/docs/content/design-patterns/cron.mdx
+++ b/docs/content/design-patterns/cron.mdx
@@ -59,7 +59,7 @@ class _WaitForSchedule(Step[_ScheduleState]):
         )
         if run_input.is_final:
             return go_to(_Run, run_input)
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(_Run, run_input),
             StepMovement.of(
                 _WaitForSchedule,
@@ -106,7 +106,7 @@ func (waitForCronSchedule) Execute(
 		return dex.GoTo(runCronSchedule{}, run), nil
 	}
 	state.RemainingRuns--
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(runCronSchedule{}, run),
 		dex.MovementOf(waitForCronSchedule{}, state),
 	), nil
@@ -135,7 +135,7 @@ final class WaitForSchedule implements Step<ScheduleState> {
         if (runInput.isFinal) {
             return StepDecision.goTo(Run.class, runInput);
         }
-        return StepDecision.goToMulti(
+        return StepDecision.goToMany(
                 StepMovement.of(Run.class, runInput),
                 StepMovement.of(
                         WaitForSchedule.class,
@@ -176,7 +176,7 @@ class WaitForSchedule implements Step<ScheduleState> {
     if (input.isFinal) {
       return goTo(Run, input);
     }
-    return goToMulti(
+    return goToMany(
       StepMovement.of(Run, input),
       StepMovement.of(WaitForSchedule, {
         interval: state.interval,

--- a/docs/content/design-patterns/parallel.mdx
+++ b/docs/content/design-patterns/parallel.mdx
@@ -8,7 +8,7 @@ Choose one of four ways to start and coordinate concurrent Step executions.
 
 ## Problem and approach
 
-Each pattern starts independent Step executions with **GoToMulti**. Use the coordination choice that matches when the Flow is allowed to continue.
+Each pattern starts independent Step executions with **GoToMany**. Use the coordination choice that matches when the Flow is allowed to continue.
 
 - [Static parallel Steps](/design-patterns/parallel/static) — Fan out to a fixed set of distinct Step types.
 - [Dynamic parallel Steps](/design-patterns/parallel/dynamic) — Fan out to a runtime-sized set of executions of one Step type.

--- a/docs/content/design-patterns/parallel/await.mdx
+++ b/docs/content/design-patterns/parallel/await.mdx
@@ -58,7 +58,7 @@ class InitStep(Step[int]):
         movements.extend(
             StepMovement.of(DoWorkStep, index) for index in range(input)
         )
-        return go_to_multi(*movements)
+        return go_to_many(*movements)
 ```
 
 </SdkSnippet>
@@ -74,7 +74,7 @@ func (awaitInitStep) Execute(_ dex.Context, count int) (*dex.StepDecision, error
 	for index := 0; index < count; index++ {
 		movements = append(movements, dex.MovementOf(awaitWorkStep{}, index))
 	}
-	return dex.GoToMulti(movements...), nil
+	return dex.GoToMany(movements...), nil
 }
 
 type awaitWorkStep struct{ dex.StepDefaultsNoWaitFor[int] }
@@ -119,7 +119,7 @@ final class InitStep implements Step<Integer> {
         for (int index = 0; index < count; index++) {
             movements[index + 1] = StepMovement.of(DoWorkStep.class, index);
         }
-        return StepDecision.goToMulti(movements);
+        return StepDecision.goToMany(movements);
     }
 }
 
@@ -170,7 +170,7 @@ class AwaitInitStep implements Step<number> {
     return "InitStep";
   }
   public execute(_context: Context, count: number): StepDecision {
-    return goToMulti(
+    return goToMany(
       StepMovement.of(AwaitStep, count),
       ...Array.from({ length: count }, (_, index) =>
         StepMovement.of(AwaitDoWorkStep, index),

--- a/docs/content/design-patterns/parallel/dynamic.mdx
+++ b/docs/content/design-patterns/parallel/dynamic.mdx
@@ -37,7 +37,7 @@ class DoWorkStep(Step[int]):
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to_multi(
+        return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )
 ```
@@ -57,7 +57,7 @@ func (dynamicInitStep) Execute(_ dex.Context, items []string) (*dex.StepDecision
 	for _, item := range items {
 		movements = append(movements, dex.MovementOf(dynamicWorkStep{}, item))
 	}
-	return dex.GoToMulti(movements...), nil
+	return dex.GoToMany(movements...), nil
 }
 
 type dynamicWorkStep struct {
@@ -88,7 +88,7 @@ final class InitStep implements Step<Integer> {
         for (int index = 0; index < count; index++) {
             movements[index] = StepMovement.of(DoWorkStep.class, index);
         }
-        return StepDecision.goToMulti(movements);
+        return StepDecision.goToMany(movements);
     }
 }
 
@@ -121,7 +121,7 @@ class DynamicInitStep implements Step<number> {
     return "InitStep";
   }
   public execute(_context: Context, count: number): StepDecision {
-    return goToMulti(
+    return goToMany(
       ...Array.from({ length: count }, (_, index) =>
         StepMovement.of(DynamicDoWorkStep, index),
       ),

--- a/docs/content/design-patterns/parallel/first-win.mdx
+++ b/docs/content/design-patterns/parallel/first-win.mdx
@@ -37,7 +37,7 @@ class DoWorkStep(Step[int]):
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to_multi(
+        return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )
 ```
@@ -55,7 +55,7 @@ func (firstWinInitStep) Execute(_ dex.Context, count int) (*dex.StepDecision, er
 	for index := 0; index < count; index++ {
 		movements = append(movements, dex.MovementOf(firstWinWorkStep{}, index))
 	}
-	return dex.GoToMulti(movements...), nil
+	return dex.GoToMany(movements...), nil
 }
 
 type firstWinWorkStep struct{ dex.StepDefaultsNoWaitFor[int] }
@@ -84,7 +84,7 @@ final class InitStep implements Step<Integer> {
         for (int index = 0; index < count; index++) {
             movements[index] = StepMovement.of(DoWorkStep.class, index);
         }
-        return StepDecision.goToMulti(movements);
+        return StepDecision.goToMany(movements);
     }
 }
 
@@ -118,7 +118,7 @@ class FirstWinInitStep implements Step<number> {
     return "InitStep";
   }
   public execute(_context: Context, count: number): StepDecision {
-    return goToMulti(
+    return goToMany(
       ...Array.from({ length: count }, (_, index) =>
         StepMovement.of(FirstWinDoWorkStep, index),
       ),

--- a/docs/content/design-patterns/parallel/static.mdx
+++ b/docs/content/design-patterns/parallel/static.mdx
@@ -40,7 +40,7 @@ class WorkBStep(Step[str]):
 class InitStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
         del context
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(WorkAStep, input),
             StepMovement.of(WorkBStep, input),
         )
@@ -57,7 +57,7 @@ type staticInitStep struct {
 func (staticInitStep) GetStepType() string { return "InitStep" }
 
 func (staticInitStep) Execute(_ dex.Context, input string) (*dex.StepDecision, error) {
-	return dex.GoToMulti(dex.MovementOf(workAStep{}, input), dex.MovementOf(workBStep{}, input)), nil
+	return dex.GoToMany(dex.MovementOf(workAStep{}, input), dex.MovementOf(workBStep{}, input)), nil
 }
 
 type workAStep struct {
@@ -93,7 +93,7 @@ final class InitStep implements Step<String> {
 
     @Override
     public StepDecision execute(final Context context, final String input) {
-        return StepDecision.goToMulti(
+        return StepDecision.goToMany(
                 StepMovement.of(WorkAStep.class, input),
                 StepMovement.of(WorkBStep.class, input));
     }
@@ -154,7 +154,7 @@ class StaticInitStep implements Step<string> {
     return "InitStep";
   }
   public execute(_context: Context, input: string): StepDecision {
-    return goToMulti(
+    return goToMany(
       StepMovement.of(WorkAStep, input),
       StepMovement.of(WorkBStep, input),
     );

--- a/docs/content/primitives/step/step-decision.mdx
+++ b/docs/content/primitives/step/step-decision.mdx
@@ -10,7 +10,7 @@ This page covers the advanced **StepDecision** features. See the [basic page](/p
 
 ## Multiple next Steps {#gotomulti}
 
-**GoTo** starts one next Step. **GoToMulti** starts multiple next Steps. Use it to fan out work that can run in parallel. Each Step movement has its own input and can also have its own Step options.
+**GoTo** starts one next Step. **GoToMany** starts multiple next Steps. Use it to fan out work that can run in parallel. Each Step movement has its own input and can also have its own Step options.
 
 <SdkTabs
   examples={{
@@ -23,7 +23,7 @@ This page covers the advanced **StepDecision** features. See the [basic page](/p
 <SdkSnippet lang="go">
 
 ```go
-return dex.GoToMulti(
+return dex.GoToMany(
 	dex.MovementOf(carrierAStep{}, Quote{Carrier: "A", Price: 10}),
 	dex.MovementOf(carrierBStep{}, Quote{Carrier: "B", Price: 12}),
 	dex.MovementOf(winnerStep{}, quote),
@@ -34,7 +34,7 @@ return dex.GoToMulti(
   <SdkSnippet lang="java">
 
 ```java
-return StepDecision.goToMulti(
+return StepDecision.goToMany(
         StepMovement.of(CarrierAStep.class, quoteA),
         StepMovement.of(CarrierBStep.class, quoteB),
         StepMovement.of(WinnerStep.class, winnerQuote));
@@ -44,7 +44,7 @@ return StepDecision.goToMulti(
   <SdkSnippet lang="python">
 
 ```python
-return go_to_multi(
+return go_to_many(
     StepMovement.of(CarrierAStep, Quote(carrier="A", price=10)),
     StepMovement.of(CarrierBStep, Quote(carrier="B", price=12)),
     StepMovement.of(WinnerStep, quote),
@@ -55,7 +55,7 @@ return go_to_multi(
   <SdkSnippet lang="typescript">
 
 ```typescript
-return goToMulti(
+return goToMany(
   StepMovement.of(CarrierAStep, { carrier: "A", price: 10 }),
   StepMovement.of(CarrierBStep, { carrier: "B", price: 12 }),
   StepMovement.of(WinnerStep, quote),
@@ -106,7 +106,7 @@ Use **GracefulComplete** when you want the remaining active Steps and branches t
 case "graceful":
 	return dex.GracefulComplete("done"), nil
 case "dead-end":
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(branchWorkerStep{}, "left"),
 		dex.MovementOf(branchWorkerStep{}, "right"),
 	), nil
@@ -124,7 +124,7 @@ case "graceful" -> {
     return StepDecision.gracefulComplete("done");
 }
 case "dead-end" -> {
-    return StepDecision.goToMulti(
+    return StepDecision.goToMany(
             StepMovement.of(BranchWorkerStep.class, "left"),
             StepMovement.of(BranchWorkerStep.class, "right"));
 }
@@ -139,7 +139,7 @@ return StepDecision.deadEnd();
 if mode == "graceful":
     return graceful_complete("done")
 if mode == "dead-end":
-    return go_to_multi(
+    return go_to_many(
         StepMovement.of(BranchWorkerStep, "left"),
         StepMovement.of(BranchWorkerStep, "right"),
     )
@@ -155,7 +155,7 @@ if (mode === "graceful") {
   return gracefulComplete("done");
 }
 if (mode === "dead-end") {
-  return goToMulti(
+  return goToMany(
     StepMovement.of(BranchWorkerStep, "left"),
     StepMovement.of(BranchWorkerStep, "right"),
   );

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -342,7 +342,7 @@ final StepOptions options = StepOptions.newBuilder()
         .waitForRetry(RetryPolicy.newBuilder().maximumAttempts(2).build())
         .waitForFailure(WaitForFailurePolicy.PROCEED)
         .build();
-return StepDecision.goToMulti(StepMovement.of(OverrideSecondStep.class, output, options));
+return StepDecision.goToMany(StepMovement.of(OverrideSecondStep.class, output, options));
 ```
 
 </SdkSnippet>
@@ -353,7 +353,7 @@ options = StepOptions(
     wait_for_retry=RetryPolicy(maximum_attempts=2),
     wait_for_failure=WaitForFailurePolicy.PROCEED,
 )
-return go_to_multi(StepMovement.of(OverrideSecondStep, output, options))
+return go_to_many(StepMovement.of(OverrideSecondStep, output, options))
 ```
 
 </SdkSnippet>
@@ -364,7 +364,7 @@ const override: StepOptions = {
   waitForRetry: { maximumAttempts: 2 },
   waitForFailure: "proceed",
 };
-return goToMulti(StepMovement.of(OverrideSecondStep, payload, override));
+return goToMany(StepMovement.of(OverrideSecondStep, payload, override));
 ```
 
 </SdkSnippet>

--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -2105,7 +2105,7 @@ func MovementOf[IN any](
 	options ...StepMoveOption,
 ) StepMovement
 
-func GoToMulti(movements ...StepMovement) *StepDecision
+func GoToMany(movements ...StepMovement) *StepDecision
 func GracefulComplete(output any) *StepDecision
 func ForceComplete(output any) *StepDecision
 func ForceFail(reason string) *StepDecision
@@ -2133,7 +2133,7 @@ func (decision *StepDecision) CancelSiblingSteps(
 
 Rules enforced by construction or Phase 3 validation:
 
-- `GoTo` constructs one movement and `GoToMulti` requires at least one valid
+- `GoTo` constructs one movement and `GoToMany` requires at least one valid
   movement.
 - graceful complete, force complete, force fail, and dead end cannot have next
   steps;
@@ -2875,7 +2875,7 @@ Add SDK external-package tests (`package dex_test`) for these scenarios:
    embeds `StepDefaults` and the latter embeds `StepDefaultsNoWaitFor[IN]`.
 3. `None` preserves typed Step, RPC, and Channel declarations without accepting
    arbitrary payloads.
-4. `DefineStep`, `DefineStartStep`, `GoTo`, `MovementOf`, and `GoToMulti`
+4. `DefineStep`, `DefineStartStep`, `GoTo`, `MovementOf`, and `GoToMany`
    preserve target step input types.
 5. A Flow method matching `RPC[IN, OUT]` preserves typed worker handlers, while
    `Client.InvokeRPC` accepts `any` and a caller-provided output pointer.
@@ -2889,7 +2889,7 @@ Add SDK external-package tests (`package dex_test`) for these scenarios:
 9. Static and map channel result methods return `[]T` without exposing raw
    condition-result types.
 10. The `Context.HasTimerFired` and `HasTimerFiredByIndex` signatures compile.
-11. Execute can return `GoTo`, `GoToMulti`, all close decisions, and conditional
+11. Execute can return `GoTo`, `GoToMany`, all close decisions, and conditional
     force-complete fallback using channel definitions directly.
 12. Step-execution local Set accepts `any`, Get accepts a caller-provided
     pointer, and `RecordEvent(name, any)` compiles.

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/cron.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/cron.mdx
@@ -60,7 +60,7 @@ class _WaitForSchedule(Step[_ScheduleState]):
         )
         if run_input.is_final:
             return go_to(_Run, run_input)
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(_Run, run_input),
             StepMovement.of(
                 _WaitForSchedule,
@@ -107,7 +107,7 @@ func (waitForCronSchedule) Execute(
 		return dex.GoTo(runCronSchedule{}, run), nil
 	}
 	state.RemainingRuns--
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(runCronSchedule{}, run),
 		dex.MovementOf(waitForCronSchedule{}, state),
 	), nil
@@ -136,7 +136,7 @@ final class WaitForSchedule implements Step<ScheduleState> {
         if (runInput.isFinal) {
             return StepDecision.goTo(Run.class, runInput);
         }
-        return StepDecision.goToMulti(
+        return StepDecision.goToMany(
                 StepMovement.of(Run.class, runInput),
                 StepMovement.of(
                         WaitForSchedule.class,
@@ -177,7 +177,7 @@ class WaitForSchedule implements Step<ScheduleState> {
     if (input.isFinal) {
       return goTo(Run, input);
     }
-    return goToMulti(
+    return goToMany(
       StepMovement.of(Run, input),
       StepMovement.of(WaitForSchedule, {
         interval: state.interval,

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/await.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/await.mdx
@@ -56,7 +56,7 @@ class InitStep(Step[int]):
         movements.extend(
             StepMovement.of(DoWorkStep, index) for index in range(input)
         )
-        return go_to_multi(*movements)
+        return go_to_many(*movements)
 ```
 
 </SdkSnippet>
@@ -72,7 +72,7 @@ func (awaitInitStep) Execute(_ dex.Context, count int) (*dex.StepDecision, error
 	for index := 0; index < count; index++ {
 		movements = append(movements, dex.MovementOf(awaitWorkStep{}, index))
 	}
-	return dex.GoToMulti(movements...), nil
+	return dex.GoToMany(movements...), nil
 }
 
 type awaitWorkStep struct{ dex.StepDefaultsNoWaitFor[int] }
@@ -117,7 +117,7 @@ final class InitStep implements Step<Integer> {
         for (int index = 0; index < count; index++) {
             movements[index + 1] = StepMovement.of(DoWorkStep.class, index);
         }
-        return StepDecision.goToMulti(movements);
+        return StepDecision.goToMany(movements);
     }
 }
 
@@ -168,7 +168,7 @@ class AwaitInitStep implements Step<number> {
     return "InitStep";
   }
   public execute(_context: Context, count: number): StepDecision {
-    return goToMulti(
+    return goToMany(
       StepMovement.of(AwaitStep, count),
       ...Array.from({ length: count }, (_, index) =>
         StepMovement.of(AwaitDoWorkStep, index),

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/dynamic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/dynamic.mdx
@@ -35,7 +35,7 @@ class DoWorkStep(Step[int]):
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to_multi(
+        return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )
 ```
@@ -55,7 +55,7 @@ func (dynamicInitStep) Execute(_ dex.Context, items []string) (*dex.StepDecision
 	for _, item := range items {
 		movements = append(movements, dex.MovementOf(dynamicWorkStep{}, item))
 	}
-	return dex.GoToMulti(movements...), nil
+	return dex.GoToMany(movements...), nil
 }
 
 type dynamicWorkStep struct {
@@ -86,7 +86,7 @@ final class InitStep implements Step<Integer> {
         for (int index = 0; index < count; index++) {
             movements[index] = StepMovement.of(DoWorkStep.class, index);
         }
-        return StepDecision.goToMulti(movements);
+        return StepDecision.goToMany(movements);
     }
 }
 
@@ -119,7 +119,7 @@ class DynamicInitStep implements Step<number> {
     return "InitStep";
   }
   public execute(_context: Context, count: number): StepDecision {
-    return goToMulti(
+    return goToMany(
       ...Array.from({ length: count }, (_, index) =>
         StepMovement.of(DynamicDoWorkStep, index),
       ),

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/first-win.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/first-win.mdx
@@ -35,7 +35,7 @@ class DoWorkStep(Step[int]):
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to_multi(
+        return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )
 ```
@@ -53,7 +53,7 @@ func (firstWinInitStep) Execute(_ dex.Context, count int) (*dex.StepDecision, er
 	for index := 0; index < count; index++ {
 		movements = append(movements, dex.MovementOf(firstWinWorkStep{}, index))
 	}
-	return dex.GoToMulti(movements...), nil
+	return dex.GoToMany(movements...), nil
 }
 
 type firstWinWorkStep struct{ dex.StepDefaultsNoWaitFor[int] }
@@ -82,7 +82,7 @@ final class InitStep implements Step<Integer> {
         for (int index = 0; index < count; index++) {
             movements[index] = StepMovement.of(DoWorkStep.class, index);
         }
-        return StepDecision.goToMulti(movements);
+        return StepDecision.goToMany(movements);
     }
 }
 
@@ -116,7 +116,7 @@ class FirstWinInitStep implements Step<number> {
     return "InitStep";
   }
   public execute(_context: Context, count: number): StepDecision {
-    return goToMulti(
+    return goToMany(
       ...Array.from({ length: count }, (_, index) =>
         StepMovement.of(FirstWinDoWorkStep, index),
       ),

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/static.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/static.mdx
@@ -38,7 +38,7 @@ class WorkBStep(Step[str]):
 class InitStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
         del context
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(WorkAStep, input),
             StepMovement.of(WorkBStep, input),
         )
@@ -55,7 +55,7 @@ type staticInitStep struct {
 func (staticInitStep) GetStepType() string { return "InitStep" }
 
 func (staticInitStep) Execute(_ dex.Context, input string) (*dex.StepDecision, error) {
-	return dex.GoToMulti(dex.MovementOf(workAStep{}, input), dex.MovementOf(workBStep{}, input)), nil
+	return dex.GoToMany(dex.MovementOf(workAStep{}, input), dex.MovementOf(workBStep{}, input)), nil
 }
 
 type workAStep struct {
@@ -91,7 +91,7 @@ final class InitStep implements Step<String> {
 
     @Override
     public StepDecision execute(final Context context, final String input) {
-        return StepDecision.goToMulti(
+        return StepDecision.goToMany(
                 StepMovement.of(WorkAStep.class, input),
                 StepMovement.of(WorkBStep.class, input));
     }
@@ -152,7 +152,7 @@ class StaticInitStep implements Step<string> {
     return "InitStep";
   }
   public execute(_context: Context, input: string): StepDecision {
-    return goToMulti(
+    return goToMany(
       StepMovement.of(WorkAStep, input),
       StepMovement.of(WorkBStep, input),
     );

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
@@ -10,7 +10,7 @@ slug: /primitives/step/step-decision
 
 ## 多个后续 Step {#gotomulti}
 
-**GoTo** 启动一个后续 Step。**GoToMulti** 启动多个后续 Step。用它 fan-out 可并行的工作。每个 Step movement 有各自的输入，也可以有各自的 Step options。
+**GoTo** 启动一个后续 Step。**GoToMany** 启动多个后续 Step。用它 fan-out 可并行的工作。每个 Step movement 有各自的输入，也可以有各自的 Step options。
 
 <SdkTabs
   examples={{
@@ -23,7 +23,7 @@ slug: /primitives/step/step-decision
 <SdkSnippet lang="go">
 
 ```go
-return dex.GoToMulti(
+return dex.GoToMany(
 	dex.MovementOf(carrierAStep{}, Quote{Carrier: "A", Price: 10}),
 	dex.MovementOf(carrierBStep{}, Quote{Carrier: "B", Price: 12}),
 	dex.MovementOf(winnerStep{}, quote),
@@ -34,7 +34,7 @@ return dex.GoToMulti(
   <SdkSnippet lang="java">
 
 ```java
-return StepDecision.goToMulti(
+return StepDecision.goToMany(
         StepMovement.of(CarrierAStep.class, quoteA),
         StepMovement.of(CarrierBStep.class, quoteB),
         StepMovement.of(WinnerStep.class, winnerQuote));
@@ -44,7 +44,7 @@ return StepDecision.goToMulti(
   <SdkSnippet lang="python">
 
 ```python
-return go_to_multi(
+return go_to_many(
     StepMovement.of(CarrierAStep, Quote(carrier="A", price=10)),
     StepMovement.of(CarrierBStep, Quote(carrier="B", price=12)),
     StepMovement.of(WinnerStep, quote),
@@ -55,7 +55,7 @@ return go_to_multi(
   <SdkSnippet lang="typescript">
 
 ```typescript
-return goToMulti(
+return goToMany(
   StepMovement.of(CarrierAStep, { carrier: "A", price: 10 }),
   StepMovement.of(CarrierBStep, { carrier: "B", price: 12 }),
   StepMovement.of(WinnerStep, quote),
@@ -106,7 +106,7 @@ Flow 可以没有任何 active Step，但仍继续运行。**DeadEnd** 停止当
 case "graceful":
 	return dex.GracefulComplete("done"), nil
 case "dead-end":
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(branchWorkerStep{}, "left"),
 		dex.MovementOf(branchWorkerStep{}, "right"),
 	), nil
@@ -124,7 +124,7 @@ case "graceful" -> {
     return StepDecision.gracefulComplete("done");
 }
 case "dead-end" -> {
-    return StepDecision.goToMulti(
+    return StepDecision.goToMany(
             StepMovement.of(BranchWorkerStep.class, "left"),
             StepMovement.of(BranchWorkerStep.class, "right"));
 }
@@ -139,7 +139,7 @@ return StepDecision.deadEnd();
 if mode == "graceful":
     return graceful_complete("done")
 if mode == "dead-end":
-    return go_to_multi(
+    return go_to_many(
         StepMovement.of(BranchWorkerStep, "left"),
         StepMovement.of(BranchWorkerStep, "right"),
     )
@@ -155,7 +155,7 @@ if (mode === "graceful") {
   return gracefulComplete("done");
 }
 if (mode === "dead-end") {
-  return goToMulti(
+  return goToMany(
     StepMovement.of(BranchWorkerStep, "left"),
     StepMovement.of(BranchWorkerStep, "right"),
   );

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -341,7 +341,7 @@ final StepOptions options = StepOptions.newBuilder()
         .waitForRetry(RetryPolicy.newBuilder().maximumAttempts(2).build())
         .waitForFailure(WaitForFailurePolicy.PROCEED)
         .build();
-return StepDecision.goToMulti(StepMovement.of(OverrideSecondStep.class, output, options));
+return StepDecision.goToMany(StepMovement.of(OverrideSecondStep.class, output, options));
 ```
 
 </SdkSnippet>
@@ -352,7 +352,7 @@ options = StepOptions(
     wait_for_retry=RetryPolicy(maximum_attempts=2),
     wait_for_failure=WaitForFailurePolicy.PROCEED,
 )
-return go_to_multi(StepMovement.of(OverrideSecondStep, output, options))
+return go_to_many(StepMovement.of(OverrideSecondStep, output, options))
 ```
 
 </SdkSnippet>
@@ -363,7 +363,7 @@ const override: StepOptions = {
   waitForRetry: { maximumAttempts: 2 },
   waitForFailure: "proceed",
 };
-return goToMulti(StepMovement.of(OverrideSecondStep, payload, override));
+return goToMany(StepMovement.of(OverrideSecondStep, payload, override));
 ```
 
 </SdkSnippet>

--- a/docs/src/components/primitives/step/StepDecisionMovementsDiagram.tsx
+++ b/docs/src/components/primitives/step/StepDecisionMovementsDiagram.tsx
@@ -20,10 +20,10 @@ type Copy = {
 };
 
 const EN: Copy = {
-  label: 'StepDecision movements: GoTo, GoToMulti, and loop',
+  label: 'StepDecision movements: GoTo, GoToMany, and loop',
   goto: {title: 'GoTo', parallel: ''},
   loop: {title: 'Loop', parallel: ''},
-  parallel: {title: 'GoToMulti', parallel: 'both active'},
+  parallel: {title: 'GoToMany', parallel: 'both active'},
   completeFlow: 'Complete Flow',
   stepA: 'StepA',
   stepB: 'StepB',
@@ -31,10 +31,10 @@ const EN: Copy = {
 };
 
 const ZH: Copy = {
-  label: 'StepDecision movement：GoTo、GoToMulti 与循环',
+  label: 'StepDecision movement：GoTo、GoToMany 与循环',
   goto: {title: 'GoTo', parallel: ''},
   loop: {title: '循环', parallel: ''},
-  parallel: {title: 'GoToMulti', parallel: '同时 active'},
+  parallel: {title: 'GoToMany', parallel: '同时 active'},
   completeFlow: 'Complete Flow',
   stepA: 'StepA',
   stepB: 'StepB',
@@ -68,7 +68,7 @@ export default function StepDecisionMovementsDiagram(): ReactNode {
           <CompactCard kicker="NEXT" title={copy.completeFlow} />
         </MovementPanel>
         <MovementPanel title={copy.parallel.title}>
-          <StepCard name="ExampleStep" executeOnly execute={`GoToMulti(${copy.stepA}, ${copy.stepB})`} />
+          <StepCard name="ExampleStep" executeOnly execute={`GoToMany(${copy.stepA}, ${copy.stepB})`} />
           <div className="flow-graph-split flow-graph-split-compact">
             <div className="flow-graph-split-stem" aria-hidden="true" />
             <div className="flow-graph-split-bar" aria-hidden="true" />

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/stretchr/testify v1.11.1
 	github.com/superdurable/dex/blob-cache-go v0.1.0
-	github.com/superdurable/dex/sdk-go v0.2.4
+	github.com/superdurable/dex/sdk-go v0.2.5
 )
 
 require (

--- a/examples/go/go.sum
+++ b/examples/go/go.sum
@@ -94,6 +94,8 @@ github.com/superdurable/dex/sdk-go v0.2.3 h1:ZgtvPOyFok1zdtiAkNWuta8PT6NAxqJ902x
 github.com/superdurable/dex/sdk-go v0.2.3/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
 github.com/superdurable/dex/sdk-go v0.2.4 h1:M5GWxCRAK4hNAxL6svGjzSSZH2VXYpv0/xkL75A//QA=
 github.com/superdurable/dex/sdk-go v0.2.4/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
+github.com/superdurable/dex/sdk-go v0.2.5 h1:d6SFTgm9Jt/w2Lkj7zKwMki/N0RV7ih8KeqRQXErrKs=
+github.com/superdurable/dex/sdk-go v0.2.5/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=

--- a/examples/go/patterns/cron/workflow.go
+++ b/examples/go/patterns/cron/workflow.go
@@ -144,7 +144,7 @@ func (waitForCronSchedule) Execute(
 		return dex.GoTo(runCronSchedule{}, run), nil
 	}
 	state.RemainingRuns--
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(runCronSchedule{}, run),
 		dex.MovementOf(waitForCronSchedule{}, state),
 	), nil

--- a/examples/go/patterns/drain-channels/internal-drain/workflow.go
+++ b/examples/go/patterns/drain-channels/internal-drain/workflow.go
@@ -77,7 +77,7 @@ func (initStep) Execute(
 	if err := MainStepExecutionCounterAttribute.Set(ctx, 0); err != nil {
 		return nil, err
 	}
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(sideStep{}, nil),
 		dex.MovementOf(mainStep{}, input),
 	), nil

--- a/examples/go/patterns/interruptible/workflow.go
+++ b/examples/go/patterns/interruptible/workflow.go
@@ -77,7 +77,7 @@ func (initStep) Execute(
 	_ dex.None,
 ) (*dex.StepDecision, error) {
 	input := WorkJobParametersInput{JobUpperBound: 15, Progress: 1}
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(workAStep{}, input),
 		dex.MovementOf(workBStep{}, input),
 	), nil

--- a/examples/go/patterns/parallel/await_parallel.go
+++ b/examples/go/patterns/parallel/await_parallel.go
@@ -56,7 +56,7 @@ func (awaitInitStep) Execute(_ dex.Context, count int) (*dex.StepDecision, error
 	for index := 0; index < count; index++ {
 		movements = append(movements, dex.MovementOf(awaitWorkStep{}, index))
 	}
-	return dex.GoToMulti(movements...), nil
+	return dex.GoToMany(movements...), nil
 }
 
 type awaitWorkStep struct{ dex.StepDefaultsNoWaitFor[int] }

--- a/examples/go/patterns/parallel/dynamic.go
+++ b/examples/go/patterns/parallel/dynamic.go
@@ -50,7 +50,7 @@ func (dynamicInitStep) Execute(_ dex.Context, items []string) (*dex.StepDecision
 	for _, item := range items {
 		movements = append(movements, dex.MovementOf(dynamicWorkStep{}, item))
 	}
-	return dex.GoToMulti(movements...), nil
+	return dex.GoToMany(movements...), nil
 }
 
 type dynamicWorkStep struct {

--- a/examples/go/patterns/parallel/first_win.go
+++ b/examples/go/patterns/parallel/first_win.go
@@ -48,7 +48,7 @@ func (firstWinInitStep) Execute(_ dex.Context, count int) (*dex.StepDecision, er
 	for index := 0; index < count; index++ {
 		movements = append(movements, dex.MovementOf(firstWinWorkStep{}, index))
 	}
-	return dex.GoToMulti(movements...), nil
+	return dex.GoToMany(movements...), nil
 }
 
 type firstWinWorkStep struct{ dex.StepDefaultsNoWaitFor[int] }

--- a/examples/go/patterns/parallel/static.go
+++ b/examples/go/patterns/parallel/static.go
@@ -45,7 +45,7 @@ type staticInitStep struct {
 func (staticInitStep) GetStepType() string { return "InitStep" }
 
 func (staticInitStep) Execute(_ dex.Context, input string) (*dex.StepDecision, error) {
-	return dex.GoToMulti(dex.MovementOf(workAStep{}, input), dex.MovementOf(workBStep{}, input)), nil
+	return dex.GoToMany(dex.MovementOf(workAStep{}, input), dex.MovementOf(workBStep{}, input)), nil
 }
 
 type workAStep struct {

--- a/examples/go/patterns/parent-child/parent.go
+++ b/examples/go/patterns/parent-child/parent.go
@@ -89,7 +89,7 @@ func (initStep) Execute(
 	for index := 0; index < ConcurrencyPerParentWorkflow; index++ {
 		movements[index] = dex.MovementOf(loopForNextTaskStep{}, nil)
 	}
-	return dex.GoToMulti(movements...), nil
+	return dex.GoToMany(movements...), nil
 }
 
 type loopForNextTaskStep struct {

--- a/examples/go/patterns/reminders/workflow.go
+++ b/examples/go/patterns/reminders/workflow.go
@@ -104,7 +104,7 @@ func (initStep) Execute(
 	if err := StatusAttribute.Set(ctx, string(StatusInitiated)); err != nil {
 		return nil, err
 	}
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(processTimeoutStep{}, nil),
 		dex.MovementOf(reminderStep{}, nil),
 	), nil

--- a/examples/go/patterns/timeout/workflow.go
+++ b/examples/go/patterns/timeout/workflow.go
@@ -54,7 +54,7 @@ func (initStep) Execute(
 	ctx dex.Context,
 	workflowSuccessful bool,
 ) (*dex.StepDecision, error) {
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(timeoutStep{}, nil),
 		dex.MovementOf(taskStep{}, workflowSuccessful),
 	), nil

--- a/examples/go/primitives/step-decision/workflow.go
+++ b/examples/go/primitives/step-decision/workflow.go
@@ -62,13 +62,13 @@ func (routeStep) Execute(_ dex.Context, input StepDecisionInput) (*dex.StepDecis
 	case "graceful":
 		return dex.GracefulComplete("done"), nil
 	case "dead-end":
-		return dex.GoToMulti(
+		return dex.GoToMany(
 			dex.MovementOf(branchWorkerStep{}, "left"),
 			dex.MovementOf(branchWorkerStep{}, "right"),
 		), nil
 	default:
 		quote := Quote{Carrier: "winner", Price: 9}
-		return dex.GoToMulti(
+		return dex.GoToMany(
 			dex.MovementOf(carrierAStep{}, Quote{Carrier: "A", Price: 10}),
 			dex.MovementOf(carrierBStep{}, Quote{Carrier: "B", Price: 12}),
 			dex.MovementOf(winnerStep{}, quote),

--- a/examples/go/products/engagement/workflow.go
+++ b/examples/go/products/engagement/workflow.go
@@ -206,7 +206,7 @@ func (initializeStep) Execute(
 	if err := Notes.Set(ctx, input.Notes); err != nil {
 		return nil, err
 	}
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(processTimeoutStep{}, nil),
 		dex.MovementOf(reminderStep{}, nil),
 		dex.MovementOf(notifyExternalSystemStep{}, StatusInitiated),

--- a/examples/go/products/microservices/workflow.go
+++ b/examples/go/products/microservices/workflow.go
@@ -84,7 +84,7 @@ func (step callAPI1Step) Execute(
 	if err := Data.Set(ctx, input); err != nil {
 		return nil, err
 	}
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(callAPI2Step{}, nil),
 		dex.MovementOf(callAPI3Step{}, nil),
 	), nil

--- a/examples/go/products/polling/workflow.go
+++ b/examples/go/products/polling/workflow.go
@@ -73,7 +73,7 @@ func (initializeStep) Execute(
 	if err := CurrentPolls.Set(ctx, 0); err != nil {
 		return nil, err
 	}
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(pollStep{}, maximumPolls),
 		dex.MovementOf(waitForTasksStep{}, nil),
 	), nil

--- a/examples/go/products/subscription/workflow.go
+++ b/examples/go/products/subscription/workflow.go
@@ -232,7 +232,7 @@ func (updateChargeAmountStep) Execute(
 }
 
 func initializeSubscription() *dex.StepDecision {
-	return dex.GoToMulti(
+	return dex.GoToMany(
 		dex.MovementOf(trialStep{}, nil),
 		dex.MovementOf(cancelStep{}, nil),
 		dex.MovementOf(updateChargeAmountStep{}, nil),

--- a/examples/go/products/subscription/workflow_test.go
+++ b/examples/go/products/subscription/workflow_test.go
@@ -44,7 +44,7 @@ var testCustomer = Customer{
 func TestInitializeSubscription(t *testing.T) {
 	decision := initializeSubscription()
 
-	require.Equal(t, dex.GoToMulti(
+	require.Equal(t, dex.GoToMany(
 		dex.MovementOf(trialStep{}, nil),
 		dex.MovementOf(cancelStep{}, nil),
 		dex.MovementOf(updateChargeAmountStep{}, nil),

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "io.superdurable:dex-sdk:0.2.4"
+    implementation "io.superdurable:dex-sdk:0.2.5"
 
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/cron/CronScheduleFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/cron/CronScheduleFlow.java
@@ -162,7 +162,7 @@ public class CronScheduleFlow implements Flow<CronScheduleFlow.Input> {
             if (runInput.isFinal) {
                 return StepDecision.goTo(Run.class, runInput);
             }
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(Run.class, runInput),
                     StepMovement.of(
                             WaitForSchedule.class,

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/drainchannels/internal/DrainInternalChannelFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/drainchannels/internal/DrainInternalChannelFlow.java
@@ -74,7 +74,7 @@ public class DrainInternalChannelFlow implements Flow<String> {
         @Override
         public StepDecision execute(final Context context, final String input) {
             mainStepExecutionCounter.set(context, 0);
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(SideStep.class, null),
                     StepMovement.of(MainStep.class, input));
         }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/interruptible/InterruptibleFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/interruptible/InterruptibleFlow.java
@@ -66,7 +66,7 @@ public class InterruptibleFlow implements Flow<Void> {
         @Override
         public StepDecision execute(final Context context, final Void unused) {
             final WorkJobParametersInput input = new WorkJobParametersInput(15, 1);
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(WorkAStep.class, input),
                     StepMovement.of(WorkBStep.class, input));
         }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/AwaitParallelStepsFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/AwaitParallelStepsFlow.java
@@ -59,7 +59,7 @@ public class AwaitParallelStepsFlow implements Flow<Integer> {
             for (int index = 0; index < count; index++) {
                 movements[index + 1] = StepMovement.of(DoWorkStep.class, index);
             }
-            return StepDecision.goToMulti(movements);
+            return StepDecision.goToMany(movements);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/DynamicParallelStepsFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/DynamicParallelStepsFlow.java
@@ -53,7 +53,7 @@ public class DynamicParallelStepsFlow implements Flow<Integer> {
             for (int index = 0; index < count; index++) {
                 movements[index] = StepMovement.of(DoWorkStep.class, index);
             }
-            return StepDecision.goToMulti(movements);
+            return StepDecision.goToMany(movements);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/FirstWinParallelStepsFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/FirstWinParallelStepsFlow.java
@@ -53,7 +53,7 @@ public class FirstWinParallelStepsFlow implements Flow<Integer> {
             for (int index = 0; index < count; index++) {
                 movements[index] = StepMovement.of(DoWorkStep.class, index);
             }
-            return StepDecision.goToMulti(movements);
+            return StepDecision.goToMany(movements);
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/StaticParallelStepsFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/parallel/StaticParallelStepsFlow.java
@@ -49,7 +49,7 @@ public class StaticParallelStepsFlow implements Flow<String> {
 
         @Override
         public StepDecision execute(final Context context, final String input) {
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(WorkAStep.class, input),
                     StepMovement.of(WorkBStep.class, input));
         }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/parentchild/ParentFlowV2.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/parentchild/ParentFlowV2.java
@@ -73,7 +73,7 @@ public class ParentFlowV2 implements Flow<Integer> {
             for (int i = 0; i < CONCURRENCY_PER_PARENT_WORKFLOW; i++) {
                 movements.add(StepMovement.of(LoopForNextTask.class, null));
             }
-            return StepDecision.goToMulti(movements.toArray(new StepMovement<?>[0]));
+            return StepDecision.goToMany(movements.toArray(new StepMovement<?>[0]));
         }
     }
 

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/reminders/ReminderFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/reminders/ReminderFlow.java
@@ -83,7 +83,7 @@ public class ReminderFlow implements Flow<Void> {
         @Override
         public StepDecision execute(final Context context, final Void input) {
             status.set(context, Status.INITIATED.name());
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(ProcessTimeout.class, null),
                     StepMovement.of(Reminder.class, null));
         }

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/timeout/FlowGracefulTimeout.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/timeout/FlowGracefulTimeout.java
@@ -53,7 +53,7 @@ public class FlowGracefulTimeout implements Flow<Boolean> {
 
         @Override
         public StepDecision execute(final Context context, final Boolean workflowSuccessful) {
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(Timeout.class, null),
                     StepMovement.of(Task.class, workflowSuccessful));
         }

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/optionsoverride/OptionsOverrideFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/optionsoverride/OptionsOverrideFlow.java
@@ -57,7 +57,7 @@ public final class OptionsOverrideFlow implements Flow<String> {
                     .waitForFailure(WaitForFailurePolicy.PROCEED)
                     .build();
             final String payload = input + "_state1";
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(OverrideSecondStep.class, payload, override));
         }
     }

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/stepdecision/StepDecisionFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/stepdecision/StepDecisionFlow.java
@@ -79,12 +79,12 @@ public final class StepDecisionFlow implements Flow<String> {
                 case "graceful":
                     return StepDecision.gracefulComplete("done");
                 case "dead-end":
-                    return StepDecision.goToMulti(
+                    return StepDecision.goToMany(
                             StepMovement.of(BranchWorkerStep.class, "left"),
                             StepMovement.of(BranchWorkerStep.class, "right"));
                 default:
                     final Quote quote = new Quote("winner", 9);
-                    return StepDecision.goToMulti(
+                    return StepDecision.goToMany(
                             StepMovement.of(CarrierAStep.class, new Quote("A", 10)),
                             StepMovement.of(CarrierBStep.class, new Quote("B", 12)),
                             StepMovement.of(WinnerStep.class, quote));

--- a/examples/java/src/main/java/io/superdurable/dex/products/engagement/EngagementFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/engagement/EngagementFlow.java
@@ -147,7 +147,7 @@ public class EngagementFlow implements Flow<EngagementInput> {
             engagementStatus.set(context, Status.INITIATED);
             lastUpdateTimestamp.set(context, System.currentTimeMillis());
             notes.set(context, input.notes);
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(ProcessTimeout.class, null),
                     StepMovement.of(Reminder.class, null),
                     StepMovement.of(NotifyExternalSystem.class, Status.INITIATED));

--- a/examples/java/src/main/java/io/superdurable/dex/products/microservices/OrchestrationFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/microservices/OrchestrationFlow.java
@@ -76,7 +76,7 @@ public class OrchestrationFlow implements Flow<String> {
         public StepDecision execute(final Context context, final String input) {
             service.callAPI1(input);
             data.set(context, input);
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(CallAPI2.class, null),
                     StepMovement.of(CallAPI3.class, null));
         }

--- a/examples/java/src/main/java/io/superdurable/dex/products/polling/PollingFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/polling/PollingFlow.java
@@ -76,7 +76,7 @@ public class PollingFlow implements Flow<Integer> {
         @Override
         public StepDecision execute(final Context context, final Integer maximumPolls) {
             currentPolls.set(context, 0);
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(Poll.class, maximumPolls),
                     StepMovement.of(WaitForTasks.class, null));
         }

--- a/examples/java/src/main/java/io/superdurable/dex/products/subscription/SubscriptionFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/products/subscription/SubscriptionFlow.java
@@ -87,7 +87,7 @@ public class SubscriptionFlow implements Flow<Customer> {
         @Override
         public StepDecision execute(final Context context, final Customer customer) {
             customerDetails.set(context, customer);
-            return StepDecision.goToMulti(
+            return StepDecision.goToMany(
                     StepMovement.of(Trial.class, null),
                     StepMovement.of(Cancel.class, null),
                     StepMovement.of(UpdateChargeAmount.class, null));

--- a/examples/python/dex_examples/patterns/cron/cron_schedule_flow.py
+++ b/examples/python/dex_examples/patterns/cron/cron_schedule_flow.py
@@ -32,7 +32,7 @@ from dex import (
     dead_end,
     force_fail,
     go_to,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -114,7 +114,7 @@ class _WaitForSchedule(Step[_ScheduleState]):
         )
         if run_input.is_final:
             return go_to(_Run, run_input)
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(_Run, run_input),
             StepMovement.of(
                 _WaitForSchedule,

--- a/examples/python/dex_examples/patterns/drain-channels/internal/drain_internal_channels_flow.py
+++ b/examples/python/dex_examples/patterns/drain-channels/internal/drain_internal_channels_flow.py
@@ -26,7 +26,7 @@ from dex import (
     StepMovement,
     Wait,
     go_to,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -127,7 +127,7 @@ class Init(Step[str]):
 
     def execute(self, context: Context, input: str) -> StepDecision:
         self.execution_counter.set(context, 0)
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(SideStep, None),
             StepMovement.of(MainStep, input),
         )

--- a/examples/python/dex_examples/patterns/interruptible/interruptible_execution_flow.py
+++ b/examples/python/dex_examples/patterns/interruptible/interruptible_execution_flow.py
@@ -28,7 +28,7 @@ from dex import (
     Timer,
     Wait,
     go_to,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
     rpc,
 )
@@ -116,7 +116,7 @@ class Init(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
         del context, input
         parameters = WorkJobParametersInput(15, 1)
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(WorkAStep, parameters),
             StepMovement.of(WorkBStep, parameters),
         )

--- a/examples/python/dex_examples/patterns/parallel/await_parallel_steps_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/await_parallel_steps_flow.py
@@ -27,7 +27,7 @@ from dex import (
     StepMovement,
     Wait,
     dead_end,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -65,7 +65,7 @@ class InitStep(Step[int]):
         movements.extend(
             StepMovement.of(DoWorkStep, index) for index in range(input)
         )
-        return go_to_multi(*movements)
+        return go_to_many(*movements)
 
 
 class AwaitParallelStepsFlow(Flow[int]):

--- a/examples/python/dex_examples/patterns/parallel/dynamic_parallel_steps_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/dynamic_parallel_steps_flow.py
@@ -23,7 +23,7 @@ from dex import (
     StepDecision,
     StepList,
     StepMovement,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -40,7 +40,7 @@ class DoWorkStep(Step[int]):
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to_multi(
+        return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )
 

--- a/examples/python/dex_examples/patterns/parallel/first_win_parallel_steps_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/first_win_parallel_steps_flow.py
@@ -23,7 +23,7 @@ from dex import (
     StepDecision,
     StepList,
     StepMovement,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -40,7 +40,7 @@ class DoWorkStep(Step[int]):
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
         del context
-        return go_to_multi(
+        return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )
 

--- a/examples/python/dex_examples/patterns/parallel/static_parallel_steps_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/static_parallel_steps_flow.py
@@ -20,7 +20,7 @@ from dex import (
     StepDecision,
     StepList,
     StepMovement,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -40,7 +40,7 @@ class WorkBStep(Step[str]):
 class InitStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
         del context
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(WorkAStep, input),
             StepMovement.of(WorkBStep, input),
         )

--- a/examples/python/dex_examples/patterns/parent-child/parent_flow_v2.py
+++ b/examples/python/dex_examples/patterns/parent-child/parent_flow_v2.py
@@ -40,7 +40,7 @@ from dex import (
     Timer,
     Wait,
     go_to,
-    go_to_multi,
+    go_to_many,
 )
 
 CONCURRENCY_PER_PARENT_WORKFLOW = 3
@@ -141,7 +141,7 @@ class Init(Step[int]):
         for index in range(input):
             self.task_queue.publish(context, index)
 
-        return go_to_multi(
+        return go_to_many(
             *(
                 StepMovement.of(LoopForNextTask, None)
                 for _ in range(CONCURRENCY_PER_PARENT_WORKFLOW)

--- a/examples/python/dex_examples/patterns/reminders/reminder_flow.py
+++ b/examples/python/dex_examples/patterns/reminders/reminder_flow.py
@@ -31,7 +31,7 @@ from dex import (
     Wait,
     force_complete,
     go_to,
-    go_to_multi,
+    go_to_many,
     rpc,
 )
 
@@ -119,7 +119,7 @@ class Init(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
         del input
         self.status.set(context, Status.INITIATED.value)
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(ProcessTimeout, None),
             StepMovement.of(Reminder, None),
         )

--- a/examples/python/dex_examples/patterns/timeout/flow_graceful_timeout.py
+++ b/examples/python/dex_examples/patterns/timeout/flow_graceful_timeout.py
@@ -28,7 +28,7 @@ from dex import (
     Wait,
     force_complete,
     force_fail,
-    go_to_multi,
+    go_to_many,
 )
 
 TIMEOUT_DURATION = timedelta(minutes=1)
@@ -64,7 +64,7 @@ class Init(Step[bool]):
 
     def execute(self, context: Context, input: bool) -> StepDecision:
         del context
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(Timeout, None),
             StepMovement.of(Task, input),
         )

--- a/examples/python/dex_examples/primitives/options_override/options_override_flow.py
+++ b/examples/python/dex_examples/primitives/options_override/options_override_flow.py
@@ -25,7 +25,7 @@ from dex import (
     StepOptions,
     Wait,
     WaitForFailurePolicy,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -41,7 +41,7 @@ class OverrideFirstStep(Step[str]):
             wait_for_failure=WaitForFailurePolicy.PROCEED,
         )
         payload = f"{input}_state1"
-        return go_to_multi(StepMovement.of(OverrideSecondStep, payload, options=override))
+        return go_to_many(StepMovement.of(OverrideSecondStep, payload, options=override))
 
 
 class OverrideSecondStep(Step[str]):

--- a/examples/python/dex_examples/primitives/step_decision/step_decision_flow.py
+++ b/examples/python/dex_examples/primitives/step_decision/step_decision_flow.py
@@ -28,7 +28,7 @@ from dex import (
     Wait,
     dead_end,
     go_to,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -48,12 +48,12 @@ class RouteStep(Step[str]):
         if mode == "graceful":
             return graceful_complete("done")
         if mode == "dead-end":
-            return go_to_multi(
+            return go_to_many(
                 StepMovement.of(BranchWorkerStep, "left"),
                 StepMovement.of(BranchWorkerStep, "right"),
             )
         quote = Quote(carrier="winner", price=9)
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(CarrierAStep, Quote(carrier="A", price=10)),
             StepMovement.of(CarrierBStep, Quote(carrier="B", price=12)),
             StepMovement.of(WinnerStep, quote),

--- a/examples/python/dex_examples/products/engagement/engagement_flow.py
+++ b/examples/python/dex_examples/products/engagement/engagement_flow.py
@@ -32,7 +32,7 @@ from dex import (
     Wait,
     dead_end,
     go_to,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
     rpc,
 )
@@ -124,7 +124,7 @@ class Initialize(Step[EngagementInput]):
         self.flow.engagement_status.set(context, Status.INITIATED)
         self.flow.last_update_timestamp.set(context, current_time_millis())
         self.flow.notes.set(context, input.notes or "")
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(ProcessTimeout, None),
             StepMovement.of(Reminder, None),
             StepMovement.of(NotifyExternalSystem, Status.INITIATED),

--- a/examples/python/dex_examples/products/microservices/orchestration_flow.py
+++ b/examples/python/dex_examples/products/microservices/orchestration_flow.py
@@ -29,7 +29,7 @@ from dex import (
     Wait,
     dead_end,
     go_to,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
     rpc,
 )
@@ -105,7 +105,7 @@ class CallAPI1(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
         self.service.call_api1(input)
         self.data.set(context, input)
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(CallAPI2, None),
             StepMovement.of(CallAPI3, None),
         )

--- a/examples/python/dex_examples/products/polling/polling_flow.py
+++ b/examples/python/dex_examples/products/polling/polling_flow.py
@@ -28,7 +28,7 @@ from dex import (
     Wait,
     dead_end,
     go_to,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -101,7 +101,7 @@ class Initialize(Step[int]):
 
     def execute(self, context: Context, input: int) -> StepDecision:
         self.current_polls.set(context, 0)
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(Poll, input),
             StepMovement.of(WaitForTasks, None),
         )

--- a/examples/python/dex_examples/products/subscription/subscription_flow.py
+++ b/examples/python/dex_examples/products/subscription/subscription_flow.py
@@ -27,7 +27,7 @@ from dex import (
     Wait,
     force_complete,
     go_to,
-    go_to_multi,
+    go_to_many,
     rpc,
 )
 
@@ -159,7 +159,7 @@ class Initialize(Step[Customer]):
 
     def execute(self, context: Context, input: Customer) -> StepDecision:
         self.customer_details.set(context, input)
-        return go_to_multi(
+        return go_to_many(
             StepMovement.of(Trial, None),
             StepMovement.of(Cancel, None),
             StepMovement.of(UpdateChargeAmount, None),

--- a/examples/python/pyproject.toml
+++ b/examples/python/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "dex-python-sdk==0.2.3",
+    "dex-python-sdk==0.2.4",
     "flask>=3.0,<4",
     "openai>=1.66.2,<2",
     "openai-agents>=0.0.4,<0.0.5",

--- a/examples/python/sync-python/sync_examples/patterns/parent_child/parent_child.py
+++ b/examples/python/sync-python/sync_examples/patterns/parent_child/parent_child.py
@@ -40,7 +40,7 @@ from dex import (
     Timer,
     Wait,
     go_to,
-    go_to_multi,
+    go_to_many,
     graceful_complete,
 )
 
@@ -158,7 +158,7 @@ class Init(Step[int]):
         for index in range(input):
             self.task_queue.publish(context, index)
 
-        return go_to_multi(
+        return go_to_many(
             *(
                 StepMovement.of(LoopForNextTask, None)
                 for _ in range(CONCURRENCY_PER_PARENT_WORKFLOW)

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -293,7 +293,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dex-python-sdk", specifier = "==0.2.3" },
+    { name = "dex-python-sdk", specifier = "==0.2.4" },
     { name = "flask", specifier = ">=3.0,<4" },
     { name = "openai", specifier = ">=1.66.2,<2" },
     { name = "openai-agents", specifier = ">=0.0.4,<0.0.5" },
@@ -312,20 +312,20 @@ dev = [
 
 [[package]]
 name = "dex-python-sdk"
-version = "0.2.3"
+version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "grpcio-status" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/35/216f227f2ff512e70813fc689aa05f85e1387399ed582a4bc8eb76c13938/dex_python_sdk-0.2.3.tar.gz", hash = "sha256:71caa465a0c5893e444fe983440986da234ad573f210a9fdecc8f8ecc3d488d0", size = 152748, upload-time = "2026-08-28T17:16:11.387Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a9/df4b9dc9f66c8fc966dc0ea66deca29b5e8c92fc653c165161f6641edff6/dex_python_sdk-0.2.4.tar.gz", hash = "sha256:b98d32e2ee9e714f5bd2b03c82678519643def996fafa81440af1a4327977d1d", size = 152760, upload-time = "2026-08-28T22:13:12.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/ae/313a650fe199fe20f68af110407bb5d661a78485a2771f5dd2c0a0bcb1e4/dex_python_sdk-0.2.3-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:fc25eeac08a307886fb95446da2db352548e82a290f6e67acac77cc951679c77", size = 635434, upload-time = "2026-08-28T17:16:06.169Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/54/ab5b96a82ea72ab2158ed43b6a23e78da44ec71dc230d46745069190cee5/dex_python_sdk-0.2.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:641f97d0f41b2361dffb3f37e7b30383fa85cd8d1dad32b07d9f7dd72b3c4fc9", size = 613900, upload-time = "2026-08-28T17:16:07.343Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/ca/8da97bd31b271fa4ca82632074d39b7664592120a938927f9907f0bc8903/dex_python_sdk-0.2.3-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:829e029d76736fb635db509fa07a4c39a73b3a086b79be86506f9895e2f40a7d", size = 676848, upload-time = "2026-08-28T17:16:08.413Z" },
-    { url = "https://files.pythonhosted.org/packages/18/9f/51e7ca151d766226b24b48bce22a4609b80351b39d1afd8f793a29505def/dex_python_sdk-0.2.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6ad752f1cdd30acea9408c8ab0ac4aad755984ca8851dbd4bd03b471eb26683", size = 679164, upload-time = "2026-08-28T17:16:09.494Z" },
-    { url = "https://files.pythonhosted.org/packages/87/57/42e34b911df4814c1399333c5f0e85f29d09a1591333276fd7f4bc999003/dex_python_sdk-0.2.3-cp311-abi3-win_amd64.whl", hash = "sha256:1ebae38d2dd2109489e0722dc430e21897cae98741160a692debbe446f046e12", size = 523095, upload-time = "2026-08-28T17:16:10.462Z" },
+    { url = "https://files.pythonhosted.org/packages/84/31/840636f9f475af96f4150a7090f6227cc12639c075bbf255febff0c2fd26/dex_python_sdk-0.2.4-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0b2e424a20dfd68d0846914f09018c2da0b8d7bffcdd3ad60eb9eff5dacb1709", size = 635430, upload-time = "2026-08-28T22:13:06.885Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2e/5fa7e481c4a44f8290e51debebeb40c22371e0c9e846db0d38ce58e215aa/dex_python_sdk-0.2.4-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:31e513c71c533ba17c7de018e9bab8eecbde223aec3a89a264f274a5aa894304", size = 613899, upload-time = "2026-08-28T22:13:08.062Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6a/92a257143e5e2443d6a8c0c447569aab0e8773f40ff18411c169ac9ec8fc/dex_python_sdk-0.2.4-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:00a20d6d563954808961fd57257ced627f8d6015ce7246b29c6e3f66d935e9fd", size = 676847, upload-time = "2026-08-28T22:13:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/56/c672629c1ee866d2fc893c2a4d0e30d71d62706e7bb11f4febd2035d9e7c/dex_python_sdk-0.2.4-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7aaaac1cb1ab143cd036e326bc3623e5f11a50c7145addca22bb7397219df4f9", size = 679162, upload-time = "2026-08-28T22:13:10.207Z" },
+    { url = "https://files.pythonhosted.org/packages/43/36/14ee5b876e4aafce09a8b4204660a0ffa0d5542ddae060522ff81a73e3d5/dex_python_sdk-0.2.4-cp311-abi3-win_amd64.whl", hash = "sha256:37be3af9e6eea9017d9228daa2a591a1c40330d61e9abd55c5543854e6fdad48", size = 523088, upload-time = "2026-08-28T22:13:11.466Z" },
 ]
 
 [[package]]

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "dex-blob-cache"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac304c9bc3e8174796f19a8a5d385dd36bcae031cebbc93cf90dce7f4b297f4"
+checksum = "0fc2eefbf9d360e836ebb651b485e3612b06bd0498a084503c74a0f9d42ee35b"
 dependencies = [
  "crc32c",
  "sha2",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "dex-protocol"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3bb22b31fafec56944de7278f33bc309c05c0de12ce91101c532cf04e86db0"
+checksum = "d8ee3bd9c2009e4b22677929cea43a6113daa971d482502342098aaf97fdc523"
 dependencies = [
  "prost",
  "prost-types",
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "dex-sdk"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842458d48044d1f9bd7362cc07566814c6c191fbb66b2b9c7b313b056f45ad6a"
+checksum = "cfa239d6d35c1d031e4df9c0db13a83b3c16a47ad3fdc98979de71a2a8f54d37"
 dependencies = [
  "dex-blob-cache",
  "dex-protocol",

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 rust-version = "1.97"
 
 [dependencies]
-dex-sdk = "=0.2.3"
+dex-sdk = "=0.2.4"
 fastrand = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@superdurable/dex-examples-typescript",
       "version": "0.0.0",
       "dependencies": {
-        "@superdurable/dex": "0.2.3",
+        "@superdurable/dex": "0.2.4",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -125,9 +125,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@superdurable/dex": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.2.3.tgz",
-      "integrity": "sha512-424ESbcQKlj3oXeWZq9maqjoI+ramCAcZnpD+l8/MNDyowxcbqxvwloqiXo9zwgrqqmZF7lJjyaHMCn3SswZfw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.2.4.tgz",
+      "integrity": "sha512-QHmMvX8xnGrTl7q2J+HxAPXZj9GVuFwpA9Lu3fl3blWRgAhbXGeuIlaPqnAW/pDOKjBklIo+JrSpHbVIY8L0aQ==",
       "license": "LicenseRef-Super-Durable-1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.13.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -16,7 +16,7 @@
     "smoke": "npm run build && node --test --experimental-test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/e2e/flow-smoke.test.js'"
   },
   "dependencies": {
-    "@superdurable/dex": "0.2.3",
+    "@superdurable/dex": "0.2.4",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/examples/typescript/src/patterns/cron/cron-schedule-flow.ts
+++ b/examples/typescript/src/patterns/cron/cron-schedule-flow.ts
@@ -23,7 +23,7 @@ import {
   deadEnd,
   forceFail,
   goTo,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   jsonCodec,
   stringCodec,
@@ -124,7 +124,7 @@ class WaitForSchedule implements Step<ScheduleState> {
     if (input.isFinal) {
       return goTo(Run, input);
     }
-    return goToMulti(
+    return goToMany(
       StepMovement.of(Run, input),
       StepMovement.of(WaitForSchedule, {
         interval: state.interval,

--- a/examples/typescript/src/patterns/drain-channels/internal/drain-internal-channels-flow.ts
+++ b/examples/typescript/src/patterns/drain-channels/internal/drain-internal-channels-flow.ts
@@ -22,7 +22,7 @@ import {
   Wait,
   doubleCodec,
   goTo,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   jsonCodec,
   stringCodec,
@@ -64,7 +64,7 @@ class Init implements Step<string> {
 
   public execute(context: Context, input: string): StepDecision {
     this.flow.mainStepExecutionCounter.set(context, 0);
-    return goToMulti(
+    return goToMany(
       StepMovement.of(SideStep, undefined),
       StepMovement.of(MainStep, input),
     );

--- a/examples/typescript/src/patterns/interruptible/interruptible-execution-flow.ts
+++ b/examples/typescript/src/patterns/interruptible/interruptible-execution-flow.ts
@@ -21,7 +21,7 @@ import {
   Timer,
   Wait,
   goTo,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   rpc,
   stringCodec,
@@ -45,7 +45,7 @@ class Init implements Step<void> {
 
   public execute(_context: Context, _input: void): StepDecision {
     const input: WorkJobParametersInput = { jobUpperBound: 15, progress: 1 };
-    return goToMulti(
+    return goToMany(
       StepMovement.of(WorkAStep, input),
       StepMovement.of(WorkBStep, input),
     );

--- a/examples/typescript/src/patterns/parallel/parallel-step-flows.ts
+++ b/examples/typescript/src/patterns/parallel/parallel-step-flows.ts
@@ -21,7 +21,7 @@ import {
   Wait,
   deadEnd,
   doubleCodec,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   stringCodec,
   voidCodec,
@@ -59,7 +59,7 @@ class StaticInitStep implements Step<string> {
     return "InitStep";
   }
   public execute(_context: Context, input: string): StepDecision {
-    return goToMulti(
+    return goToMany(
       StepMovement.of(WorkAStep, input),
       StepMovement.of(WorkBStep, input),
     );
@@ -100,7 +100,7 @@ class DynamicInitStep implements Step<number> {
     return "InitStep";
   }
   public execute(_context: Context, count: number): StepDecision {
-    return goToMulti(
+    return goToMany(
       ...Array.from({ length: count }, (_, index) =>
         StepMovement.of(DynamicDoWorkStep, index),
       ),
@@ -157,7 +157,7 @@ class AwaitInitStep implements Step<number> {
     return "InitStep";
   }
   public execute(_context: Context, count: number): StepDecision {
-    return goToMulti(
+    return goToMany(
       StepMovement.of(AwaitStep, count),
       ...Array.from({ length: count }, (_, index) =>
         StepMovement.of(AwaitDoWorkStep, index),
@@ -200,7 +200,7 @@ class FirstWinInitStep implements Step<number> {
     return "InitStep";
   }
   public execute(_context: Context, count: number): StepDecision {
-    return goToMulti(
+    return goToMany(
       ...Array.from({ length: count }, (_, index) =>
         StepMovement.of(FirstWinDoWorkStep, index),
       ),

--- a/examples/typescript/src/patterns/parent-child/parent-flow-v2.ts
+++ b/examples/typescript/src/patterns/parent-child/parent-flow-v2.ts
@@ -23,7 +23,7 @@ import {
   Wait,
   doubleCodec,
   goTo,
-  goToMulti,
+  goToMany,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -62,7 +62,7 @@ class Init implements Step<number> {
     for (let index = 0; index < CONCURRENCY_PER_PARENT_WORKFLOW; index += 1) {
       movements.push(StepMovement.of(LoopForNextTask, undefined));
     }
-    return goToMulti(...movements);
+    return goToMany(...movements);
   }
 }
 

--- a/examples/typescript/src/patterns/reminders/reminder-flow.ts
+++ b/examples/typescript/src/patterns/reminders/reminder-flow.ts
@@ -23,7 +23,7 @@ import {
   Wait,
   forceComplete,
   goTo,
-  goToMulti,
+  goToMany,
   rpc,
   stringCodec,
   voidCodec,
@@ -58,7 +58,7 @@ class Init implements Step<void> {
 
   public execute(context: Context, _input: void): StepDecision {
     this.flow.status.set(context, "INITIATED");
-    return goToMulti(
+    return goToMany(
       StepMovement.of(ProcessTimeout, undefined),
       StepMovement.of(Reminder, undefined),
     );

--- a/examples/typescript/src/patterns/timeout/flow-graceful-timeout.ts
+++ b/examples/typescript/src/patterns/timeout/flow-graceful-timeout.ts
@@ -22,7 +22,7 @@ import {
   booleanCodec,
   forceComplete,
   forceFail,
-  goToMulti,
+  goToMany,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -40,7 +40,7 @@ class Init implements Step<boolean> {
   }
 
   public execute(_context: Context, workflowSuccessful: boolean): StepDecision {
-    return goToMulti(
+    return goToMany(
       StepMovement.of(Timeout, undefined),
       StepMovement.of(Task, workflowSuccessful),
     );

--- a/examples/typescript/src/primitives/options-override/options-override-flow.ts
+++ b/examples/typescript/src/primitives/options-override/options-override-flow.ts
@@ -18,7 +18,7 @@ import {
   StepList,
   StepMovement,
   Wait,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   stringCodec,
   type Context,
@@ -44,7 +44,7 @@ class OverrideFirstStep implements Step<string> {
       waitForFailure: "proceed",
     };
     const payload = `${input}_state1`;
-    return goToMulti(StepMovement.of(OverrideSecondStep, payload, override));
+    return goToMany(StepMovement.of(OverrideSecondStep, payload, override));
   }
 }
 

--- a/examples/typescript/src/primitives/step-decision/step-decision-flow.ts
+++ b/examples/typescript/src/primitives/step-decision/step-decision-flow.ts
@@ -21,7 +21,7 @@ import {
   Wait,
   deadEnd,
   goTo,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   jsonCodec,
   stringCodec,
@@ -54,13 +54,13 @@ class RouteStep implements Step<string> {
       return gracefulComplete("done");
     }
     if (mode === "dead-end") {
-      return goToMulti(
+      return goToMany(
         StepMovement.of(BranchWorkerStep, "left"),
         StepMovement.of(BranchWorkerStep, "right"),
       );
     }
     const quote: Quote = { carrier: "winner", price: 9 };
-    return goToMulti(
+    return goToMany(
       StepMovement.of(CarrierAStep, { carrier: "A", price: 10 }),
       StepMovement.of(CarrierBStep, { carrier: "B", price: 12 }),
       StepMovement.of(WinnerStep, quote),

--- a/examples/typescript/src/products/engagement/engagement-flow.ts
+++ b/examples/typescript/src/products/engagement/engagement-flow.ts
@@ -24,7 +24,7 @@ import {
   Wait,
   deadEnd,
   goTo,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   int64Codec,
   optionalCodec,
@@ -170,7 +170,7 @@ class Initialize implements Step<EngagementInput> {
     this.flow.engagementStatus.set(context, Status.INITIATED);
     this.flow.lastUpdateTimestamp.set(context, BigInt(Date.now()));
     this.flow.notes.set(context, input.notes);
-    return goToMulti(
+    return goToMany(
       StepMovement.of(ProcessTimeout, undefined),
       StepMovement.of(Reminder, undefined),
       StepMovement.of(NotifyExternalSystem, Status.INITIATED),

--- a/examples/typescript/src/products/microservices/orchestration-flow.ts
+++ b/examples/typescript/src/products/microservices/orchestration-flow.ts
@@ -23,7 +23,7 @@ import {
   Wait,
   deadEnd,
   goTo,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   rpc,
   stringCodec,
@@ -93,7 +93,7 @@ class CallAPI1 implements Step<string> {
   public execute(context: Context, input: string): StepDecision {
     this.flow.service.callAPI1(input);
     this.flow.data.set(context, input);
-    return goToMulti(
+    return goToMany(
       StepMovement.of(CallAPI2, undefined),
       StepMovement.of(CallAPI3, undefined),
     );

--- a/examples/typescript/src/products/polling/polling-flow.ts
+++ b/examples/typescript/src/products/polling/polling-flow.ts
@@ -24,7 +24,7 @@ import {
   deadEnd,
   doubleCodec,
   goTo,
-  goToMulti,
+  goToMany,
   gracefulComplete,
   voidCodec,
   type Context,
@@ -85,7 +85,7 @@ class Initialize implements Step<number> {
 
   public execute(context: Context, maximumPolls: number): StepDecision {
     this.flow.currentPolls.set(context, 0);
-    return goToMulti(
+    return goToMany(
       StepMovement.of(Poll, maximumPolls),
       StepMovement.of(WaitForTasks, undefined),
     );

--- a/examples/typescript/src/products/subscription/subscription-flow.ts
+++ b/examples/typescript/src/products/subscription/subscription-flow.ts
@@ -25,7 +25,7 @@ import {
   doubleCodec,
   forceComplete,
   goTo,
-  goToMulti,
+  goToMany,
   jsonCodec,
   rpc,
   voidCodec,
@@ -101,7 +101,7 @@ class Initialize implements Step<Customer> {
 
   public execute(context: Context, customer: Customer): StepDecision {
     this.flow.customerDetails.set(context, customer);
-    return goToMulti(
+    return goToMany(
       StepMovement.of(Trial, undefined),
       StepMovement.of(Cancel, undefined),
       StepMovement.of(UpdateChargeAmount, undefined),


### PR DESCRIPTION
## Summary

- update Go, Java, Python, Rust, and TypeScript examples to the published SDK releases
- replace GoToMulti, goToMulti, and go_to_multi with the GoToMany API family
- synchronize English and Simplified Chinese product documentation and the StepDecision diagram

## Rationale

The multi-step movement API was renamed before launch. Examples and documentation must use the public names shipped by the five SDK releases.

## User impact

Copyable examples and product documentation now compile and run against the released SDK versions and use the current API name.

## Validation

- `make -C examples/go unitTests`
- `make -C examples/go e2eTests`
- `examples/java/run-integration-tests.sh --rerun-tasks`
- `make -C examples/python unitTests`
- `examples/python/run-e2e-tests.sh --maxfail=1`
- `make -C examples/rust test`
- `npm test` and `npm run check` in `examples/typescript`
- `examples/typescript/run-integration-tests.sh`
- `npm run check` in `docs`
- `make docs-prose-check`
- `make copyright-check`
