### PR TITLE
docs: describe patterns before graphs

### DIFF
--- a/docs/content/design-patterns/durable-timer/inactiveness-tracker-timer.mdx
+++ b/docs/content/design-patterns/durable-timer/inactiveness-tracker-timer.mdx
@@ -4,9 +4,9 @@ title: Inactiveness Tracker Timer
 
 # Inactiveness Tracker Timer
 
-![InactivenessTrackerFlow](/img/design-patterns/inactiveness-tracker-timer-flow.png)
-
 Use this pattern when an action should happen only after a period without activity. **InactivenessTrackerFlow** starts with **TrackerStep**. It waits for either the Timer or the **Active** Channel. Activity arrives first, so **TrackerStep** moves to itself and starts a fresh Timer. If the Timer fires first, the Flow moves to **ProcessInactivenessStep**.
+
+![InactivenessTrackerFlow](/img/design-patterns/inactiveness-tracker-timer-flow.png)
 
 ## Core Step
 

--- a/docs/content/design-patterns/durable-timer/reminder.mdx
+++ b/docs/content/design-patterns/durable-timer/reminder.mdx
@@ -4,9 +4,9 @@ title: Reminder
 
 # Reminder
 
-![ReminderFlow](/img/design-patterns/reminder-flow.png)
-
 **ReminderFlow** sends a reminder every interval until the recipient opts out. **ReminderStep** waits for either the interval Timer or the **OptOut** Channel. When the timer fires, it sends a reminder and moves to itself. When **OptOut** arrives first, the Step completes the Flow.
+
+![ReminderFlow](/img/design-patterns/reminder-flow.png)
 
 ## Core Step
 

--- a/docs/content/design-patterns/polling/backoff.mdx
+++ b/docs/content/design-patterns/polling/backoff.mdx
@@ -4,14 +4,14 @@ title: Backoff Polling
 
 # Backoff Polling
 
+**BackoffPollingFlow** runs **PollingStep** against an external service. When the condition is not met, the Step returns an expected error. Its **ExecuteRetry** policy retries that same execution with exponential backoff; a successful response completes the Flow.
+
+Use **RetryAfter** to request the exact delay for the next retry while preserving the error. Because the expected not-ready result is a failed Step attempt, operation monitors and runbooks must classify it as expected and must not page on-call for it.
+
 <img
   alt="BackoffPollingFlow"
   src="/img/design-patterns/backoff-polling-flow.png"
 />
-
-**BackoffPollingFlow** runs **PollingStep** against an external service. When the condition is not met, the Step returns an expected error. Its **ExecuteRetry** policy retries that same execution with exponential backoff; a successful response completes the Flow.
-
-Use **RetryAfter** to request the exact delay for the next retry while preserving the error. Because the expected not-ready result is a failed Step attempt, operation monitors and runbooks must classify it as expected and must not page on-call for it.
 
 ## Core implementation
 

--- a/docs/content/design-patterns/polling/iteration.mdx
+++ b/docs/content/design-patterns/polling/iteration.mdx
@@ -4,9 +4,9 @@ title: Iteration
 
 # Iteration
 
-![IterationFlow](/img/design-patterns/iteration-flow.png)
-
 **IterationFlow** migrates a large collection one page at a time. **IterationStep** reads and processes the page, then passes the next page token as the input of its next execution. When there is no token, the Flow completes. This is structurally similar to timer polling, but the loop carries pagination state.
+
+![IterationFlow](/img/design-patterns/iteration-flow.png)
 
 ## Core implementation
 

--- a/docs/content/design-patterns/polling/timer.mdx
+++ b/docs/content/design-patterns/polling/timer.mdx
@@ -4,9 +4,9 @@ title: Polling with Timer
 
 # Polling with Timer
 
-![PollingWithTimerFlow](/img/design-patterns/polling-with-timer-flow.png)
-
 **PollingWithTimerFlow** makes the wait explicit. **PollingStep** waits for a Timer, checks the external condition, then either completes or moves to itself for another interval. It uses more code than retry-based polling, but the not-ready outcome is a normal Step decision rather than a failed attempt.
+
+![PollingWithTimerFlow](/img/design-patterns/polling-with-timer-flow.png)
 
 ## Core implementation
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/durable-timer/inactiveness-tracker-timer.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/durable-timer/inactiveness-tracker-timer.mdx
@@ -5,9 +5,9 @@ sidebar_label: Inactiveness Tracker Timer
 
 # Inactiveness Tracker Timer
 
-![InactivenessTrackerFlow](/img/design-patterns/inactiveness-tracker-timer-flow.png)
-
 当一个动作只应在一段时间没有活动后才发生时，使用这个模式。**InactivenessTrackerFlow** 从 **TrackerStep** 开始，等待 Timer 或 **Active** Channel。活动先到达时，**TrackerStep** 跳回自身并开始一个新的 Timer；Timer 先触发时，Flow 跳转到 **ProcessInactivenessStep**。
+
+![InactivenessTrackerFlow](/img/design-patterns/inactiveness-tracker-timer-flow.png)
 
 ## 核心 Step
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/durable-timer/reminder.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/durable-timer/reminder.mdx
@@ -5,9 +5,9 @@ sidebar_label: Reminder
 
 # Reminder
 
-![ReminderFlow](/img/design-patterns/reminder-flow.png)
-
 **ReminderFlow** 会按 interval 发送提醒，直到接收者 opt-out。**ReminderStep** 等待 interval Timer 或 **OptOut** Channel。Timer 先触发时，Step 发送提醒并跳回自身；**OptOut** 先到达时，Step 完成 Flow。
+
+![ReminderFlow](/img/design-patterns/reminder-flow.png)
 
 ## 核心 Step
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/polling/backoff.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/polling/backoff.mdx
@@ -4,11 +4,11 @@ title: Backoff Polling
 
 # Backoff Polling
 
+**BackoffPollingFlow** 中的 **PollingStep** 会调用外部服务。条件尚未满足时，Step 返回预期错误，**ExecuteRetry** 会按指数退避重试该 execution；成功时完成 Flow。
+
+可以使用 **RetryAfter** 精确指定下一次 retry 的等待时间，同时保留当前错误。因为未就绪会显示为失败的 Step attempt，监控和 runbook 必须把它归为预期结果，不应为此呼叫 on-call。
+
 <img
   alt="BackoffPollingFlow"
   src="/img/design-patterns/backoff-polling-flow.png"
 />
-
-**BackoffPollingFlow** 中的 **PollingStep** 会调用外部服务。条件尚未满足时，Step 返回预期错误，**ExecuteRetry** 会按指数退避重试该 execution；成功时完成 Flow。
-
-可以使用 **RetryAfter** 精确指定下一次 retry 的等待时间，同时保留当前错误。因为未就绪会显示为失败的 Step attempt，监控和 runbook 必须把它归为预期结果，不应为此呼叫 on-call。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/polling/iteration.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/polling/iteration.mdx
@@ -4,6 +4,6 @@ title: Iteration
 
 # Iteration
 
-![IterationFlow](/img/design-patterns/iteration-flow.png)
-
 **IterationFlow** 一页一页地迁移大量数据。**IterationStep** 读取并处理当前页，再将下一页 token 作为下一次 execution 的 input；没有 token 时完成 Flow。这与 Timer polling 的循环结构类似，但循环会携带分页状态。
+
+![IterationFlow](/img/design-patterns/iteration-flow.png)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/polling/timer.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/polling/timer.mdx
@@ -5,6 +5,6 @@ sidebar_label: Polling with Timer
 
 # 使用 Timer 的 Polling
 
-![PollingWithTimerFlow](/img/design-patterns/polling-with-timer-flow.png)
-
 **PollingWithTimerFlow** 显式等待 Timer。**PollingStep** 在每个 interval 后检查外部条件，然后完成，或调度自身进行下一轮检查。它的代码多一点，但未就绪是正常的 Step decision，而不是失败的 attempt。
+
+![PollingWithTimerFlow](/img/design-patterns/polling-with-timer-flow.png)


### PR DESCRIPTION
## Summary

- Place the explanation before the Step Graph on five Design Pattern pages.
- Keep English and Simplified Chinese documentation in sync.

## Rationale

Readers now receive the context for each pattern before seeing its workflow graph.

## User impact

The documentation is easier to scan without changing the underlying examples or diagrams.

## Validation

- `cd docs && npm run build`
