### PR TITLE
fix(python): export retry-after helper

### DIFF
--- a/sdk-python/dex/__init__.py
+++ b/sdk-python/dex/__init__.py
@@ -8,6 +8,7 @@
 # Legacy Materials remain under their original licenses.
 # See LICENSE and LEGACY_NOTICES.md.
 
+from dex._grpc_errors import RetryAfterError, retry_after
 from dex.async_client import AsyncClient
 from dex.async_worker import AsyncWorker
 from dex.attribute import (
@@ -140,6 +141,7 @@ __all__ = [
     "LongPollTimeoutError",
     "PersistenceSchema",
     "RPCResult",
+    "RetryAfterError",
     "RpcLockConflictError",
     "Registry",
     "TimeTravelOptions",
@@ -184,4 +186,5 @@ __all__ = [
     "go_to_many",
     "open_blob_cache",
     "rpc",
+    "retry_after",
 ]

--- a/sdk-python/dex/_grpc_errors.py
+++ b/sdk-python/dex/_grpc_errors.py
@@ -37,7 +37,18 @@ _STACK_TRACE_TRUNCATION_MARKER = b"\n... stack trace truncated by Dex Python SDK
 
 @dataclass(frozen=True)
 class RetryAfterError(Exception):
-    """Requests a delay before the next retry while preserving the current failure."""
+    """Requests a delay before Dex retries a failed worker method.
+
+    Raise an instance with :func:`retry_after` from a Step method when the
+    failure is retryable but the next attempt should happen at a known time.
+    Dex reports the original cause as the worker failure and uses the requested
+    delay instead of the retry policy's calculated interval.
+
+    Attributes:
+        after_seconds (int): Positive delay in seconds before the next retry.
+        cause (BaseException): Original failure reported to Dex and re-raised
+            as the retry cause.
+    """
 
     after_seconds: int
     cause: BaseException
@@ -47,6 +58,23 @@ class RetryAfterError(Exception):
 
 
 def retry_after(after_seconds: int, cause: BaseException) -> RetryAfterError:
+    """Creates an error that sets the delay before Dex retries a worker method.
+
+    Raise the returned error from a Step method after an external dependency
+    reports that it is not ready. For example::
+
+        raise retry_after(5, RuntimeError("service is not ready"))
+
+    Args:
+        after_seconds (int): Positive delay in seconds before the next retry.
+        cause (BaseException): Failure that Dex records as the worker error.
+
+    Returns:
+        RetryAfterError: Error to raise from the worker method.
+
+    Raises:
+        ValueError: If **after_seconds** is not positive or **cause** is None.
+    """
     if cause is None:
         raise ValueError("cause is required")
     if after_seconds <= 0:

--- a/sdk-python/tests/test_errors.py
+++ b/sdk-python/tests/test_errors.py
@@ -18,8 +18,10 @@ from dex import (
     FlowNotActiveError,
     FlowNotFoundError,
     LongPollTimeoutError,
+    RetryAfterError,
     RpcLockConflictError,
     WorkerInvocationError,
+    retry_after,
 )
 from dex._grpc_errors import translate_rpc_error
 from dex.dexpb import dex_pb2 as pb
@@ -90,6 +92,16 @@ def test_other_known_sub_statuses_have_explicit_errors() -> None:
     )
     assert isinstance(timeout, LongPollTimeoutError)
     assert timeout.flow_id == "flow-id"
+
+
+def test_retry_after_is_available_from_the_sdk_package() -> None:
+    cause = RuntimeError("try again")
+
+    result = retry_after(1, cause)
+
+    assert isinstance(result, RetryAfterError)
+    assert result.after_seconds == 1
+    assert result.cause is cause
 
 
 def test_missing_and_malformed_details_use_generic_fallback() -> None:


### PR DESCRIPTION
## Summary

- Export `retry_after` and `RetryAfterError` from the Python SDK package.
- Document the now-public retry-delay API and add an import contract test.

## Rationale

Applications need a supported top-level import when a Step must request the exact delay before its next retry.

## User impact

Python workers can write `from dex import retry_after` rather than importing an internal module.

## Validation

- `uv run --python 3.11 --frozen pytest tests/test_errors.py`
- `uv run --python 3.11 --frozen python scripts/check_public_docs.py`
- `uv run --python 3.11 --frozen isort --check-only dex/__init__.py dex/_grpc_errors.py tests/test_errors.py`
- `uv run --python 3.11 --frozen black --check dex/__init__.py dex/_grpc_errors.py tests/test_errors.py`
- `uv run --python 3.11 --frozen ruff check dex/__init__.py dex/_grpc_errors.py tests/test_errors.py`
- `uv run --python 3.11 --frozen mypy --strict dex/__init__.py dex/_grpc_errors.py tests/test_errors.py`
