### PR TITLE
docs: move commit boundaries to primitives

### DIFF
--- a/docs/content/intro/what-is-dex.mdx
+++ b/docs/content/intro/what-is-dex.mdx
@@ -19,8 +19,6 @@ A **Step** can optionally **WaitFor** some condition (**Channel**, **Timer**, or
 
 **Execute** returns a decision for the next Steps or for completing the Flow. Within the Steps and RPCs, user code can read or write **Attributes**, and/or publish durable **Channel** messages as communication from external events or within threads of a Flow.
 
-Each **WaitFor**, **Execute**, and RPC invocation is a separate commit boundary. Dex Server stages its Attribute writes and Channel publications, then commits them together only after that method completes successfully. If the method fails, none of those changes are committed. **WaitFor** and **Execute** do not share a commit, and external API calls are outside this atomic boundary.
-
 ## Order processing as an example
 
 If you have not read [What is Durable Execution?](/intro/what-is-durable-execution), the example below is the order-processing flow from that page.

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -17,6 +17,8 @@ A **Client** invokes an RPC. **Dex Server** sends it to a **Worker**. The **Work
 
 RPC can read and write durable state through Attributes, publish Channels, and trigger a brand-new Step to run.
 
+Each RPC invocation is a commit boundary. Dex Server stages the Attribute writes and Channel publications from the RPC, then commits them together with the RPC result only after the method returns successfully. If the RPC fails, none of those durable changes are committed. External API calls are outside this atomic boundary.
+
 <SdkTabs
   examples={{
     python: 'examples/python/dex_examples/primitives/rpc',

--- a/docs/content/primitives/step/basic.mdx
+++ b/docs/content/primitives/step/basic.mdx
@@ -36,6 +36,8 @@ If a Step does not implement **WaitFor**, **Execute** runs immediately.
 
 **Execute** is required. It returns a **StepDecision** that moves to the next Step, branches to several Steps, or closes the Flow.
 
+Each **WaitFor** or **Execute** invocation is a separate commit boundary. Dex Server stages the Attribute writes and Channel publications from that method, then commits them with its **Wait** or **StepDecision** only after the method returns successfully. If the method fails, none of those durable changes are committed. **WaitFor** and **Execute** do not share a commit. External API calls are outside this atomic boundary.
+
 <StepWaitExecuteDiagram />
 
 <SdkTabs

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro/what-is-dex.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro/what-is-dex.mdx
@@ -19,8 +19,6 @@ Dex 是结构化编程，只有少数几个概念作为 [primitives](/primitives
 
 **Execute** 返回 decision，用来决定下一步或完成这条 Flow。在 Step 和 RPC 里，用户代码可以读写 **Attribute**，也可以 publish durable 的 **Channel** 消息，用来接外部事件，或在同一条 Flow 的线程之间通信。
 
-每次 **WaitFor**、**Execute** 和 RPC 调用都有独立的 commit 边界。Dex Server 会暂存一个 method 内的 Attribute 写入和 Channel publish，并只在该 method 成功完成后一起 commit。如果 method 失败，这些变更都不会被 commit。**WaitFor** 和 **Execute** 不共享一次 commit，外部 API 调用也不在这个原子边界内。
-
 ## 订单处理作为一个例子
 
 还没看过 [什么是 Durable Execution？](/intro/what-is-durable-execution) 的话，下面用那一页的 order-processing 例子。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -18,6 +18,8 @@ RPC 是 “Remote Procedure Call” 的缩写，允许外部系统与 Flow execu
 
 RPC 可以通过 Attribute 读取和写入 durable state、向 Channel publish，也可以 trigger 一个全新的 Step 来运行。
 
+每次 RPC 调用都是一个 commit 边界。Dex Server 会暂存 RPC 中的 Attribute 写入和 Channel publish，并只在 method 成功返回时，将它们与 RPC result 一起 commit。如果 RPC 失败，这些 durable 变更都不会被 commit。外部 API 调用不在这个原子边界内。
+
 <SdkTabs
   examples={{
     python: 'examples/python/dex_examples/primitives/rpc',

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
@@ -102,6 +102,8 @@ Step implementation 通常只有一个或两个小方法：**WaitFor** -> **Exec
 
 **Execute** 是必需的。它返回 **StepDecision**，用于流转到下一个 Step、分支到多个 Step，或关闭 Flow。
 
+每次 **WaitFor** 或 **Execute** 调用都有独立的 commit 边界。Dex Server 会暂存该 method 内的 Attribute 写入和 Channel publish，并只在 method 成功返回时，将它们与相应的 **Wait** 或 **StepDecision** 一起 commit。如果 method 失败，这些 durable 变更都不会被 commit。**WaitFor** 和 **Execute** 不共享一次 commit，外部 API 调用也不在这个原子边界内。
+
 <StepWaitExecuteDiagram />
 
 <SdkTabs


### PR DESCRIPTION
## Summary

- move durable method commit semantics from the introductory Why Dex page to the Step Basics and RPC Primitive pages
- document that WaitFor and Execute have separate commit boundaries
- document that Attribute writes and Channel publications from one successful Step or RPC method commit together
- keep English and Simplified Chinese documentation synchronized

## Rationale

Commit behavior is a primitive-level contract. Readers need it beside the Step and RPC APIs that define those handler boundaries, rather than in a high-level introduction.

## User impact

Application developers can determine when durable state becomes visible, avoid assuming WaitFor and Execute share a transaction, and keep external API calls idempotent or compensatable.

## Validation

- `npm run check` in `docs`
