### PR TITLE
Constrain Temporal skill routing

### DIFF
--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -26,6 +26,17 @@ Keep the Cursor (`.cursor/rules/`), Codex (`AGENTS.md`), and Claude
 (`CLAUDE.md`) coding-agent rules synchronized. Any addition or modification to
 one requires equivalent updates to all three in the same commit.
 
+## Temporal Skill Routing
+
+- In this repository, use the `temporal-developer` skill only when changing or
+  diagnosing `server/service/interpreter/**` requires Temporal runtime or SDK
+  semantics.
+- Do not use it for other modules, SDKs, examples, docs, routine integration
+  tests, or merely because Temporal, workflow, signal, query, worker,
+  heartbeat, or `temporalIntegTests` is mentioned.
+- An explicit user request to use `temporal-developer` overrides this
+  restriction.
+
 ## Compatibility
 
 - The project has not launched. Remove dead config fields immediately.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,17 @@ Keep the Cursor (`.cursor/rules/`), Codex (`AGENTS.md`), and Claude
 (`CLAUDE.md`) coding-agent rules synchronized. Any addition or modification to
 one requires equivalent updates to all three in the same commit.
 
+### Temporal Skill Routing
+
+- In this repository, use the `temporal-developer` skill only when changing or
+  diagnosing `server/service/interpreter/**` requires Temporal runtime or SDK
+  semantics.
+- Do not use it for other modules, SDKs, examples, docs, routine integration
+  tests, or merely because Temporal, workflow, signal, query, worker,
+  heartbeat, or `temporalIntegTests` is mentioned.
+- An explicit user request to use `temporal-developer` overrides this
+  restriction.
+
 ### Regenerate the Entire Repository After Proto Changes
 
 Whenever any `.proto` file changes, run `make generated-code` from the repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,17 @@ Keep the Cursor (`.cursor/rules/`), Codex (`AGENTS.md`), and Claude
 (`CLAUDE.md`) coding-agent rules synchronized. Any addition or modification to
 one requires equivalent updates to all three in the same commit.
 
+## Temporal Skill Routing
+
+- In this repository, use the `temporal-developer` skill only when changing or
+  diagnosing `server/service/interpreter/**` requires Temporal runtime or SDK
+  semantics.
+- Do not use it for other modules, SDKs, examples, docs, routine integration
+  tests, or merely because Temporal, workflow, signal, query, worker,
+  heartbeat, or `temporalIntegTests` is mentioned.
+- An explicit user request to use `temporal-developer` overrides this
+  restriction.
+
 ## Compatibility
 
 - The project has not launched. Remove dead config fields immediately.


### PR DESCRIPTION
## Summary

- Limit implicit `temporal-developer` skill use to changes or diagnosis under `server/service/interpreter/**` that require Temporal runtime or SDK semantics.
- Prevent incidental Temporal terminology, routine integration tests, docs, examples, SDKs, and other modules from triggering the skill.
- Keep explicit user invocation available and synchronize the rule across Codex, Claude, and Cursor instructions.

## Rationale

The installed Temporal skill has broad trigger language. Dex uses Temporal-related terms throughout the repository, so unrelated work can select the skill unnecessarily. This rule narrows its project-specific routing without disabling the skill globally.

## User impact

Repository tasks outside the interpreter should no longer invoke the Temporal skill implicitly. Interpreter work that depends on Temporal behavior and explicit user requests remain supported.

## Validation

- `git diff --check origin/main...HEAD`
- Tests not run: agent-instruction-only change with no product or test code modifications.
