### PR TITLE
docs: expand data storage pattern

### DIFF
--- a/docs/content/design-patterns/entity-store.mdx
+++ b/docs/content/design-patterns/entity-store.mdx
@@ -1,48 +1,46 @@
 ---
-title: Entity Store
+title: Data Storage
+sidebar_label: Data Storage
 ---
 
-# Entity Store
+# Data Storage
 
-Keep durable entity state in one Flow per entity while projecting selected fields
-into an application-owned PostgreSQL table.
+Keep one durable Flow for each application entity, then project selected
+Attributes into an application-owned SQL table. The Flow is the write model and
+source of truth. SQL is an asynchronous, latest-state projection for reads and
+queries.
 
-## Problem and approach
+The runnable example keeps one **UserProfileFlow** per user. Its Flow ID becomes
+the **user_id** primary key in **public.user_profiles**. The Server configuration
+names the projection target **entityStore**.
 
-Applications often need both durable orchestration state and a conventional SQL
-read model. **UserProfileFlow** uses the user ID as its Flow ID, stores the profile
-as seven Attributes, and opts those definitions into Attribute Store sync. The
-Flow selects the Server store named **entityStore**, whose destination table uses
-the Flow ID as its **user_id** primary key.
+## When to use this pattern
 
-Dex remains authoritative. SQL projection is asynchronous, latest-state only,
-and cannot roll back a successful Flow Attribute write.
+Use this pattern when an entity needs durable state or RPC updates, while the
+application also needs database queries over its latest state. Do not use the
+SQL projection to make Flow decisions: Dex state remains authoritative.
 
-## Key components
+## How it works
 
-1. **UserProfileFlow**: One long-lived Flow per user.
-2. **Synced Attribute definitions**: text, boolean, integer, double, datetime,
-   and JSON fields project every initial value, RPC update, and deletion.
-3. **FlowConfig**: Selects the Server-configured **entityStore** target.
-4. **user_profiles**: Application-owned PostgreSQL table whose primary key is
-   populated from the Flow ID.
+1. Use the entity ID as the Flow ID.
+2. Mark every projected Attribute with **syncToAttributeStore**.
+3. Select the Server-configured Attribute Store in **FlowConfig** when starting
+   the Flow.
+4. Update or delete Attributes through the Flow. Dex projects their resulting
+   values to SQL.
 
-## API endpoints
+The example projects text, boolean, integer, double, datetime, and JSON values.
+Deleting an Attribute keeps the SQL row and projects **NULL** to its column.
 
-- **POST /patterns/entity-store/profile** — create a profile Flow
-- **POST /patterns/entity-store/profile/update** — update its synced fields
-- **GET /patterns/entity-store/profile?userId=...** — read authoritative Flow state
-- **POST /patterns/entity-store/profile/clear?userId=...** — delete the synced values
+## Core implementation
 
-Clearing the profile leaves its SQL row in place and projects SQL **NULL** into the
-seven nullable columns.
+### Define synced Attributes
 
-Full runnable samples live under examples/go, examples/java, examples/python, examples/typescript, and examples/rust (HTTP prefix **/patterns/entity-store/...**). Try them from the examples playground (**examples/playground**); see **examples/README.md**.
+Every SDK marks the same profile fields for projection. Their Flow persistence
+schemas include the definitions, so the values are durable before Dex syncs them.
 
-## SDK definitions
-
-<SdkTabs>
-  <SdkSnippet lang="python">
+<SdkTabs examples={{python: 'examples/python/dex_examples/patterns/entity-store/user_profile_flow.py', go: 'examples/go/patterns/entity-store/workflow.go', java: 'examples/java/src/main/java/io/superdurable/dex/patterns/entitystore/UserProfileFlow.java', typescript: 'examples/typescript/src/patterns/entity-store/user-profile-flow.ts', rust: 'examples/rust/src/patterns/entity_store/flow.rs'}}>
+<SdkSnippet lang="python">
 
 ```python
 class UserProfileFlow(Flow[None]):
@@ -56,70 +54,310 @@ class UserProfileFlow(Flow[None]):
     last_logged_in_time = Attribute(
         "last_logged_in_time", datetime, sync_to_attribute_store=True
     )
-    metadata = Attribute("metadata", UserProfileMetadata, sync_to_attribute_store=True)
+    metadata = Attribute(
+        "metadata", UserProfileMetadata, sync_to_attribute_store=True
+    )
 
-await client.start_flow(
-    flow,
-    user_id,
-    None,
-    StartFlowOptions(
-        attributes=[...],
-        config_override=FlowConfig(attribute_store_names=["entityStore"]),
-    ),
-)
+    def get_persistence_schema(self) -> PersistenceSchema:
+        return PersistenceSchema.of(
+            self.display_name,
+            self.email,
+            self.marketing_opt_in,
+            self.credits,
+            self.weight,
+            self.last_logged_in_time,
+            self.metadata,
+        )
 ```
 
-  </SdkSnippet>
-  <SdkSnippet lang="go">
+</SdkSnippet>
+<SdkSnippet lang="go">
 
 ```go
-var DisplayName = dex.DefineAttribute[string](
-    "display_name",
-    dex.SyncToAttributeStore(),
+var (
+	DisplayName = dex.DefineAttribute[string](
+		"display_name",
+		dex.SyncToAttributeStore(),
+	)
+	Email = dex.DefineAttribute[string]("email", dex.SyncToAttributeStore())
+	MarketingOptIn = dex.DefineAttribute[bool](
+		"marketing_opt_in",
+		dex.SyncToAttributeStore(),
+	)
+	Credits = dex.DefineAttribute[int64]("credits", dex.SyncToAttributeStore())
+	Weight = dex.DefineAttribute[float64]("weight", dex.SyncToAttributeStore())
+	LastLoggedIn = dex.DefineAttribute[time.Time](
+		"last_logged_in_time",
+		dex.SyncToAttributeStore(),
+	)
+	Metadata = dex.DefineAttribute[UserProfileMetadata](
+		"metadata",
+		dex.SyncToAttributeStore(),
+	)
 )
 
-config := dex.FlowConfig{
-    AttributeStoreNames: []string{"entityStore"},
+func (*UserProfileFlow) GetPersistenceSchema() dex.PersistenceSchema {
+	return dex.PersistenceSchema{Attributes: []dex.AttributeDef{
+		DisplayName, Email, MarketingOptIn, Credits, Weight, LastLoggedIn, Metadata,
+	}}
 }
 ```
 
-  </SdkSnippet>
-  <SdkSnippet lang="java">
+</SdkSnippet>
+<SdkSnippet lang="java">
 
 ```java
-Attribute<String> displayName =
-    Attribute.define("display_name", String.class).syncToAttributeStore();
+public final Attribute<String> displayName =
+        Attribute.define("display_name", String.class).syncToAttributeStore();
+public final Attribute<String> email =
+        Attribute.define("email", String.class).syncToAttributeStore();
+public final Attribute<Boolean> marketingOptIn =
+        Attribute.define("marketing_opt_in", Boolean.class).syncToAttributeStore();
+public final Attribute<Long> credits =
+        Attribute.define("credits", Long.class).syncToAttributeStore();
+public final Attribute<Double> weight =
+        Attribute.define("weight", Double.class).syncToAttributeStore();
+public final Attribute<Instant> lastLoggedInTime =
+        Attribute.define("last_logged_in_time", Instant.class).syncToAttributeStore();
+public final Attribute<UserProfileMetadata> metadata =
+        Attribute.define("metadata", UserProfileMetadata.class).syncToAttributeStore();
 
-FlowConfig config = FlowConfig.newBuilder()
-    .attributeStoreNames("entityStore")
-    .build();
+@Override
+public PersistenceSchema getPersistenceSchema() {
+    return PersistenceSchema.of(
+            displayName,
+            email,
+            marketingOptIn,
+            credits,
+            weight,
+            lastLoggedInTime,
+            metadata);
+}
 ```
 
-  </SdkSnippet>
-  <SdkSnippet lang="typescript">
+</SdkSnippet>
+<SdkSnippet lang="typescript">
 
 ```typescript
-const displayName = new Attribute("display_name", stringCodec)
+public readonly displayName = new Attribute("display_name", stringCodec)
   .syncToAttributeStore();
+public readonly email = new Attribute("email", stringCodec).syncToAttributeStore();
+public readonly marketingOptIn = new Attribute("marketing_opt_in", booleanCodec)
+  .syncToAttributeStore();
+public readonly credits = new Attribute("credits", int64Codec)
+  .syncToAttributeStore();
+public readonly weight = new Attribute("weight", doubleCodec)
+  .syncToAttributeStore();
+public readonly lastLoggedInTime = new Attribute("last_logged_in_time", dateCodec)
+  .syncToAttributeStore();
+public readonly metadata = new Attribute("metadata", metadataCodec).syncToAttributeStore();
 
-const options = {
-  attributes: [InitialAttribute.of(displayName, "Ada Lovelace")],
-  configOverride: { attributeStoreNames: ["entityStore"] },
-};
+public getPersistenceSchema(): PersistenceSchema {
+  return { attributes: [
+    this.displayName, this.email, this.marketingOptIn, this.credits,
+    this.weight, this.lastLoggedInTime, this.metadata,
+  ] };
+}
 ```
 
-  </SdkSnippet>
+</SdkSnippet>
+<SdkSnippet lang="rust">
+
+```rust
+fn persistence(&self) -> PersistenceSchema {
+    PersistenceSchema::new()
+        .attribute(&DISPLAY_NAME)
+        .attribute(&EMAIL)
+        .attribute(&MARKETING_OPT_IN)
+        .attribute(&CREDITS)
+        .attribute(&WEIGHT)
+        .attribute(&LAST_LOGGED_IN_TIME)
+        .attribute(&METADATA)
+}
+
+static DISPLAY_NAME: LazyLock<Attribute<String>> = LazyLock::new(|| {
+    Attribute::new("display_name").sync_to_attribute_store()
+});
+static METADATA: LazyLock<Attribute<UserProfileMetadata>> = LazyLock::new(|| {
+    Attribute::new("metadata").sync_to_attribute_store()
+});
+```
+
+</SdkSnippet>
 </SdkTabs>
+
+### Update through a Flow RPC
+
+The RPC is the write path. Each implementation validates the profile at its
+boundary, then updates every projected Attribute.
+
+<SdkTabs examples={{python: 'examples/python/dex_examples/patterns/entity-store/user_profile_flow.py', go: 'examples/go/patterns/entity-store/workflow.go', java: 'examples/java/src/main/java/io/superdurable/dex/patterns/entitystore/UserProfileFlow.java', typescript: 'examples/typescript/src/patterns/entity-store/user-profile-flow.ts', rust: 'examples/rust/src/patterns/entity_store/flow.rs'}}>
+<SdkSnippet lang="python">
+
+```python
+@rpc
+def update_profile(self, context: Context, input: UserProfile) -> None:
+    input.validate()
+    self.display_name.set(context, input.display_name)
+    self.email.set(context, input.email)
+    self.marketing_opt_in.set(context, input.marketing_opt_in)
+    self.credits.set(context, input.credits)
+    self.weight.set(context, input.weight)
+    self.last_logged_in_time.set(context, input.last_logged_in_time)
+    self.metadata.set(context, input.metadata)
+```
+
+</SdkSnippet>
+<SdkSnippet lang="go">
+
+```go
+func (*UserProfileFlow) UpdateProfile(
+	ctx dex.Context,
+	profile UserProfile,
+) (*dex.RPCResult[dex.None], error) {
+	if err := validateProfile(profile); err != nil {
+		return nil, err
+	}
+	if err := DisplayName.Set(ctx, profile.DisplayName); err != nil {
+		return nil, err
+	}
+	if err := Email.Set(ctx, profile.Email); err != nil {
+		return nil, err
+	}
+	if err := MarketingOptIn.Set(ctx, profile.MarketingOptIn); err != nil {
+		return nil, err
+	}
+	if err := Credits.Set(ctx, profile.Credits); err != nil {
+		return nil, err
+	}
+	if err := Weight.Set(ctx, profile.Weight); err != nil {
+		return nil, err
+	}
+	if err := LastLoggedIn.Set(ctx, profile.LastLoggedIn); err != nil {
+		return nil, err
+	}
+	if err := Metadata.Set(ctx, profile.Metadata); err != nil {
+		return nil, err
+	}
+	return &dex.RPCResult[dex.None]{}, nil
+}
+```
+
+</SdkSnippet>
+<SdkSnippet lang="java">
+
+```java
+@RPC
+public void updateProfile(final Context context, final UserProfile profile) {
+    profile.validate();
+    displayName.set(context, profile.displayName);
+    email.set(context, profile.email);
+    marketingOptIn.set(context, profile.marketingOptIn);
+    credits.set(context, profile.credits);
+    weight.set(context, profile.weight);
+    lastLoggedInTime.set(context, profile.lastLoggedInTime);
+    metadata.set(context, profile.metadata);
+}
+```
+
+</SdkSnippet>
+<SdkSnippet lang="typescript">
+
+```typescript
+@rpc({ inputCodec: userProfileCodec })
+public updateProfile(context: Context, profile: UserProfile): void {
+  this.displayName.set(context, profile.displayName);
+  this.email.set(context, profile.email);
+  this.marketingOptIn.set(context, profile.marketingOptIn);
+  this.credits.set(context, BigInt(profile.credits));
+  this.weight.set(context, profile.weight);
+  this.lastLoggedInTime.set(context, profile.lastLoggedInTime);
+  this.metadata.set(context, profile.metadata);
+}
+```
+
+</SdkSnippet>
+<SdkSnippet lang="rust">
+
+```rust
+fn update(&self, context: &mut Context, replacement: UserProfile) -> HandlerResult<()> {
+    validate_profile(&replacement)?;
+    DISPLAY_NAME.set(context, replacement.display_name)?;
+    EMAIL.set(context, replacement.email)?;
+    MARKETING_OPT_IN.set(context, replacement.marketing_opt_in)?;
+    CREDITS.set(context, replacement.credits)?;
+    WEIGHT.set(context, replacement.weight)?;
+    LAST_LOGGED_IN_TIME.set(context, replacement.last_logged_in_time)?;
+    METADATA.set(context, replacement.metadata)
+}
+```
+
+</SdkSnippet>
+</SdkTabs>
+
+### Select the storage target at Flow start
+
+The Attribute Store is configured on the Server. Select it in **FlowConfig**
+when starting the Flow; the initial Attribute values in that same request also
+project to SQL.
+
+<SdkTabs examples={{python: 'examples/python/dex_examples/patterns/entity-store/controller.py', go: 'examples/go/patterns/entity-store/controller.go', java: 'examples/java/src/main/java/io/superdurable/dex/patterns/entitystore/EntityStoreController.java', typescript: 'examples/typescript/src/patterns/entity-store/controller.ts', rust: 'examples/rust/src/patterns/entity_store/flow.rs'}}>
+<SdkSnippet lang="python">
+
+```python
+config_override=FlowConfig(attribute_store_names=[STORE_NAME]),
+```
+
+</SdkSnippet>
+<SdkSnippet lang="go">
+
+```go
+options.ConfigOverride = &sdk.FlowConfig{
+	AttributeStoreNames: []string{StoreName},
+}
+```
+
+</SdkSnippet>
+<SdkSnippet lang="java">
+
+```java
+.configOverride(FlowConfig.newBuilder()
+        .attributeStoreNames(UserProfileFlow.STORE_NAME)
+        .build())
+```
+
+</SdkSnippet>
+<SdkSnippet lang="typescript">
+
+```typescript
+configOverride: { attributeStoreNames: [ENTITY_STORE_NAME] },
+```
+
+</SdkSnippet>
+<SdkSnippet lang="rust">
+
+```rust
+FlowConfig::new().attribute_store_names(vec![STORE_NAME.to_owned()])
+```
+
+</SdkSnippet>
+</SdkTabs>
+
+## API endpoints
+
+- **POST /patterns/entity-store/profile** — create a profile Flow
+- **POST /patterns/entity-store/profile/update** — update its synced fields
+- **GET /patterns/entity-store/profile?userId=...** — read authoritative Flow state
+- **POST /patterns/entity-store/profile/clear?userId=...** — delete the synced values
 
 ## Run with PostgreSQL
 
 The [shared example setup](https://github.com/superdurable/dex/tree/main/examples/entity-store)
 starts PostgreSQL, creates **public.user_profiles**, and passes the **entityStore**
-configuration to **dexcli dev**. The language examples intentionally keep their
-normal test suites independent of PostgreSQL.
+configuration to **dexcli dev**. It includes the table schema and curl commands
+for every language example.
 
 ## Related
 
 - [Attribute Store projection](/primitives/attribute#attribute-store-projection)
 - [Custom Attribute Store operations](/production/attribute-store)
-- [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/content/design-patterns/index.mdx
+++ b/docs/content/design-patterns/index.mdx
@@ -22,5 +22,7 @@ Full samples live under examples/go, examples/java, examples/python, examples/ty
 - [Polling and Iteration](/design-patterns/polling) — Revisit external state or process paginated work over time.
 - [Reminders](/design-patterns/reminders) — Send periodic reminders until opt-out or timeout.
 - [Resettable timer](/design-patterns/resettable-timer) — Extend or reset a wait window based on fresh activity.
-- [Entity Store](/design-patterns/entity-store) — Project durable per-entity Flow Attributes into an application-owned SQL table.
+- [Scalable parallel](/design-patterns/scalable-parallel) — Control fan-out with parent/child Flows for large parallel workloads.
+- [Data Storage](/design-patterns/entity-store) — Project durable per-entity Flow Attributes into an application-owned SQL table.
+- [Timeout](/design-patterns/timeout) — Bound work with graceful timeout and dead-end paths.
 - [Wait for Step completion](/design-patterns/wait-for-step-completion) — Let callers wait for a Step while background work continues.

--- a/docs/content/design-patterns/index.mdx
+++ b/docs/content/design-patterns/index.mdx
@@ -22,7 +22,5 @@ Full samples live under examples/go, examples/java, examples/python, examples/ty
 - [Polling and Iteration](/design-patterns/polling) — Revisit external state or process paginated work over time.
 - [Reminders](/design-patterns/reminders) — Send periodic reminders until opt-out or timeout.
 - [Resettable timer](/design-patterns/resettable-timer) — Extend or reset a wait window based on fresh activity.
-- [Scalable parallel](/design-patterns/scalable-parallel) — Control fan-out with parent/child Flows for large parallel workloads.
 - [Data Storage](/design-patterns/entity-store) — Project durable per-entity Flow Attributes into an application-owned SQL table.
-- [Timeout](/design-patterns/timeout) — Bound work with graceful timeout and dead-end paths.
 - [Wait for Step completion](/design-patterns/wait-for-step-completion) — Let callers wait for a Step while background work continues.

--- a/docs/content/design-patterns/parallel-subflows/back-pressure.mdx
+++ b/docs/content/design-patterns/parallel-subflows/back-pressure.mdx
@@ -350,4 +350,4 @@ fn enqueue_request(client: &Client, parent_id: &str, request: String) -> Handler
 ## Related
 
 - [Multiple parents with partitioning](/design-patterns/parallel-subflows/partitioning)
-- [Failure recovery](/design-patterns/recovery)
+- [Failure Handling](/design-patterns/failure-handling)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/entity-store.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/entity-store.mdx
@@ -1,0 +1,55 @@
+---
+title: Data Storage
+sidebar_label: Data Storage
+---
+
+# Data Storage
+
+为每个 application entity 保留一个 durable Flow，再将选定的 Attribute 投影到
+application 自有的 SQL table。Flow 是 write model 和 source of truth；SQL 是用于读取和
+查询的 asynchronous、latest-state projection。
+
+可运行示例为每个 user 创建一个 **UserProfileFlow**。Flow ID 会成为
+**public.user_profiles** 的 **user_id** primary key；Server configuration 将 projection
+target 命名为 **entityStore**。
+
+## 适用场景
+
+当一个 entity 既需要 durable state 或 RPC update，又需要通过 database tools 查询其
+latest state 时，使用此 pattern。不要通过 SQL projection 做 Flow decision，因为 Dex state
+始终 authoritative。
+
+## Projection 如何工作
+
+1. 将 entity ID 用作 Flow ID。
+2. 用 **syncToAttributeStore** 标记每个需要投影的 Attribute。
+3. 启动 Flow 时通过 **FlowConfig** 选择 Server-configured Attribute Store。
+4. 通过 Flow write、update 或 delete Attribute；Dex 将最终值投影到 SQL。
+
+示例投影 text、boolean、integer、double、datetime 和 JSON values。删除 Attribute 会保留
+SQL row，并将该 column 投影为 **NULL**。
+
+## 核心实现
+
+五种 SDK 都实现同一组 **UserProfileFlow** Attribute、persistence schema、update RPC 和
+**FlowConfig** target selection。English page 的 SDK tabs 包含对应的 Python、Go、Java、
+TypeScript 和 Rust core snippets；每个 tab 都链接到可运行 sample source。
+
+## API endpoints
+
+- **POST /patterns/entity-store/profile** — 创建 profile Flow
+- **POST /patterns/entity-store/profile/update** — 更新同步 fields
+- **GET /patterns/entity-store/profile?userId=...** — 读取 authoritative Flow state
+- **POST /patterns/entity-store/profile/clear?userId=...** — 删除同步 values
+
+## 使用 PostgreSQL 运行
+
+[shared example setup](https://github.com/superdurable/dex/tree/main/examples/entity-store)
+会启动 PostgreSQL、创建 **public.user_profiles**，并将 **entityStore** configuration
+传给 **dexcli dev**。其中还包含 table schema 和五种语言示例的 curl commands。
+
+## 相关内容
+
+- [Attribute Store projection](/primitives/attribute#attribute-store-projection)
+- [Custom Attribute Store operations](/production/attribute-store)
+- [Examples on GitHub](https://github.com/superdurable/dex/tree/main/examples)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/index.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/index.mdx
@@ -22,7 +22,5 @@ slug: /design-patterns
 - [Polling and Iteration](/design-patterns/polling) — 周期性检查外部状态，或按页处理大量数据。
 - [Reminders](/design-patterns/reminders) — 定期发送提醒，直到 opt-out 或超时。
 - [Resettable timer](/design-patterns/resettable-timer) — 根据新活动延长或重置等待窗口。
-- [Scalable parallel](/design-patterns/scalable-parallel) — 用父/子 Flow 控制大规模 fan-out。
 - [Data Storage](/design-patterns/entity-store) — 将每个实体的 durable Flow Attribute 投影到应用自有的 SQL 表。
-- [Timeout](/design-patterns/timeout) — 用优雅的 timeout 和 dead-end 路径限制工作时间。
 - [Wait for Step completion](/design-patterns/wait-for-step-completion) — 让调用方在后台工作继续时等待一个 Step。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/index.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/index.mdx
@@ -22,5 +22,7 @@ slug: /design-patterns
 - [Polling and Iteration](/design-patterns/polling) — 周期性检查外部状态，或按页处理大量数据。
 - [Reminders](/design-patterns/reminders) — 定期发送提醒，直到 opt-out 或超时。
 - [Resettable timer](/design-patterns/resettable-timer) — 根据新活动延长或重置等待窗口。
-- [Entity Store](/design-patterns/entity-store) — 将每个实体的 durable Flow Attribute 投影到应用自有的 SQL 表。
+- [Scalable parallel](/design-patterns/scalable-parallel) — 用父/子 Flow 控制大规模 fan-out。
+- [Data Storage](/design-patterns/entity-store) — 将每个实体的 durable Flow Attribute 投影到应用自有的 SQL 表。
+- [Timeout](/design-patterns/timeout) — 用优雅的 timeout 和 dead-end 路径限制工作时间。
 - [Wait for Step completion](/design-patterns/wait-for-step-completion) — 让调用方在后台工作继续时等待一个 Step。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/back-pressure.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/back-pressure.mdx
@@ -350,4 +350,4 @@ fn enqueue_request(client: &Client, parent_id: &str, request: String) -> Handler
 ## 相关内容
 
 - [多父 Flow 分区](/design-patterns/parallel-subflows/partitioning)
-- [故障恢复](/design-patterns/recovery)
+- [Failure Handling](/design-patterns/failure-handling)


### PR DESCRIPTION
## Summary

- Rename the Entity Store design pattern to Data Storage.
- Explain authoritative Flow state, asynchronous SQL projection, and Attribute deletion behavior.
- Add Python, Go, Java, TypeScript, and Rust snippets for synced Attributes, RPC updates, and Attribute Store selection.
- Add the matching Simplified Chinese page and navigation label.

## User impact

Readers can compare the same data-storage shape across every SDK and see where the SQL projection belongs relative to durable Flow state.

## Validation

- `npm run build` in `docs/`
- `make docs-prose-check`
