### PR TITLE
Keep Chinese docs sidebar labels in English

### DIFF
--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/manual-recovery.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/manual-recovery.mdx
@@ -1,5 +1,6 @@
 ---
 title: 人工恢复
+sidebar_label: Manual Recovery
 ---
 
 # 人工恢复

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel.mdx
@@ -1,5 +1,6 @@
 ---
 title: 并行 Step
+sidebar_label: Parallel Steps
 ---
 
 # 并行 Step

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/await.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/await.mdx
@@ -1,5 +1,6 @@
 ---
 title: 等待并行 Step
+sidebar_label: Await Parallel Steps
 ---
 
 # 等待并行 Step

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/dynamic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/dynamic.mdx
@@ -1,5 +1,6 @@
 ---
 title: 动态并行 Step
+sidebar_label: Dynamic Parallel Steps
 ---
 
 # 动态并行 Step

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/first-win.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/first-win.mdx
@@ -1,5 +1,6 @@
 ---
 title: 首个获胜的并行 Step
+sidebar_label: First-Win Parallel Steps
 ---
 
 # 首个获胜的并行 Step

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/static.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/static.mdx
@@ -1,5 +1,6 @@
 ---
 title: 静态并行 Step
+sidebar_label: Static Parallel Steps
 ---
 
 # 静态并行 Step

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/stream.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/stream.mdx
@@ -1,6 +1,7 @@
 ---
 title: Stream
 slug: /primitives/stream
+sidebar_label: Stream
 ---
 
 # Stream

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/use-cases/ai-agent-email.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/use-cases/ai-agent-email.mdx
@@ -1,5 +1,6 @@
 ---
 title: AI agent email
+sidebar_label: AI agent email
 ---
 
 # AI agent email


### PR DESCRIPTION
## Summary

- Keep the Simplified Chinese docs sidebar labels in English.
- Add explicit sidebar labels for pages that were inheriting translated titles.

## Rationale

Localized page titles should not change navigation terminology.

## User impact

The Chinese documentation sidebar now consistently uses the English labels specified by the documentation navigation policy.

## Validation

- `cd docs && npm run check`
