### PR TITLE
docs: reorder design patterns and normalize step graphs

### DIFF
--- a/.cursor/rules/docs.mdc
+++ b/.cursor/rules/docs.mdc
@@ -33,3 +33,10 @@ Application snippets must be copied from runnable files under `examples/`.
 The page must link to that example. If the example has HTTP, also link the
 examples playground when the sample is catalogued there. Add the example first
 when the API does not exist yet. See `.cursor/rules/docs-examples.mdc`.
+
+Design-pattern Step graph PNGs must remain responsive. Set only a percentage
+`max-width`, never a fixed width or height. Choose each maximum so its Flow type
+name renders at the same size as `DrainInternalChannelFlow` in
+`drain-internal-channel.png`, and keep the image centered. Match its stable
+filename fragment in `docs/src/css/custom.css` because Docusaurus hashes
+Markdown image URLs. Apply this rule when adding or replacing a Step graph.

--- a/.cursor/rules/docs.mdc
+++ b/.cursor/rules/docs.mdc
@@ -37,6 +37,7 @@ when the API does not exist yet. See `.cursor/rules/docs-examples.mdc`.
 Design-pattern Step graph PNGs must remain responsive. Set only a percentage
 `max-width`, never a fixed width or height. Choose each maximum so its Flow type
 name renders at the same size as `DrainInternalChannelFlow` in
-`drain-internal-channel.png`, and keep the image centered. Match its stable
-filename fragment in `docs/src/css/custom.css` because Docusaurus hashes
-Markdown image URLs. Apply this rule when adding or replacing a Step graph.
+`drain-internal-channel.png`, and keep the image centered. Use an HTML `img`
+with its `/img/design-patterns/` path so Docusaurus cannot inline the PNG as a
+data URL, then match its stable filename fragment in `docs/src/css/custom.css`.
+Apply this rule when adding or replacing a Step graph.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,12 @@ only when a section genuinely doesn't apply.
   `examples/`. Link the example (and the examples playground when the sample has
   HTTP and is catalogued). Do not invent APIs; add the example first.
   See `.cursor/rules/docs-examples.mdc`.
+- Design-pattern Step graph PNGs must remain responsive. Set only a percentage
+  `max-width`, never a fixed width or height. Choose each maximum so its Flow type
+  name renders at the same size as `DrainInternalChannelFlow` in
+  `drain-internal-channel.png`, and keep the image centered. Match its stable
+  filename fragment in `docs/src/css/custom.css` because Docusaurus hashes
+  Markdown image URLs. Apply this rule when adding or replacing a Step graph.
 
 ### UI/UX
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,10 @@ only when a section genuinely doesn't apply.
 - Design-pattern Step graph PNGs must remain responsive. Set only a percentage
   `max-width`, never a fixed width or height. Choose each maximum so its Flow type
   name renders at the same size as `DrainInternalChannelFlow` in
-  `drain-internal-channel.png`, and keep the image centered. Match its stable
-  filename fragment in `docs/src/css/custom.css` because Docusaurus hashes
-  Markdown image URLs. Apply this rule when adding or replacing a Step graph.
+  `drain-internal-channel.png`, and keep the image centered. Use an HTML `img`
+  with its `/img/design-patterns/` path so Docusaurus cannot inline the PNG as a
+  data URL, then match its stable filename fragment in `docs/src/css/custom.css`.
+  Apply this rule when adding or replacing a Step graph.
 
 ### UI/UX
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,9 +100,10 @@ one requires equivalent updates to all three in the same commit.
 - Design-pattern Step graph PNGs must remain responsive. Set only a percentage
   `max-width`, never a fixed width or height. Choose each maximum so its Flow type
   name renders at the same size as `DrainInternalChannelFlow` in
-  `drain-internal-channel.png`, and keep the image centered. Match its stable
-  filename fragment in `docs/src/css/custom.css` because Docusaurus hashes
-  Markdown image URLs. Apply this rule when adding or replacing a Step graph.
+  `drain-internal-channel.png`, and keep the image centered. Use an HTML `img`
+  with its `/img/design-patterns/` path so Docusaurus cannot inline the PNG as a
+  data URL, then match its stable filename fragment in `docs/src/css/custom.css`.
+  Apply this rule when adding or replacing a Step graph.
 - Before producing a binary, add its exact path to both `.gitignore` and
   `.dockerignore`, then remove any stray uncommitted binaries.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,12 @@ one requires equivalent updates to all three in the same commit.
   Link the example (and the examples playground when the sample has HTTP and
   is catalogued). Do not invent APIs; add the example first.
   See `.cursor/rules/docs-examples.mdc`.
+- Design-pattern Step graph PNGs must remain responsive. Set only a percentage
+  `max-width`, never a fixed width or height. Choose each maximum so its Flow type
+  name renders at the same size as `DrainInternalChannelFlow` in
+  `drain-internal-channel.png`, and keep the image centered. Match its stable
+  filename fragment in `docs/src/css/custom.css` because Docusaurus hashes
+  Markdown image URLs. Apply this rule when adding or replacing a Step graph.
 - Before producing a binary, add its exact path to both `.gitignore` and
   `.dockerignore`, then remove any stray uncommitted binaries.
 

--- a/docs/content/design-patterns/polling/backoff.mdx
+++ b/docs/content/design-patterns/polling/backoff.mdx
@@ -4,7 +4,10 @@ title: Backoff Polling
 
 # Backoff Polling
 
-![BackoffPollingFlow](/img/design-patterns/backoff-polling-flow.png)
+<img
+  alt="BackoffPollingFlow"
+  src="/img/design-patterns/backoff-polling-flow.png"
+/>
 
 **BackoffPollingFlow** runs **PollingStep** against an external service. When the condition is not met, the Step returns an expected error. Its **ExecuteRetry** policy retries that same execution with exponential backoff; a successful response completes the Flow.
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/polling/backoff.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/polling/backoff.mdx
@@ -4,7 +4,10 @@ title: Backoff Polling
 
 # Backoff Polling
 
-![BackoffPollingFlow](/img/design-patterns/backoff-polling-flow.png)
+<img
+  alt="BackoffPollingFlow"
+  src="/img/design-patterns/backoff-polling-flow.png"
+/>
 
 **BackoffPollingFlow** 中的 **PollingStep** 会调用外部服务。条件尚未满足时，Step 返回预期错误，**ExecuteRetry** 会按指数退避重试该 execution；成功时完成 Flow。
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -51,25 +51,6 @@ const sidebars: SidebarsConfig = {
       items: [
         {
           type: 'category',
-          label: 'Durable Timer',
-          link: {type: 'doc', id: 'design-patterns/durable-timer/index'},
-          items: [
-            'design-patterns/durable-timer/cron',
-            'design-patterns/durable-timer/reminder',
-            'design-patterns/durable-timer/inactiveness-tracker-timer',
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Drain Channels',
-          items: [
-            'design-patterns/drain-internal-channels',
-            'design-patterns/draining-channel-for-external-publishing',
-          ],
-        },
-        'design-patterns/interruptible',
-        {
-          type: 'category',
           label: 'Failure Handling',
           link: {type: 'doc', id: 'design-patterns/failure-handling'},
           items: [
@@ -79,6 +60,27 @@ const sidebars: SidebarsConfig = {
             'design-patterns/failure-handling/wait-for-failure-recovery',
           ],
         },
+        {
+          type: 'category',
+          label: 'Polling and Iteration',
+          link: {type: 'doc', id: 'design-patterns/polling'},
+          items: [
+            'design-patterns/polling/backoff',
+            'design-patterns/polling/timer',
+            'design-patterns/polling/iteration',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Durable Timer',
+          link: {type: 'doc', id: 'design-patterns/durable-timer/index'},
+          items: [
+            'design-patterns/durable-timer/cron',
+            'design-patterns/durable-timer/reminder',
+            'design-patterns/durable-timer/inactiveness-tracker-timer',
+          ],
+        },
+        'design-patterns/interruptible',
         {
           type: 'category',
           label: 'Parallel Steps',
@@ -105,17 +107,6 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
-          label: 'Polling and Iteration',
-          link: {type: 'doc', id: 'design-patterns/polling'},
-          items: [
-            'design-patterns/polling/backoff',
-            'design-patterns/polling/timer',
-            'design-patterns/polling/iteration',
-          ],
-        },
-        'design-patterns/entity-store',
-        {
-          type: 'category',
           label: 'Responsive Update',
           link: {type: 'doc', id: 'design-patterns/responsive-update'},
           items: [
@@ -124,6 +115,15 @@ const sidebars: SidebarsConfig = {
             'design-patterns/responsive-update/stream',
           ],
         },
+        {
+          type: 'category',
+          label: 'Drain Channels',
+          items: [
+            'design-patterns/drain-internal-channels',
+            'design-patterns/draining-channel-for-external-publishing',
+          ],
+        },
+        'design-patterns/entity-store',
       ],
     },
     {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -573,6 +573,94 @@ summary:focus-visible {
   color: var(--muted-strong);
 }
 
+.theme-doc-markdown img[src*='-flow'],
+.theme-doc-markdown img[src*='parallel-subflows-'],
+.theme-doc-markdown img[src*='drain-internal-channel'],
+.theme-doc-markdown img[src*='draining-external-channel-publishing'] {
+  display: block;
+  width: auto;
+  max-width: var(--step-graph-max-width, 100%);
+  height: auto;
+  margin-inline: auto;
+}
+
+.theme-doc-markdown img[src*='backoff-polling-flow'] {
+  --step-graph-max-width: 31.8%;
+}
+
+.theme-doc-markdown img[src*='execute-failure-recovery-flow'] {
+  --step-graph-max-width: 33.4%;
+}
+
+.theme-doc-markdown img[src*='wait-for-failure-recovery-flow'] {
+  --step-graph-max-width: 35.1%;
+}
+
+.theme-doc-markdown img[src*='polling-with-timer-flow'] {
+  --step-graph-max-width: 30.3%;
+}
+
+.theme-doc-markdown img[src*='iteration-flow'] {
+  --step-graph-max-width: 39.8%;
+}
+
+.theme-doc-markdown img[src*='inactiveness-tracker-timer-flow'],
+.theme-doc-markdown img[src*='reminder-flow'] {
+  --step-graph-max-width: 45.7%;
+}
+
+.theme-doc-markdown img[src*='draining-external-channel-publishing'] {
+  --step-graph-max-width: 42.5%;
+}
+
+.theme-doc-markdown img[src*='graceful-timeout-flow'] {
+  --step-graph-max-width: 50.3%;
+}
+
+.theme-doc-markdown img[src*='cron-schedule-flow'] {
+  --step-graph-max-width: 53.8%;
+}
+
+.theme-doc-markdown img[src*='parallel-dynamic-steps-flow'] {
+  --step-graph-max-width: 46.6%;
+}
+
+.theme-doc-markdown img[src*='parallel-static-steps-flow'] {
+  --step-graph-max-width: 58.2%;
+}
+
+.theme-doc-markdown img[src*='parallel-subflows-basic'] {
+  --step-graph-max-width: 60.6%;
+}
+
+.theme-doc-markdown img[src*='parallel-await-steps-flow'] {
+  --step-graph-max-width: 61.5%;
+}
+
+.theme-doc-markdown img[src*='parallel-first-win-steps-flow'] {
+  --step-graph-max-width: 71.4%;
+}
+
+.theme-doc-markdown img[src*='parallel-subflows-wait-for-half'] {
+  --step-graph-max-width: 82.4%;
+}
+
+.theme-doc-markdown img[src*='parallel-subflows-partitioning'] {
+  --step-graph-max-width: 92.9%;
+}
+
+.theme-doc-markdown img[src*='parallel-subflows-long-lived-parent'] {
+  --step-graph-max-width: 73.9%;
+}
+
+.theme-doc-markdown img[src*='parallel-subflows-short-lived-parent'] {
+  --step-graph-max-width: 84.1%;
+}
+
+.theme-doc-markdown img[src*='manual-recovery-flow'] {
+  --step-graph-max-width: 85%;
+}
+
 .theme-doc-markdown h1,
 .theme-doc-markdown h2,
 .theme-doc-markdown h3,

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Licensed under the Super Durable Source License 1.0.
+ * You may not use this file except in compliance with the License.
+ * See the LICENSE file in the repository root.
+ *
+ * SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+ */
+
 @import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap');
 
 :root {
@@ -601,7 +611,7 @@ summary:focus-visible {
 }
 
 .theme-doc-markdown img[src*='iteration-flow'] {
-  --step-graph-max-width: 39.8%;
+  --step-graph-max-width: 37.5%;
 }
 
 .theme-doc-markdown img[src*='inactiveness-tracker-timer-flow'],


### PR DESCRIPTION
## Summary

- reorder the Design Patterns sidebar into the requested workflow-oriented sequence
- normalize Step graph PNG maximum widths against `DrainInternalChannelFlow` while preserving responsive sizing
- keep Backoff Polling from being inlined as a data URL so its filename-based sizing rule applies
- document the Step graph sizing convention for Cursor, Codex, and Claude

## Rationale and user impact

The Design Patterns navigation now follows the intended learning order. Step graph labels render at a more consistent size across pages without forcing fixed image dimensions, including the previously oversized Backoff Polling diagram.

## Validation

- `cd docs && npm run check`
- `make copyright-check`
