### PR TITLE
docs: recalibrate cropped step graphs

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -614,6 +614,14 @@ summary:focus-visible {
   --step-graph-max-width: 37.5%;
 }
 
+.theme-doc-markdown img[src*='drain-internal-channel'] {
+  --step-graph-max-width: 52.3%;
+}
+
+.theme-doc-markdown img[src*='interruptible-flow'] {
+  --step-graph-max-width: 57.9%;
+}
+
 .theme-doc-markdown img[src*='inactiveness-tracker-timer-flow'],
 .theme-doc-markdown img[src*='reminder-flow'] {
   --step-graph-max-width: 45.7%;
@@ -668,7 +676,7 @@ summary:focus-visible {
 }
 
 .theme-doc-markdown img[src*='manual-recovery-flow'] {
-  --step-graph-max-width: 85%;
+  --step-graph-max-width: 49%;
 }
 
 .theme-doc-markdown h1,


### PR DESCRIPTION
## Summary

- recalculate responsive maximum widths for the three Step graph PNGs cropped in #402
- restore the previously calibrated Flow type text size for Manual Recovery, Drain Internal Channels, and Interruptible
- preserve responsive percentage sizing and centered rendering

## Rationale and user impact

Cropping changed each PNG canvas width without changing its internal text pixels. The previous percentages therefore rendered the cropped diagrams too large. These values account for the new canvas dimensions while keeping the diagrams responsive.

## Validation

- `cd docs && npm run check`
- `make copyright-check`
- visually verified all three pages in English and Simplified Chinese
