### PR TITLE
docs: group channel draining patterns

### DIFF
--- a/docs/content/design-patterns/drain-internal-channels.mdx
+++ b/docs/content/design-patterns/drain-internal-channels.mdx
@@ -1,8 +1,8 @@
 ---
-title: Drain Internal Channel
+title: Drain Internal Channels
 ---
 
-# Drain Internal Channel
+# Drain Internal Channels
 
 Finish a producer/consumer Flow after its internally published Channel messages have been processed.
 

--- a/docs/content/design-patterns/draining-channel-for-external-publishing.mdx
+++ b/docs/content/design-patterns/draining-channel-for-external-publishing.mdx
@@ -1,8 +1,8 @@
 ---
-title: Drain External Channel
+title: Drain External Channels
 ---
 
-# Drain External Channel
+# Drain External Channels
 
 Process externally published Channel messages, then close the short-lived Flow when its queue is empty.
 

--- a/docs/content/design-patterns/index.mdx
+++ b/docs/content/design-patterns/index.mdx
@@ -12,8 +12,9 @@ Reusable Flow shapes from the Dex examples. Each pattern page explains the probl
 Full samples live under examples/go, examples/java, examples/python, examples/typescript, and examples/rust (HTTP prefix /patterns/name/... where applicable). Try them from the examples playground (**examples/playground**); see **examples/README.md**.
 
 - [Cron schedule](/design-patterns/cron) — Run cron-like fixed-interval work in one Flow.
-- [Drain Internal Channel](/design-patterns/drain-internal-channels) — Gracefully finish producer/consumer Flows without losing in-flight Channel messages.
-- [Drain External Channel](/design-patterns/draining-channel-for-external-publishing) — Process externally published messages, then complete when the Channel is empty.
+- Drain Channels
+  - [Drain Internal Channels](/design-patterns/drain-internal-channels) — Gracefully finish producer/consumer Flows without losing in-flight Channel messages.
+  - [Drain External Channels](/design-patterns/draining-channel-for-external-publishing) — Process externally published messages, then complete when the Channel is empty.
 - [Interruptible execution](/design-patterns/interruptible) — Stop or redirect long work gracefully based on durable control signals.
 - [Manual Recovery](/design-patterns/manual-recovery) — After retries are exhausted, let a person retry the work or fail the Flow.
 - [Parallel Steps](/design-patterns/parallel) — Choose static, dynamic, await-all, or first-win concurrent Step coordination.

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/draining-channel-for-external-publishing.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/draining-channel-for-external-publishing.mdx
@@ -1,9 +1,9 @@
 ---
-title: Drain External Channel
-sidebar_label: Drain External Channel
+title: Drain External Channels
+sidebar_label: Drain External Channels
 ---
 
-# Drain External Channel
+# Drain External Channels
 
 处理外部发布到 Channel 的消息；队列为空时完成这条短生命周期的 Flow。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/index.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/index.mdx
@@ -12,8 +12,9 @@ slug: /design-patterns
 完整示例位于 examples/go、examples/java、examples/python、examples/typescript 和 examples/rust。可在 examples playground 中试用 HTTP 示例；见 **examples/README.md**。
 
 - [Cron schedule](/design-patterns/cron) — 在一条 Flow 中按固定间隔运行工作。
-- [Drain internal channels](/design-patterns/drain-internal-channels) — 让 producer/consumer Flow 不丢失在途 Channel 消息地完成。
-- [排空外部 Channel](/design-patterns/draining-channel-for-external-publishing) — 处理外部发布的消息，并在 Channel 为空时完成。
+- Drain Channels
+  - [Drain Internal Channels](/design-patterns/drain-internal-channels) — 让 producer/consumer Flow 不丢失在途 Channel 消息地完成。
+  - [Drain External Channels](/design-patterns/draining-channel-for-external-publishing) — 处理外部发布的消息，并在 Channel 为空时完成。
 - [可中断执行](/design-patterns/interruptible) — 根据 durable 控制消息，优雅地停止或转向长时间工作。
 - [人工恢复](/design-patterns/manual-recovery) — 重试耗尽后，让人工决定重试工作或使 Flow 失败。
 - [Parallel Steps](/design-patterns/parallel) — 选择静态、动态、等待全部完成或首个获胜的并发 Step 协调方式。

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -52,8 +52,14 @@ const sidebars: SidebarsConfig = {
       link: {type: 'doc', id: 'design-patterns/index'},
       items: [
         'design-patterns/cron',
-        'design-patterns/drain-internal-channels',
-        'design-patterns/draining-channel-for-external-publishing',
+        {
+          type: 'category',
+          label: 'Drain Channels',
+          items: [
+            'design-patterns/drain-internal-channels',
+            'design-patterns/draining-channel-for-external-publishing',
+          ],
+        },
         'design-patterns/interruptible',
         'design-patterns/manual-recovery',
         {


### PR DESCRIPTION
## Summary

- Group the internal and external Channel draining patterns under Drain Channels in the documentation sidebar.
- Nest the two patterns in the English and Simplified Chinese design-pattern overviews.
- Align the child pattern titles with their plural Channel scope.

## Rationale

The two patterns describe the same Channel-draining family. Grouping them makes the relationship clear without changing their examples, body content, or URLs.

## User impact

Readers can find both Channel-draining approaches under one navigation category while existing links remain valid.

## Validation

- `make docs-prose-check`
- `make copyright-check`
- `npm run check` (from `docs/`)
