### PR TITLE
docs: add Dex developer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Unlike replay-based durable execution engines, Dex does not split your logic int
 
 Learn more: [What is Durable Execution?](https://docs.superdurable.io/intro/what-is-durable-execution) · [Why Dex?](https://docs.superdurable.io/intro/what-is-dex)
 
+AI coding assistants can use the repository's [Dex Developer skill](skills/dex-developer/SKILL.md) to build, test, and operate Dex applications through Dex's public programming model.
 
 ## Quick start
 

--- a/skills/dex-developer/SKILL.md
+++ b/skills/dex-developer/SKILL.md
@@ -44,6 +44,8 @@ Keep external side effects in **Execute**. Use **WaitFor** to declare durable Co
 
 Read [modeling.md](references/modeling.md) for design rules and [primitives.md](references/primitives.md) when choosing or combining primitives.
 
+Read [large-attributes-and-locality.md](references/large-attributes-and-locality.md) when a Flow keeps large documents, conversation history, or API/MCP results in Attributes, or when deploying replicated Workers. Do not add an application-managed blob store or cache solely because an Attribute is large; first evaluate Dex blob hydration, the SDK BlobCache, and headless Worker locality.
+
 ## Choose proven Flow shapes
 
 Prefer an existing Dex pattern over an ad hoc coordination loop. Read [patterns.md](references/patterns.md) when the request involves retries with compensation, polling, reminders, inactivity, parallel work, fan-out, back pressure, interruption, external publishing, responsive updates, or durable entity state.

--- a/skills/dex-developer/SKILL.md
+++ b/skills/dex-developer/SKILL.md
@@ -44,7 +44,7 @@ Keep external side effects in **Execute**. Use **WaitFor** to declare durable Co
 
 Read [modeling.md](references/modeling.md) for design rules and [primitives.md](references/primitives.md) when choosing or combining primitives.
 
-Read [large-attributes-and-locality.md](references/large-attributes-and-locality.md) when a Flow keeps large documents, conversation history, or API/MCP results in Attributes, or when deploying replicated Workers. Do not add an application-managed blob store or cache solely because an Attribute is large; first evaluate Dex blob hydration, the SDK BlobCache, and headless Worker locality.
+Read [large-attributes-and-locality.md](references/large-attributes-and-locality.md) when a Flow keeps large documents, conversation history, or API/MCP results in Attributes; when choosing AttributeMap instances or external projections for a growing collection; or when deploying replicated Workers. Do not add an application-managed blob store, cache, or dual-write path solely because an Attribute is large; first evaluate Dex blob hydration, the SDK BlobCache, headless Worker locality, and Attribute Store synchronization.
 
 ## Choose proven Flow shapes
 

--- a/skills/dex-developer/SKILL.md
+++ b/skills/dex-developer/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: dex-developer
+description: Develop, debug, test, and operate applications built with Superdurable Dex in Python, Go, Java, TypeScript, or Rust. Use when a user mentions Dex Flows, Steps, Attributes, Channels, Streams, RPCs, SubFlows, Workers, Dex Web, Dex Server, or dexcli. Do not activate for unrelated uses of the word "dex" or for Dex framework/server implementation work.
+---
+
+# Dex Developer
+
+Build reliable applications through Dex's public programming model. Keep the user's experience entirely in Dex terms and APIs.
+
+## Stay at the Dex boundary
+
+- Model application behavior with Flows, Steps, Waits, Attributes, Channels, Streams, RPCs, Timers, SubFlows, Workers, and the Client.
+- Use Dex Web, dexcli, SDK errors, and application logs for inspection and recovery.
+- Do not require users to understand, install, configure, or inspect the execution engine inside Dex Server.
+- Do not expose internal server concepts as application requirements. Only discuss internals when the user explicitly asks to develop or debug Dex itself.
+
+## Establish the project context
+
+Before writing code:
+
+1. Identify the language, package manager, installed Dex SDK version, existing Flow registry, Worker bootstrap, Client bootstrap, and test commands.
+2. Preserve the project's SDK version unless the user asks to upgrade. Do not mix APIs copied from another version.
+3. Prefer the project's existing Dex code and conventions. In a Dex source checkout, use runnable files under **examples/** as the API source of truth.
+4. For a new project, use the current official docs at https://docs.superdurable.io and the matching language examples at https://github.com/superdurable/dex/tree/main/examples.
+5. Never invent Dex APIs. If an exact signature is uncertain, inspect the installed SDK or a version-matched example before coding.
+
+Read [getting-started.md](references/getting-started.md) when installing Dex, creating the first Flow, or wiring a Worker and Client. Read [languages.md](references/languages.md) for language-specific package names, source locations, and verification commands.
+
+## Model the application first
+
+Write a short application-level design before a non-trivial implementation:
+
+- Flow type and business identity
+- start input and completion output
+- Step types and transitions
+- durable state held in Attributes
+- durable commands or events carried by Channels
+- synchronous interactions exposed as RPCs
+- low-latency, best-effort updates exposed as Streams
+- timers, retries, timeouts, and failure paths
+- SubFlow boundaries and concurrency limits
+
+Keep external side effects in **Execute**. Use **WaitFor** to declare durable Conditions and prepare state needed for the wait. Make every Step transition and terminal decision explicit.
+
+Read [modeling.md](references/modeling.md) for design rules and [primitives.md](references/primitives.md) when choosing or combining primitives.
+
+## Choose proven Flow shapes
+
+Prefer an existing Dex pattern over an ad hoc coordination loop. Read [patterns.md](references/patterns.md) when the request involves retries with compensation, polling, reminders, inactivity, parallel work, fan-out, back pressure, interruption, external publishing, responsive updates, or durable entity state.
+
+Adapt the nearest runnable example to the project's language and SDK version. Preserve the example's Flow shape while replacing only the application domain and integrations.
+
+## Implement a complete vertical slice
+
+For application changes, include the pieces needed to run and exercise the behavior:
+
+- typed inputs, outputs, and application errors
+- Flow and Step definitions
+- persistence schema entries for every used Attribute and Channel
+- constructor-injected application dependencies
+- Flow registry entry
+- Worker and Client wiring when not already present
+- an application boundary such as an HTTP handler, CLI command, or service method
+- an integration test that starts and interacts with a real Flow
+
+Do not add global mutable dependencies or post-construction setter injection. Keep stable Flow, Step, Attribute, Channel, Stream, and RPC names compatible with open executions unless the user explicitly plans a migration.
+
+## Verify and operate
+
+Use the repository's own build and test entrypoints. Prefer an integration test against **dexcli dev** for behavior that crosses Worker, Client, persistence, waiting, retry, or RPC boundaries. Use unique Flow IDs and poll for convergence instead of fixed sleeps.
+
+For diagnosis, begin with read-only evidence: application logs, Dex Web, and **dexcli flow inspect**. Do not stop, time travel, publish, invoke, or mutate a Flow unless the user requested that action. Resolve the exact Flow and run before any mutation.
+
+Read [operations.md](references/operations.md) for test scenarios, diagnostic order, safe recovery, and versioning constraints.
+
+## Completion criteria
+
+Before handing off application code:
+
+- build or type-check succeeds
+- the relevant integration scenario passes
+- every used durable primitive is registered
+- retry, timeout, duplicate request, and terminal behavior are intentional
+- Worker and Client share compatible registry and payload/blob configuration
+- user-facing instructions mention only Dex components and commands

--- a/skills/dex-developer/agents/openai.yaml
+++ b/skills/dex-developer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dex Developer"
+  short_description: "Build and operate durable applications with Dex"
+  default_prompt: "Use $dex-developer to build a reliable Dex Flow for this application."

--- a/skills/dex-developer/references/getting-started.md
+++ b/skills/dex-developer/references/getting-started.md
@@ -1,0 +1,59 @@
+# Getting started
+
+Use this guide for a new Dex application or when Worker and Client wiring is missing.
+
+## Local environment
+
+Install **dexcli** with the supported package for the user's platform. On macOS:
+
+```bash
+brew install superdurable/tap/dexcli
+dexcli dev
+```
+
+Use the Dex Server and Dex Web addresses printed by the command. Defaults are usually **127.0.0.1:8801** and **http://127.0.0.1:8802**, but another local process can cause different ports. Pass the printed server address to the application instead of assuming the default.
+
+## First vertical slice
+
+Build the smallest end-to-end path in this order:
+
+1. Define one typed start input and one start Step.
+2. Make the Step return a terminal decision with a typed output.
+3. Define the Flow's Step list.
+4. Register the Flow in the application registry.
+5. Create one Worker using that registry and a reachable bind/advertise address.
+6. Create one Client using the same registry and blob/payload configuration.
+7. Start the Worker before accepting application requests.
+8. Start the Flow through an HTTP handler, CLI command, or service method.
+9. Add an integration test that starts the Flow and waits for its result.
+
+Add Attributes, Channels, RPCs, Streams, or SubFlows only when the first path runs successfully.
+
+## Required topology
+
+- Dex Server receives public Client calls and dispatches handler work.
+- The Worker hosts registered Flow, Step, and RPC implementations.
+- The Client starts and interacts with Flow executions.
+- Dex Web inspects Flow state and Step progress.
+- The application owns its HTTP, messaging, database, and third-party integrations.
+
+The Worker must be reachable from Dex Server. A bind address controls where the Worker listens; an advertised target controls the address Dex Server calls. These differ when containers, proxies, or load balancers are involved.
+
+## Configuration checks
+
+Before debugging code, verify:
+
+- the application uses the server address printed by **dexcli dev**
+- the Worker advertised target is reachable from Dex Server
+- the Flow type is present in the Worker and Client registries
+- the Worker and Client use compatible payload codecs and blob cache/storage
+- all Attributes and Channels used by handlers are in the Flow persistence schema
+- Indexed Attributes are synchronized before the Worker starts serving
+
+## Source material
+
+- Quick start: https://docs.superdurable.io/quick-start
+- Primitive overview: https://docs.superdurable.io/primitives
+- Runnable examples: https://github.com/superdurable/dex/tree/main/examples
+
+When a local Dex checkout is available, copy API usage from its runnable **examples/** files rather than from prose or memory.

--- a/skills/dex-developer/references/languages.md
+++ b/skills/dex-developer/references/languages.md
@@ -1,0 +1,45 @@
+# Language routing
+
+Match the language and exact SDK version already used by the project. For new projects, resolve the current stable version from the official package registry or Dex documentation.
+
+| Language | Package | Runnable examples | Common verification |
+| --- | --- | --- | --- |
+| Python | **dex-python-sdk** | **examples/python/dex_examples/** | **mypy**, **pytest**, project integration script |
+| Go | **github.com/superdurable/dex/sdk-go** | **examples/go/** | **go test** through the project Makefile, example E2E script |
+| Java | **io.superdurable:dex-sdk** | **examples/java/** | Gradle compile/test, example integration script |
+| TypeScript | **@superdurable/dex** | **examples/typescript/** | **tsc**, Node tests, example integration script |
+| Rust | **dex-sdk** | **examples/rust/** | **cargo fmt**, **cargo clippy**, **cargo test**, example integration script |
+
+## Selection workflow
+
+1. Read the dependency manifest and lockfile.
+2. Find the nearest primitive or product example in the same language.
+3. Confirm imported names and signatures against the installed SDK source.
+4. Follow the application's existing registry, Worker, Client, codec, and error-handling conventions.
+5. Run formatting and static checks before integration tests.
+
+## Language-specific cautions
+
+### Python
+
+Preserve whether the application uses the synchronous or asynchronous SDK style. Do not mix them in one execution path. Use typed models and the project's configured codec behavior.
+
+### Go
+
+Use typed definitions and return every SDK error. Follow the repository's constructor and interface conventions. Prefer project Makefile targets for full suites.
+
+### Java
+
+Keep Flow, Step, and RPC types explicit. Use the project's dependency injection and lifecycle conventions without making Worker-managed definitions request-scoped.
+
+### TypeScript
+
+Provide codecs for typed values where required by the installed SDK. Preserve async boundaries and await Client or handler operations supported by that version.
+
+### Rust
+
+Follow the installed SDK's ownership model. In the Dex repository examples and SDK integration tests, define Attribute, Channel, and Stream schemas as module-level **LazyLock** statics when that convention applies.
+
+## Version discipline
+
+Package versions across languages may be released at different times. Do not infer that equal-looking version numbers expose identical APIs. Use language-native examples from the same release whenever possible.

--- a/skills/dex-developer/references/large-attributes-and-locality.md
+++ b/skills/dex-developer/references/large-attributes-and-locality.md
@@ -1,0 +1,63 @@
+# Large Attributes and Worker locality
+
+Read this guide when a Flow stores large documents, conversation history, model context, or API/MCP results, especially with replicated Workers.
+
+## Use the built-in large-value path
+
+Dex durably owns an Attribute even when its serialized value is stored as a blob. With server-side blob offload and lazy loading enabled, handler requests carry an opaque blob ID instead of repeatedly transferring the full value.
+
+The SDK hydrates each blob-backed value before application code uses it:
+
+1. Check the local BlobCache by immutable blob ID.
+2. Deduplicate IDs needed by the invocation.
+3. Fetch cache misses together through Dex.
+4. Store fetched values in the bounded disk cache.
+5. Decode the hydrated values for the handler.
+
+A cache hit avoids another remote blob fetch. It still incurs local cache reading and decoding. Treat the BlobCache as disposable acceleration; Dex remains the durable source of truth.
+
+Create one cache-owned, writable directory per Worker replica. Share the opened BlobCache between that process's Worker and Client when the SDK supports it, size it for the hot set, and close it after both stop. A persistent volume can preserve entries across process restarts, but correctness must not depend on that volume or on cache admission.
+
+Use the installed SDK and its version-matched examples for exact BlobCache constructors and lifecycle APIs.
+
+## Combine caching with headless Worker locality
+
+For a headless Worker target, Dex resolves individual Worker endpoints and prefers the endpoint that most recently handled the same Flow ID. Repeated Steps and RPCs for one Flow therefore tend to reach a Worker whose BlobCache is already warm.
+
+Configure a target as headless only when its **host:port** resolves to individual Worker replicas, such as a Kubernetes headless Service. A normal load-balanced target does not give Dex direct control over replica selection.
+
+Sticky routing is a performance hint, not a placement guarantee. Dex may select another Worker after a transport failure, endpoint removal, routing-entry eviction, or server restart. The replacement Worker loads each missing blob once and warms its own cache. Never keep Flow correctness state only in Worker memory or its cache.
+
+For API/MCP agents that do not need a code sandbox, this combination is often sufficient:
+
+```text
+Flow Attributes -> Dex blob storage -> sticky Worker -> local BlobCache -> handler
+```
+
+Do not build application-level blob references, download logic, deduplication, or cache eviction unless product requirements exceed this path.
+
+## Model updates for cache reuse
+
+BlobCache entries are keyed by immutable blob ID. Updating a large Attribute produces a new value and therefore a new blob ID. A single ever-growing array, such as one **messages** Attribute, rewrites the full array and creates a cold blob version on each append. Stickiness cannot remove that write amplification.
+
+Prefer immutable or infrequently changed values:
+
+- store messages, tool results, or document parts in an AttributeMap
+- group small records into immutable bounded chunks
+- keep only the active window or summary in a small mutable Attribute
+- update old chunks only when the product operation truly edits history
+
+Old chunks retain their blob IDs and stay reusable in the local cache; one newly added chunk causes only its own first hydration miss.
+
+An external application store becomes useful when the data needs relational queries, independent pagination, cross-Flow sharing, analytics, or a retention lifecycle different from the Flow. Do not choose one merely to avoid repeat reads of unchanged large Attributes.
+
+## Verify the deployment
+
+Exercise the actual topology with an integration test:
+
+- invoke the same Flow repeatedly and confirm unchanged values hydrate correctly
+- replace the serving Worker and confirm the Flow continues after a cold-cache load
+- update one chunk and confirm old state remains readable
+- verify the cache directory is writable, bounded, and not treated as durable state
+
+When diagnosing latency, distinguish remote blob loads from local cache reads and value decoding. Worker affinity can improve the first; data shape determines how much work remains on every invocation.

--- a/skills/dex-developer/references/large-attributes-and-locality.md
+++ b/skills/dex-developer/references/large-attributes-and-locality.md
@@ -49,7 +49,35 @@ Prefer immutable or infrequently changed values:
 
 Old chunks retain their blob IDs and stay reusable in the local cache; one newly added chunk causes only its own first hydration miss.
 
-An external application store becomes useful when the data needs relational queries, independent pagination, cross-Flow sharing, analytics, or a retention lifecycle different from the Flow. Do not choose one merely to avoid repeat reads of unchanged large Attributes.
+### Use AttributeMap deliberately
+
+Choose one Attribute when the value is a cohesive snapshot that handlers normally read and replace together. Choose an AttributeMap when keys are known only at runtime and instances are read, written, or deleted independently. Each instance is a separate blob, so changing one message chunk, tool result, item, or document part does not rewrite the others.
+
+Use stable domain identifiers or monotonic chunk IDs as instance keys. Do not place volatile or unbounded user text in keys. Group very small records into bounded chunks when per-instance overhead would dominate, and define when old instances are deleted.
+
+Inside a handler, map size and instance-key enumeration include buffered writes and deletes. They do not provide server-side pagination. An unbounded map can therefore avoid blob rewrite amplification while still becoming expensive to enumerate, transfer, and decode.
+
+Locks are scoped to one AttributeMap instance. Lock the exact instance when parallel Steps or RPCs perform a read-modify-write on the same value; unrelated instances can remain concurrent.
+
+An indexed AttributeMap does not create one searchable entry per instance. Every instance writes the same fixed Flow search field, a later instance can replace the prior indexed value, and the instance key is not searchable. Use a regular Attribute with a keyword-array index for a bounded searchable collection, or an external projection for per-instance queries.
+
+## Project Attributes for external queries
+
+When data needs relational queries, independent pagination, cross-Flow access, analytics, or a different retention lifecycle, first consider Dex Attribute Store synchronization instead of application-managed dual writes.
+
+Attribute Store synchronization is opt-in for each Attribute or AttributeMap, and a Flow selects one or more Server-configured stores. Dex asynchronously projects latest-state writes and retries transient failures. A projection failure does not roll back the Flow Attribute, and retry exhaustion does not automatically replay or backfill the missed batch. Keep Dex or the application's authoritative database as the source of truth and make important projections reconcilable.
+
+The built-in Attribute Store targets are currently PostgreSQL and MySQL. They project into columns of an existing table keyed by Flow ID; Dex does not create the table. They are not direct Elasticsearch or vector-store connectors, and synchronization does not generate embeddings or transform documents.
+
+For Elasticsearch or a vector database, choose among:
+
+- synchronize a suitable SQL projection, then use CDC or another downstream indexer
+- run an explicit durable projection Step when chunking, embedding, deletion, or version checks are required
+- add a Dex Attribute Store backend when direct projection is a product requirement
+
+An AttributeMap does not automatically become child rows or vector records in the built-in SQL stores. Verify how every physical instance name maps to the destination schema before enabling synchronization for a dynamic map.
+
+Do not introduce an external projection merely to avoid repeat reads of unchanged large Attributes; BlobCache and Worker locality already address that path.
 
 ## Verify the deployment
 

--- a/skills/dex-developer/references/modeling.md
+++ b/skills/dex-developer/references/modeling.md
@@ -30,7 +30,9 @@ Use stable domain names. A Step type is part of the durable contract of open exe
 
 ## Persist only durable coordination state
 
-Use Attributes for state that later Steps, RPCs, Clients, search, or recovery need. Keep authoritative long-lived business records in the application's database when their lifetime exceeds the Flow or they need relational querying.
+Use Attributes for state that later Steps, RPCs, Clients, search, or recovery need. Large size alone does not require a separate application store: Dex can keep large values as blobs and hydrate them through the SDK BlobCache. Read [large-attributes-and-locality.md](large-attributes-and-locality.md) before designing another blob or cache layer.
+
+Keep authoritative long-lived business records in the application's database when their lifetime exceeds the Flow or they need relational querying, independent pagination, cross-Flow access, analytics, or retention policies that differ from the Flow.
 
 Use Indexed Attributes for bounded lookup and operational search. Use Attribute Store sync when an application-owned database needs a durable projection.
 

--- a/skills/dex-developer/references/modeling.md
+++ b/skills/dex-developer/references/modeling.md
@@ -1,0 +1,72 @@
+# Flow modeling
+
+Use this guide before implementing a non-trivial Flow or when a Flow has become difficult to reason about.
+
+## Find the Flow boundary
+
+A Flow should represent one durable business execution with a stable identity and lifecycle, such as an order, subscription, transfer, approval, or processing job.
+
+Prefer a SubFlow when work needs its own identity, lifecycle, retry boundary, independent scaling, or bounded fan-out. Prefer another Step when the work is only the next state in the same business execution.
+
+## Turn the business process into a Step graph
+
+For each Step, record:
+
+- typed input
+- Conditions returned by **WaitFor**
+- side effects performed by **Execute**
+- Attribute and Channel reads or writes
+- retry and timeout policy
+- success transition
+- exhausted-retry or business-failure transition
+
+Use stable domain names. A Step type is part of the durable contract of open executions, not merely a function name.
+
+## Separate waiting from work
+
+**WaitFor** declares when a Step may execute. It may prepare durable state needed to establish that wait. Do not call third-party services or perform irreversible side effects there.
+
+**Execute** performs application work and returns the next movement or terminal decision. Make external operations idempotent when Dex may retry the Step.
+
+## Persist only durable coordination state
+
+Use Attributes for state that later Steps, RPCs, Clients, search, or recovery need. Keep authoritative long-lived business records in the application's database when their lifetime exceeds the Flow or they need relational querying.
+
+Use Indexed Attributes for bounded lookup and operational search. Use Attribute Store sync when an application-owned database needs a durable projection.
+
+Do not use Channels as generic storage. A Channel message is consumed by a matching wait. Use Attributes for current state and Channels for ordered durable messages.
+
+## Make failure behavior part of the graph
+
+For every external side effect, decide:
+
+- which failures are retryable
+- total retry budget and backoff
+- whether the operation needs heartbeat/progress reporting
+- what happens after retry exhaustion
+- whether compensation is required
+- whether an operator can recover the Flow
+- what deadline ends the business process
+
+Represent compensation and operator recovery as explicit Steps. Do not catch every error and silently mark the Flow successful.
+
+## Design for open executions
+
+Running Flows can outlive a deployment. Prefer additive changes:
+
+- add new Step types instead of changing incompatible behavior in an existing type
+- add optional Attributes and RPCs
+- retain old Step implementations while open executions can reference them
+- version request schemas or RPC names when compatibility cannot be preserved
+
+Use a new routing flag or Attribute so only new executions enter an incompatible path.
+
+## Review checklist
+
+- Can the graph explain every success, wait, failure, cancellation, and timeout path?
+- Are Step inputs and transitions typed?
+- Are side effects idempotent under retry?
+- Does each Channel have one clear producer/consumer contract?
+- Are shared state changes protected when concurrent Steps or RPCs can race?
+- Is fan-out bounded?
+- Can an operator identify the current business state from Dex Web or dexcli?

--- a/skills/dex-developer/references/operations.md
+++ b/skills/dex-developer/references/operations.md
@@ -1,0 +1,69 @@
+# Testing, diagnosis, and operations
+
+## Test the durable behavior
+
+Prefer integration tests for behavior involving Dex Server, a Worker, a Client, waiting, retry, persistence, or RPCs. Useful scenarios include:
+
+- start the Flow and verify its terminal output
+- publish a Channel message and verify the waiting Step advances
+- invoke an RPC and verify its response and durable state change
+- verify a Timer branch without relying on a fixed sleep
+- force a retryable failure and verify retry or exhausted-retry routing
+- verify duplicate start behavior with a stable request or Flow ID
+- restart or replace a Worker and verify an open Flow continues
+- verify concurrent Step or RPC updates preserve locked invariants
+- verify terminal Flows reject interactions that require an active Flow
+
+Use unique Flow IDs per test. Poll with a deadline for asynchronous convergence. Keep the Dex environment isolated or cleanly namespaced.
+
+## Diagnostic order
+
+1. Capture the exact Flow ID, run ID, Flow type, SDK version, and Dex Server address.
+2. Check Worker application logs for handler and connectivity errors.
+3. Inspect the Flow in Dex Web.
+4. Run a bounded read-only inspection:
+
+```bash
+dexcli flow inspect <flow-id> --all-history
+```
+
+5. Compare the active Step, Attributes, Channel waits, Timers, and recent semantic events with the intended graph.
+6. Reproduce with the smallest matching integration test.
+7. Fix application code or configuration, then decide whether existing executions need recovery.
+
+Use **dexcli flow search**, **summary**, **state**, and **history** for narrower JSON output. Use **--no-hydrate** when payload contents are unnecessary or sensitive.
+
+## Common failure classes
+
+- Worker unavailable: verify bind address, advertised target, network path, and process health.
+- Unknown Flow or Step type: verify registry contents and deployment version.
+- Attribute or Channel rejected: verify the persistence schema and exact stable name.
+- Flow does not advance: inspect the active Step's Conditions and pending Channel/Timer state.
+- Repeated side effect: make **Execute** idempotent and align retry policy with the external API.
+- Closed Flow interaction: handle the SDK's typed not-active error at the application boundary.
+- Large payload failure: verify Worker and Client blob/payload configuration matches.
+- Incompatible deployment: restore the required Step type or fix forward with a new compatible path.
+
+## Safe recovery
+
+Diagnosis is read-only by default. Stop, time travel, publish, invoke, skip a Timer, or mutate Attributes only when the user asks to change the Flow.
+
+Before a mutation:
+
+- resolve the current exact run
+- explain the expected state change
+- use the public Client or dexcli operation
+- satisfy any explicit confirmation flag
+- re-inspect the Flow afterward
+
+Time travel is appropriate after deploying a code fix when replaying from a safe Step boundary will not duplicate an unprotected side effect. If that cannot be established, design an explicit recovery or compensation Step instead.
+
+## Deployment changes
+
+Open Flows can continue after new Worker code is deployed. Before removing or changing a durable contract, search for open executions that may still reference it. Keep old Step types and schemas available until those executions finish or are deliberately migrated.
+
+Sources:
+
+- Dex CLI: https://docs.superdurable.io/references/cli
+- Application operations: https://docs.superdurable.io/production/application-operations
+- Versioning: https://docs.superdurable.io/production/versioning

--- a/skills/dex-developer/references/patterns.md
+++ b/skills/dex-developer/references/patterns.md
@@ -1,0 +1,34 @@
+# Pattern selection
+
+Choose the smallest pattern that matches the business requirement, then adapt its runnable example.
+
+| Requirement | Dex pattern | Key design choice |
+| --- | --- | --- |
+| Run independent work concurrently | Parallel Steps | Static, dynamic, await-all, or first-win |
+| Fan out work with separate identities | Parallel SubFlows | Parent lifetime, partitioning, and concurrency bound |
+| Prevent producers from overwhelming consumers | SubFlow back pressure | Admission limit and durable retry |
+| Poll external state | Polling and iteration | Fixed timer loop or retry backoff |
+| Remind, schedule, or detect inactivity | Durable Timer | Repeating reminder, cron, or resettable inactivity deadline |
+| Undo completed side effects | Failure handling | Compensation Steps in reverse business order |
+| Let an operator recover exhausted work | Manual recovery | Durable decision Channel and recovery Step |
+| End work on a business deadline | Graceful timeout | Terminal policy or explicit timeout handler |
+| Interrupt long-running work | Interruptible execution | Durable control signal and cleanup path |
+| Process all queued messages before closing | Drain Channels | Internal producer completion or external close condition |
+| Push UI progress with low latency | Responsive update | Step completion, Attribute wait, or Stream |
+| Keep durable entity state queryable in SQL | Data storage | Synced Attributes and application-owned schema |
+
+## Pattern rules
+
+- Prefer a Channel or Attribute Condition over application-side sleep and polling.
+- Bound dynamic parallelism. A runtime-sized input is not itself a safe concurrency policy.
+- When racing branches, define cancellation and cleanup for losing work.
+- When draining an externally published Channel, define who closes admission and how the Flow knows no more messages can arrive.
+- Keep compensation idempotent and observable. Compensation failure needs its own recovery path.
+- Separate progress updates from durable commands: Streams are best effort; Channels are durable.
+
+## Sources
+
+- Pattern catalog: https://docs.superdurable.io/design-patterns
+- Runnable implementations: https://github.com/superdurable/dex/tree/main/examples
+
+In a Dex checkout, locate the corresponding directory under each language's **patterns/** tree and preserve its tested Flow shape.

--- a/skills/dex-developer/references/primitives.md
+++ b/skills/dex-developer/references/primitives.md
@@ -20,7 +20,11 @@ Docs: https://docs.superdurable.io/primitives/step
 
 Use an Attribute for durable state inside one Flow execution. Register every Attribute in the persistence schema before reading or writing it.
 
-Use an AttributeMap for a dynamic set of keyed values. Use indexes for search and locks when concurrent handlers update shared state.
+Use one Attribute when the value is cohesive and should be replaced as a unit. Use an AttributeMap when runtime-keyed instances change independently; each instance is stored separately, avoiding a rewrite of the whole collection. Use stable domain keys and delete instances that are no longer needed.
+
+Lock the exact AttributeMap instance when Steps or RPCs can race on it. Do not treat an AttributeMap index as an index over its instances: all instances share one Flow search field, later writes replace that field, and instance keys are not searchable. AttributeMap enumeration is not server-side pagination.
+
+Read [large-attributes-and-locality.md](large-attributes-and-locality.md) for large values, map chunking, BlobCache locality, and external projections.
 
 Docs: https://docs.superdurable.io/primitives/attribute
 

--- a/skills/dex-developer/references/primitives.md
+++ b/skills/dex-developer/references/primitives.md
@@ -1,0 +1,65 @@
+# Primitive selection
+
+Read only the sections relevant to the task.
+
+## Flow
+
+Use a Flow as the top-level durable business execution. It owns the Step list, persistence schema, and RPC handlers. Give the Flow type and execution ID stable business meanings.
+
+Docs: https://docs.superdurable.io/primitives/flow
+
+## Step and Wait
+
+Use a Step for retried background work and explicit state transitions. **WaitFor** returns Conditions; **Execute** performs work and returns a Step decision.
+
+Use multiple next Steps for parallel work. Use cancellation deliberately when a first-winner branch makes siblings unnecessary.
+
+Docs: https://docs.superdurable.io/primitives/step
+
+## Attribute
+
+Use an Attribute for durable state inside one Flow execution. Register every Attribute in the persistence schema before reading or writing it.
+
+Use an AttributeMap for a dynamic set of keyed values. Use indexes for search and locks when concurrent handlers update shared state.
+
+Docs: https://docs.superdurable.io/primitives/attribute
+
+## Channel
+
+Use a Channel for ordered, durable, typed messages scoped to one Flow execution. One matching wait consumes a message once.
+
+Use a ChannelMap when the same message contract is partitioned by a dynamic key. Plan how externally published messages are drained before Flow completion.
+
+Docs: https://docs.superdurable.io/primitives/channel
+
+## RPC
+
+Use an RPC for a typed request/response interaction with an active Flow. RPC handlers may read or update Attributes and publish Channels. Protect shared mutations with Attribute locks when they can race with Steps or other RPCs.
+
+Use a Channel instead when the caller should enqueue work without synchronous application-level handling.
+
+Docs: https://docs.superdurable.io/primitives/rpc
+
+## Stream
+
+Use a Stream for low-latency, best-effort, resumable updates such as progress displayed in a UI. Do not use a Stream when delivery must be durable; use a Channel or Attribute instead.
+
+Docs: https://docs.superdurable.io/primitives/stream
+
+## Timer
+
+Use a Timer Condition for a durable delay, reminder, deadline branch, or scheduling loop. Decide what happens if a timer is skipped and whether the business deadline should complete, cancel, fail, or route to a handler.
+
+Docs: https://docs.superdurable.io/primitives/timer
+
+## SubFlow
+
+Use a SubFlow for child work that benefits from a separate Flow identity and lifecycle. Bound parallel SubFlows and define their reuse, cancellation, and parent-completion behavior.
+
+Docs: https://docs.superdurable.io/primitives/subflow
+
+## Client
+
+Use the Client at application boundaries to start, stop, inspect, search, and interact with Flows. Handle typed SDK failures for duplicate starts, missing Flows, closed Flows, long-poll expiry, and uncompleted closure.
+
+Docs: https://docs.superdurable.io/primitives/client


### PR DESCRIPTION
## Summary

- add a distributable `dex-developer` skill for building, testing, debugging, and operating Dex applications
- keep user guidance entirely within Dex's public Flow, Step, Attribute, Channel, Stream, RPC, Timer, SubFlow, Worker, Client, Dex Web, and dexcli model
- provide progressively loaded references for setup, modeling, primitive selection, design patterns, supported languages, testing, and operations
- link the skill from the repository README

## Rationale

Dex users should be able to build durable applications without learning implementation details inside Dex Server. The skill directs coding agents to version-matched SDK examples and public Dex tools, while preventing invented APIs and unsafe Flow mutations.

## User impact

Users can invoke `$dex-developer` to get Dex-native guidance across Python, Go, Java, TypeScript, and Rust. Existing runtime behavior is unchanged.

## Validation

- `python quick_validate.py skills/dex-developer` (`Skill is valid!`)
- `make ci-runner-check`
- parsed `skills/dex-developer/agents/openai.yaml`
- verified all referenced skill files exist
- verified the skill contains no scaffold placeholders or internal execution-engine names
- `git diff --check origin/main...HEAD`
