### PR TITLE
Add Python SDK Step streaming

### DIFF
--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -790,7 +790,7 @@ fire-and-forget frame on the current Worker response stream, so it does not make
 a Worker-to-server FlowService call. One invocation may emit any number of
 messages to the same or different Streams. The server attempts them in order;
 write failures are observable only through server logs and metrics. Step frames
-use `runID#stepExecutionID` as source metadata. RPC writes are rejected.
+use `#stepExecutionID` as source metadata. RPC writes are rejected.
 
 `Client.WriteStream` accepts the exact registered Stream, Flow ID, non-empty
 source, and typed value. Sources may repeat and may contain `#`.

--- a/docs/design/plan/python-sdk-step-streaming.md
+++ b/docs/design/plan/python-sdk-step-streaming.md
@@ -1,0 +1,76 @@
+# Python SDK Step streaming
+
+## Handler contracts
+
+WorkerService WaitFor and Execute are unary-request/server-streaming RPCs. Python
+keeps different application shapes for its synchronous and asynchronous runtimes.
+
+A synchronous Step may return its final Wait or StepDecision directly. A handler
+that emits progress instead declares `Generator[StepOutput, None, Wait]` or
+`Generator[StepOutput, None, StepDecision]`. It yields only values created by
+`heartbeat(...)` or `Stream.write(...)`, then returns the final result through
+`StopIteration.value`. Yielding a final result, yielding another object, or ending
+without a correctly typed return is an invalid Step result.
+
+The sync Worker iterates the application generator on its existing gRPC worker
+thread. A yielded frame is sent before the generator resumes. A bare Stream.write
+call does not emit anything because sync gRPC has no public write method; application
+code must yield the returned StepOutput. This avoids a second per-invocation thread.
+
+An asynchronous Step remains a normal coroutine returning Wait or StepDecision. It
+annotates AsyncContext, calls Stream.write synchronously to enqueue a frame, and
+awaits `context.heartbeat(...)`. Async generators are rejected. Async RPC and Flow
+timeout handlers continue to use Context because neither API emits Step progress.
+
+## Output ordering and cancellation
+
+Each async invocation owns one unbounded asyncio queue. Stream.write uses
+`put_nowait`; heartbeat encodes its value, enqueues it, and yields once to the event
+loop. The service drains frames in call order. After the handler completes, it drains
+already-enqueued progress, writes exactly one result frame, and closes the response.
+No SDK output waits for a Dex Stream Store acknowledgement.
+
+Canceling an async Worker stream closes its emitter and cancels the handler task.
+Later Stream.write calls are discarded; heartbeat observes task cancellation. Sync
+handler cancellation remains cooperative. Closing the gRPC iterator closes the
+application generator, and long-running sync code checks Context cancellation at
+natural boundaries.
+
+## Heartbeat values
+
+`heartbeat()` and `await context.heartbeat()` emit a heartbeat with no Value. This
+explicitly clears previously persisted heartbeat details. Passing any argument,
+including Python `None`, emits a present Value encoded through the Registry codec
+configuration.
+
+Context exposes `has_last_heartbeat_value()` and
+`get_last_heartbeat_value(ExpectedType)`. The presence method distinguishes no
+details from a persisted Python `None`. The getter returns `None` when details are
+absent and otherwise decodes with the requested Flow codec. A Stream frame remains
+an implicit server heartbeat and preserves the latest explicit heartbeat state.
+Local activities ignore heartbeat frames and do not pass their values to fallback.
+
+## Stream writes and source
+
+Step Stream writes contain only Stream name, capacity, and encoded Value. The SDK no
+longer calls FlowService WriteStream from a Step and no longer limits one write per
+Stream. Dex assigns `#<stepExecutionID>` as source metadata. Repeated source values
+append independently.
+
+Client and AsyncClient WriteStream remain acknowledged unary calls. Their public
+parameter and StreamMessage field are named `source`. Source is required, may contain
+`#`, and has no idempotency semantics.
+
+## Validation and defaults
+
+Registry requires exact generator annotations for synchronous progress handlers and
+AsyncContext for coroutine Step handlers. Ordinary sync handlers remain valid in an
+AsyncWorker, but sync generators require Worker. RPC and Flow timeout Contexts reject
+heartbeat and Stream output.
+
+The SDK sends unset options to the server. Server defaults are synchronous Step
+durability, four hours of total retry duration, two-hour regular attempts, and a
+one-minute regular heartbeat timeout. Explicit heartbeat timeout values use the
+server-configured minimum, which defaults to ten seconds. Async durability uses at
+most three local attempts in seven seconds before regular fallback; local execution
+ignores method and heartbeat timeouts.

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -13,6 +13,7 @@ the shared Rust Core is used only for BlobCache.
 
 ```python
 from datetime import timedelta
+from typing import Generator
 
 import dex
 
@@ -30,8 +31,9 @@ class Run(dex.Step[str]):
 
     def execute(
         self, context: dex.Context, input: str
-    ) -> dex.StepDecision:
-        progress.write(context, "running")
+    ) -> Generator[dex.StepOutput, None, dex.StepDecision]:
+        yield progress.write(context, "running")
+        yield dex.heartbeat({"phase": "running"})
         return dex.graceful_complete(input)
 
 class CounterFlow(dex.Flow[str]):
@@ -111,9 +113,10 @@ Applications implement two generic interfaces from [`dex`](dex/):
   binds the Flow input to the starting Step input. Use `StepList.empty()` when
   a Flow has no Steps.
 - `Step[INPUT]` implements `execute` and optionally `wait_for`. The default
-  Worker path requires synchronous handlers. With `AsyncWorker` and
-  `Registry(..., allow_async_handlers=True)`, handlers may be `async def` and
-  `await` an `AsyncClient`.
+  Worker accepts ordinary synchronous handlers and generator handlers. A generator
+  yields `StepOutput` progress frames and returns its final `Wait` or `StepDecision`.
+  With `AsyncWorker` and `Registry(..., allow_async_handlers=True)`, Step
+  coroutines use `AsyncContext`; async RPCs keep `Context`.
 
 `StepOptions.wait_for_method_timeout` and `execute_method_timeout` bound the
 two handler calls. Timer and channel conditions determine how long a Step waits.
@@ -123,6 +126,58 @@ two handler calls. Timer and channel conditions determine how long a Step waits.
 attempts, total duration, and 1-based attempt numbers. Fallback starts
 immediately; later regular retries continue the backoff sequence at the
 cumulative attempt.
+
+The default Step durability is synchronous. A Flow configuration can select
+asynchronous durability, and a Step method override has highest precedence. The
+default retry total duration is four hours. Regular attempts default to a two-hour
+method timeout and one-minute heartbeat timeout; an explicit heartbeat timeout must
+meet the server minimum, which defaults to ten seconds. Asynchronous durability
+first allows at most three local attempts in seven seconds. The local phase ignores
+method timeouts and heartbeat frames before falling back to a regular activity.
+
+### Step progress and heartbeat recovery
+
+A synchronous handler yields every heartbeat and Stream write. The generator return
+value is the only final result:
+
+```python
+def execute(
+    self, context: dex.Context, input: str
+) -> Generator[dex.StepOutput, None, dex.StepDecision]:
+    yield dex.heartbeat({"offset": 10})
+    yield progress.write(context, "processed 10 items")
+    return dex.graceful_complete(input)
+```
+
+An asynchronous handler keeps its normal coroutine return. Stream writes enqueue
+without waiting for Stream Store acknowledgement; heartbeat waits only for the
+Worker output queue:
+
+```python
+async def execute(
+    self, context: dex.AsyncContext, input: str
+) -> dex.StepDecision:
+    progress.write(context, "started")
+    await context.heartbeat({"offset": 10})
+    return dex.graceful_complete(input)
+```
+
+Call `heartbeat()` or `await context.heartbeat()` without a value to clear previous
+details. Passing Python `None` persists a present null Value. On a later regular
+attempt, use `context.has_last_heartbeat_value()` before decoding with
+`context.get_last_heartbeat_value(ExpectedType)`. A Stream frame is also an implicit
+heartbeat, but it preserves the latest explicit heartbeat state.
+
+A Step may write the same Stream any number of times. Dex assigns
+`#<stepExecutionID>` as each Step message's `StreamMessage.source`. Client writes
+provide their own non-empty source; duplicate sources and `#` are allowed and every
+write appends:
+
+```python
+client.write_stream(flow_id, progress, "frontend#preview", "rendering")
+message = client.read_stream(flow_id, progress)
+print(message.source)
+```
 
 ### Canceling Step executions
 
@@ -257,14 +312,14 @@ serialization, and invalid handler returns use `FlowDefinitionError`,
 ### Sync vs asyncio
 
 - **Sync (default):** `Client` and `Worker` use blocking gRPC and a thread-pool
-  Worker. Blocking `Client` calls inside `Step.execute` are safe (one pool
-  thread is occupied; other RPCs still run).
+  Worker. A progress generator cooperatively hands each yielded frame to gRPC;
+  `Stream.write` must therefore be yielded. Blocking Client calls inside
+  `Step.execute` are safe while other pool threads remain available.
 - **Asyncio:** `AsyncClient` and `AsyncWorker` use `grpc.aio`. Use
   `Registry(..., allow_async_handlers=True)` when Steps/RPCs are coroutines.
-  Inside async `execute`, inject `AsyncClient` — do not call sync `Client` on
-  the Worker event loop. Sync `Worker` still rejects coroutine handlers at
-  registry construction unless `allow_async_handlers=True` (and even then the
-  sync Worker dispatcher rejects awaitable return values).
+  Step coroutines annotate `AsyncContext`, call `Stream.write` without `await`,
+  and await `context.heartbeat`. Inside async `execute`, inject `AsyncClient` —
+  do not call sync `Client` on the Worker event loop. Async generators are rejected.
 
 Integration scenarios live under
 [`tests/integ`](tests/integ/README.md). They exercise the same workflows,
@@ -277,7 +332,8 @@ The strongly typed contracts, registry, synchronous Client/Worker, optional
 `AsyncClient`/`AsyncWorker` (`grpc.aio`), and Rust-backed BlobCache are
 implemented. Python owns its gRPC transport; the native bridge is limited to
 the shared BlobCache. Design notes:
-[`docs/design/plan/python-sdk-async-apis.md`](../docs/design/plan/python-sdk-async-apis.md).
+[`python-sdk-async-apis.md`](../docs/design/plan/python-sdk-async-apis.md) and
+[`python-sdk-step-streaming.md`](../docs/design/plan/python-sdk-step-streaming.md).
 
 ## Running Dex locally
 

--- a/sdk-python/dex/__init__.py
+++ b/sdk-python/dex/__init__.py
@@ -35,7 +35,7 @@ from dex.codec import (
     WireKind,
 )
 from dex.condition import ConditionCombination
-from dex.context import Context
+from dex.context import AsyncContext, Context
 from dex.flow import Flow, PersistenceSchema, Registry, RPCResult, rpc
 from dex.flow_config import ActiveStepSearchMode, FlowConfig
 from dex.flow_info import (
@@ -80,6 +80,7 @@ from dex.step import (
     StepList,
     StepMovement,
     StepOptions,
+    StepOutput,
     WaitForFailurePolicy,
     dead_end,
     force_complete,
@@ -88,6 +89,7 @@ from dex.step import (
     go_to,
     go_to_many,
     graceful_complete,
+    heartbeat,
 )
 from dex.step_execution import StepExecutionId, TimerId
 from dex.stream import Stream, StreamMessage
@@ -108,6 +110,7 @@ __all__ = [
     "AttributeIndex",
     "AttributeLock",
     "AttributeMap",
+    "AsyncContext",
     "AsyncClient",
     "AsyncWorker",
     "BlobCache",
@@ -161,6 +164,7 @@ __all__ = [
     "StepList",
     "StepDurability",
     "StepMovement",
+    "StepOutput",
     "StepOptions",
     "Stream",
     "StreamMessage",
@@ -182,6 +186,7 @@ __all__ = [
     "force_complete_if_channels_empty",
     "force_fail",
     "graceful_complete",
+    "heartbeat",
     "go_to",
     "go_to_many",
     "open_blob_cache",

--- a/sdk-python/dex/_async_value_hydrator.py
+++ b/sdk-python/dex/_async_value_hydrator.py
@@ -75,10 +75,16 @@ class AsyncValueHydrator:
     ) -> pb.InvokeWaitForMethodRequest:
         result = pb.InvokeWaitForMethodRequest()
         result.CopyFrom(request)
-        values = [request.step_input, *(entry.value for entry in request.attributes)]
-        hydrated = await self.hydrate_all(values)
-        result.step_input.CopyFrom(hydrated[0])
-        for entry, value in zip(result.attributes, hydrated[1:]):
+        has_heartbeat = request.context.HasField("last_heartbeat_value")
+        values = [request.step_input]
+        if has_heartbeat:
+            values.append(request.context.last_heartbeat_value)
+        values.extend(entry.value for entry in request.attributes)
+        hydrated = iter(await self.hydrate_all(values))
+        result.step_input.CopyFrom(next(hydrated))
+        if has_heartbeat:
+            result.context.last_heartbeat_value.CopyFrom(next(hydrated))
+        for entry, value in zip(result.attributes, hydrated):
             entry.value.CopyFrom(value)
         return result
 
@@ -89,7 +95,10 @@ class AsyncValueHydrator:
         result = pb.InvokeExecuteMethodRequest()
         result.CopyFrom(request)
         has_step_input = request.HasField("step_input")
+        has_heartbeat = request.context.HasField("last_heartbeat_value")
         values = [request.step_input] if has_step_input else []
+        if has_heartbeat:
+            values.append(request.context.last_heartbeat_value)
         values.extend(entry.value for entry in request.attributes)
         values.extend(entry.value for entry in request.step_exe_locals)
         for channel_result in request.condition_results.channel_results:
@@ -97,6 +106,8 @@ class AsyncValueHydrator:
         hydrated = iter(await self.hydrate_all(values))
         if has_step_input:
             result.step_input.CopyFrom(next(hydrated))
+        if has_heartbeat:
+            result.context.last_heartbeat_value.CopyFrom(next(hydrated))
         for entry in result.attributes:
             entry.value.CopyFrom(next(hydrated))
         for entry in result.step_exe_locals:

--- a/sdk-python/dex/_async_worker_dispatcher.py
+++ b/sdk-python/dex/_async_worker_dispatcher.py
@@ -8,7 +8,10 @@
 
 from __future__ import annotations
 
-from inspect import isawaitable
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import suppress
+from inspect import isawaitable, isgenerator
 from typing import Any, Callable
 
 from dex._async_value_hydrator import AsyncValueHydrator
@@ -18,8 +21,30 @@ from dex._worker_dispatcher import _TIMEOUT_HANDLER_STEP_TYPE, WorkerDispatcher
 from dex.dexpb import dex_pb2 as pb
 from dex.flow import Registry, RPCResult
 from dex.runtime_errors import InvalidStepResultError, ValueMappingError
-from dex.step import StepDecision
+from dex.step import StepDecision, StepOutput
 from dex.wait import Wait
+
+
+class _AsyncStepOutputEmitter:
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue[StepOutput] = asyncio.Queue()
+        self._is_closed = False
+
+    def emit_nowait(self, output: StepOutput) -> None:
+        if self._is_closed:
+            return
+        self.queue.put_nowait(output)
+
+    async def emit(self, output: StepOutput) -> None:
+        if self._is_closed:
+            raise asyncio.CancelledError
+        self.queue.put_nowait(output)
+        await asyncio.sleep(0)
+        if self._is_closed:
+            raise asyncio.CancelledError
+
+    def close(self) -> None:
+        self._is_closed = True
 
 
 class AsyncWorkerDispatcher(WorkerDispatcher):
@@ -28,17 +53,32 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
         registry: Registry,
         values: ValueMapper,
         hydrator: AsyncValueHydrator,
-        stream_writer: Callable[[pb.WriteStreamRequest], Any],
     ) -> None:
         self._registry = registry
         self._values = values
         self._async_hydrator = hydrator
-        self._stream_writer = stream_writer
 
     async def invoke_wait_for(  # type: ignore[override]
         self,
         original: pb.InvokeWaitForMethodRequest,
         is_active: Callable[[], bool] | None = None,
+    ) -> AsyncGenerator[pb.InvokeWaitForMethodOutput, None]:
+        emitter = _AsyncStepOutputEmitter()
+        handler = asyncio.create_task(
+            self._invoke_wait_for_result(original, emitter, is_active)
+        )
+        try:
+            async for output in self._drain_outputs(emitter, handler):
+                yield self._map_wait_for_output(output)
+            yield pb.InvokeWaitForMethodOutput(result=await handler)
+        finally:
+            await self._close_invocation(emitter, handler)
+
+    async def _invoke_wait_for_result(
+        self,
+        original: pb.InvokeWaitForMethodRequest,
+        emitter: _AsyncStepOutputEmitter,
+        is_active: Callable[[], bool] | None,
     ) -> pb.InvokeWaitForMethodResponse:
         request = await self._async_hydrator.wait_for_request(original)
         flow = self._registry._flow_by_type(request.flow_type)
@@ -48,12 +88,20 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             flow,
             request.context,
             self._values,
-            self._stream_writer,
             request.attributes,
             is_active=is_active,
+            output_emitter=emitter,
         )
         input = self._values.decode(request.step_input, step.input_codec)
         wait = step.step.wait_for(context, input)
+        if isgenerator(wait):
+            wait.close()
+            raise InvalidStepResultError(
+                flow.name,
+                step.name,
+                "wait_for",
+                "synchronous generators require Worker",
+            )
         if isawaitable(wait):
             wait = await wait
         try:
@@ -78,11 +126,30 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
         self,
         original: pb.InvokeExecuteMethodRequest,
         is_active: Callable[[], bool] | None = None,
+    ) -> AsyncGenerator[pb.InvokeExecuteMethodOutput, None]:
+        if original.step_type == _TIMEOUT_HANDLER_STEP_TYPE:
+            response = await self._invoke_timeout_handler_async(original)
+            yield pb.InvokeExecuteMethodOutput(result=response)
+            return
+        emitter = _AsyncStepOutputEmitter()
+        handler = asyncio.create_task(
+            self._invoke_execute_result(original, emitter, is_active)
+        )
+        try:
+            async for output in self._drain_outputs(emitter, handler):
+                yield self._map_execute_output(output)
+            yield pb.InvokeExecuteMethodOutput(result=await handler)
+        finally:
+            await self._close_invocation(emitter, handler)
+
+    async def _invoke_execute_result(
+        self,
+        original: pb.InvokeExecuteMethodRequest,
+        emitter: _AsyncStepOutputEmitter,
+        is_active: Callable[[], bool] | None,
     ) -> pb.InvokeExecuteMethodResponse:
         request = await self._async_hydrator.execute_request(original)
         flow = self._registry._flow_by_type(request.flow_type)
-        if request.step_type == _TIMEOUT_HANDLER_STEP_TYPE:
-            return await self._invoke_timeout_handler_async(request, flow)
         step = flow.step(request.step_type)
         condition_results = (
             request.condition_results if request.HasField("condition_results") else None
@@ -92,14 +159,22 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             flow,
             request.context,
             self._values,
-            self._stream_writer,
             request.attributes,
             request.step_exe_locals,
             condition_results,
             is_active=is_active,
+            output_emitter=emitter,
         )
         input = self._values.decode(request.step_input, step.input_codec)
         decision: Any = step.step.execute(context, input)
+        if isgenerator(decision):
+            decision.close()
+            raise InvalidStepResultError(
+                flow.name,
+                step.name,
+                "execute",
+                "synchronous generators require Worker",
+            )
         if isawaitable(decision):
             decision = await decision
         try:
@@ -119,9 +194,10 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
 
     async def _invoke_timeout_handler_async(
         self,
-        request: pb.InvokeExecuteMethodRequest,
-        flow: Any,
+        original: pb.InvokeExecuteMethodRequest,
     ) -> pb.InvokeExecuteMethodResponse:
+        request = await self._async_hydrator.execute_request(original)
+        flow = self._registry._flow_by_type(request.flow_type)
         if request.HasField("step_input"):
             raise InvalidStepResultError(
                 flow.name, _TIMEOUT_HANDLER_STEP_TYPE, "execute", "input must be absent"
@@ -137,11 +213,10 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             request.condition_results if request.HasField("condition_results") else None
         )
         context = InvocationContext(
-            InvocationMethod.EXECUTE,
+            InvocationMethod.TIMEOUT,
             flow,
             request.context,
             self._values,
-            self._stream_writer,
             request.attributes,
             request.step_exe_locals,
             condition_results,
@@ -177,7 +252,6 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             flow,
             request.context,
             self._values,
-            self._stream_writer,
             request.attributes,
             channel_infos=dict(request.channel_infos),
             is_active=is_active,
@@ -218,3 +292,38 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             raise
         except (TypeError, ValueError) as error:
             raise InvalidStepResultError(flow.name, None, "rpc", str(error)) from error
+
+    async def _drain_outputs(
+        self,
+        emitter: _AsyncStepOutputEmitter,
+        handler: asyncio.Task[Any],
+    ) -> AsyncIterator[StepOutput]:
+        while not handler.done() or not emitter.queue.empty():
+            if not emitter.queue.empty():
+                yield emitter.queue.get_nowait()
+                continue
+            output = asyncio.create_task(emitter.queue.get())
+            try:
+                done, _ = await asyncio.wait(
+                    (handler, output),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if output in done:
+                    yield output.result()
+            finally:
+                if not output.done():
+                    output.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await output
+
+    async def _close_invocation(
+        self,
+        emitter: _AsyncStepOutputEmitter,
+        handler: asyncio.Task[Any],
+    ) -> None:
+        emitter.close()
+        if handler.done():
+            return
+        handler.cancel()
+        with suppress(asyncio.CancelledError):
+            await handler

--- a/sdk-python/dex/_async_worker_service.py
+++ b/sdk-python/dex/_async_worker_service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 from asyncio import CancelledError, current_task
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any, TypeVar
 
 import grpc
@@ -33,30 +33,32 @@ class AsyncWorkerService(dex_pb2_grpc.WorkerServiceServicer):
         request: pb.InvokeWaitForMethodRequest,
         context: grpc.aio.ServicerContext[
             pb.InvokeWaitForMethodRequest,
-            pb.InvokeWaitForMethodResponse,
+            pb.InvokeWaitForMethodOutput,
         ],
-    ) -> pb.InvokeWaitForMethodResponse:
-        return await self._invoke(
+    ) -> AsyncIterator[pb.InvokeWaitForMethodOutput]:
+        async for output in self._invoke_stream(
             context,
             lambda: self._dispatcher.invoke_wait_for(
                 request, lambda: self._is_active(context)
             ),
-        )
+        ):
+            yield output
 
     async def InvokeExecuteMethod(
         self,
         request: pb.InvokeExecuteMethodRequest,
         context: grpc.aio.ServicerContext[
             pb.InvokeExecuteMethodRequest,
-            pb.InvokeExecuteMethodResponse,
+            pb.InvokeExecuteMethodOutput,
         ],
-    ) -> pb.InvokeExecuteMethodResponse:
-        return await self._invoke(
+    ) -> AsyncIterator[pb.InvokeExecuteMethodOutput]:
+        async for output in self._invoke_stream(
             context,
             lambda: self._dispatcher.invoke_execute(
                 request, lambda: self._is_active(context)
             ),
-        )
+        ):
+            yield output
 
     async def InvokeWorkerRPC(
         self,
@@ -85,6 +87,28 @@ class AsyncWorkerService(dex_pb2_grpc.WorkerServiceServicer):
     ) -> ResponseT:
         try:
             return await invocation()
+        except CancelledError:
+            raise
+        except BaseException as error:
+            if not AsyncWorkerService._is_active(context):
+                await context.abort(
+                    grpc.StatusCode.CANCELLED,
+                    "Python AsyncWorker invocation canceled",
+                )
+            _LOGGER.exception("Python AsyncWorker invocation failed")
+            await async_abort_worker_error(context, error)
+            raise RuntimeError("gRPC abort returned unexpectedly") from error
+
+    @staticmethod
+    async def _invoke_stream(
+        context: grpc.aio.ServicerContext[Any, Any],
+        invocation: Callable[[], AsyncIterator[ResponseT]],
+    ) -> AsyncIterator[ResponseT]:
+        try:
+            async for response in invocation():
+                yield response
+        except GeneratorExit:
+            raise
         except CancelledError:
             raise
         except BaseException as error:

--- a/sdk-python/dex/_invocation_context.py
+++ b/sdk-python/dex/_invocation_context.py
@@ -9,8 +9,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from inspect import isawaitable
-from typing import Any, Callable, Sequence, TypeVar, cast
+from typing import Any, Callable, Protocol, Sequence, TypeVar, cast
 from urllib.parse import unquote
 
 from dex._utils import require_name
@@ -21,6 +20,12 @@ from dex.codec import Codec
 from dex.dexpb import dex_pb2 as pb
 from dex.flow import Registry, _RegisteredFlow
 from dex.flow_result import FlowResult, flow_result_from_proto
+from dex.step import (
+    _NO_HEARTBEAT_VALUE,
+    StepOutput,
+    _HeartbeatStepOutput,
+    _StreamStepOutput,
+)
 from dex.stream import Stream
 
 ValueT = TypeVar("ValueT")
@@ -33,6 +38,13 @@ class InvocationMethod(Enum):
     WAIT_FOR = "wait_for"
     EXECUTE = "execute"
     RPC = "rpc"
+    TIMEOUT = "timeout"
+
+
+class _StepOutputEmitter(Protocol):
+    def emit_nowait(self, output: StepOutput) -> None: ...
+
+    async def emit(self, output: StepOutput) -> None: ...
 
 
 class InvocationContext:
@@ -42,29 +54,28 @@ class InvocationContext:
         flow: _RegisteredFlow,
         metadata: pb.Context,
         values: ValueMapper,
-        stream_writer: Callable[[pb.WriteStreamRequest], Any],
         attributes: Sequence[pb.KV],
         locals: Sequence[pb.KV] = (),
         condition_results: pb.ConditionResults | None = None,
         channel_infos: dict[str, pb.ChannelInfo] | None = None,
         is_active: Callable[[], bool] | None = None,
+        output_emitter: _StepOutputEmitter | None = None,
     ) -> None:
         self._method = method
         self._flow = flow
         self._metadata = metadata
         self._values = values
-        self._stream_writer = stream_writer
         self._attributes = self._map_values("Attribute", attributes)
         self._locals = self._map_values("step-execution local", locals)
         self._condition_results = condition_results
         self._channel_infos = dict(channel_infos or {})
         self._is_active = is_active or _always_active
+        self._output_emitter = output_emitter
         self.attribute_writes: dict[str, pb.AttributeWrite] = {}
         self.local_writes: dict[str, pb.KV] = {}
         self.events: list[pb.KV] = []
         self.publications: list[pb.ChannelMessage] = []
         self._event_names: set[str] = set()
-        self._stream_writes: set[int] = set()
 
     @property
     def flow_id(self) -> str:
@@ -85,6 +96,35 @@ class InvocationContext:
     @property
     def attempt(self) -> int:
         return self._metadata.attempt
+
+    def has_last_heartbeat_value(self) -> bool:
+        return self._metadata.HasField("last_heartbeat_value")
+
+    def get_last_heartbeat_value(
+        self,
+        value_type: type[ValueT],
+    ) -> ValueT | None:
+        if not self.has_last_heartbeat_value():
+            return None
+        return cast(
+            ValueT,
+            self._values.decode(
+                self._metadata.last_heartbeat_value,
+                self._flow_codec(value_type),
+            ),
+        )
+
+    async def heartbeat(self, value: object = _NO_HEARTBEAT_VALUE) -> None:
+        if (
+            self._method not in (InvocationMethod.WAIT_FOR, InvocationMethod.EXECUTE)
+            or self._output_emitter is None
+        ):
+            raise ValueError("heartbeat requires an asynchronous Step Context")
+        has_value = value is not _NO_HEARTBEAT_VALUE
+        encoded_value = self._values.encode_dynamic(value) if has_value else None
+        await self._output_emitter.emit(
+            _HeartbeatStepOutput(has_value, value, encoded_value)
+        )
 
     def has_timer_fired(self, index: int | None = None) -> bool:
         if self._condition_results is None:
@@ -162,43 +202,24 @@ class InvocationContext:
         self,
         definition: Stream[ValueT],
         value: ValueT,
-    ) -> Any:
-        if self._method is InvocationMethod.RPC:
+    ) -> StepOutput | None:
+        if self._method not in (InvocationMethod.WAIT_FOR, InvocationMethod.EXECUTE):
             raise ValueError("Stream writes require a Step Context")
         self._require_registered(definition)
-        identity = id(definition)
-        if identity in self._stream_writes:
-            raise ValueError(
-                f"Stream {definition.name} was already written by this Step execution"
+        output = _StreamStepOutput(
+            pb.StepStreamWrite(
+                stream_name=definition.name,
+                stream_capacity_bytes=definition.stream_capacity_bytes,
+                value=self._values.encode(
+                    value,
+                    self._values.codec(definition.value_type),
+                ),
             )
-        request = pb.WriteStreamRequest(
-            flow_id=self.flow_id,
-            flow_type=self._flow.name,
-            stream_name=definition.name,
-            stream_capacity_bytes=definition.stream_capacity_bytes,
-            value=self._values.encode(
-                value,
-                self._values.codec(definition.value_type),
-            ),
-            idempotency_key=f"{self.run_id}#{self.step_execution_id}",
         )
-        result = self._stream_writer(request)
-        if isawaitable(result):
-            self._stream_writes.add(identity)
-            return self._finish_async_stream_write(result, identity)
-        self._stream_writes.add(identity)
+        if self._output_emitter is None:
+            return output
+        self._output_emitter.emit_nowait(output)
         return None
-
-    async def _finish_async_stream_write(
-        self,
-        result: Any,
-        identity: int,
-    ) -> None:
-        try:
-            await result
-        except BaseException:
-            self._stream_writes.remove(identity)
-            raise
 
     def _get_attribute(
         self,

--- a/sdk-python/dex/_value_hydrator.py
+++ b/sdk-python/dex/_value_hydrator.py
@@ -75,10 +75,16 @@ class ValueHydrator:
     ) -> pb.InvokeWaitForMethodRequest:
         result = pb.InvokeWaitForMethodRequest()
         result.CopyFrom(request)
-        values = [request.step_input, *(entry.value for entry in request.attributes)]
-        hydrated = self.hydrate_all(values)
-        result.step_input.CopyFrom(hydrated[0])
-        for entry, value in zip(result.attributes, hydrated[1:]):
+        has_heartbeat = request.context.HasField("last_heartbeat_value")
+        values = [request.step_input]
+        if has_heartbeat:
+            values.append(request.context.last_heartbeat_value)
+        values.extend(entry.value for entry in request.attributes)
+        hydrated = iter(self.hydrate_all(values))
+        result.step_input.CopyFrom(next(hydrated))
+        if has_heartbeat:
+            result.context.last_heartbeat_value.CopyFrom(next(hydrated))
+        for entry, value in zip(result.attributes, hydrated):
             entry.value.CopyFrom(value)
         return result
 
@@ -89,7 +95,10 @@ class ValueHydrator:
         result = pb.InvokeExecuteMethodRequest()
         result.CopyFrom(request)
         has_step_input = request.HasField("step_input")
+        has_heartbeat = request.context.HasField("last_heartbeat_value")
         values = [request.step_input] if has_step_input else []
+        if has_heartbeat:
+            values.append(request.context.last_heartbeat_value)
         values.extend(entry.value for entry in request.attributes)
         values.extend(entry.value for entry in request.step_exe_locals)
         for channel_result in request.condition_results.channel_results:
@@ -101,6 +110,8 @@ class ValueHydrator:
         hydrated = iter(self.hydrate_all(values))
         if has_step_input:
             result.step_input.CopyFrom(next(hydrated))
+        if has_heartbeat:
+            result.context.last_heartbeat_value.CopyFrom(next(hydrated))
         for entry in result.attributes:
             entry.value.CopyFrom(next(hydrated))
         for entry in result.step_exe_locals:

--- a/sdk-python/dex/_worker_dispatcher.py
+++ b/sdk-python/dex/_worker_dispatcher.py
@@ -9,8 +9,8 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from inspect import isawaitable
-from typing import Any, Callable, cast
+from inspect import isawaitable, isgenerator
+from typing import Any, Callable, Generator, cast
 
 from dex._invocation_context import InvocationContext, InvocationMethod
 from dex._value_hydrator import ValueHydrator
@@ -36,7 +36,10 @@ from dex.step import (
     StepDurability,
     StepMovement,
     StepOptions,
+    StepOutput,
     WaitForFailurePolicy,
+    _HeartbeatStepOutput,
+    _StreamStepOutput,
 )
 from dex.wait import Wait, WaitKind
 
@@ -49,18 +52,16 @@ class WorkerDispatcher:
         registry: Registry,
         values: ValueMapper,
         hydrator: ValueHydrator,
-        stream_writer: Callable[[pb.WriteStreamRequest], Any],
     ) -> None:
         self._registry = registry
         self._values = values
         self._hydrator = hydrator
-        self._stream_writer = stream_writer
 
     def invoke_wait_for(
         self,
         original: pb.InvokeWaitForMethodRequest,
         is_active: Callable[[], bool] | None = None,
-    ) -> pb.InvokeWaitForMethodResponse:
+    ) -> Generator[pb.InvokeWaitForMethodOutput, None, None]:
         request = self._hydrator.wait_for_request(original)
         flow = self._registry._flow_by_type(request.flow_type)
         step = flow.step(request.step_type)
@@ -69,17 +70,21 @@ class WorkerDispatcher:
             flow,
             request.context,
             self._values,
-            self._stream_writer,
             request.attributes,
             is_active=is_active,
         )
         input = self._values.decode(request.step_input, step.input_codec)
         wait = step.step.wait_for(context, input)
+        if isawaitable(wait):
+            raise InvalidStepResultError(
+                flow.name,
+                step.name,
+                "wait_for",
+                "wait_for returned an awaitable; use AsyncWorker for async handlers",
+            )
+        if isgenerator(wait):
+            wait = yield from self._wait_for_generator(flow, step, wait)
         try:
-            if isawaitable(wait):
-                raise TypeError(
-                    "wait_for returned an awaitable; use AsyncWorker for async handlers"
-                )
             if not isinstance(wait, Wait):
                 raise TypeError("wait_for must return Wait")
             response = pb.InvokeWaitForMethodResponse(
@@ -91,7 +96,7 @@ class WorkerDispatcher:
             waiting = self._map_wait(flow, wait)
             if waiting is not None:
                 response.waiting_condition.CopyFrom(waiting)
-            return response
+            yield pb.InvokeWaitForMethodOutput(result=response)
         except (TypeError, ValueError) as error:
             raise InvalidStepResultError(
                 flow.name, step.name, "wait_for", str(error)
@@ -101,11 +106,14 @@ class WorkerDispatcher:
         self,
         original: pb.InvokeExecuteMethodRequest,
         is_active: Callable[[], bool] | None = None,
-    ) -> pb.InvokeExecuteMethodResponse:
+    ) -> Generator[pb.InvokeExecuteMethodOutput, None, None]:
         request = self._hydrator.execute_request(original)
         flow = self._registry._flow_by_type(request.flow_type)
         if request.step_type == _TIMEOUT_HANDLER_STEP_TYPE:
-            return self._invoke_timeout_handler(request, flow)
+            yield pb.InvokeExecuteMethodOutput(
+                result=self._invoke_timeout_handler(request, flow)
+            )
+            return
         step = flow.step(request.step_type)
         condition_results = (
             request.condition_results if request.HasField("condition_results") else None
@@ -115,7 +123,6 @@ class WorkerDispatcher:
             flow,
             request.context,
             self._values,
-            self._stream_writer,
             request.attributes,
             request.step_exe_locals,
             condition_results,
@@ -123,19 +130,26 @@ class WorkerDispatcher:
         )
         input = self._values.decode(request.step_input, step.input_codec)
         decision = step.step.execute(context, input)
+        if isawaitable(decision):
+            raise InvalidStepResultError(
+                flow.name,
+                step.name,
+                "execute",
+                "execute returned an awaitable; use AsyncWorker for async handlers",
+            )
+        if isgenerator(decision):
+            decision = yield from self._execute_generator(flow, step, decision)
         try:
-            if isawaitable(decision):
-                raise TypeError(
-                    "execute returned an awaitable; use AsyncWorker for async handlers"
-                )
             if not isinstance(decision, StepDecision):
                 raise TypeError("execute must return StepDecision")
-            return pb.InvokeExecuteMethodResponse(
-                step_decision=self._map_decision(flow, decision),
-                upsert_attributes=list(context.attribute_writes.values()),
-                record_events=context.events,
-                upsert_step_exe_locals=list(context.local_writes.values()),
-                publish_to_channel=context.publications,
+            yield pb.InvokeExecuteMethodOutput(
+                result=pb.InvokeExecuteMethodResponse(
+                    step_decision=self._map_decision(flow, decision),
+                    upsert_attributes=list(context.attribute_writes.values()),
+                    record_events=context.events,
+                    upsert_step_exe_locals=list(context.local_writes.values()),
+                    publish_to_channel=context.publications,
+                )
             )
         except (TypeError, ValueError) as error:
             raise InvalidStepResultError(
@@ -162,11 +176,10 @@ class WorkerDispatcher:
             request.condition_results if request.HasField("condition_results") else None
         )
         context = InvocationContext(
-            InvocationMethod.EXECUTE,
+            InvocationMethod.TIMEOUT,
             flow,
             request.context,
             self._values,
-            self._stream_writer,
             request.attributes,
             request.step_exe_locals,
             condition_results,
@@ -204,7 +217,6 @@ class WorkerDispatcher:
             flow,
             request.context,
             self._values,
-            self._stream_writer,
             request.attributes,
             channel_infos=dict(request.channel_infos),
             is_active=is_active,
@@ -247,6 +259,77 @@ class WorkerDispatcher:
             raise
         except (TypeError, ValueError) as error:
             raise InvalidStepResultError(flow.name, None, "rpc", str(error)) from error
+
+    def _wait_for_generator(
+        self,
+        flow: _RegisteredFlow,
+        step: _RegisteredStep,
+        outputs: Generator[Any, None, Any],
+    ) -> Generator[pb.InvokeWaitForMethodOutput, None, Any]:
+        while True:
+            try:
+                output = next(outputs)
+            except StopIteration as completion:
+                return completion.value
+            try:
+                yield self._map_wait_for_output(output)
+            except (TypeError, ValueError) as error:
+                raise InvalidStepResultError(
+                    flow.name, step.name, "wait_for", str(error)
+                ) from error
+
+    def _execute_generator(
+        self,
+        flow: _RegisteredFlow,
+        step: _RegisteredStep,
+        outputs: Generator[Any, None, Any],
+    ) -> Generator[pb.InvokeExecuteMethodOutput, None, Any]:
+        while True:
+            try:
+                output = next(outputs)
+            except StopIteration as completion:
+                return completion.value
+            try:
+                yield self._map_execute_output(output)
+            except (TypeError, ValueError) as error:
+                raise InvalidStepResultError(
+                    flow.name, step.name, "execute", str(error)
+                ) from error
+
+    def _map_wait_for_output(
+        self,
+        output: StepOutput,
+    ) -> pb.InvokeWaitForMethodOutput:
+        heartbeat, stream_write = self._map_step_output(output)
+        if heartbeat is not None:
+            return pb.InvokeWaitForMethodOutput(heartbeat=heartbeat)
+        return pb.InvokeWaitForMethodOutput(stream_write=stream_write)
+
+    def _map_execute_output(
+        self,
+        output: StepOutput,
+    ) -> pb.InvokeExecuteMethodOutput:
+        heartbeat, stream_write = self._map_step_output(output)
+        if heartbeat is not None:
+            return pb.InvokeExecuteMethodOutput(heartbeat=heartbeat)
+        return pb.InvokeExecuteMethodOutput(stream_write=stream_write)
+
+    def _map_step_output(
+        self,
+        output: StepOutput,
+    ) -> tuple[pb.StepMethodHeartbeat | None, pb.StepStreamWrite | None]:
+        if isinstance(output, _HeartbeatStepOutput):
+            heartbeat = pb.StepMethodHeartbeat()
+            if output.has_value:
+                heartbeat.value.CopyFrom(
+                    output.encoded_value
+                    if output.encoded_value is not None
+                    else self._values.encode_dynamic(output.value)
+                )
+            return heartbeat, None
+        if isinstance(output, _StreamStepOutput):
+            return None, output.stream_write
+        raise TypeError("Step generator must yield StepOutput values")
 
     def map_step_options(
         self,

--- a/sdk-python/dex/_worker_service.py
+++ b/sdk-python/dex/_worker_service.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from typing import Callable, TypeVar
 
 import grpc
@@ -30,8 +31,8 @@ class WorkerService(dex_pb2_grpc.WorkerServiceServicer):
         self,
         request: pb.InvokeWaitForMethodRequest,
         context: grpc.ServicerContext,
-    ) -> pb.InvokeWaitForMethodResponse:
-        return self._invoke(
+    ) -> Iterator[pb.InvokeWaitForMethodOutput]:
+        return self._invoke_stream(
             context,
             lambda: self._dispatcher.invoke_wait_for(request, context.is_active),
         )
@@ -40,8 +41,8 @@ class WorkerService(dex_pb2_grpc.WorkerServiceServicer):
         self,
         request: pb.InvokeExecuteMethodRequest,
         context: grpc.ServicerContext,
-    ) -> pb.InvokeExecuteMethodResponse:
-        return self._invoke(
+    ) -> Iterator[pb.InvokeExecuteMethodOutput]:
+        return self._invoke_stream(
             context,
             lambda: self._dispatcher.invoke_execute(request, context.is_active),
         )
@@ -63,6 +64,25 @@ class WorkerService(dex_pb2_grpc.WorkerServiceServicer):
     ) -> ResponseT:
         try:
             return invocation()
+        except BaseException as error:
+            if not context.is_active():
+                context.abort(
+                    grpc.StatusCode.CANCELLED,
+                    "Python Worker invocation canceled",
+                )
+            _LOGGER.exception("Python Worker invocation failed")
+            abort_worker_error(context, error)
+            raise RuntimeError("gRPC abort returned unexpectedly") from error
+
+    @staticmethod
+    def _invoke_stream(
+        context: grpc.ServicerContext,
+        invocation: Callable[[], Iterator[ResponseT]],
+    ) -> Iterator[ResponseT]:
+        try:
+            yield from invocation()
+        except GeneratorExit:
+            raise
         except BaseException as error:
             if not context.is_active():
                 context.abort(

--- a/sdk-python/dex/async_client.py
+++ b/sdk-python/dex/async_client.py
@@ -98,7 +98,6 @@ class AsyncClient:
             registry,
             self._values,
             cast(Any, self._hydrator),
-            self._service.WriteStream,
         )
         self._closed = False
 
@@ -508,26 +507,24 @@ class AsyncClient:
         self,
         flow_id: str,
         stream: Stream[ValueT],
-        idempotency_key: str,
+        source: str,
         value: ValueT,
     ) -> None:
-        """Await one typed best-effort Stream append with client idempotency.
+        """Await one typed best-effort Stream append with source metadata.
 
         Args:
             flow_id: Logical Flow instance ID; the Flow need not exist or be active.
             stream: Exact Stream object registered in one Flow schema.
-            idempotency_key: Non-empty key without ``#``; retained duplicates are no-ops.
+            source: Non-empty informational source. Repeated values still append.
             value: Typed message to append.
 
         Raises:
-            ValueError: If an ID is empty or the key contains the reserved separator.
+            ValueError: If the Flow ID or source is empty.
             FlowDefinitionError: If the Stream is not registered.
             ValueMappingError: If the message cannot be encoded.
             DexServiceError: If FlowService cannot append the message.
         """
-        require_name(idempotency_key)
-        if "#" in idempotency_key:
-            raise ValueError("Stream client idempotency key must not contain #")
+        require_name(source)
         flow = self.registry._flow_for_stream(stream)
         await self._call(
             self._service.WriteStream,
@@ -540,7 +537,7 @@ class AsyncClient:
                     value,
                     self._values.codec(stream.value_type),
                 ),
-                idempotency_key=idempotency_key,
+                source=source,
             ),
             "write_stream",
             flow_id,
@@ -563,7 +560,7 @@ class AsyncClient:
             timeout: Optional non-negative server-side long-poll duration.
 
         Returns:
-            The decoded message, next resume token, creation time, and idempotency key.
+            The decoded message, next resume token, creation time, and source.
 
         Raises:
             LongPollTimeoutError: If no message arrives before the server wait expires.
@@ -604,7 +601,7 @@ class AsyncClient:
             ),
             response.message.resume_token,
             response.message.created_time.ToDatetime(tzinfo=timezone.utc),
-            response.message.idempotency_key,
+            response.message.source,
         )
 
     async def wait_for_flow(

--- a/sdk-python/dex/async_worker.py
+++ b/sdk-python/dex/async_worker.py
@@ -69,7 +69,6 @@ class AsyncWorker:
             registry,
             values,
             AsyncValueHydrator(self._flow_service, blob_cache),
-            self._flow_service.WriteStream,
         )
         self._server = grpc.aio.server()
         dex_pb2_grpc.add_WorkerServiceServicer_to_server(  # type: ignore[no-untyped-call]

--- a/sdk-python/dex/client.py
+++ b/sdk-python/dex/client.py
@@ -98,7 +98,6 @@ class Client:
             registry,
             self._values,
             self._hydrator,
-            self._service.WriteStream,
         )
         self._closed = False
 
@@ -509,26 +508,24 @@ class Client:
         self,
         flow_id: str,
         stream: Stream[ValueT],
-        idempotency_key: str,
+        source: str,
         value: ValueT,
     ) -> None:
-        """Append one typed best-effort Stream message with client idempotency.
+        """Append one typed best-effort Stream message with source metadata.
 
         Args:
             flow_id: Logical Flow instance ID; the Flow need not exist or be active.
             stream: Exact Stream object registered in one Flow schema.
-            idempotency_key: Non-empty key without ``#``; retained duplicates are no-ops.
+            source: Non-empty informational source. Repeated values still append.
             value: Typed message to append.
 
         Raises:
-            ValueError: If an ID is empty or the key contains the reserved separator.
+            ValueError: If the Flow ID or source is empty.
             FlowDefinitionError: If the Stream is not registered.
             ValueMappingError: If the message cannot be encoded.
             DexServiceError: If FlowService cannot append the message.
         """
-        require_name(idempotency_key)
-        if "#" in idempotency_key:
-            raise ValueError("Stream client idempotency key must not contain #")
+        require_name(source)
         flow = self.registry._flow_for_stream(stream)
         self._call(
             self._service.WriteStream,
@@ -541,7 +538,7 @@ class Client:
                     value,
                     self._values.codec(stream.value_type),
                 ),
-                idempotency_key=idempotency_key,
+                source=source,
             ),
             "write_stream",
             flow_id,
@@ -564,7 +561,7 @@ class Client:
             timeout: Optional non-negative server-side long-poll duration.
 
         Returns:
-            The decoded message, next resume token, creation time, and idempotency key.
+            The decoded message, next resume token, creation time, and source.
 
         Raises:
             LongPollTimeoutError: If no message arrives before the server wait expires.
@@ -605,7 +602,7 @@ class Client:
             ),
             response.message.resume_token,
             response.message.created_time.ToDatetime(tzinfo=timezone.utc),
-            response.message.idempotency_key,
+            response.message.source,
         )
 
     def wait_for_flow(

--- a/sdk-python/dex/context.py
+++ b/sdk-python/dex/context.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Protocol, Sequence, TypeVar
 if TYPE_CHECKING:
     from dex.attribute import Attribute, AttributeMap
     from dex.channel import Channel, ChannelMap
+    from dex.step import StepOutput
     from dex.stream import Stream
 
 ValueT = TypeVar("ValueT")
@@ -71,6 +72,35 @@ class Context(Protocol):
 
         Returns:
             ``1`` for the initial attempt and a larger value after retries.
+        """
+        ...
+
+    def has_last_heartbeat_value(self) -> bool:
+        """Report whether the previous regular attempt persisted heartbeat details.
+
+        Returns:
+            ``True`` when a heartbeat Value is present. A persisted Python ``None``
+            still counts as present.
+        """
+        ...
+
+    def get_last_heartbeat_value(
+        self,
+        value_type: type[ValueT],
+    ) -> ValueT | None:
+        """Decode the previous regular attempt's heartbeat checkpoint.
+
+        Use :meth:`has_last_heartbeat_value` to distinguish an absent checkpoint
+        from a persisted Python ``None``.
+
+        Args:
+            value_type: The expected Python type and codec selection.
+
+        Returns:
+            The decoded checkpoint, or ``None`` when no Value is present.
+
+        Raises:
+            ValueMappingError: If the Value cannot be decoded as ``value_type``.
         """
         ...
 
@@ -195,4 +225,30 @@ class Context(Protocol):
         self,
         definition: Stream[ValueT],
         value: ValueT,
-    ) -> object: ...
+    ) -> StepOutput | None: ...
+
+
+class AsyncContext(Context, Protocol):
+    """Expose Context operations available to asynchronous Step handlers.
+
+    AsyncWorker supplies this protocol to coroutine ``wait_for`` and ``execute``
+    methods. Stream writes enqueue synchronously; heartbeat waits only for the
+    Worker output queue and never for Dex Stream Store persistence.
+    """
+
+    async def heartbeat(self, value: object = ...) -> None:
+        """Emit one heartbeat from the current asynchronous Step attempt.
+
+        Calling this method without ``value`` clears prior persisted details.
+        Passing any value, including Python ``None``, persists a present Value.
+        Local activity execution ignores heartbeat frames.
+
+        Args:
+            value: Optional codec-supported checkpoint value.
+
+        Raises:
+            asyncio.CancelledError: If the active Worker invocation is canceled.
+            ValueError: If called outside a Step handler.
+            ValueMappingError: If ``value`` cannot be encoded.
+        """
+        ...

--- a/sdk-python/dex/flow.py
+++ b/sdk-python/dex/flow.py
@@ -11,9 +11,15 @@
 from __future__ import annotations
 
 from abc import ABC
+from collections.abc import Generator as GeneratorABC
 from dataclasses import dataclass, replace
 from datetime import timedelta
-from inspect import iscoroutinefunction, signature
+from inspect import (
+    isasyncgenfunction,
+    iscoroutinefunction,
+    isgeneratorfunction,
+    signature,
+)
 from types import MappingProxyType
 from typing import (
     Any,
@@ -32,10 +38,10 @@ from dex._utils import require_name
 from dex.attribute import Attribute, AttributeLock, AttributeMap
 from dex.channel import Channel, ChannelMap
 from dex.codec import Codec, CodecRegistry
-from dex.context import Context
+from dex.context import AsyncContext, Context
 from dex.dexpb import dex_pb2 as pb
 from dex.runtime_errors import FlowDefinitionError
-from dex.step import Step, StepDecision, StepList, StepMovement, _StepDef
+from dex.step import Step, StepDecision, StepList, StepMovement, StepOutput, _StepDef
 from dex.stream import Stream
 from dex.wait import Wait
 
@@ -345,9 +351,9 @@ class Registry:
         Args:
             flows: Flow instances with unique Flow types.
             codec_registry: Optional custom codecs; defaults to ``CodecRegistry()``.
-            allow_async_handlers: Accept ``async def`` Step and RPC handlers. Sync
-                Client/Worker construction leaves this ``False``; Async variants use
-                ``True``.
+            allow_async_handlers: Accept ``async def`` Step and RPC handlers. Async
+                Steps annotate AsyncContext; async RPCs and timeout handlers keep
+                Context. Sync Client/Worker construction leaves this ``False``.
 
         Raises:
             FlowDefinitionError: If any Flow, Step, RPC, persistence definition,
@@ -662,6 +668,10 @@ class Registry:
         *,
         allow_async_handlers: bool,
     ) -> Any:
+        if isasyncgenfunction(handler):
+            raise TypeError(
+                f"Step {step.get_step_type()} {handler_name} must not be an async generator"
+            )
         if iscoroutinefunction(handler) and not allow_async_handlers:
             raise TypeError(
                 f"Step {step.get_step_type()} {handler_name} must be synchronous"
@@ -673,16 +683,32 @@ class Registry:
                 f"Step {step.get_step_type()} {handler_name} must accept context and input"
             )
         context_parameter, input_parameter = parameters
-        if hints.get(context_parameter.name) is not Context:
+        expected_context = AsyncContext if iscoroutinefunction(handler) else Context
+        if hints.get(context_parameter.name) is not expected_context:
             raise TypeError(
-                f"Step {step.get_step_type()} {handler_name} context must be Context"
+                f"Step {step.get_step_type()} {handler_name} context must be "
+                f"{expected_context.__name__}"
             )
         input_type = hints.get(input_parameter.name)
         if input_type is None:
             raise TypeError(
                 f"Step {step.get_step_type()} {handler_name} input must be annotated"
             )
-        if hints.get("return") is not return_type:
+        annotated_return = hints.get("return")
+        if isgeneratorfunction(handler):
+            arguments = get_args(annotated_return)
+            if (
+                get_origin(annotated_return) is not GeneratorABC
+                or len(arguments) != 3
+                or arguments[0] is not StepOutput
+                or arguments[1] not in (None, type(None))
+                or arguments[2] is not return_type
+            ):
+                raise TypeError(
+                    f"Step {step.get_step_type()} {handler_name} generator must return "
+                    f"Generator[StepOutput, None, {return_type.__name__}]"
+                )
+        elif annotated_return is not return_type:
             raise TypeError(
                 f"Step {step.get_step_type()} {handler_name} must return "
                 f"{return_type.__name__}"

--- a/sdk-python/dex/step.py
+++ b/sdk-python/dex/step.py
@@ -14,22 +14,72 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
 from datetime import timedelta
 from enum import Enum
-from typing import Any, Generic, Iterator, TypeVar
+from typing import Any, Generator, Generic, Iterator, TypeVar
 
 from dex.attribute import AttributeLock
 from dex.channel import Channel, ChannelMap
 from dex.context import Context
+from dex.dexpb import dex_pb2 as pb
 from dex.wait import Wait
 
 InputT = TypeVar("InputT")
 StartT = TypeVar("StartT")
+_NO_HEARTBEAT_VALUE = object()
+
+
+class StepOutput:
+    """Represent one progress frame yielded by a synchronous Step handler.
+
+    Create outputs with :func:`heartbeat` or :meth:`dex.stream.Stream.write`.
+    A synchronous generator yields these frames and returns its final Wait or
+    StepDecision through the generator return value.
+    """
+
+    def __new__(cls, *args: object, **kwargs: object) -> StepOutput:
+        """Reject direct construction of the abstract output marker."""
+        if cls is StepOutput:
+            raise TypeError("StepOutput must be created by heartbeat or Stream.write")
+        return super().__new__(cls)
+
+
+@dataclass(frozen=True)
+class _HeartbeatStepOutput(StepOutput):
+    has_value: bool
+    value: object
+    encoded_value: pb.Value | None = None
+
+
+@dataclass(frozen=True)
+class _StreamStepOutput(StepOutput):
+    stream_write: pb.StepStreamWrite
+
+
+def heartbeat(value: object = _NO_HEARTBEAT_VALUE) -> StepOutput:
+    """Create a heartbeat frame for a synchronous Step generator.
+
+    Yield ``heartbeat()`` to clear persisted heartbeat details. Passing a value,
+    including ``None``, persists that codec-supported value for the next regular
+    activity attempt. Local activity execution ignores heartbeat frames.
+
+    Args:
+        value: Optional checkpoint value. Omitting it clears prior details.
+
+    Returns:
+        A StepOutput that must be yielded by the current synchronous handler.
+
+    Examples:
+        >>> def execute(context: Context, input: int) -> Generator[StepOutput, None, StepDecision]:
+        ...     yield heartbeat({"completed": input})
+        ...     return graceful_complete()
+    """
+    return _HeartbeatStepOutput(value is not _NO_HEARTBEAT_VALUE, value)
 
 
 class StepDurability(Enum):
     """Control when a Step handler result is durably acknowledged.
 
     Attributes:
-        DEFAULT: Use the Flow or server durability policy.
+        DEFAULT: Use FlowConfig, then the server's synchronous default.
         SYNC: Persist the result before acknowledging the Worker call.
         ASYNC: Allow acknowledgement before persistence completes.
     """
@@ -55,7 +105,8 @@ class WaitForFailurePolicy(Enum):
 class RetryPolicy:
     """Configure exponential retries for a Step handler or Flow.
 
-    A ``None`` duration or zero numeric value uses the server default.
+    A ``None`` duration or zero numeric value uses the server default. The default
+    total duration is four hours.
     Attempts include the initial call. Retries stop at the first configured limit.
     With asynchronous Step durability, local and regular execution share attempts
     and elapsed duration. Fallback is immediate; later regular retries continue the
@@ -66,7 +117,8 @@ class RetryPolicy:
         backoff_coefficient: Interval multiplier; zero uses the server default.
         maximum_interval: Upper bound for one retry delay.
         maximum_attempts: Total attempt limit; zero uses the server default.
-        total_duration: Overall elapsed-time limit for all attempts.
+        total_duration: Overall elapsed-time limit for all attempts; ``None`` uses
+            four hours.
     """
 
     initial_interval: timedelta | None = None
@@ -82,12 +134,18 @@ class StepOptions:
 
     Fields set to ``None`` or ``DEFAULT`` use Flow or server policy. Attribute
     locks are acquired separately for ``wait_for`` and ``execute`` and must reference
-    definitions in the containing Flow's ``PersistenceSchema``.
+    definitions in the containing Flow's ``PersistenceSchema``. Asynchronous
+    durability first uses a local activity capped at seven seconds and three
+    attempts; that phase ignores method and heartbeat timeouts before regular
+    fallback applies the remaining retry budget.
 
     Attributes:
-        wait_for_method_timeout: Maximum duration of one ``wait_for`` attempt.
-        execute_method_timeout: Maximum duration of one ``execute`` attempt.
-        heartbeat_timeout: Cooperative cancellation heartbeat for regular activities.
+        wait_for_method_timeout: Maximum duration of one regular ``wait_for``
+            attempt; ``None`` uses two hours.
+        execute_method_timeout: Maximum duration of one regular ``execute``
+            attempt; ``None`` uses two hours.
+        heartbeat_timeout: Regular-activity progress deadline; ``None`` or zero uses
+            one minute. The server-configured explicit minimum defaults to ten seconds.
         wait_for_retry: Optional retry policy for ``wait_for``.
         execute_retry: Optional retry policy for ``execute``.
         wait_for_failure: Behavior after all ``wait_for`` attempts fail.
@@ -150,15 +208,20 @@ class Step(Generic[InputT], ABC):
         self,
         context: Context,
         input: InputT,
-    ) -> StepDecision:
-        """Execute application logic and return the next durable decision.
+    ) -> StepDecision | Generator[StepOutput, None, StepDecision]:
+        """Execute application logic and produce the next durable decision.
+
+        An ordinary handler returns StepDecision directly. A progress handler yields
+        heartbeat and Stream StepOutput values, then returns StepDecision as its
+        generator return value.
 
         Args:
             context: Execution metadata and decision-local persistence operations.
             input: The decoded value passed by the incoming Step movement.
 
         Returns:
-            A StepDecision describing movements or Flow completion.
+            A StepDecision, or a generator that yields StepOutput and returns the
+            StepDecision describing movements or Flow completion.
 
         Raises:
             Exception: Application exceptions are retried according to StepOptions
@@ -166,18 +229,25 @@ class Step(Generic[InputT], ABC):
         """
         raise NotImplementedError
 
-    def wait_for(self, context: Context, input: InputT) -> Wait:
+    def wait_for(
+        self,
+        context: Context,
+        input: InputT,
+    ) -> Wait | Generator[StepOutput, None, Wait]:
         """Describe durable conditions that must be ready before ``execute``.
 
         Override this method only when the Step waits. Dex skips the base
-        implementation and invokes ``execute`` immediately.
+        implementation and invokes ``execute`` immediately. A progress handler
+        yields heartbeat and Stream StepOutput values, then returns Wait as its
+        generator return value.
 
         Args:
             context: Execution metadata and decision-local persistence operations.
             input: The same decoded input later passed to ``execute``.
 
         Returns:
-            A durable Wait condition tree.
+            A durable Wait condition tree, or a generator that yields StepOutput
+            and returns that Wait.
         """
         del context, input
         raise RuntimeError("framework must skip the default wait_for")

--- a/sdk-python/dex/stream.py
+++ b/sdk-python/dex/stream.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar, overload
 
 from dex._utils import require_name
+from dex.step import StepOutput
 
 if TYPE_CHECKING:
-    from dex.context import Context
+    from dex.context import AsyncContext, Context
 
 ValueT = TypeVar("ValueT")
 
@@ -47,18 +48,43 @@ class Stream(Generic[ValueT]):
         if self.stream_capacity_bytes <= 0:
             raise ValueError("Stream stream_capacity_bytes must be positive")
 
-    def write(self, context: Context, value: ValueT) -> Any:
-        """Append one message immediately from the current Step execution.
+    @overload
+    def write(  # type: ignore[overload-overlap]
+        self,
+        context: AsyncContext,
+        value: ValueT,
+    ) -> None:
+        """Enqueue one message from an asynchronous Step handler."""
+        ...
 
-        Synchronous handlers call this method directly. Async handlers must await its
-        result. One Step execution may write once per Stream, and RPC Contexts reject it.
+    @overload
+    def write(self, context: Context, value: ValueT) -> StepOutput:
+        """Create one message output for a synchronous Step generator."""
+        ...
+
+    def write(
+        self,
+        context: Context,
+        value: ValueT,
+    ) -> StepOutput | None:
+        """Emit one best-effort message from the current Step execution.
+
+        A synchronous generator must yield the returned StepOutput. An asynchronous
+        Step calls this method without ``await``; the message enters the invocation's
+        ordered output queue immediately. Neither form waits for Dex Stream Store
+        persistence. Calls may write the same Stream any number of times. RPC and
+        Flow-timeout Contexts reject Stream writes.
 
         Args:
             context: Current synchronous or asynchronous Step Context.
             value: Typed message to append.
 
         Returns:
-            ``None`` for a synchronous Worker or an awaitable for an AsyncWorker.
+            A StepOutput for a synchronous Context, or ``None`` for AsyncContext.
+
+        Raises:
+            ValueError: If the Stream is unregistered or the Context is not a Step.
+            ValueMappingError: If ``value`` cannot be encoded.
         """
         return context._write_stream(self, value)
 
@@ -71,10 +97,10 @@ class StreamMessage(Generic[ValueT]):
         value: Decoded application message.
         resume_token: Opaque token for the next read.
         created_time: Server-assigned UTC creation time.
-        idempotency_key: Client key or Step-generated runID#stepExecutionID key.
+        source: Informational client source or Step-generated ``#stepExecutionID``.
     """
 
     value: ValueT
     resume_token: str
     created_time: datetime
-    idempotency_key: str
+    source: str

--- a/sdk-python/dex/worker.py
+++ b/sdk-python/dex/worker.py
@@ -79,7 +79,6 @@ class Worker:
             registry,
             values,
             ValueHydrator(self._flow_service, blob_cache),
-            self._flow_service.WriteStream,
         )
         concurrency = max(2, min(32, os.cpu_count() or 2))
         self._executor = ThreadPoolExecutor(

--- a/sdk-python/tests/integ/README.md
+++ b/sdk-python/tests/integ/README.md
@@ -34,7 +34,9 @@ uv run --frozen pyright tests/integ
 - Synchronous Client shapes match Java and Go while preserving Python naming.
 - Sync and async suites cover singleton Attribute and AttributeMap instance equality waits;
   local contracts cover Condition IDs and map introspection.
-- Stream integration is pending the server-streaming Worker API update.
+- Sync generator and async coroutine suites cover ordered heartbeat and Stream
+  frames, repeated Stream sources, heartbeat-value recovery, explicit clearing,
+  and persisted Python `None`.
 
 ## Error coverage
 

--- a/sdk-python/tests/integ/async_stream_flow.py
+++ b/sdk-python/tests/integ/async_stream_flow.py
@@ -9,13 +9,16 @@
 # See LICENSE and LEGACY_NOTICES.md.
 
 from dex import (
-    Context,
+    AsyncContext,
     Flow,
     PersistenceSchema,
     Step,
     StepDecision,
+    StepDurability,
     StepList,
+    StepOptions,
     Stream,
+    Wait,
     graceful_complete,
 )
 
@@ -24,14 +27,33 @@ class AsyncStreamTestStep(Step[None]):
     def __init__(self, progress: Stream[str]) -> None:
         self.progress = progress
 
+    async def wait_for(  # type: ignore[override]
+        self,
+        context: AsyncContext,
+        input: None,
+    ) -> Wait:
+        del input
+        self.progress.write(context, "async-wait")
+        await context.heartbeat("async-wait-checkpoint")
+        return Wait.skip_immediately()
+
     async def execute(  # type: ignore[override]
         self,
-        context: Context,
+        context: AsyncContext,
         input: None,
     ) -> StepDecision:
         del input
-        await self.progress.write(context, "async-step-progress")
+        self.progress.write(context, "async-step-first")
+        await context.heartbeat("async-checkpoint")
+        self.progress.write(context, "async-step-second")
+        await context.heartbeat()
         return graceful_complete()
+
+    def get_step_options(self) -> StepOptions:
+        return StepOptions(
+            wait_for_durability=StepDurability.ASYNC,
+            execute_durability=StepDurability.ASYNC,
+        )
 
 
 class AsyncStreamTestFlow(Flow[None]):

--- a/sdk-python/tests/integ/step_cancellation_flow.py
+++ b/sdk-python/tests/integ/step_cancellation_flow.py
@@ -16,6 +16,7 @@ from enum import Enum
 from typing import Any
 
 from dex import (
+    AsyncContext,
     Attribute,
     Context,
     Flow,
@@ -78,14 +79,24 @@ class CancellationBlockingExecute(Step[None]):
         self.flow = flow
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: None
+        self, context: AsyncContext, input: None
     ) -> StepDecision:
         del input
         self.flow.blocking_invocations += 1
         self.flow.blocking_started.set()
         duration = 7 if self.flow.scenario is CancellationScenario.NO_HEARTBEAT else 10
         try:
-            await asyncio.sleep(duration)
+            if self.flow.scenario is CancellationScenario.LOCAL_EXECUTE:
+                await context.heartbeat()
+            if self.flow.scenario in {
+                CancellationScenario.HEARTBEAT_EXECUTE,
+                CancellationScenario.LOCAL_TIMEOUT_FALLBACK,
+            }:
+                for _ in range(duration):
+                    await asyncio.sleep(1)
+                    await context.heartbeat()
+            else:
+                await asyncio.sleep(duration)
         except asyncio.CancelledError:
             self.flow.handler_canceled = True
             self.flow.context_reported_cancellation = (
@@ -100,7 +111,7 @@ class CancellationBlockingExecute(Step[None]):
         options = StepOptions(
             execute_method_timeout=timedelta(seconds=15),
             heartbeat_timeout=(
-                timedelta(seconds=2)
+                timedelta(seconds=10)
                 if self.flow.scenario
                 in {
                     CancellationScenario.HEARTBEAT_EXECUTE,
@@ -126,13 +137,15 @@ class CancellationBlockingWaitFor(Step[None]):
         self.flow = flow
 
     async def wait_for(  # type: ignore[override]
-        self, context: Context, input: None
+        self, context: AsyncContext, input: None
     ) -> Wait:
         del input
         self.flow.blocking_invocations += 1
         self.flow.blocking_started.set()
         try:
-            await asyncio.sleep(10)
+            for _ in range(10):
+                await asyncio.sleep(1)
+                await context.heartbeat()
         except asyncio.CancelledError:
             self.flow.handler_canceled = True
             self.flow.context_reported_cancellation = (
@@ -149,7 +162,7 @@ class CancellationBlockingWaitFor(Step[None]):
     def get_step_options(self) -> StepOptions:
         return StepOptions(
             wait_for_method_timeout=timedelta(seconds=15),
-            heartbeat_timeout=timedelta(seconds=2),
+            heartbeat_timeout=timedelta(seconds=10),
             wait_for_failure=WaitForFailurePolicy.PROCEED,
             wait_for_durability=StepDurability.SYNC,
         )
@@ -166,7 +179,7 @@ class CancellationWinner(Step[None]):
         return Wait.until(Timer.by_duration(timedelta(seconds=3)))
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: None
+        self, context: AsyncContext, input: None
     ) -> StepDecision:
         del context, input
         if self.flow.scenario is CancellationScenario.LOCAL_EXECUTE:
@@ -230,7 +243,7 @@ class CancellationSelectorWinner(Step[None]):
         return Wait.until(Timer.by_duration(timedelta(seconds=1)))
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: None
+        self, context: AsyncContext, input: None
     ) -> StepDecision:
         del context, input
         await asyncio.wait_for(self.flow.selector_waits_registered.wait(), timeout=10)

--- a/sdk-python/tests/integ/step_streaming_flow.py
+++ b/sdk-python/tests/integ/step_streaming_flow.py
@@ -1,0 +1,96 @@
+# Portions of this file are derived from indeedeng/iwf-java-sdk.
+# Those portions are licensed under the Apache License, Version 2.0.
+# See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+#
+# Modifications Copyright (c) 2026 Super Durable, Inc.
+#
+# Modifications are licensed under the Super Durable Source License 1.0.
+# Third-Party Materials remain under the Apache License, Version 2.0.
+# See LICENSE and LEGACY_NOTICES.md.
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Generator
+
+from dex import (
+    Context,
+    Flow,
+    PersistenceSchema,
+    RetryPolicy,
+    Step,
+    StepDecision,
+    StepList,
+    StepOptions,
+    StepOutput,
+    Stream,
+    Wait,
+    graceful_complete,
+    heartbeat,
+)
+
+
+class StepStreamingStep(Step[None]):
+    def __init__(self, progress: Stream[str]) -> None:
+        self.progress = progress
+
+    def wait_for(
+        self,
+        context: Context,
+        input: None,
+    ) -> Generator[StepOutput, None, Wait]:
+        del input
+        yield heartbeat("wait-checkpoint")
+        yield self.progress.write(context, "wait-stream")
+        return Wait.skip_immediately()
+
+    def execute(
+        self,
+        context: Context,
+        input: None,
+    ) -> Generator[StepOutput, None, StepDecision]:
+        del input
+        if context.attempt == 1:
+            yield heartbeat("execute-checkpoint")
+            yield self.progress.write(context, "attempt-1-first")
+            yield self.progress.write(context, "attempt-1-second")
+            raise RuntimeError("retry after persisted checkpoint")
+        if context.attempt == 2:
+            if not context.has_last_heartbeat_value():
+                raise AssertionError("attempt 2 checkpoint is absent")
+            if context.get_last_heartbeat_value(str) != "execute-checkpoint":
+                raise AssertionError("attempt 2 checkpoint is incorrect")
+            yield heartbeat()
+            yield self.progress.write(context, "attempt-2-after-clear")
+            raise RuntimeError("retry after clearing checkpoint")
+        if context.attempt == 3:
+            if context.has_last_heartbeat_value():
+                raise AssertionError("attempt 3 checkpoint was not cleared")
+            yield heartbeat(None)
+            raise RuntimeError("retry after persisted None")
+        if not context.has_last_heartbeat_value():
+            raise AssertionError("attempt 4 None checkpoint is absent")
+        if context.get_last_heartbeat_value(type(None)) is not None:
+            raise AssertionError("attempt 4 None checkpoint is incorrect")
+        return graceful_complete("recovered")
+
+    def get_step_options(self) -> StepOptions:
+        return StepOptions(
+            heartbeat_timeout=timedelta(seconds=10),
+            execute_retry=RetryPolicy(
+                initial_interval=timedelta(seconds=1),
+                maximum_attempts=4,
+            ),
+        )
+
+
+class StepStreamingFlow(Flow[None]):
+    def __init__(self) -> None:
+        self.progress = Stream("step-streaming-progress", str, 1 << 20)
+        self.start = StepStreamingStep(self.progress)
+
+    def get_steps(self) -> StepList[None]:
+        return StepList.start_step(self.start)
+
+    def get_persistence_schema(self) -> PersistenceSchema:
+        return PersistenceSchema.of(self.progress)

--- a/sdk-python/tests/integ/stream_flow.py
+++ b/sdk-python/tests/integ/stream_flow.py
@@ -8,6 +8,8 @@
 # Third-Party Materials remain under the Apache License, Version 2.0.
 # See LICENSE and LEGACY_NOTICES.md.
 
+from typing import Generator
+
 from dex import (
     Context,
     Flow,
@@ -15,6 +17,7 @@ from dex import (
     Step,
     StepDecision,
     StepList,
+    StepOutput,
     Stream,
     graceful_complete,
 )
@@ -24,9 +27,13 @@ class StreamTestStep(Step[None]):
     def __init__(self, progress: Stream[str]) -> None:
         self.progress = progress
 
-    def execute(self, context: Context, input: None) -> StepDecision:
+    def execute(
+        self,
+        context: Context,
+        input: None,
+    ) -> Generator[StepOutput, None, StepDecision]:
         del input
-        self.progress.write(context, "step-progress")
+        yield self.progress.write(context, "step-progress")
         return graceful_complete()
 
 

--- a/sdk-python/tests/integ/test_async_runtime.py
+++ b/sdk-python/tests/integ/test_async_runtime.py
@@ -16,13 +16,14 @@ from typing import Callable
 
 from dex import (
     AsyncClient,
+    AsyncContext,
     Context,
     Flow,
     PersistenceSchema,
+    StartFlowOptions,
     Step,
     StepDecision,
     StepList,
-    StartFlowOptions,
     force_complete,
     go_to,
     graceful_complete,
@@ -138,7 +139,7 @@ class StartChild(Step[int]):
         self._finish = finish
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: int
+        self, context: AsyncContext, input: int
     ) -> StepDecision:
         del context
         client = self._client_provider()

--- a/sdk-python/tests/integ/test_async_stream_runtime.py
+++ b/sdk-python/tests/integ/test_async_stream_runtime.py
@@ -27,7 +27,7 @@ async def _async_stream_round_trip() -> None:
         allow_async_handlers=True,
     ) as environment:
         flow_id = unique_id("async-stream")
-        run_id = await environment.client.start_flow(flow, flow_id, None)
+        await environment.client.start_flow(flow, flow_id, None)
         await environment.client.wait_for_flow(flow_id, timedelta(seconds=30))
 
         await environment.client.write_stream(
@@ -37,23 +37,41 @@ async def _async_stream_round_trip() -> None:
             "async-client-progress",
         )
 
-        step = await environment.client.read_stream(
+        wait = await environment.client.read_stream(
             flow_id,
             flow.progress,
             timeout=timedelta(seconds=30),
         )
-        assert step.value == "async-step-progress"
-        assert step.resume_token
-        assert step.created_time > datetime(1970, 1, 1, tzinfo=timezone.utc)
-        assert step.idempotency_key.startswith(f"{run_id}#")
+        assert wait.value == "async-wait"
+        assert wait.resume_token
+        assert wait.created_time > datetime(1970, 1, 1, tzinfo=timezone.utc)
+        assert wait.source.startswith("#AsyncStreamTestStep-")
+
+        first = await environment.client.read_stream(
+            flow_id,
+            flow.progress,
+            wait.resume_token,
+            timeout=timedelta(seconds=30),
+        )
+        assert first.value == "async-step-first"
+        assert first.source == wait.source
+
+        second = await environment.client.read_stream(
+            flow_id,
+            flow.progress,
+            first.resume_token,
+            timeout=timedelta(seconds=30),
+        )
+        assert second.value == "async-step-second"
+        assert second.source == wait.source
 
         client = await environment.client.read_stream(
             flow_id,
             flow.progress,
-            step.resume_token,
+            second.resume_token,
             timeout=timedelta(seconds=30),
         )
         assert client.value == "async-client-progress"
-        assert client.resume_token != step.resume_token
+        assert client.resume_token != wait.resume_token
         assert client.created_time > datetime(1970, 1, 1, tzinfo=timezone.utc)
-        assert client.idempotency_key == "async-client-write"
+        assert client.source == "async-client-write"

--- a/sdk-python/tests/integ/test_channels_runtime.py
+++ b/sdk-python/tests/integ/test_channels_runtime.py
@@ -13,7 +13,7 @@ from datetime import timedelta
 
 import pytest
 
-from dex import FlowNotActiveError, StepExecutionId, TimerId
+from dex import DexServiceError, FlowNotActiveError, StepExecutionId, TimerId
 
 from .async_environment import AsyncDexDevTestEnvironment
 from .basic_internal_channel_flow import BasicInternalChannelFlow
@@ -96,13 +96,30 @@ async def _signal_conditions_and_timer_skip() -> None:
         await environment.client.publish(flow_id, flow.first, 2, 3, 5)
         await environment.client.publish(flow_id, flow.third, None)
         await environment.client.publish(flow_id, flow.signal_map, "one", 4)
-        await environment.client.skip_timer(
-            flow_id,
-            StepExecutionId("SignalCombinationStep"),
-            TimerId.by_condition_id("test-timer-id"),
-        )
+        await _skip_signal_timer_when_pending(environment, flow_id)
         assert (
             await environment.client.wait_for_flow(flow_id, WAIT_TIMEOUT)
         ).single_output(int) == 6
         with pytest.raises(FlowNotActiveError):
             await environment.client.publish(flow_id, flow.first, 8)
+
+
+async def _skip_signal_timer_when_pending(
+    environment: AsyncDexDevTestEnvironment,
+    flow_id: str,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + 10
+    while True:
+        try:
+            await environment.client.skip_timer(
+                flow_id,
+                StepExecutionId("SignalCombinationStep"),
+                TimerId.by_condition_id("test-timer-id"),
+            )
+            return
+        except DexServiceError as error:
+            if "does not exist or is not pending" not in error.detail:
+                raise
+            if asyncio.get_running_loop().time() >= deadline:
+                raise
+            await asyncio.sleep(0.01)

--- a/sdk-python/tests/integ/test_step_cancellation_runtime.py
+++ b/sdk-python/tests/integ/test_step_cancellation_runtime.py
@@ -70,6 +70,15 @@ async def _run_step_cancellation(scenario: CancellationScenario) -> None:
             await asyncio.wait_for(flow.cancellation_observed.wait(), timeout=8)
             assert flow.handler_canceled
             assert flow.context_reported_cancellation
-        assert flow.blocking_invocations == 1
+        expected_invocations = (
+            2
+            if scenario
+            in {
+                CancellationScenario.LOCAL_EXECUTE,
+                CancellationScenario.LOCAL_TIMEOUT_FALLBACK,
+            }
+            else 1
+        )
+        assert flow.blocking_invocations == expected_invocations
         assert not flow.recovery_ran
         assert await environment.client.get_attribute(flow_id, flow.late_write) is None

--- a/sdk-python/tests/integ/test_step_streaming_runtime.py
+++ b/sdk-python/tests/integ/test_step_streaming_runtime.py
@@ -1,0 +1,44 @@
+# Portions of this file are derived from indeedeng/iwf-java-sdk.
+# Those portions are licensed under the Apache License, Version 2.0.
+# See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+#
+# Modifications Copyright (c) 2026 Super Durable, Inc.
+#
+# Modifications are licensed under the Super Durable Source License 1.0.
+# Third-Party Materials remain under the Apache License, Version 2.0.
+# See LICENSE and LEGACY_NOTICES.md.
+
+from datetime import timedelta
+
+from .environment import DexDevTestEnvironment
+from .shared import unique_id
+from .step_streaming_flow import StepStreamingFlow
+
+
+def test_step_streaming_restores_heartbeat_values_across_retries() -> None:
+    flow = StepStreamingFlow()
+    with DexDevTestEnvironment(flow) as environment:
+        flow_id = unique_id("step-streaming")
+        environment.client.start_flow(flow, flow_id, None)
+        result = environment.client.wait_for_flow(flow_id, timedelta(seconds=30))
+        assert result.single_output(str) == "recovered"
+
+        messages: list[tuple[str, str]] = []
+        resume_token = ""
+        for _ in range(4):
+            message = environment.client.read_stream(
+                flow_id,
+                flow.progress,
+                resume_token,
+                timedelta(seconds=30),
+            )
+            messages.append((message.value, message.source))
+            resume_token = message.resume_token
+
+        assert [value for value, _ in messages] == [
+            "wait-stream",
+            "attempt-1-first",
+            "attempt-1-second",
+            "attempt-2-after-clear",
+        ]
+        assert {source for _, source in messages} == {"#StepStreamingStep-1"}

--- a/sdk-python/tests/integ/test_stream_runtime.py
+++ b/sdk-python/tests/integ/test_stream_runtime.py
@@ -19,14 +19,14 @@ def test_stream_round_trip() -> None:
     flow = StreamTestFlow()
     with DexDevTestEnvironment(flow) as environment:
         flow_id = unique_id("stream")
-        run_id = environment.client.start_flow(flow, flow_id, None)
+        environment.client.start_flow(flow, flow_id, None)
         environment.client.wait_for_flow(flow_id, timedelta(seconds=30))
 
         environment.client.write_stream(
-            flow_id, flow.progress, "client-write", "client-progress"
+            flow_id, flow.progress, "client#write", "client-progress"
         )
         environment.client.write_stream(
-            flow_id, flow.progress, "client-write", "duplicate-ignored"
+            flow_id, flow.progress, "client#write", "duplicate-retained"
         )
 
         step = environment.client.read_stream(
@@ -35,7 +35,7 @@ def test_stream_round_trip() -> None:
         assert step.value == "step-progress"
         assert step.resume_token
         assert step.created_time > datetime(1970, 1, 1, tzinfo=timezone.utc)
-        assert step.idempotency_key.startswith(f"{run_id}#")
+        assert step.source.startswith("#StreamTestStep-")
 
         client = environment.client.read_stream(
             flow_id,
@@ -46,4 +46,13 @@ def test_stream_round_trip() -> None:
         assert client.value == "client-progress"
         assert client.resume_token != step.resume_token
         assert client.created_time > datetime(1970, 1, 1, tzinfo=timezone.utc)
-        assert client.idempotency_key == "client-write"
+        assert client.source == "client#write"
+
+        duplicate = environment.client.read_stream(
+            flow_id,
+            flow.progress,
+            client.resume_token,
+            timeout=timedelta(seconds=30),
+        )
+        assert duplicate.value == "duplicate-retained"
+        assert duplicate.source == "client#write"

--- a/sdk-python/tests/integ/test_subflow_runtime.py
+++ b/sdk-python/tests/integ/test_subflow_runtime.py
@@ -12,6 +12,7 @@ import time
 from datetime import timedelta
 
 from dex import (
+    DexServiceError,
     FlowConfig,
     FlowNotFoundError,
     FlowStatus,
@@ -142,11 +143,7 @@ def test_subflow_partial_results_survive_continue_as_new_without_restart() -> No
         )
         _await_new_run(environment, flow_id, first_parent_run_id)
         completed_run_id = environment.client.describe_flow(completed_id).run_id
-        environment.client.skip_timer(
-            delayed_id,
-            StepExecutionId("TimerStep"),
-            TimerId.by_condition_id("test-timer-id"),
-        )
+        _skip_subflow_timer_when_pending(environment, delayed_id)
         output = environment.client.wait_for_flow(flow_id, WAIT_TIMEOUT).single_output(
             str
         )
@@ -174,11 +171,7 @@ def _assert_running_reuse(policy: SubFlowReusePolicy, expects_restart: bool) -> 
             first_run_id if expects_restart else None,
         )
         assert (active_run_id != first_run_id) is expects_restart
-        environment.client.skip_timer(
-            child_id,
-            StepExecutionId("TimerStep"),
-            TimerId.by_condition_id("test-timer-id"),
-        )
+        _skip_subflow_timer_when_pending(environment, child_id)
         output = environment.client.wait_for_flow(flow_id, WAIT_TIMEOUT).single_output(
             str
         )
@@ -201,6 +194,27 @@ def _await_running(
             return info.run_id
         time.sleep(0.01)
     raise AssertionError(f"SubFlow did not reach expected running execution: {flow_id}")
+
+
+def _skip_subflow_timer_when_pending(
+    environment: DexDevTestEnvironment,
+    flow_id: str,
+) -> None:
+    deadline = time.monotonic() + 10
+    while True:
+        try:
+            environment.client.skip_timer(
+                flow_id,
+                StepExecutionId("TimerStep"),
+                TimerId.by_condition_id("test-timer-id"),
+            )
+            return
+        except DexServiceError as error:
+            if "does not exist or is not pending" not in error.detail:
+                raise
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.01)
 
 
 def _await_new_run(

--- a/sdk-python/tests/test_contracts.py
+++ b/sdk-python/tests/test_contracts.py
@@ -8,15 +8,18 @@
 # Legacy Materials remain under their original licenses.
 # See LICENSE and LEGACY_NOTICES.md.
 
+import asyncio
+from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast
+from typing import Any, Generator, cast
 
 import pytest
 
 from dex import (
     INT64,
     STRING,
+    AsyncContext,
     Attribute,
     AttributeMap,
     BlobCache,
@@ -41,6 +44,7 @@ from dex import (
     StepDurability,
     StepList,
     StepOptions,
+    StepOutput,
     Stream,
     Timer,
     ValueMappingError,
@@ -48,9 +52,11 @@ from dex import (
     WaitForFailurePolicy,
     WireKind,
     graceful_complete,
+    heartbeat,
     open_blob_cache,
     rpc,
 )
+from dex._async_worker_dispatcher import AsyncWorkerDispatcher
 from dex._invocation_context import InvocationContext, InvocationMethod
 from dex._value_mapper import ValueMapper
 from dex._worker_dispatcher import WorkerDispatcher
@@ -125,14 +131,14 @@ class OrderFlow(Flow[OrderInput]):
 class AsyncApproveOrder(Step[OrderInput]):
     async def execute(  # type: ignore[override]
         self,
-        context: Context,
+        context: AsyncContext,
         input: OrderInput,
     ) -> StepDecision:
         del context, input
         return graceful_complete()
 
     async def wait_for(  # type: ignore[override]
-        self, context: Context, input: OrderInput
+        self, context: AsyncContext, input: OrderInput
     ) -> Wait:
         del context, input
         return Wait.skip_immediately()
@@ -336,7 +342,6 @@ def test_invalid_step_result_has_flow_and_step_context() -> None:
         registry,
         values,
         cast(Any, PassthroughHydrator()),
-        lambda _request: pb.WriteStreamRequest(),
     )
     request = pb.InvokeExecuteMethodRequest(
         flow_type="InvalidFlow",
@@ -344,7 +349,7 @@ def test_invalid_step_result_has_flow_and_step_context() -> None:
         step_input=values.encode(1, values.codec(int)),
     )
     with pytest.raises(InvalidStepResultError) as captured:
-        dispatcher.invoke_execute(request)
+        list(dispatcher.invoke_execute(request))
     assert captured.value.flow_type == "InvalidFlow"
     assert captured.value.step_type == "InvalidStep"
     assert captured.value.method == "execute"
@@ -420,17 +425,19 @@ def test_worker_maps_only_user_provided_condition_ids() -> None:
         registry,
         values,
         cast(Any, PassthroughHydrator()),
-        lambda _request: pb.WriteStreamRequest(),
     )
 
     def invoke(input: str) -> pb.InvokeWaitForMethodResponse:
-        return dispatcher.invoke_wait_for(
-            pb.InvokeWaitForMethodRequest(
-                flow_type="ConditionFlow",
-                step_type="ConditionStep",
-                step_input=values.encode(input, values.codec(str)),
+        outputs = list(
+            dispatcher.invoke_wait_for(
+                pb.InvokeWaitForMethodRequest(
+                    flow_type="ConditionFlow",
+                    step_type="ConditionStep",
+                    step_input=values.encode(input, values.codec(str)),
+                )
             )
         )
+        return outputs[-1].result
 
     unnamed = invoke("unnamed").waiting_condition
     assert unnamed.timer_conditions[0].condition_id == ""
@@ -465,7 +472,6 @@ def test_map_introspection_tracks_buffered_changes() -> None:
         registry._flow_by_type("MapFlow"),
         pb.Context(),
         values,
-        lambda _request: pb.WriteStreamRequest(),
         (
             pb.KV(
                 key=Registry.physical_name("items", special),
@@ -551,7 +557,7 @@ def test_attribute_store_sync_mapping_preserves_presence() -> None:
     client.close()
 
 
-def test_step_stream_write_uses_execution_idempotency_key() -> None:
+def test_step_stream_write_creates_repeatable_outputs() -> None:
     thinking = Stream("thinking", str, 1_048_576)
 
     class StreamFlow(Flow[str]):
@@ -560,7 +566,6 @@ def test_step_stream_write_uses_execution_idempotency_key() -> None:
 
     registry = Registry((StreamFlow(),))
     values = ValueMapper(registry.codec_registry)
-    requests: list[pb.WriteStreamRequest] = []
     context = InvocationContext(
         InvocationMethod.EXECUTE,
         registry._flow_by_type("StreamFlow"),
@@ -570,28 +575,28 @@ def test_step_stream_write_uses_execution_idempotency_key() -> None:
             step_execution_id="step-1",
         ),
         values,
-        requests.append,
         (),
     )
 
-    assert thinking.write(context, "checking") is None
-    assert len(requests) == 1
-    request = requests[0]
-    assert request.flow_id == "flow-1"
-    assert request.flow_type == "StreamFlow"
-    assert request.stream_name == "thinking"
-    assert request.stream_capacity_bytes == 1_048_576
-    assert request.idempotency_key == "run-1#step-1"
-    assert values.decode(request.value, values.codec(str)) == "checking"
-    with pytest.raises(ValueError, match="already written"):
-        thinking.write(context, "again")
+    first = thinking.write(context, "checking")
+    second = thinking.write(context, "again")
+    assert isinstance(first, StepOutput)
+    assert isinstance(second, StepOutput)
+    assert first is not second
+    assert isinstance(heartbeat(), StepOutput)
+    assert isinstance(heartbeat(None), StepOutput)
+    with pytest.raises(TypeError, match="must be created"):
+        StepOutput()
+    with pytest.raises(ValueError, match="does not belong"):
+        Stream("other", str, 1024).write(context, "unregistered")
+    with pytest.raises(ValueMappingError):
+        thinking.write(context, cast(Any, 1))
 
     rpc_context = InvocationContext(
         InvocationMethod.RPC,
         registry._flow_by_type("StreamFlow"),
         pb.Context(),
         values,
-        requests.append,
         (),
     )
     with pytest.raises(ValueError, match="Step Context"):
@@ -621,7 +626,7 @@ def test_client_stream_transport_and_metadata() -> None:
             response.message.value.string_value = "working"
             response.message.resume_token = "resume-1"
             response.message.created_time.FromDatetime(created_time)
-            response.message.idempotency_key = "client-1"
+            response.message.source = "client-1"
             return response
 
     client = Client(Registry((StreamFlow(),)), cast(BlobCache, object()))
@@ -639,15 +644,491 @@ def test_client_stream_transport_and_metadata() -> None:
         assert service.write_request.flow_type == "StreamFlow"
         assert service.write_request.stream_name == "thinking"
         assert service.write_request.stream_capacity_bytes == 1_048_576
-        assert service.write_request.idempotency_key == "client-1"
+        assert service.write_request.source == "client-1"
         assert service.read_request is not None
         assert service.read_request.resume_token == "previous"
         assert service.read_request.wait_time_seconds == 2
         assert message.value == "working"
         assert message.resume_token == "resume-1"
         assert message.created_time == datetime(2026, 8, 27, 12, tzinfo=timezone.utc)
-        assert message.idempotency_key == "client-1"
-        with pytest.raises(ValueError, match="must not contain"):
-            client.write_stream("flow-1", thinking, "bad#key", "ignored")
+        assert message.source == "client-1"
+        client.write_stream("flow-1", thinking, "allowed#source", "accepted")
+        assert service.write_request.source == "allowed#source"
+        with pytest.raises(ValueError, match="required"):
+            client.write_stream("flow-1", thinking, "", "rejected")
     finally:
         client.close()
+
+
+def test_sync_step_generator_maps_ordered_progress_and_result() -> None:
+    progress = Stream("sync-progress", str, 1_048_576)
+
+    class StreamingStep(Step[str]):
+        def wait_for(
+            self,
+            context: Context,
+            input: str,
+        ) -> Generator[StepOutput, None, Wait]:
+            yield heartbeat(f"wait-{input}")
+            yield progress.write(context, "wait-stream")
+            return Wait.skip_immediately()
+
+        def execute(
+            self,
+            context: Context,
+            input: str,
+        ) -> Generator[StepOutput, None, StepDecision]:
+            yield heartbeat()
+            yield progress.write(context, "first")
+            yield heartbeat(None)
+            yield progress.write(context, "second")
+            return graceful_complete(input)
+
+    class StreamingFlow(Flow[str]):
+        start = StreamingStep()
+
+        def get_steps(self) -> StepList[str]:
+            return StepList.start_step(self.start)
+
+        def get_persistence_schema(self) -> PersistenceSchema:
+            return PersistenceSchema.of(progress)
+
+    class PassthroughHydrator:
+        @staticmethod
+        def wait_for_request(
+            request: pb.InvokeWaitForMethodRequest,
+        ) -> pb.InvokeWaitForMethodRequest:
+            return request
+
+        @staticmethod
+        def execute_request(
+            request: pb.InvokeExecuteMethodRequest,
+        ) -> pb.InvokeExecuteMethodRequest:
+            return request
+
+    registry = Registry((StreamingFlow(),))
+    values = ValueMapper(registry.codec_registry)
+    dispatcher = WorkerDispatcher(
+        registry,
+        values,
+        cast(Any, PassthroughHydrator()),
+    )
+    encoded_input = values.encode("input", values.codec(str))
+
+    wait_outputs = list(
+        dispatcher.invoke_wait_for(
+            pb.InvokeWaitForMethodRequest(
+                flow_type="StreamingFlow",
+                step_type="StreamingStep",
+                step_input=encoded_input,
+            )
+        )
+    )
+    assert [output.WhichOneof("output") for output in wait_outputs] == [
+        "heartbeat",
+        "stream_write",
+        "result",
+    ]
+    assert (
+        values.decode(wait_outputs[0].heartbeat.value, values.codec(str))
+        == "wait-input"
+    )
+    assert wait_outputs[1].stream_write.stream_name == "sync-progress"
+
+    execute_outputs = list(
+        dispatcher.invoke_execute(
+            pb.InvokeExecuteMethodRequest(
+                flow_type="StreamingFlow",
+                step_type="StreamingStep",
+                step_input=encoded_input,
+            )
+        )
+    )
+    assert [output.WhichOneof("output") for output in execute_outputs] == [
+        "heartbeat",
+        "stream_write",
+        "heartbeat",
+        "stream_write",
+        "result",
+    ]
+    assert not execute_outputs[0].heartbeat.HasField("value")
+    assert execute_outputs[2].heartbeat.HasField("value")
+    assert (
+        values.decode(execute_outputs[2].heartbeat.value, values.codec(type(None)))
+        is None
+    )
+    assert [
+        values.decode(output.stream_write.value, values.codec(str))
+        for output in (execute_outputs[1], execute_outputs[3])
+    ] == ["first", "second"]
+
+
+@pytest.mark.parametrize("invalid_output", [graceful_complete(), object()])
+def test_sync_step_generator_rejects_invalid_yields(invalid_output: object) -> None:
+    class InvalidGeneratorStep(Step[None]):
+        def execute(
+            self,
+            context: Context,
+            input: None,
+        ) -> Generator[StepOutput, None, StepDecision]:
+            del context, input
+            yield cast(StepOutput, invalid_output)
+            return graceful_complete()
+
+    class InvalidGeneratorFlow(Flow[None]):
+        start = InvalidGeneratorStep()
+
+        def get_steps(self) -> StepList[None]:
+            return StepList.start_step(self.start)
+
+    class PassthroughHydrator:
+        @staticmethod
+        def execute_request(
+            request: pb.InvokeExecuteMethodRequest,
+        ) -> pb.InvokeExecuteMethodRequest:
+            return request
+
+    registry = Registry((InvalidGeneratorFlow(),))
+    values = ValueMapper(registry.codec_registry)
+    dispatcher = WorkerDispatcher(
+        registry,
+        values,
+        cast(Any, PassthroughHydrator()),
+    )
+    with pytest.raises(InvalidStepResultError, match="must yield StepOutput"):
+        list(
+            dispatcher.invoke_execute(
+                pb.InvokeExecuteMethodRequest(
+                    flow_type="InvalidGeneratorFlow",
+                    step_type="InvalidGeneratorStep",
+                    step_input=values.encode_dynamic(None),
+                )
+            )
+        )
+
+
+def test_sync_step_generator_requires_final_return() -> None:
+    class MissingResultStep(Step[None]):
+        def execute(  # type: ignore[return]
+            self,
+            context: Context,
+            input: None,
+        ) -> Generator[StepOutput, None, StepDecision]:
+            del context, input
+            yield heartbeat()
+
+    class MissingResultFlow(Flow[None]):
+        start = MissingResultStep()
+
+        def get_steps(self) -> StepList[None]:
+            return StepList.start_step(self.start)
+
+    class PassthroughHydrator:
+        @staticmethod
+        def execute_request(
+            request: pb.InvokeExecuteMethodRequest,
+        ) -> pb.InvokeExecuteMethodRequest:
+            return request
+
+    registry = Registry((MissingResultFlow(),))
+    values = ValueMapper(registry.codec_registry)
+    dispatcher = WorkerDispatcher(
+        registry,
+        values,
+        cast(Any, PassthroughHydrator()),
+    )
+    with pytest.raises(InvalidStepResultError, match="must return StepDecision"):
+        list(
+            dispatcher.invoke_execute(
+                pb.InvokeExecuteMethodRequest(
+                    flow_type="MissingResultFlow",
+                    step_type="MissingResultStep",
+                    step_input=values.encode_dynamic(None),
+                )
+            )
+        )
+
+
+def test_sync_step_generator_preserves_application_errors() -> None:
+    class FailingGeneratorStep(Step[None]):
+        def execute(
+            self,
+            context: Context,
+            input: None,
+        ) -> Generator[StepOutput, None, StepDecision]:
+            del context, input
+            yield heartbeat()
+            raise ValueError("application failure")
+
+    class FailingGeneratorFlow(Flow[None]):
+        start = FailingGeneratorStep()
+
+        def get_steps(self) -> StepList[None]:
+            return StepList.start_step(self.start)
+
+    class PassthroughHydrator:
+        @staticmethod
+        def execute_request(
+            request: pb.InvokeExecuteMethodRequest,
+        ) -> pb.InvokeExecuteMethodRequest:
+            return request
+
+    registry = Registry((FailingGeneratorFlow(),))
+    values = ValueMapper(registry.codec_registry)
+    dispatcher = WorkerDispatcher(
+        registry,
+        values,
+        cast(Any, PassthroughHydrator()),
+    )
+    with pytest.raises(ValueError, match="application failure"):
+        list(
+            dispatcher.invoke_execute(
+                pb.InvokeExecuteMethodRequest(
+                    flow_type="FailingGeneratorFlow",
+                    step_type="FailingGeneratorStep",
+                    step_input=values.encode_dynamic(None),
+                )
+            )
+        )
+
+
+def test_registry_validates_generator_shapes() -> None:
+    class WrongGeneratorStep(Step[None]):
+        def execute(  # type: ignore[override]
+            self,
+            context: Context,
+            input: None,
+        ) -> Iterator[StepOutput]:
+            del context, input
+            yield heartbeat()
+
+    class WrongGeneratorFlow(Flow[None]):
+        start = WrongGeneratorStep()
+
+        def get_steps(self) -> StepList[None]:
+            return StepList.start_step(self.start)
+
+    class AsyncGeneratorStep(Step[None]):
+        async def execute(  # type: ignore[override]
+            self,
+            context: AsyncContext,
+            input: None,
+        ) -> AsyncIterator[StepOutput]:
+            del context, input
+            yield heartbeat()
+
+    class AsyncGeneratorFlow(Flow[None]):
+        start = AsyncGeneratorStep()
+
+        def get_steps(self) -> StepList[None]:
+            return StepList.start_step(self.start)
+
+    class WrongAsyncContextStep(Step[None]):
+        async def execute(  # type: ignore[override]
+            self,
+            context: Context,
+            input: None,
+        ) -> StepDecision:
+            del context, input
+            return graceful_complete()
+
+    class WrongAsyncContextFlow(Flow[None]):
+        start = WrongAsyncContextStep()
+
+        def get_steps(self) -> StepList[None]:
+            return StepList.start_step(self.start)
+
+    with pytest.raises(FlowDefinitionError, match=r"Generator\[StepOutput"):
+        Registry((WrongGeneratorFlow(),))
+    with pytest.raises(FlowDefinitionError, match="must not be an async generator"):
+        Registry((AsyncGeneratorFlow(),), allow_async_handlers=True)
+    with pytest.raises(FlowDefinitionError, match="AsyncContext"):
+        Registry((WrongAsyncContextFlow(),), allow_async_handlers=True)
+
+
+def test_context_decodes_last_heartbeat_presence() -> None:
+    class HeartbeatFlow(Flow[None]):
+        pass
+
+    registry = Registry((HeartbeatFlow(),))
+    values = ValueMapper(registry.codec_registry)
+    absent = InvocationContext(
+        InvocationMethod.EXECUTE,
+        registry._flow_by_type("HeartbeatFlow"),
+        pb.Context(),
+        values,
+        (),
+    )
+    assert not absent.has_last_heartbeat_value()
+    assert absent.get_last_heartbeat_value(str) is None
+
+    present = InvocationContext(
+        InvocationMethod.EXECUTE,
+        registry._flow_by_type("HeartbeatFlow"),
+        pb.Context(last_heartbeat_value=values.encode_dynamic(None)),
+        values,
+        (),
+    )
+    assert present.has_last_heartbeat_value()
+    assert present.get_last_heartbeat_value(type(None)) is None
+    incompatible = InvocationContext(
+        InvocationMethod.EXECUTE,
+        registry._flow_by_type("HeartbeatFlow"),
+        pb.Context(last_heartbeat_value=values.encode_dynamic("checkpoint")),
+        values,
+        (),
+    )
+    with pytest.raises(ValueMappingError):
+        incompatible.get_last_heartbeat_value(int)
+
+
+def test_async_step_outputs_preserve_call_order() -> None:
+    asyncio.run(_assert_async_step_outputs_preserve_call_order())
+
+
+async def _assert_async_step_outputs_preserve_call_order() -> None:
+    progress = Stream("async-progress", str, 1_048_576)
+
+    class AsyncStreamingStep(Step[str]):
+        async def execute(  # type: ignore[override]
+            self,
+            context: AsyncContext,
+            input: str,
+        ) -> StepDecision:
+            progress.write(context, "first")
+            await context.heartbeat()
+            progress.write(context, "second")
+            await context.heartbeat(None)
+            return graceful_complete(input)
+
+    class AsyncStreamingFlow(Flow[str]):
+        start = AsyncStreamingStep()
+
+        def get_steps(self) -> StepList[str]:
+            return StepList.start_step(self.start)
+
+        def get_persistence_schema(self) -> PersistenceSchema:
+            return PersistenceSchema.of(progress)
+
+    class AsyncPassthroughHydrator:
+        @staticmethod
+        async def execute_request(
+            request: pb.InvokeExecuteMethodRequest,
+        ) -> pb.InvokeExecuteMethodRequest:
+            return request
+
+    registry = Registry((AsyncStreamingFlow(),), allow_async_handlers=True)
+    values = ValueMapper(registry.codec_registry)
+    dispatcher = AsyncWorkerDispatcher(
+        registry,
+        values,
+        cast(Any, AsyncPassthroughHydrator()),
+    )
+    outputs = [
+        output
+        async for output in dispatcher.invoke_execute(
+            pb.InvokeExecuteMethodRequest(
+                flow_type="AsyncStreamingFlow",
+                step_type="AsyncStreamingStep",
+                step_input=values.encode("input", values.codec(str)),
+            )
+        )
+    ]
+    assert [output.WhichOneof("output") for output in outputs] == [
+        "stream_write",
+        "heartbeat",
+        "stream_write",
+        "heartbeat",
+        "result",
+    ]
+    assert not outputs[1].heartbeat.HasField("value")
+    assert outputs[3].heartbeat.HasField("value")
+
+
+def test_async_step_stream_cancellation_cancels_handler() -> None:
+    asyncio.run(_assert_async_step_stream_cancellation_cancels_handler())
+
+
+async def _assert_async_step_stream_cancellation_cancels_handler() -> None:
+    canceled = asyncio.Event()
+    heartbeat_canceled = asyncio.Event()
+    progress = Stream("canceled-progress", str, 1024)
+
+    class BlockingStep(Step[None]):
+        async def execute(  # type: ignore[override]
+            self,
+            context: AsyncContext,
+            input: None,
+        ) -> StepDecision:
+            del input
+            await context.heartbeat("running")
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                progress.write(context, "dropped")
+                try:
+                    await context.heartbeat("dropped")
+                except asyncio.CancelledError:
+                    heartbeat_canceled.set()
+                raise
+            finally:
+                canceled.set()
+            return graceful_complete()
+
+    class BlockingFlow(Flow[None]):
+        start = BlockingStep()
+
+        def get_steps(self) -> StepList[None]:
+            return StepList.start_step(self.start)
+
+        def get_persistence_schema(self) -> PersistenceSchema:
+            return PersistenceSchema.of(progress)
+
+    class AsyncPassthroughHydrator:
+        @staticmethod
+        async def execute_request(
+            request: pb.InvokeExecuteMethodRequest,
+        ) -> pb.InvokeExecuteMethodRequest:
+            return request
+
+    registry = Registry((BlockingFlow(),), allow_async_handlers=True)
+    values = ValueMapper(registry.codec_registry)
+    dispatcher = AsyncWorkerDispatcher(
+        registry,
+        values,
+        cast(Any, AsyncPassthroughHydrator()),
+    )
+    outputs = dispatcher.invoke_execute(
+        pb.InvokeExecuteMethodRequest(
+            flow_type="BlockingFlow",
+            step_type="BlockingStep",
+            step_input=values.encode_dynamic(None),
+        )
+    )
+    assert (await anext(outputs)).WhichOneof("output") == "heartbeat"
+    await outputs.aclose()
+    await asyncio.wait_for(canceled.wait(), timeout=1)
+    await asyncio.wait_for(heartbeat_canceled.wait(), timeout=1)
+
+
+def test_rpc_and_timeout_contexts_reject_progress() -> None:
+    stream = Stream("restricted-progress", str, 1024)
+
+    class RestrictedFlow(Flow[None]):
+        def get_persistence_schema(self) -> PersistenceSchema:
+            return PersistenceSchema.of(stream)
+
+    registry = Registry((RestrictedFlow(),))
+    values = ValueMapper(registry.codec_registry)
+    for method in (InvocationMethod.RPC, InvocationMethod.TIMEOUT):
+        context = InvocationContext(
+            method,
+            registry._flow_by_type("RestrictedFlow"),
+            pb.Context(),
+            values,
+            (),
+        )
+        with pytest.raises(ValueError, match="Step Context"):
+            stream.write(context, "rejected")
+        with pytest.raises(ValueError, match="asynchronous Step Context"):
+            asyncio.run(context.heartbeat())

--- a/sdk-python/tests/typecheck_contracts.py
+++ b/sdk-python/tests/typecheck_contracts.py
@@ -7,9 +7,10 @@
 # SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 from dataclasses import dataclass
-from typing import cast
+from typing import Generator, cast
 
 from dex import (
+    AsyncContext,
     Attribute,
     AttributeMap,
     BlobCache,
@@ -24,10 +25,12 @@ from dex import (
     Step,
     StepDecision,
     StepList,
+    StepOutput,
     Stream,
     StreamMessage,
     Worker,
     graceful_complete,
+    heartbeat,
     rpc,
 )
 
@@ -45,6 +48,28 @@ class Output:
 class TypedStep(Step[Input]):
     def execute(self, context: Context, input: Input) -> StepDecision:
         del context, input
+        return graceful_complete()
+
+
+class StreamingStep(Step[Input]):
+    def execute(
+        self,
+        context: Context,
+        input: Input,
+    ) -> Generator[StepOutput, None, StepDecision]:
+        yield heartbeat({"input": input.value})
+        yield progress.write(context, "working")
+        return graceful_complete()
+
+
+class AsyncTypedStep(Step[Input]):
+    async def execute(  # type: ignore[override]
+        self,
+        context: AsyncContext,
+        input: Input,
+    ) -> StepDecision:
+        progress.write(context, input.value)
+        await context.heartbeat(input.value)
         return graceful_complete()
 
 
@@ -77,6 +102,7 @@ output: Output = client.invoke_rpc(
 )
 client.write_stream("flow-id", progress, "frontend/1", "starting")
 stream_message: StreamMessage[str] = client.read_stream("flow-id", progress)
+stream_source: str = stream_message.source
 
 status = Attribute("status", str, sync_to_attribute_store=True)
 items = AttributeMap("items", int, sync_to_attribute_store=True)


### PR DESCRIPTION
## Summary

- add sync Step generator outputs for heartbeats and Stream writes, with the generator return value as the final result
- add AsyncContext heartbeats and ordered fire-and-forget Stream writes for async Step handlers
- stream WaitFor and Execute worker responses while preserving unary WorkerRpc and timeout-handler behavior
- expose persisted heartbeat details and rename external Stream write metadata from idempotency_key to source
- add contract, static type, and integration coverage plus Python SDK design and README updates

## Rationale

This is the Python SDK layer for the server-side Step worker streaming protocol introduced by #417. It lets application code report progress and emit multiple Stream messages without a separate Worker-to-Dex RPC.

## User impact

- sync Step handlers can return a normal result or yield StepOutput values from a generator
- async Step handlers use await context.heartbeat(...) and synchronous Stream.write(...)
- heartbeat value presence distinguishes an omitted value from Python None
- Client.write_stream and AsyncClient.write_stream now accept source, which may repeat and contain #

## Validation

- `uv run --frozen pytest tests/test_contracts.py`
- strict mypy, Pyright, Black, Ruff, and pycln checks
- `./run-integration-tests.sh --coverage`
- `make generated-code-check`
- `make copyright-check`
- `make docs-prose-check`
- Python public API documentation checker

## Stack

Depends on #417 and targets `codex/step-worker-server-streaming`.
