### PR TITLE
Remove no-op del statements from Python examples

### DIFF
--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -112,6 +112,11 @@ one requires equivalent updates to all three in the same commit.
   Prefer capturing a small id/string or building a new tiny value over cloning.
   Copy only when an algorithm must mutate a distinct shared value in place.
 
+## Python Examples
+
+Do not use `del` in Python examples merely to mark parameters or local values
+as unused. Keep required callback parameters unused instead.
+
 ## License Headers
 
 - Every new or edited `.go` / `.java` / `.py` file (and hand-written OpenAPI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,11 @@ LazyLock<T>`. Do not use a function to construct or return one of these
 definitions. Reuse the static directly, or clone its initialized value only
 when an owned field is required.
 
+### Python Examples
+
+Do not use `del` in Python examples merely to mark parameters or local values
+as unused. Keep required callback parameters unused instead.
+
 ### Fluent SDK Call Sites
 
 Design SDK APIs so application code reads like a natural phrase in its host

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,11 @@ LazyLock<T>`. Do not use a function to construct or return one of these
 definitions. Reuse the static directly, or clone its initialized value only
 when an owned field is required.
 
+# Python Examples
+
+Do not use `del` in Python examples merely to mark parameters or local values
+as unused. Keep required callback parameters unused instead.
+
 # Server Go Conventions (`server/**/*.go`)
 
 ## File Ordering

--- a/docs/content/design-patterns/cron.mdx
+++ b/docs/content/design-patterns/cron.mdx
@@ -43,7 +43,6 @@ class _WaitForSchedule(Step[_ScheduleState]):
         self.skip = skip
 
     def wait_for(self, context: Context, state: _ScheduleState) -> Wait:
-        del context
         return Wait.any_of(
             Timer.by_duration(state.interval.duration()),
             self.trigger.for_one(),

--- a/docs/content/design-patterns/drain-internal-channels.mdx
+++ b/docs/content/design-patterns/drain-internal-channels.mdx
@@ -42,11 +42,9 @@ class MainStep(Step[str]):
 
 class SideStep(Step[None]):
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(self.side_step_data.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         document = self.side_step_data.results(context)[0]
         self.mongo_collection.upsert(document)
         if document.final_command:
@@ -55,7 +53,6 @@ class SideStep(Step[None]):
 
 class Finalize(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         self.side_step_data.publish(
             context, MongoDocument("documentId-1", "FINALIZED", True)
         )

--- a/docs/content/design-patterns/draining-channel-for-external-publishing.mdx
+++ b/docs/content/design-patterns/draining-channel-for-external-publishing.mdx
@@ -32,7 +32,6 @@ class ProcessMessage(Step[str]):
         self.queue_channel = queue_channel
 
     def wait_for(self, context: Context, input: str) -> Wait:
-        del context
         if input is None:
             return Wait.until(self.queue_channel.for_one())
         return Wait.skip_immediately()

--- a/docs/content/design-patterns/failure-handling/execute-failure-recovery.mdx
+++ b/docs/content/design-patterns/failure-handling/execute-failure-recovery.mdx
@@ -34,12 +34,10 @@ class FailingStep(Step[str]):
         ).on_execute_failure_proceed_to(RecoveryStep)
 
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context, input
         raise RuntimeError("planned Execute failure")
 
 class RecoveryStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(f"recovered {input}")
 ```
 

--- a/docs/content/design-patterns/failure-handling/graceful-timeout.mdx
+++ b/docs/content/design-patterns/failure-handling/graceful-timeout.mdx
@@ -24,11 +24,9 @@ The complete Flow definition registers **LongWaitStep** through its start Step a
 ```python
 class LongWaitStep(Step[bool]):
     def wait_for(self, context: Context, successful: bool) -> Wait:
-        del context
         return Wait.skip_immediately() if successful else Wait.until(Timer.by_duration(timedelta(seconds=65)))
 
     def execute(self, context: Context, successful: bool) -> StepDecision:
-        del context, successful
         return force_complete("Workflow completed successfully")
 
 class FlowGracefulTimeout(Flow[bool]):
@@ -39,7 +37,6 @@ class FlowGracefulTimeout(Flow[bool]):
         return StepList.start_step(self.long_wait_step)
 
     def handle_timeout(self, context: Context) -> StepDecision:
-        del context
         return force_fail("Workflow did not finish the task in time")
 ```
 

--- a/docs/content/design-patterns/failure-handling/manual-recovery.mdx
+++ b/docs/content/design-patterns/failure-handling/manual-recovery.mdx
@@ -37,21 +37,18 @@ class DoWorkStep(Step[bool]):
         ).on_execute_failure_proceed_to(ManualStep)
 
     def execute(self, context: Context, should_fail: bool) -> StepDecision:
-        del context
         if should_fail:
             raise RuntimeError("work failed")
         return graceful_complete("work completed")
 
 class ManualStep(Step[bool]):
     def wait_for(self, context: Context, input: bool) -> Wait:
-        del context, input
         return Wait.any_of(
             retry_channel.for_one(),
             skip_channel.for_one(),
         )
 
     def execute(self, context: Context, input: bool) -> StepDecision:
-        del input
         if retry_channel.results(context):
             return go_to(DoWorkStep, False)
         return force_fail("manual recovery skipped")

--- a/docs/content/design-patterns/failure-handling/wait-for-failure-recovery.mdx
+++ b/docs/content/design-patterns/failure-handling/wait-for-failure-recovery.mdx
@@ -35,7 +35,6 @@ class FailingStep(Step[str]):
         )
 
     def wait_for(self, context: Context, input: str) -> Wait:
-        del context, input
         raise RuntimeError("planned WaitFor failure")
 
     def execute(self, context: Context, input: str) -> StepDecision:
@@ -45,7 +44,6 @@ class FailingStep(Step[str]):
 
 class RecoveryStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(f"recovered {input}")
 ```
 

--- a/docs/content/design-patterns/interruptible.mdx
+++ b/docs/content/design-patterns/interruptible.mdx
@@ -32,7 +32,6 @@ class WorkAStep(Step[WorkJobParametersInput]):
         self.interrupt_signal = interrupt_signal
 
     def wait_for(self, context: Context, input: WorkJobParametersInput) -> Wait:
-        del context, input
         return Wait.until(Timer.by_duration(timedelta(seconds=2)))
 
     def execute(

--- a/docs/content/design-patterns/parallel-subflows/back-pressure.mdx
+++ b/docs/content/design-patterns/parallel-subflows/back-pressure.mdx
@@ -37,7 +37,6 @@ class SubmitStep(Step[SubmitRequestInput]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: SubmitRequestInput
     ) -> StepDecision:
-        del context
         if not input.parent_ids:
             raise ValueError("at least one parent Flow ID is required")
         parent_id = input.parent_ids[partition(input.request, len(input.parent_ids))]

--- a/docs/content/design-patterns/parallel-subflows/basic.mdx
+++ b/docs/content/design-patterns/parallel-subflows/basic.mdx
@@ -21,13 +21,11 @@ class SubFlowsStep(Step[list[str]]):
         self.example_subflow = example_subflow
 
     def wait_for(self, context: Context, requests: list[str]) -> Wait:
-        del context
         return Wait.all_of(
             *(SubFlow.run(self.example_subflow, request) for request in requests)
         )
 
     def execute(self, context: Context, requests: list[str]) -> StepDecision:
-        del context, requests
         return graceful_complete()
 
 

--- a/docs/content/design-patterns/parallel-subflows/long-lived-parent.mdx
+++ b/docs/content/design-patterns/parallel-subflows/long-lived-parent.mdx
@@ -59,11 +59,9 @@ class LongLiveHandleRequestStep(Step[None]):
         return "HandleRequestStep"
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(self.request_channel.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         return go_to(LongLiveHandleSubFlowStep, self.request_channel.results(context)[0])
 
 
@@ -80,11 +78,9 @@ class LongLiveHandleSubFlowStep(Step[str]):
         return "HandleSubFlowStep"
 
     def wait_for(self, context: Context, request: str) -> Wait:
-        del context
         return Wait.until(SubFlow.run(self.example_subflow, request))
 
     def execute(self, context: Context, request: str) -> StepDecision:
-        del request
         if self.stopped.get(context):
             return graceful_complete()
         return go_to(LongLiveHandleRequestStep, None)

--- a/docs/content/design-patterns/parallel-subflows/short-lived-parent.mdx
+++ b/docs/content/design-patterns/parallel-subflows/short-lived-parent.mdx
@@ -67,11 +67,9 @@ class ShortLiveHandleRequestStep(Step[None]):
         return StepOptions(execute_lock_attributes=(self.curr_subflow_num.lock(),))
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(self.request_channel.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         request = self.request_channel.results(context)[0]
         self.curr_subflow_num.set(context, (self.curr_subflow_num.get(context) or 0) + 1)
         return go_to(ShortLiveHandleSubFlowStep, request)
@@ -95,11 +93,9 @@ class ShortLiveHandleSubFlowStep(Step[str]):
         return StepOptions(execute_lock_attributes=(self.curr_subflow_num.lock(),))
 
     def wait_for(self, context: Context, request: str) -> Wait:
-        del context
         return Wait.until(SubFlow.run(self.example_subflow, request))
 
     def execute(self, context: Context, request: str) -> StepDecision:
-        del request
         current = (self.curr_subflow_num.get(context) or 0) - 1
         self.curr_subflow_num.set(context, current)
         if current == 0:

--- a/docs/content/design-patterns/parallel-subflows/wait-for-half.mdx
+++ b/docs/content/design-patterns/parallel-subflows/wait-for-half.mdx
@@ -20,7 +20,6 @@ The important detail is that the parent does not complete immediately after reac
 ```python
 class WaitForHalfInitStep(Step[list[str]]):
     def execute(self, context: Context, requests: list[str]) -> StepDecision:
-        del context
         if not requests:
             return graceful_complete()
         return go_to_many(
@@ -43,11 +42,9 @@ class SubFlowStep(Step[str]):
         self.all_done_ch = all_done_ch
 
     def wait_for(self, context: Context, request: str) -> Wait:
-        del context
         return Wait.any_of(SubFlow.run(self.example_subflow, request), self.all_done_ch.for_one())
 
     async def execute(self, context: Context, request: str) -> StepDecision:
-        del request
         if SubFlow.get_condition_results(context).status is not FlowStatus.RUNNING:
             self.subflow_completed_ch.publish(context, True)
             return graceful_complete()
@@ -63,7 +60,6 @@ class WaitSubFlowsStep(Step[int]):
         self.all_done_ch = all_done_ch
 
     def wait_for(self, context: Context, total: int) -> Wait:
-        del context
         return Wait.until(self.subflow_completed_ch.for_n((total + 1) // 2))
 
     def execute(self, context: Context, total: int) -> StepDecision:

--- a/docs/content/design-patterns/parallel/await.mdx
+++ b/docs/content/design-patterns/parallel/await.mdx
@@ -32,7 +32,6 @@ class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: int
     ) -> StepDecision:
-        del input
         await asyncio.sleep(random.uniform(0.05, 0.5))
         self.complete_ch.publish(context, None)
         return dead_end()
@@ -43,17 +42,14 @@ class AwaitStep(Step[int]):
         self.complete_ch = complete_ch
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.until(self.complete_ch.for_n(input))
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return graceful_complete(input)
 
 
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         movements: list[StepMovement[Any]] = [StepMovement.of(AwaitStep, input)]
         movements.extend(
             StepMovement.of(DoWorkStep, index) for index in range(input)

--- a/docs/content/design-patterns/parallel/dynamic.mdx
+++ b/docs/content/design-patterns/parallel/dynamic.mdx
@@ -29,14 +29,12 @@ class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: int
     ) -> StepDecision:
-        del context
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input)
 
 
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )

--- a/docs/content/design-patterns/parallel/first-win.mdx
+++ b/docs/content/design-patterns/parallel/first-win.mdx
@@ -29,14 +29,12 @@ class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: int
     ) -> StepDecision:
-        del context
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input).with_canceling_sibling_steps(DoWorkStep)
 
 
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )

--- a/docs/content/design-patterns/parallel/static.mdx
+++ b/docs/content/design-patterns/parallel/static.mdx
@@ -27,19 +27,16 @@ The starting Step returns both movements in one decision.
 ```python
 class WorkAStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(f"A:{input}")
 
 
 class WorkBStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(f"B:{input}")
 
 
 class InitStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return go_to_many(
             StepMovement.of(WorkAStep, input),
             StepMovement.of(WorkBStep, input),

--- a/docs/content/design-patterns/polling/backoff.mdx
+++ b/docs/content/design-patterns/polling/backoff.mdx
@@ -61,7 +61,6 @@ class PollingStep(Step[None]):
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del context, input
         try:
             result = self.service.attempt_external_api_call(
                 "Poll for BackoffPollingFlow"

--- a/docs/content/intro/what-is-dex.mdx
+++ b/docs/content/intro/what-is-dex.mdx
@@ -90,7 +90,6 @@ class ShipStep(Step[OrderRequest]):
         )
 
     def wait_for(self, context: Context, input: OrderRequest) -> Wait:
-        del context, input
         return Wait.any_of(
             seller_ok.for_one(),
             Timer.by_duration(timedelta(hours=24)),

--- a/docs/content/primitives/channel.mdx
+++ b/docs/content/primitives/channel.mdx
@@ -37,7 +37,6 @@ class ChannelWaitStep(Step[int]):
         self.approval = approval
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.any_of(
             self.approval.for_one(),
             Timer.by_duration(timedelta(seconds=input)),

--- a/docs/content/primitives/step/basic.mdx
+++ b/docs/content/primitives/step/basic.mdx
@@ -54,7 +54,6 @@ approval = Channel("Approval", str)
 
 class StepSecond(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return graceful_complete(input + 1)
 
 
@@ -63,11 +62,9 @@ class ExampleStep(Step[int]):
         self.second = second
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context, input
         return Wait.until(approval.for_one())
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return go_to(StepSecond, input + 1)
 ```
 
@@ -543,7 +540,6 @@ def get_step_options(self) -> StepOptions:
     )
 
 def wait_for(self, context: Context, input: str) -> Wait:
-    del context, input
     raise RuntimeError("planned WaitFor failure")
 
 def execute(self, context: Context, input: str) -> StepDecision:

--- a/docs/content/primitives/step/step-decision.mdx
+++ b/docs/content/primitives/step/step-decision.mdx
@@ -224,11 +224,9 @@ public StepDecision execute(final Context context, final Boolean workflowSuccess
 
 ```python
 def execute(self, context: Context, input: None) -> StepDecision:
-    del context, input
     return force_fail("Workflow did not finish the task in time")
 
 def execute(self, context: Context, input: bool) -> StepDecision:
-    del context, input
     return force_complete("Workflow completed successfully")
 ```
 

--- a/docs/content/primitives/step/waiting-condition.mdx
+++ b/docs/content/primitives/step/waiting-condition.mdx
@@ -32,7 +32,6 @@ class ChannelWaitStep(Step[int]):
         self.approval = approval
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.any_of(
             self.approval.for_one(),
             Timer.by_duration(timedelta(seconds=input)),
@@ -182,7 +181,6 @@ rust: 'examples/rust/src/primitives/subflow/flow.rs',
 
 ```python
 def execute(self, context: Context, input: int) -> StepDecision:
-    del input
     result = SubFlow.get_condition_results(context)
     output = result.single_output(int)
     return graceful_complete(f"{SubFlow.get_flow_id(context)}|{output}")
@@ -357,7 +355,6 @@ def wait_for(self, context: Context, input: int) -> Wait:
     return Wait.until(approval.for_one())
 
 def execute(self, context: Context, input: int) -> StepDecision:
-    del input
     note = context.get_step_execution_local("note", str)
     return graceful_complete(note or "")
 ```

--- a/docs/content/primitives/subflow.mdx
+++ b/docs/content/primitives/subflow.mdx
@@ -36,11 +36,9 @@ class SubFlowParentStep(Step[int]):
         )
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.until(SubFlow.run(self.target, input, self.options))
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del input
         result = SubFlow.get_condition_results(context)
         output = result.single_output(int)
         return graceful_complete(f"{SubFlow.get_flow_id(context)}|{output}")

--- a/docs/content/quick-start/index.mdx
+++ b/docs/content/quick-start/index.mdx
@@ -93,7 +93,6 @@ class ShipStep(Step[OrderRequest]):
         )
 
     def wait_for(self, context: Context, input: OrderRequest) -> Wait:
-        del context, input
         return Wait.any_of(
             seller_ok.for_one(),
             Timer.by_duration(timedelta(hours=24)),

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/cron.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/cron.mdx
@@ -44,7 +44,6 @@ class _WaitForSchedule(Step[_ScheduleState]):
         self.skip = skip
 
     def wait_for(self, context: Context, state: _ScheduleState) -> Wait:
-        del context
         return Wait.any_of(
             Timer.by_duration(state.interval.duration()),
             self.trigger.for_one(),

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/draining-channel-for-external-publishing.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/draining-channel-for-external-publishing.mdx
@@ -33,7 +33,6 @@ class ProcessMessage(Step[str]):
         self.queue_channel = queue_channel
 
     def wait_for(self, context: Context, input: str) -> Wait:
-        del context
         if input is None:
             return Wait.until(self.queue_channel.for_one())
         return Wait.skip_immediately()

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/failure-handling/execute-failure-recovery.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/failure-handling/execute-failure-recovery.mdx
@@ -34,12 +34,10 @@ class FailingStep(Step[str]):
         ).on_execute_failure_proceed_to(RecoveryStep)
 
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context, input
         raise RuntimeError("planned Execute failure")
 
 class RecoveryStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(f"recovered {input}")
 ```
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/failure-handling/graceful-timeout.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/failure-handling/graceful-timeout.mdx
@@ -24,11 +24,9 @@ title: Graceful Timeout
 ```python
 class LongWaitStep(Step[bool]):
     def wait_for(self, context: Context, successful: bool) -> Wait:
-        del context
         return Wait.skip_immediately() if successful else Wait.until(Timer.by_duration(timedelta(seconds=65)))
 
     def execute(self, context: Context, successful: bool) -> StepDecision:
-        del context, successful
         return force_complete("Workflow completed successfully")
 
 class FlowGracefulTimeout(Flow[bool]):
@@ -39,7 +37,6 @@ class FlowGracefulTimeout(Flow[bool]):
         return StepList.start_step(self.long_wait_step)
 
     def handle_timeout(self, context: Context) -> StepDecision:
-        del context
         return force_fail("Workflow did not finish the task in time")
 ```
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/failure-handling/manual-recovery.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/failure-handling/manual-recovery.mdx
@@ -37,21 +37,18 @@ class DoWorkStep(Step[bool]):
         ).on_execute_failure_proceed_to(ManualStep)
 
     def execute(self, context: Context, should_fail: bool) -> StepDecision:
-        del context
         if should_fail:
             raise RuntimeError("work failed")
         return graceful_complete("work completed")
 
 class ManualStep(Step[bool]):
     def wait_for(self, context: Context, input: bool) -> Wait:
-        del context, input
         return Wait.any_of(
             retry_channel.for_one(),
             skip_channel.for_one(),
         )
 
     def execute(self, context: Context, input: bool) -> StepDecision:
-        del input
         if retry_channel.results(context):
             return go_to(DoWorkStep, False)
         return force_fail("manual recovery skipped")

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/failure-handling/wait-for-failure-recovery.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/failure-handling/wait-for-failure-recovery.mdx
@@ -31,7 +31,6 @@ class FailingStep(Step[str]):
         )
 
     def wait_for(self, context: Context, input: str) -> Wait:
-        del context, input
         raise RuntimeError("planned WaitFor failure")
 
     def execute(self, context: Context, input: str) -> StepDecision:
@@ -41,7 +40,6 @@ class FailingStep(Step[str]):
 
 class RecoveryStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(f"recovered {input}")
 ```
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/interruptible.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/interruptible.mdx
@@ -33,7 +33,6 @@ class WorkAStep(Step[WorkJobParametersInput]):
         self.interrupt_signal = interrupt_signal
 
     def wait_for(self, context: Context, input: WorkJobParametersInput) -> Wait:
-        del context, input
         return Wait.until(Timer.by_duration(timedelta(seconds=2)))
 
     def execute(

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/back-pressure.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/back-pressure.mdx
@@ -37,7 +37,6 @@ class SubmitStep(Step[SubmitRequestInput]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: SubmitRequestInput
     ) -> StepDecision:
-        del context
         if not input.parent_ids:
             raise ValueError("at least one parent Flow ID is required")
         parent_id = input.parent_ids[partition(input.request, len(input.parent_ids))]

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/basic.mdx
@@ -21,13 +21,11 @@ class SubFlowsStep(Step[list[str]]):
         self.example_subflow = example_subflow
 
     def wait_for(self, context: Context, requests: list[str]) -> Wait:
-        del context
         return Wait.all_of(
             *(SubFlow.run(self.example_subflow, request) for request in requests)
         )
 
     def execute(self, context: Context, requests: list[str]) -> StepDecision:
-        del context, requests
         return graceful_complete()
 
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/long-lived-parent.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/long-lived-parent.mdx
@@ -39,11 +39,9 @@ class LongLiveHandleSubFlowStep(Step[str]):
         return "HandleSubFlowStep"
 
     def wait_for(self, context: Context, request: str) -> Wait:
-        del context
         return Wait.until(SubFlow.run(self.example_subflow, request))
 
     def execute(self, context: Context, request: str) -> StepDecision:
-        del request
         if self.stopped.get(context):
             return graceful_complete()
         return go_to(LongLiveHandleRequestStep, None)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/short-lived-parent.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/short-lived-parent.mdx
@@ -44,11 +44,9 @@ class ShortLiveHandleSubFlowStep(Step[str]):
         return StepOptions(execute_lock_attributes=(self.curr_subflow_num.lock(),))
 
     def wait_for(self, context: Context, request: str) -> Wait:
-        del context
         return Wait.until(SubFlow.run(self.example_subflow, request))
 
     def execute(self, context: Context, request: str) -> StepDecision:
-        del request
         current = (self.curr_subflow_num.get(context) or 0) - 1
         self.curr_subflow_num.set(context, current)
         if current == 0:

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/wait-for-half.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/wait-for-half.mdx
@@ -20,7 +20,6 @@ title: 等待一半完成
 ```python
 class WaitForHalfInitStep(Step[list[str]]):
     def execute(self, context: Context, requests: list[str]) -> StepDecision:
-        del context
         if not requests:
             return graceful_complete()
         return go_to_many(
@@ -43,11 +42,9 @@ class SubFlowStep(Step[str]):
         self.all_done_ch = all_done_ch
 
     def wait_for(self, context: Context, request: str) -> Wait:
-        del context
         return Wait.any_of(SubFlow.run(self.example_subflow, request), self.all_done_ch.for_one())
 
     async def execute(self, context: Context, request: str) -> StepDecision:
-        del request
         if SubFlow.get_condition_results(context).status is not FlowStatus.RUNNING:
             self.subflow_completed_ch.publish(context, True)
             return graceful_complete()
@@ -63,7 +60,6 @@ class WaitSubFlowsStep(Step[int]):
         self.all_done_ch = all_done_ch
 
     def wait_for(self, context: Context, total: int) -> Wait:
-        del context
         return Wait.until(self.subflow_completed_ch.for_n((total + 1) // 2))
 
     def execute(self, context: Context, total: int) -> StepDecision:

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/await.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/await.mdx
@@ -31,7 +31,6 @@ class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: int
     ) -> StepDecision:
-        del input
         await asyncio.sleep(random.uniform(0.05, 0.5))
         self.complete_ch.publish(context, None)
         return dead_end()
@@ -42,17 +41,14 @@ class AwaitStep(Step[int]):
         self.complete_ch = complete_ch
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.until(self.complete_ch.for_n(input))
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return graceful_complete(input)
 
 
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         movements: list[StepMovement[Any]] = [StepMovement.of(AwaitStep, input)]
         movements.extend(
             StepMovement.of(DoWorkStep, index) for index in range(input)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/dynamic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/dynamic.mdx
@@ -28,14 +28,12 @@ class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: int
     ) -> StepDecision:
-        del context
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input)
 
 
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/first-win.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/first-win.mdx
@@ -28,14 +28,12 @@ class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: int
     ) -> StepDecision:
-        del context
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input).with_canceling_sibling_steps(DoWorkStep)
 
 
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/static.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/static.mdx
@@ -26,19 +26,16 @@ sidebar_label: Static Parallel Steps
 ```python
 class WorkAStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(f"A:{input}")
 
 
 class WorkBStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(f"B:{input}")
 
 
 class InitStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return go_to_many(
             StepMovement.of(WorkAStep, input),
             StepMovement.of(WorkBStep, input),

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro/what-is-dex.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro/what-is-dex.mdx
@@ -90,7 +90,6 @@ class ShipStep(Step[OrderRequest]):
         )
 
     def wait_for(self, context: Context, input: OrderRequest) -> Wait:
-        del context, input
         return Wait.any_of(
             seller_ok.for_one(),
             Timer.by_duration(timedelta(hours=24)),

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
@@ -38,7 +38,6 @@ class ChannelWaitStep(Step[int]):
         self.approval = approval
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.any_of(
             self.approval.for_one(),
             Timer.by_duration(timedelta(seconds=input)),

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
@@ -31,11 +31,9 @@ Dex Step 由原生代码实现。实现该 Step 的 struct 或 class 决定 **St
 
 ```python
 def execute(self, context: Context, input: int) -> StepDecision:
-    del context
     return go_to(StepSecond, input + 1)
 
 def execute(self, context: Context, input: int) -> StepDecision:
-    del context
     return graceful_complete(input + 1)
 ```
 
@@ -122,7 +120,6 @@ approval = Channel("Approval", str)
 
 class StepSecond(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return graceful_complete(input + 1)
 
 
@@ -131,11 +128,9 @@ class ExampleStep(Step[int]):
         self.second = second
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context, input
         return Wait.until(approval.for_one())
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return go_to(StepSecond, input + 1)
 ```
 
@@ -460,7 +455,6 @@ def get_step_options(self) -> StepOptions:
     )
 
 def wait_for(self, context: Context, input: str) -> Wait:
-    del context, input
     raise RuntimeError("planned WaitFor failure")
 
 def execute(self, context: Context, input: str) -> StepDecision:

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-decision.mdx
@@ -224,11 +224,9 @@ public StepDecision execute(final Context context, final Boolean workflowSuccess
 
 ```python
 def execute(self, context: Context, input: None) -> StepDecision:
-    del context, input
     return force_fail("Workflow did not finish the task in time")
 
 def execute(self, context: Context, input: bool) -> StepDecision:
-    del context, input
     return force_complete("Workflow completed successfully")
 ```
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/waiting-condition.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/waiting-condition.mdx
@@ -31,7 +31,6 @@ class ChannelWaitStep(Step[int]):
         self.approval = approval
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.any_of(
             self.approval.for_one(),
             Timer.by_duration(timedelta(seconds=input)),
@@ -181,7 +180,6 @@ impl Step for ChannelWait {
 
 ```python
 def execute(self, context: Context, input: int) -> StepDecision:
-    del input
     result = SubFlow.get_condition_results(context)
     output = result.single_output(int)
     return graceful_complete(f"{SubFlow.get_flow_id(context)}|{output}")
@@ -355,7 +353,6 @@ def wait_for(self, context: Context, input: int) -> Wait:
     return Wait.until(approval.for_one())
 
 def execute(self, context: Context, input: int) -> StepDecision:
-    del input
     note = context.get_step_execution_local("note", str)
     return graceful_complete(note or "")
 ```

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/subflow.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/subflow.mdx
@@ -37,11 +37,9 @@ class SubFlowParentStep(Step[int]):
         )
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.until(SubFlow.run(self.target, input, self.options))
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del input
         result = SubFlow.get_condition_results(context)
         output = result.single_output(int)
         return graceful_complete(f"{SubFlow.get_flow_id(context)}|{output}")

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quick-start/index.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quick-start/index.mdx
@@ -89,7 +89,6 @@ class ShipStep(Step[OrderRequest]):
         )
 
     def wait_for(self, context: Context, input: OrderRequest) -> Wait:
-        del context, input
         return Wait.any_of(
             seller_ok.for_one(),
             Timer.by_duration(timedelta(hours=24)),

--- a/examples/python/dex_examples/_import_paths.py
+++ b/examples/python/dex_examples/_import_paths.py
@@ -67,7 +67,6 @@ class ExampleModuleFinder(importlib.abc.MetaPathFinder):
         path: object | None = None,
         target: object | None = None,
     ) -> importlib.machinery.ModuleSpec | None:
-        del path, target
         resolved = _resolve_module(fullname)
         if resolved is None:
             return None

--- a/examples/python/dex_examples/http_app.py
+++ b/examples/python/dex_examples/http_app.py
@@ -175,5 +175,4 @@ def handle_dex_exception(error: DexServiceError) -> tuple[str, int]:
 
 
 def handle_unexpected_exception(error: Exception) -> tuple[str, int]:
-    del error
     return traceback.format_exc(), 500

--- a/examples/python/dex_examples/patterns/cron/cron_schedule_flow.py
+++ b/examples/python/dex_examples/patterns/cron/cron_schedule_flow.py
@@ -82,7 +82,6 @@ class _Start(Step[CronScheduleInput]):
     def execute(
         self, context: Context, input: CronScheduleInput
     ) -> StepDecision:
-        del context
         if input.run_count <= 0 or input.interval.value <= 0:
             return force_fail("interval value and run count must be positive")
         return go_to(_WaitForSchedule, _ScheduleState(input.interval, input.run_count))
@@ -98,7 +97,6 @@ class _WaitForSchedule(Step[_ScheduleState]):
         self.skip = skip
 
     def wait_for(self, context: Context, state: _ScheduleState) -> Wait:
-        del context
         return Wait.any_of(
             Timer.by_duration(state.interval.duration()),
             self.trigger.for_one(),

--- a/examples/python/dex_examples/patterns/drain-channels/external_publishing/draining_channel_flow.py
+++ b/examples/python/dex_examples/patterns/drain-channels/external_publishing/draining_channel_flow.py
@@ -39,7 +39,6 @@ class ProcessMessage(Step[str]):
         self.queue_channel = queue_channel
 
     def wait_for(self, context: Context, input: str) -> Wait:
-        del context
         if input is None:
             return Wait.until(self.queue_channel.for_one())
         return Wait.skip_immediately()

--- a/examples/python/dex_examples/patterns/drain-channels/internal/drain_internal_channels_flow.py
+++ b/examples/python/dex_examples/patterns/drain-channels/internal/drain_internal_channels_flow.py
@@ -41,7 +41,6 @@ class Finalize(Step[None]):
         self.side_step_data = side_step_data
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         self.side_step_data.publish(
             context,
             MongoDocument("documentId-1", "FINALIZED", True),
@@ -94,11 +93,9 @@ class SideStep(Step[None]):
         self.side_step_data = side_step_data
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(self.side_step_data.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         documents = self.side_step_data.results(context)
         if not documents:
             raise RuntimeError("No document was sent")

--- a/examples/python/dex_examples/patterns/interruptible/interruptible_execution_flow.py
+++ b/examples/python/dex_examples/patterns/interruptible/interruptible_execution_flow.py
@@ -45,7 +45,6 @@ class WorkAStep(Step[WorkJobParametersInput]):
         self.interrupt_signal = interrupt_signal
 
     def wait_for(self, context: Context, input: WorkJobParametersInput) -> Wait:
-        del context, input
         return Wait.until(Timer.by_duration(timedelta(seconds=2)))
 
     def execute(
@@ -76,7 +75,6 @@ class WorkBStep(Step[WorkJobParametersInput]):
         self.interrupt_signal = interrupt_signal
 
     def wait_for(self, context: Context, input: WorkJobParametersInput) -> Wait:
-        del context, input
         return Wait.until(Timer.by_duration(timedelta(seconds=3)))
 
     def execute(
@@ -114,7 +112,6 @@ class Init(Step[None]):
         self.interrupt_signal = interrupt_signal
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del context, input
         parameters = WorkJobParametersInput(15, 1)
         return go_to_many(
             StepMovement.of(WorkAStep, parameters),

--- a/examples/python/dex_examples/patterns/intervention/manual_recovery_flow.py
+++ b/examples/python/dex_examples/patterns/intervention/manual_recovery_flow.py
@@ -47,7 +47,6 @@ class DoWorkStep(Step[bool]):
         ).on_execute_failure_proceed_to(ManualStep)
 
     def execute(self, context: Context, should_fail: bool) -> StepDecision:
-        del context
         if should_fail:
             raise RuntimeError("work failed")
         return graceful_complete("work completed")
@@ -63,14 +62,12 @@ class ManualStep(Step[bool]):
         self.skip_channel = skip_channel
 
     def wait_for(self, context: Context, input: bool) -> Wait:
-        del context, input
         return Wait.any_of(
             self.retry_channel.for_one(),
             self.skip_channel.for_one(),
         )
 
     def execute(self, context: Context, input: bool) -> StepDecision:
-        del input
         if self.retry_channel.results(context):
             return go_to(DoWorkStep, False)
         return force_fail("manual recovery skipped")

--- a/examples/python/dex_examples/patterns/parallel-subflows/flows.py
+++ b/examples/python/dex_examples/patterns/parallel-subflows/flows.py
@@ -62,7 +62,6 @@ class SubmitRequestInput:
 
 class DoWorkStep(Step[str]):
     async def execute(self, context: Context, request: str) -> StepDecision:
-        del context
         await asyncio.sleep((50 + len(request) % 10 * 50) / 1000)
         return graceful_complete(request)
 
@@ -80,13 +79,11 @@ class SubFlowsStep(Step[list[str]]):
         self.example_subflow = example_subflow
 
     def wait_for(self, context: Context, requests: list[str]) -> Wait:
-        del context
         return Wait.all_of(
             *(SubFlow.run(self.example_subflow, request) for request in requests)
         )
 
     def execute(self, context: Context, requests: list[str]) -> StepDecision:
-        del context, requests
         return graceful_complete()
 
 
@@ -100,7 +97,6 @@ class BasicParentFlow(Flow[list[str]]):
 
 class WaitForHalfInitStep(Step[list[str]]):
     def execute(self, context: Context, requests: list[str]) -> StepDecision:
-        del context
         if not requests:
             return graceful_complete()
         return go_to_many(
@@ -123,7 +119,6 @@ class SubFlowStep(Step[str]):
         self.all_done_ch = all_done_ch
 
     def wait_for(self, context: Context, request: str) -> Wait:
-        del context
         return Wait.any_of(
             SubFlow.run(self.example_subflow, request), self.all_done_ch.for_one()
         )
@@ -131,7 +126,6 @@ class SubFlowStep(Step[str]):
     async def execute(  # type: ignore[override]
         self, context: Context, request: str
     ) -> StepDecision:
-        del request
         result = SubFlow.get_condition_results(context)
         if result.status is not FlowStatus.RUNNING:
             self.subflow_completed_ch.publish(context, True)
@@ -148,7 +142,6 @@ class WaitSubFlowsStep(Step[int]):
         self.all_done_ch = all_done_ch
 
     def wait_for(self, context: Context, total: int) -> Wait:
-        del context
         return Wait.until(self.subflow_completed_ch.for_n((total + 1) // 2))
 
     def execute(self, context: Context, total: int) -> StepDecision:
@@ -213,11 +206,9 @@ class LongLiveHandleRequestStep(Step[None]):
         return "HandleRequestStep"
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(self.request_channel.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         return go_to(LongLiveHandleSubFlowStep, self.request_channel.results(context)[0])
 
 
@@ -234,11 +225,9 @@ class LongLiveHandleSubFlowStep(Step[str]):
         return "HandleSubFlowStep"
 
     def wait_for(self, context: Context, request: str) -> Wait:
-        del context
         return Wait.until(SubFlow.run(self.example_subflow, request))
 
     def execute(self, context: Context, request: str) -> StepDecision:
-        del request
         if self.stopped.get(context):
             return graceful_complete()
         return go_to(LongLiveHandleRequestStep, None)
@@ -311,11 +300,9 @@ class ShortLiveHandleRequestStep(Step[None]):
         return StepOptions(execute_lock_attributes=(self.curr_subflow_num.lock(),))
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(self.request_channel.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         request = self.request_channel.results(context)[0]
         self.curr_subflow_num.set(context, (self.curr_subflow_num.get(context) or 0) + 1)
         return go_to(ShortLiveHandleSubFlowStep, request)
@@ -339,11 +326,9 @@ class ShortLiveHandleSubFlowStep(Step[str]):
         return StepOptions(execute_lock_attributes=(self.curr_subflow_num.lock(),))
 
     def wait_for(self, context: Context, request: str) -> Wait:
-        del context
         return Wait.until(SubFlow.run(self.example_subflow, request))
 
     def execute(self, context: Context, request: str) -> StepDecision:
-        del request
         current = (self.curr_subflow_num.get(context) or 0) - 1
         self.curr_subflow_num.set(context, current)
         if current == 0:
@@ -396,7 +381,6 @@ class SubmitStep(Step[SubmitRequestInput]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: SubmitRequestInput
     ) -> StepDecision:
-        del context
         if not input.parent_ids:
             raise ValueError("at least one parent Flow ID is required")
         parent_id = input.parent_ids[partition(input.request, len(input.parent_ids))]

--- a/examples/python/dex_examples/patterns/parallel/await_parallel_steps_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/await_parallel_steps_flow.py
@@ -39,7 +39,6 @@ class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: int
     ) -> StepDecision:
-        del input
         await asyncio.sleep(random.uniform(0.05, 0.5))
         self.complete_ch.publish(context, None)
         return dead_end()
@@ -50,17 +49,14 @@ class AwaitStep(Step[int]):
         self.complete_ch = complete_ch
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.until(self.complete_ch.for_n(input))
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return graceful_complete(input)
 
 
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         movements: list[StepMovement[Any]] = [StepMovement.of(AwaitStep, input)]
         movements.extend(
             StepMovement.of(DoWorkStep, index) for index in range(input)

--- a/examples/python/dex_examples/patterns/parallel/dynamic_parallel_steps_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/dynamic_parallel_steps_flow.py
@@ -32,14 +32,12 @@ class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: int
     ) -> StepDecision:
-        del context
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input)
 
 
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )

--- a/examples/python/dex_examples/patterns/parallel/first_win_parallel_steps_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/first_win_parallel_steps_flow.py
@@ -32,14 +32,12 @@ class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: int
     ) -> StepDecision:
-        del context
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input).with_canceling_sibling_steps(DoWorkStep)
 
 
 class InitStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return go_to_many(
             *(StepMovement.of(DoWorkStep, index) for index in range(input))
         )

--- a/examples/python/dex_examples/patterns/parallel/static_parallel_steps_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/static_parallel_steps_flow.py
@@ -27,19 +27,16 @@ from dex import (
 
 class WorkAStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(f"A:{input}")
 
 
 class WorkBStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(f"B:{input}")
 
 
 class InitStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return go_to_many(
             StepMovement.of(WorkAStep, input),
             StepMovement.of(WorkBStep, input),

--- a/examples/python/dex_examples/patterns/polling/backoff_polling_flow.py
+++ b/examples/python/dex_examples/patterns/polling/backoff_polling_flow.py
@@ -51,7 +51,6 @@ class PollingStep(Step[None]):
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del context, input
         try:
             result = self.service.attempt_external_api_call(
                 "Poll for BackoffPollingFlow"

--- a/examples/python/dex_examples/patterns/polling/iteration_flow.py
+++ b/examples/python/dex_examples/patterns/polling/iteration_flow.py
@@ -17,7 +17,6 @@ from dex import Context, Flow, PersistenceSchema, Step, StepDecision, StepList, 
 
 class IterationStep(Step[str]):
     def execute(self, context: Context, page_token: str) -> StepDecision:
-        del context
         next_page_token = "page-2" if not page_token else "page-3" if page_token == "page-2" else ""
         print(f"Migrating page {page_token}")
         return graceful_complete() if not next_page_token else go_to(IterationStep, next_page_token)

--- a/examples/python/dex_examples/patterns/polling/simple_polling_flow.py
+++ b/examples/python/dex_examples/patterns/polling/simple_polling_flow.py
@@ -35,11 +35,9 @@ POLLING_INTERVAL = timedelta(seconds=10)
 class PollingStep(Step[None]):
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(Timer.by_duration(POLLING_INTERVAL))
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del context, input
         if self._is_system_ready():
             return graceful_complete()
         return go_to(PollingStep, None)

--- a/examples/python/dex_examples/patterns/recovery/failure_recovery_flow.py
+++ b/examples/python/dex_examples/patterns/recovery/failure_recovery_flow.py
@@ -38,23 +38,19 @@ from dex_examples.patterns.recovery.failure_recovery_workflow_input import (
 
 class DatabaseConnection:
     def reduce_quantity(self, item_name: str, quantity: int) -> None:
-        del item_name
         print(f"Reducing quantity: {quantity}")
         if quantity > random.randrange(10):
             raise RuntimeError("not enough items available")
 
     def increase_quantity(self, item_name: str, quantity: int) -> None:
-        del item_name
         print(f"Increasing quantity: {quantity}")
 
     def get_item_price(self, item_name: str) -> float:
-        del item_name
         return 3.14
 
 
 class PaymentProcessor:
     def process_payment(self, price: float) -> None:
-        del price
         raise RuntimeError("Payment could not be processed")
 
     def void_payment(self, price: float) -> None:
@@ -70,7 +66,6 @@ class UpdateQuantityRecovery(Step[FailureRecoveryWorkflowInput]):
         context: Context,
         input: FailureRecoveryWorkflowInput,
     ) -> StepDecision:
-        del context
         self.database.increase_quantity(input.item_name, input.requested_quantity)
         return force_fail("Failed to process transaction")
 
@@ -89,7 +84,6 @@ class VoidPaymentRecovery(Step[int]):
         self.workflow_input = workflow_input
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del input
         workflow = self.workflow_input.get(context)
         item_value = self.database.get_item_price(workflow.item_name)
         self.payment_processor.void_payment(workflow.requested_quantity * item_value)
@@ -115,7 +109,6 @@ class ChargeForItems(Step[int]):
         ).on_execute_failure_proceed_to(VoidPaymentRecovery)
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del input
         workflow = self.workflow_input.get(context)
         item_value = self.database.get_item_price(workflow.item_name)
         self.payment_processor.process_payment(workflow.requested_quantity * item_value)

--- a/examples/python/dex_examples/patterns/reminders/reminder_flow.py
+++ b/examples/python/dex_examples/patterns/reminders/reminder_flow.py
@@ -58,14 +58,12 @@ class ProcessTimeout(Step[None]):
         self.complete_process = complete_process
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.any_of(
             Timer.by_duration(PROCESS_TIMEOUT),
             self.complete_process.for_one(),
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         accepted = self.status.get(context) == Status.ACCEPTED.value
         self.service.update_external_system(
             "notify for status: " + ("ACCEPTED" if accepted else "TIMEOUT")
@@ -85,14 +83,12 @@ class Reminder(Step[None]):
         self.opt_out_reminder = opt_out_reminder
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.any_of(
             Timer.by_duration(REMINDER_INTERVAL),
             self.opt_out_reminder.for_one(),
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         if self.status.get(context) == Status.ACCEPTED.value:
             print("Reminder state timer expired, but status already ACCEPTED")
             return force_complete("done")
@@ -117,7 +113,6 @@ class Init(Step[None]):
         self.status = status
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         self.status.set(context, Status.INITIATED.value)
         return go_to_many(
             StepMovement.of(ProcessTimeout, None),

--- a/examples/python/dex_examples/patterns/resettable-timer/resettable_timer_flow.py
+++ b/examples/python/dex_examples/patterns/resettable-timer/resettable_timer_flow.py
@@ -38,7 +38,6 @@ TIMER_DURATION = timedelta(minutes=5)
 
 class TimerExpired(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
-        del context, input
         print("Timer fired; this is where we would send an email")
         return graceful_complete()
 
@@ -53,14 +52,12 @@ class ResettableTimerStep(Step[None]):
         self.reset_timer_channel = reset_timer_channel
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.any_of(
             Timer.by_duration(TIMER_DURATION),
             self.reset_timer_channel.for_one(),
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         if context.has_timer_fired():
             return go_to(TimerExpired, None)
         return go_to(ResettableTimerStep, None)

--- a/examples/python/dex_examples/patterns/resource-control/controller_flow.py
+++ b/examples/python/dex_examples/patterns/resource-control/controller_flow.py
@@ -62,7 +62,6 @@ MAX_BUFFERED_REQUESTS = 20
 
 class MoveToAnotherInstance(Step[None]):
     def execute(self, context: Context, input: None) -> StepDecision:
-        del context, input
         print("move all the started child flows to another instance")
         return graceful_complete("moved to another instance")
 
@@ -89,7 +88,6 @@ class LoopForNextRequest(Step[None]):
         self.shutdown_requested = shutdown_requested
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del input
         waiting = self.current_wait_child_wfs.get(context) or []
         conditions = [self.child_complete.for_one(child_id) for child_id in waiting]
         if len(waiting) < CONCURRENCY_PER_CONTROLLER_FLOW:
@@ -99,7 +97,6 @@ class LoopForNextRequest(Step[None]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: None
     ) -> StepDecision:
-        del input
         waiting = list(self.current_wait_child_wfs.get(context) or [])
 
         requests = self.request_queue.results(context)

--- a/examples/python/dex_examples/patterns/resource-control/processing_flow.py
+++ b/examples/python/dex_examples/patterns/resource-control/processing_flow.py
@@ -64,7 +64,6 @@ class Complete(Step[None]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: None
     ) -> StepDecision:
-        del input
         parent_flow_id = self.parent_flow_id.get(context)
         if parent_flow_id:
             try:
@@ -93,11 +92,9 @@ class GpuProcessingComplete(Step[None]):
         self.status = status
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(Timer.by_duration(POLL_INTERVAL))
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         print(
             "check gpu processing in "
             f"{self.instance_id.get(context)} by calling the instance API"
@@ -120,7 +117,6 @@ class GpuProcessingStart(Step[None]):
         self.status = status
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         print(
             f"start processing of request {self.request.get(context)} in "
             f"{self.instance_id.get(context)} by calling the instance API"
@@ -141,11 +137,9 @@ class ValidationComplete(Step[None]):
         self.status = status
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(Timer.by_duration(POLL_INTERVAL))
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         print(
             "completed validation in "
             f"{self.instance_id.get(context)} by calling the instance API"

--- a/examples/python/dex_examples/patterns/timeout/flow_graceful_timeout.py
+++ b/examples/python/dex_examples/patterns/timeout/flow_graceful_timeout.py
@@ -34,13 +34,11 @@ SLOW_TASK_DURATION = timedelta(seconds=65)
 
 class LongWaitStep(Step[bool]):
     def wait_for(self, context: Context, input: bool) -> Wait:
-        del context
         if input:
             return Wait.skip_immediately()
         return Wait.until(Timer.by_duration(SLOW_TASK_DURATION))
 
     def execute(self, context: Context, input: bool) -> StepDecision:
-        del context, input
         return force_complete("Workflow completed successfully")
 
 
@@ -55,5 +53,4 @@ class FlowGracefulTimeout(Flow[bool]):
         return PersistenceSchema.of()
 
     def handle_timeout(self, context: Context) -> StepDecision:
-        del context
         return force_fail("Workflow did not finish the task in time")

--- a/examples/python/dex_examples/patterns/wait-for-step-completion/wait_for_step_completion_flow.py
+++ b/examples/python/dex_examples/patterns/wait-for-step-completion/wait_for_step_completion_flow.py
@@ -42,7 +42,6 @@ class UpdateExternalSystem(Step[JobSeekerData]):
         self.external_service = external_service
 
     def execute(self, context: Context, input: JobSeekerData) -> StepDecision:
-        del context
         self.external_service.update_external_system(
             json.dumps(asdict(input), sort_keys=True)
         )

--- a/examples/python/dex_examples/primitives/channel/channel_flow.py
+++ b/examples/python/dex_examples/primitives/channel/channel_flow.py
@@ -38,7 +38,6 @@ class ChannelWaitStep(Step[int]):
         self.approval = approval
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.any_of(
             self.approval.for_one(),
             Timer.by_duration(timedelta(seconds=input)),

--- a/examples/python/dex_examples/primitives/durability/durability_flow.py
+++ b/examples/python/dex_examples/primitives/durability/durability_flow.py
@@ -36,7 +36,6 @@ class RouteDurabilityStep(Step[str]):
         self.flow = flow
 
     def execute(self, context: Context, mode: str) -> StepDecision:
-        del context
         if mode == "async":
             return go_to(AsyncWorkStep, mode)
         return go_to(SyncWorkStep, mode)
@@ -50,7 +49,6 @@ class SyncWorkStep(Step[str]):
         return StepOptions(execute_durability=StepDurability.SYNC)
 
     def execute(self, context: Context, mode: str) -> StepDecision:
-        del context
         return go_to(FinishDurabilityStep, f"sync:{mode}")
 
 
@@ -62,17 +60,14 @@ class AsyncWorkStep(Step[str]):
         return StepOptions(execute_durability=StepDurability.ASYNC)
 
     def execute(self, context: Context, mode: str) -> StepDecision:
-        del context
         return go_to(FinishDurabilityStep, f"async:{mode}")
 
 
 class FinishDurabilityStep(Step[str]):
     def wait_for(self, context: Context, label: str) -> Wait:
-        del context, label
         return Wait.until(Timer.by_duration(timedelta(seconds=1)))
 
     def execute(self, context: Context, label: str) -> StepDecision:
-        del context
         return graceful_complete(label)
 
 

--- a/examples/python/dex_examples/primitives/flow/example_flow.py
+++ b/examples/python/dex_examples/primitives/flow/example_flow.py
@@ -46,11 +46,9 @@ class ExampleStep(Step[int]):
 
     def wait_for(self, context: Context, input: int) -> Wait:
         status.set(context, "running")
-        del input
         return Wait.skip_immediately()
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return go_to(FinishStep, input + 1)
 
 

--- a/examples/python/dex_examples/primitives/options_override/options_override_flow.py
+++ b/examples/python/dex_examples/primitives/options_override/options_override_flow.py
@@ -35,7 +35,6 @@ class OverrideFirstStep(Step[str]):
         self.second = second
 
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         override = StepOptions(
             wait_for_retry=RetryPolicy(maximum_attempts=2),
             wait_for_failure=WaitForFailurePolicy.PROCEED,
@@ -46,7 +45,6 @@ class OverrideFirstStep(Step[str]):
 
 class OverrideSecondStep(Step[str]):
     def wait_for(self, context: Context, input: str) -> Wait:
-        del context, input
         raise RuntimeError("state 2 wait failure")
 
     def execute(self, context: Context, input: str) -> StepDecision:

--- a/examples/python/dex_examples/primitives/proceed_on_wait_failure/proceed_on_wait_failure_flow.py
+++ b/examples/python/dex_examples/primitives/proceed_on_wait_failure/proceed_on_wait_failure_flow.py
@@ -33,7 +33,6 @@ from dex import (
 
 class FinishStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(input)
 
 
@@ -48,7 +47,6 @@ class FailingWaitStep(Step[str]):
         )
 
     def wait_for(self, context: Context, input: str) -> Wait:
-        del context, input
         raise RuntimeError("planned WaitFor failure")
 
     def execute(self, context: Context, input: str) -> StepDecision:

--- a/examples/python/dex_examples/primitives/rpc/rpc_flow.py
+++ b/examples/python/dex_examples/primitives/rpc/rpc_flow.py
@@ -42,23 +42,19 @@ class RpcWaitStep(Step[int]):
         self.second = second
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context, input
         return Wait.until(self.internal.for_one())
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context, input
         return go_to(RpcCompleteStep, 0)
 
 
 class RpcCompleteStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return graceful_complete(input + 1)
 
 
 class ExampleStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context
         return graceful_complete(input)
 
 

--- a/examples/python/dex_examples/primitives/step/step_flow.py
+++ b/examples/python/dex_examples/primitives/step/step_flow.py
@@ -34,7 +34,6 @@ approval = Channel("Approval", str)
 
 class StepSecond(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return graceful_complete(input + 1)
 
 
@@ -43,11 +42,9 @@ class ExampleStep(Step[int]):
         self.second = second
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context, input
         return Wait.until(approval.for_one())
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return go_to(StepSecond, input + 1)
 
 

--- a/examples/python/dex_examples/primitives/step_decision/step_decision_flow.py
+++ b/examples/python/dex_examples/primitives/step_decision/step_decision_flow.py
@@ -44,7 +44,6 @@ class RouteStep(Step[str]):
         self.flow = flow
 
     def execute(self, context: Context, mode: str) -> StepDecision:
-        del context
         if mode == "graceful":
             return graceful_complete("done")
         if mode == "dead-end":
@@ -62,27 +61,22 @@ class RouteStep(Step[str]):
 
 class BranchWorkerStep(Step[str]):
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context, input
         return dead_end()
 
 
 class CarrierAStep(Step[Quote]):
     def wait_for(self, context: Context, quote: Quote) -> Wait:
-        del context, quote
         return Wait.until(Timer.by_duration(timedelta(seconds=2)))
 
     def execute(self, context: Context, quote: Quote) -> StepDecision:
-        del context, quote
         return dead_end()
 
 
 class CarrierBStep(Step[Quote]):
     def wait_for(self, context: Context, quote: Quote) -> Wait:
-        del context, quote
         return Wait.until(Timer.by_duration(timedelta(seconds=2)))
 
     def execute(self, context: Context, quote: Quote) -> StepDecision:
-        del context, quote
         return dead_end()
 
 
@@ -91,7 +85,6 @@ class WinnerStep(Step[Quote]):
         self.flow = flow
 
     def execute(self, context: Context, quote: Quote) -> StepDecision:
-        del context
         return go_to(RecordQuoteStep, quote).with_canceling_steps(
             CarrierAStep,
             self.flow.carrier_b,
@@ -100,7 +93,6 @@ class WinnerStep(Step[Quote]):
 
 class RecordQuoteStep(Step[Quote]):
     def execute(self, context: Context, quote: Quote) -> StepDecision:
-        del context
         return graceful_complete(quote)
 
 

--- a/examples/python/dex_examples/primitives/step_execution_local/step_execution_local_flow.py
+++ b/examples/python/dex_examples/primitives/step_execution_local/step_execution_local_flow.py
@@ -37,7 +37,6 @@ class NoteWaitStep(Step[int]):
         return Wait.until(approval.for_one())
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del input
         note = context.get_step_execution_local("note", str)
         return graceful_complete(note or "")
 

--- a/examples/python/dex_examples/primitives/subflow/subflow_flow.py
+++ b/examples/python/dex_examples/primitives/subflow/subflow_flow.py
@@ -34,7 +34,6 @@ from dex import (
 
 class SubFlowChildStep(Step[int]):
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context
         return graceful_complete(input + 1)
 
 
@@ -55,11 +54,9 @@ class SubFlowParentStep(Step[int]):
         )
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.until(SubFlow.run(self.target, input, self.options))
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del input
         result = SubFlow.get_condition_results(context)
         output = result.single_output(int)
         return graceful_complete(f"{SubFlow.get_flow_id(context)}|{output}")

--- a/examples/python/dex_examples/primitives/timer/timer_flow.py
+++ b/examples/python/dex_examples/primitives/timer/timer_flow.py
@@ -32,11 +32,9 @@ from dex import (
 
 class TimerStep(Step[int]):
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context
         return Wait.until(Timer.by_duration(timedelta(seconds=input)))
 
     def execute(self, context: Context, input: int) -> StepDecision:
-        del context, input
         return graceful_complete("timer-fired")
 
 

--- a/examples/python/dex_examples/primitives/wait_types/wait_types_flow.py
+++ b/examples/python/dex_examples/primitives/wait_types/wait_types_flow.py
@@ -44,7 +44,6 @@ class WaitTypesInput:
 
 class WaitTypesStep(Step[WaitTypesInput]):
     def wait_for(self, context: Context, input: WaitTypesInput) -> Wait:
-        del context
         timeout = timedelta(seconds=input.timeout_seconds)
         if input.mode == "any":
             return Wait.any_of(
@@ -69,7 +68,6 @@ class WaitTypesStep(Step[WaitTypesInput]):
         raise ValueError(f"unknown wait mode {input.mode!r}")
 
     def execute(self, context: Context, input: WaitTypesInput) -> StepDecision:
-        del context
         return graceful_complete(input.mode)
 
 

--- a/examples/python/dex_examples/products/ai-agent-email/ai_agent_flow.py
+++ b/examples/python/dex_examples/products/ai-agent-email/ai_agent_flow.py
@@ -99,7 +99,6 @@ class Sending(Step[None]):
         return SENDING_OPTIONS
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         recipient = self.flow.email_recipient.get(context) or ""
         subject = self.flow.email_subject.get(context) or ""
         body = self.flow.email_body.get(context) or ""
@@ -129,7 +128,6 @@ class Schedule(Step[None]):
         self.sending = sending
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del input
         self.flow.status.set(context, STATUS_WAITING)
         send_time = self.flow.scheduled_time_seconds.get(context)
         return Wait.any_of(
@@ -139,7 +137,6 @@ class Schedule(Step[None]):
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         requests = user_input.results(context)
         if not requests:
             return go_to(Sending, None)
@@ -162,7 +159,6 @@ class Agent(Step[None]):
         return AGENT_OPTIONS
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del input
         self.flow.status.set(context, STATUS_WAITING)
         return Wait.until(user_input.for_one())
 
@@ -171,7 +167,6 @@ class Agent(Step[None]):
         context: Context,
         input: None,
     ) -> StepDecision:
-        del input
         requests = user_input.results(context)
         if not requests:
             raise RuntimeError("no user request found")
@@ -237,7 +232,6 @@ class Init(Step[None]):
         self.flow = flow
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         self.flow.status.set(context, STATUS_INITIALIZED)
         print(f"flow started, id: {context.flow_id}")
 

--- a/examples/python/dex_examples/products/engagement/engagement_flow.py
+++ b/examples/python/dex_examples/products/engagement/engagement_flow.py
@@ -67,14 +67,12 @@ class Reminder(Step[None]):
         self.flow = flow
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.any_of(
             Timer.by_duration(timedelta(seconds=5)),
             self.flow.opt_out_reminder.for_one(),
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         status = self.flow.engagement_status.get(context)
         if status is not Status.INITIATED:
             return dead_end()
@@ -94,14 +92,12 @@ class ProcessTimeout(Step[None]):
         self.flow = flow
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.any_of(
             Timer.by_duration(timedelta(days=60)),
             self.flow.complete_process.for_one(),
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         description = self.flow.describe_engagement(context)
         result = "timeout"
         if description.current_status == Status.ACCEPTED:

--- a/examples/python/dex_examples/products/job-post/job_post_flow.py
+++ b/examples/python/dex_examples/products/job-post/job_post_flow.py
@@ -55,7 +55,6 @@ class ExternalUpdate(Step[None]):
         return EXTERNAL_UPDATE_OPTIONS
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del context, input
         self.service.update_external_system("this is an update to external service")
         return dead_end()
 

--- a/examples/python/dex_examples/products/microservices/orchestration_flow.py
+++ b/examples/python/dex_examples/products/microservices/orchestration_flow.py
@@ -43,7 +43,6 @@ class CallAPI4(Step[None]):
         self.data = data
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         value = self.data.get(context)
         self.service.call_api4(value)
         return graceful_complete(value)
@@ -63,14 +62,12 @@ class CallAPI3(Step[None]):
         self.call_api4 = call_api4
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.any_of(
             Timer.by_duration(timedelta(hours=24)),
             self.ready.for_one(),
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         value = self.data.get(context)
         self.service.call_api3(value)
         if context.has_timer_fired():
@@ -84,7 +81,6 @@ class CallAPI2(Step[None]):
         self.data = data
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         self.service.call_api2(self.data.get(context))
         return dead_end()
 

--- a/examples/python/dex_examples/products/money-transfer/money_transfer_flow.py
+++ b/examples/python/dex_examples/products/money-transfer/money_transfer_flow.py
@@ -42,7 +42,6 @@ class Compensate(Step[TransferRequest]):
         return StepOptions(execute_retry=COMPENSATE_RETRY)
 
     def execute(self, context: Context, input: TransferRequest) -> StepDecision:
-        del context
         self.service.undo_credit(input.to_account, input.amount)
         self.service.undo_create_credit_memo(
             input.to_account,
@@ -81,7 +80,6 @@ class Credit(Step[TransferRequest]):
         return self.options
 
     def execute(self, context: Context, input: TransferRequest) -> StepDecision:
-        del context
         self.service.credit(input.to_account, input.amount)
         return graceful_complete(
             f"transfer is done from {input.from_account} "
@@ -104,7 +102,6 @@ class CreateCreditMemo(Step[TransferRequest]):
         return self.options
 
     def execute(self, context: Context, input: TransferRequest) -> StepDecision:
-        del context
         self.service.create_credit_memo(input.to_account, input.amount, input.notes)
         return go_to(Credit, input)
 
@@ -124,7 +121,6 @@ class Debit(Step[TransferRequest]):
         return self.options
 
     def execute(self, context: Context, input: TransferRequest) -> StepDecision:
-        del context
         self.service.debit(input.from_account, input.amount)
         return go_to(CreateCreditMemo, input)
 
@@ -144,7 +140,6 @@ class CreateDebitMemo(Step[TransferRequest]):
         return self.options
 
     def execute(self, context: Context, input: TransferRequest) -> StepDecision:
-        del context
         self.service.create_debit_memo(input.from_account, input.amount, input.notes)
         return go_to(Debit, input)
 
@@ -159,7 +154,6 @@ class CheckBalance(Step[TransferRequest]):
         self.create_debit_memo = create_debit_memo
 
     def execute(self, context: Context, input: TransferRequest) -> StepDecision:
-        del context
         if not self.service.check_balance(input.from_account, input.amount):
             return force_fail("insufficient funds")
         return go_to(CreateDebitMemo, input)

--- a/examples/python/dex_examples/products/order-processing/order_processing_flow.py
+++ b/examples/python/dex_examples/products/order-processing/order_processing_flow.py
@@ -89,7 +89,6 @@ class ShipStep(Step[OrderRequest]):
         )
 
     def wait_for(self, context: Context, input: OrderRequest) -> Wait:
-        del context, input
         return Wait.any_of(
             seller_ok.for_one(),
             Timer.by_duration(timedelta(hours=24)),

--- a/examples/python/dex_examples/products/polling/polling_flow.py
+++ b/examples/python/dex_examples/products/polling/polling_flow.py
@@ -51,7 +51,6 @@ class WaitForTasks(Step[None]):
         self.task_c_completed = task_c_completed
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.all_of(
             self.task_a_completed.for_one(),
             self.task_b_completed.for_one(),
@@ -59,7 +58,6 @@ class WaitForTasks(Step[None]):
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del context, input
         return graceful_complete("all tasks completed")
 
 
@@ -75,7 +73,6 @@ class Poll(Step[int]):
         self.task_c_completed = task_c_completed
 
     def wait_for(self, context: Context, input: int) -> Wait:
-        del context, input
         return Wait.until(Timer.by_duration(timedelta(seconds=1)))
 
     def execute(self, context: Context, input: int) -> StepDecision:

--- a/examples/python/dex_examples/products/shortlist-candidates/employer_opt_in_flow.py
+++ b/examples/python/dex_examples/products/shortlist-candidates/employer_opt_in_flow.py
@@ -42,7 +42,6 @@ class OptOut(Step[None]):
         self.opted_in = opted_in
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         self.opted_in.set(context, False)
         return force_complete()
 
@@ -86,7 +85,6 @@ class EmployerOptInFlow(Flow[EmployerOptInInput]):
 
     @rpc
     def opt_out(self, context: Context) -> RPCResult[None]:
-        del context
         return RPCResult(
             None,
             next_steps=(StepMovement.of(OptOut, None),),

--- a/examples/python/dex_examples/products/shortlist-candidates/shortlist_flow.py
+++ b/examples/python/dex_examples/products/shortlist-candidates/shortlist_flow.py
@@ -62,7 +62,6 @@ class SendEmail(Step[None]):
         self.revoke_shortlist = revoke_shortlist
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.any_of(
             Timer.by_duration(timedelta(minutes=5)),
             self.revoke_shortlist.for_one(),
@@ -71,7 +70,6 @@ class SendEmail(Step[None]):
     async def execute(  # type: ignore[override]
         self, context: Context, input: None
     ) -> StepDecision:
-        del input
         employer = self.employer_id.get(context)
         candidate = self.candidate_id.get(context)
 

--- a/examples/python/dex_examples/products/signup/user_signup_flow.py
+++ b/examples/python/dex_examples/products/signup/user_signup_flow.py
@@ -47,14 +47,12 @@ class Verify(Step[None]):
         self.verify_channel = verify_channel
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.any_of(
             Timer.by_duration(timedelta(seconds=24)),
             self.verify_channel.for_one(),
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         signup_form = self.form.get(context)
         if self.verify_channel.results(context):
             self.service.send_email(signup_form.email, "welcome", "welcome to Indeed!")

--- a/examples/python/dex_examples/products/subscription/subscription_flow.py
+++ b/examples/python/dex_examples/products/subscription/subscription_flow.py
@@ -51,7 +51,6 @@ class ChargeCurrentBill(Step[None]):
         self.billing_period_number = billing_period_number
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del input
         customer = self.customer_details.get(context)
         period_number = self.billing_period_number.get(context)
         if subscription_billing.is_subscription_over(customer, period_number):
@@ -63,7 +62,6 @@ class ChargeCurrentBill(Step[None]):
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         customer = self.customer_details.get(context)
         if context.get_step_execution_local(SUBSCRIPTION_OVER_KEY, bool):
             subscription_billing.send_subscription_over_email(customer, self.service)
@@ -86,7 +84,6 @@ class Trial(Step[None]):
         self.charge_current_bill = charge_current_bill
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del input
         customer = self.customer_details.get(context)
         subscription_billing.send_welcome_email(customer, self.service)
         return Wait.until(
@@ -94,7 +91,6 @@ class Trial(Step[None]):
         )
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         self.billing_period_number.set(context, 0)
         return go_to(ChargeCurrentBill, None)
 
@@ -111,11 +107,9 @@ class Cancel(Step[None]):
         self.cancel_subscription = cancel_subscription
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(self.cancel_subscription.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         customer = self.customer_details.get(context)
         subscription_billing.send_canceled_email(customer, self.service)
         return force_complete("subscription canceled")
@@ -131,11 +125,9 @@ class UpdateChargeAmount(Step[None]):
         self.update_charge_amount = update_charge_amount
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(self.update_charge_amount.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         amounts = self.update_charge_amount.results(context)
         amount = subscription_billing.require_single_charge_amount(amounts)
         customer = self.customer_details.get(context)

--- a/examples/python/sync-python/sync_examples/patterns/parent_child/parent_child.py
+++ b/examples/python/sync-python/sync_examples/patterns/parent_child/parent_child.py
@@ -54,11 +54,9 @@ class WaitForChildInput:
 
 class ChildProcessing(Step[str]):
     def wait_for(self, context: Context, input: str) -> Wait:
-        del context, input
         return Wait.until(Timer.by_duration(timedelta(seconds=random.randint(1, 3))))
 
     def execute(self, context: Context, input: str) -> StepDecision:
-        del context, input
         return graceful_complete()
 
 
@@ -81,11 +79,9 @@ class AwaitChildWorkflowCompletion(Step[WaitForChildInput]):
         self.client_provider = client_provider
 
     def wait_for(self, context: Context, input: WaitForChildInput) -> Wait:
-        del context
         return Wait.until(Timer.by_duration(timedelta(seconds=input.timer_seconds)))
 
     def execute(self, context: Context, input: WaitForChildInput) -> StepDecision:
-        del context
         try:
             self.client_provider().wait_for_flow(
                 input.child_wf_id,
@@ -140,11 +136,9 @@ class LoopForNextTask(Step[None]):
         self.task_queue = task_queue
 
     def wait_for(self, context: Context, input: None) -> Wait:
-        del context, input
         return Wait.until(self.task_queue.for_one())
 
     def execute(self, context: Context, input: None) -> StepDecision:
-        del input
         request = self.task_queue.results(context)[0]
         return go_to(StartChildWorkflow, request)
 


### PR DESCRIPTION
## Summary

- Remove no-op Python `del` statements from runnable examples.
- Remove matching Python snippets from English and Simplified Chinese product documentation.

## Rationale

The statements only removed local parameter bindings and could make readers think Dex state was being deleted.

## User impact

Examples and documentation are clearer; runtime behavior is unchanged.

## Validation

- `make docs-prose-check`
- `make -C examples/python unitTests`
- `make copyright-check`
