### PR TITLE
docs: fix back pressure recovery link

### DIFF
--- a/docs/content/design-patterns/parallel-subflows/back-pressure.mdx
+++ b/docs/content/design-patterns/parallel-subflows/back-pressure.mdx
@@ -350,4 +350,4 @@ fn enqueue_request(client: &Client, parent_id: &str, request: String) -> Handler
 ## Related
 
 - [Multiple parents with partitioning](/design-patterns/parallel-subflows/partitioning)
-- [Failure recovery](/design-patterns/recovery)
+- [Failure Handling](/design-patterns/failure-handling)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/back-pressure.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/back-pressure.mdx
@@ -350,4 +350,4 @@ fn enqueue_request(client: &Client, parent_id: &str, request: String) -> Handler
 ## 相关内容
 
 - [多父 Flow 分区](/design-patterns/parallel-subflows/partitioning)
-- [故障恢复](/design-patterns/recovery)
+- [Failure Handling](/design-patterns/failure-handling)


### PR DESCRIPTION
## Summary

- Replace the stale Failure recovery route in the back-pressure guide.
- Keep the Simplified Chinese version linked to the current Failure Handling guide.

## Rationale

The deploy-docs workflow failed because the old /design-patterns/recovery route no longer exists.

## User impact

Readers can navigate from the back-pressure guide to the supported failure-handling documentation.

## Validation

- npm run build (docs; English and Simplified Chinese)
