### PR TITLE
Implement Rust Step worker streaming

### DIFF
--- a/docs/design/rust-sdk-user-interface.md
+++ b/docs/design/rust-sdk-user-interface.md
@@ -190,6 +190,41 @@ reuse. User handlers run on the runtime's blocking executor; tonic stubs are
 cloned per call so long polls do not serialize unrelated Client operations.
 `Context` propagates invocation cancellation into blocking user handlers.
 
+### Step Worker response streams
+
+WaitFor and Execute use unary-request, server-streaming Worker RPCs. Each invocation owns a bounded
+channel with capacity one. The synchronous handler uses blocking sends for heartbeat and Stream
+frames, while tonic consumes them asynchronously. A successful handler enqueues exactly one final
+result after all progress frames and then closes the response with a clean EOF. Hydration, handler,
+and result-mapping failures terminate the RPC with a gRPC status instead.
+
+Dropping the response stream cancels the invocation, closes the emitter, and aborts the producer
+task. A blocked send wakes with `HandlerError`, and the existing Context cancellation methods expose
+the state to user code. The handler still runs on Tokio's blocking executor; streaming does not add
+one OS thread per RPC.
+
+```rust
+fn execute(&self, context: &mut Context, input: Import) -> HandlerResult<StepDecision> {
+    let checkpoint = context.last_heartbeat_value::<Option<Checkpoint>>()?;
+    for batch in remaining_batches(input, checkpoint)? {
+        self.progress.write(context, batch.summary())?;
+        context.record_heartbeat_value(Some(batch.checkpoint()))?;
+    }
+    Ok(StepDecision::graceful_complete(()))
+}
+```
+
+`record_heartbeat()` emits no Value and clears backend heartbeat details. An encoded JSON null is a
+present Value, so decoding `Option<T>` returns outer `Some` with inner `None`. A Stream frame is an
+implicit backend heartbeat that reuses the last explicit Worker heartbeat value, including its
+absence. Local activities ignore heartbeat details but still forward Stream frames.
+
+Step Stream writes are fire-and-forget relative to Dex storage. Calls report local registration,
+capacity, encoding, cancellation, and response-stream errors, but receive no Stream Store ack.
+Repeated writes are allowed and retain handler order. Dex assigns `#<stepExecutionID>` as their
+source. External `Client::write_stream` remains unary, accepts any non-empty source including `#`,
+and appends repeated sources. `StreamMessage::source` is metadata, not an idempotency key.
+
 ## Tests
 
 The `dex-sdk` integration target mirrors every Java integration workflow and

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -169,8 +169,35 @@ impl Step for Greet {
 `Client` calls block and return their final result. `Worker::start` serves until
 another thread calls `Worker::stop`. Synchronous user handlers run on Tokio's
 blocking executor, so they do not occupy gRPC I/O tasks. Long-running handlers
-can call `Context::wait_for_cancellation` or poll `Context::is_cancelled` to
-observe method deadlines and disconnected callers.
+should emit heartbeats or Stream messages while polling `Context::is_cancelled`.
+Cancellation becomes observable when the Worker response stream closes.
+
+### Step progress and Streams
+
+WaitFor, Execute, and Flow timeout handlers can send progress before returning:
+
+```rust
+if let Some(checkpoint) = context.last_heartbeat_value::<Checkpoint>()? {
+    resume_from(checkpoint)?;
+}
+context.record_heartbeat_value(Checkpoint::Saved { offset })?;
+events.write(context, Event::Imported { offset })?;
+context.record_heartbeat()?;
+```
+
+`record_heartbeat_value` persists a typed checkpoint for the next regular activity attempt.
+`record_heartbeat` sends a heartbeat without a Value and clears the persisted details. A missing
+Value and an encoded JSON null remain distinguishable by decoding `Option<T>`: the latter returns
+`Some(None)`. Local activities transmit heartbeat frames but Dex ignores their values.
+
+Each call blocks only when the Worker's single-frame output buffer is full. This bounded
+backpressure preserves handler order without unbounded memory. `Stream::write` uses the same Step
+response stream and may append repeatedly to the same Stream. It does not wait for a Stream Store
+acknowledgment; storage rejection or failure is observable on Dex, not by the handler.
+
+External writes remain unary. `Client::write_stream` requires a non-empty `source`, accepts `#`,
+and appends every call even when a source repeats. Read messages return that metadata in
+`StreamMessage::source`. Step writes use `#<stepExecutionID>`.
 
 ### Canceling Step executions
 

--- a/sdk-rust/crates/dex-sdk/src/client.rs
+++ b/sdk-rust/crates/dex-sdk/src/client.rs
@@ -332,27 +332,24 @@ impl Client {
         )
     }
 
-    /// Appends one typed best-effort Stream message with client idempotency.
+    /// Appends one typed best-effort Stream message with source metadata.
     ///
-    /// The Flow instance need not exist or be active. Retained duplicate keys are successful
-    /// first-write-wins no-ops.
+    /// The Flow instance need not exist or be active. Every call appends a message, including calls
+    /// that repeat the same source. A source may contain `#`.
     ///
     /// # Errors
     ///
-    /// Returns a definition error for an unregistered Stream, InvalidArgument for an empty ID or
-    /// key containing `#`, a mapping error, or a FlowService failure.
+    /// Returns a definition error for an unregistered Stream, InvalidArgument for an empty Flow ID
+    /// or source, a mapping error, or a FlowService failure.
     pub fn write_stream<T: Value>(
         &self,
         flow_id: &str,
         stream: &Stream<T>,
-        idempotency_key: &str,
+        source: &str,
         value: T,
     ) -> SdkResult<()> {
         require_name(flow_id, "Flow ID")?;
-        require_name(idempotency_key, "Stream idempotency key")?;
-        if idempotency_key.contains('#') {
-            return Err(invalid("Stream client idempotency key must not contain #"));
-        }
+        require_name(source, "Stream source")?;
         let flow_type = self.registry.flow_for_stream(stream)?.name.to_string();
         let request = WriteStreamRequest {
             flow_id: flow_id.to_string(),
@@ -360,7 +357,7 @@ impl Client {
             stream_name: stream.name().to_string(),
             stream_capacity_bytes: stream.stream_capacity_bytes(),
             value: Some(value_mapper::encode(&value)?),
-            idempotency_key: idempotency_key.to_string(),
+            source: source.to_string(),
         };
         self.call_empty(
             "write_stream",
@@ -996,7 +993,7 @@ impl Client {
             value: value_mapper::decode(&value)?,
             resume_token: message.resume_token,
             created_time,
-            idempotency_key: message.idempotency_key,
+            source: message.source,
         })
     }
 

--- a/sdk-rust/crates/dex-sdk/src/context.rs
+++ b/sdk-rust/crates/dex-sdk/src/context.rs
@@ -13,15 +13,13 @@ use std::time::{Duration, SystemTime};
 
 use dex_protocol::dex::{
     AttributeWrite, ChannelInfo, ChannelMessage, ConditionResults, ConditionStatus,
-    Context as ProtoContext, Kv, Value as ProtoValue, WriteStreamRequest,
-    flow_service_client::FlowServiceClient, value,
+    Context as ProtoContext, Kv, StepStreamWrite, Value as ProtoValue, value,
 };
-use tokio::runtime::Handle;
-use tonic::transport::Channel as TransportChannel;
 
 use crate::persistence::PersistenceKind;
 use crate::registry::{RegisteredFlow, decode_instance, physical_name};
 use crate::value_mapper;
+use crate::worker_output::StepOutputEmitter;
 use crate::{
     Attribute, AttributeMap, Channel, ChannelMap, FlowResult, HandlerError, HandlerResult, Stream,
     Value,
@@ -52,8 +50,7 @@ pub(crate) struct ContextInput {
 pub struct Context {
     method: InvocationMethod,
     flow: RegisteredFlow,
-    runtime_handle: Handle,
-    flow_service: FlowServiceClient<TransportChannel>,
+    output_emitter: Option<StepOutputEmitter>,
     metadata: ProtoContext,
     attributes: HashMap<String, ProtoValue>,
     locals: HashMap<String, ProtoValue>,
@@ -64,21 +61,19 @@ pub struct Context {
     events: Vec<Kv>,
     event_names: HashSet<String>,
     publications: Vec<ChannelMessage>,
-    stream_writes: HashSet<usize>,
     cancellation: InvocationCancellation,
 }
 
 impl Context {
     pub(crate) fn new(
         input: ContextInput,
-        runtime_handle: Handle,
-        flow_service: FlowServiceClient<TransportChannel>,
+        output_emitter: Option<StepOutputEmitter>,
+        cancellation: InvocationCancellation,
     ) -> HandlerResult<Self> {
         Ok(Self {
             method: input.method,
             flow: input.flow,
-            runtime_handle,
-            flow_service,
+            output_emitter,
             metadata: input.metadata,
             attributes: map_values("Attribute", input.attributes)?,
             locals: map_values("step-execution local", input.locals)?,
@@ -89,8 +84,7 @@ impl Context {
             events: Vec::new(),
             event_names: HashSet::new(),
             publications: Vec::new(),
-            stream_writes: HashSet::new(),
-            cancellation: InvocationCancellation::new(),
+            cancellation,
         })
     }
 
@@ -127,6 +121,76 @@ impl Context {
     /// Returns the one-based handler attempt number.
     pub fn attempt(&self) -> u32 {
         u32::try_from(self.metadata.attempt).unwrap_or_default()
+    }
+
+    /// Records a heartbeat without a Value and clears persisted heartbeat details.
+    ///
+    /// The call blocks only while the Worker's one-frame output buffer is full. It does not wait
+    /// for Dex to process the heartbeat. Flow RPC Contexts reject this operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] for an RPC Context, cancellation, or a closed Worker response
+    /// stream.
+    pub fn record_heartbeat(&mut self) -> HandlerResult<()> {
+        self.step_output_emitter()?.send_heartbeat(None)
+    }
+
+    /// Records a heartbeat carrying a typed checkpoint Value.
+    ///
+    /// A later regular attempt can decode the most recently accepted checkpoint with
+    /// [`Self::last_heartbeat_value`]. Local activities accept the frame but do not persist it.
+    /// The call uses the same bounded local buffering as [`Self::record_heartbeat`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dex_sdk::{Context, HandlerResult};
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(Deserialize, Serialize)]
+    /// struct Checkpoint {
+    ///     offset: u64,
+    /// }
+    ///
+    /// fn import_batch(context: &mut Context, next_offset: u64) -> HandlerResult<()> {
+    ///     let previous = context.last_heartbeat_value::<Checkpoint>()?;
+    ///     let offset = previous.map_or(next_offset, |checkpoint| checkpoint.offset);
+    ///     context.record_heartbeat_value(Checkpoint { offset })
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] for an RPC Context, encoding failure, cancellation, or a closed
+    /// Worker response stream.
+    pub fn record_heartbeat_value<T: Value>(&mut self, value: T) -> HandlerResult<()> {
+        let value = value_mapper::encode_handler(&value)?;
+        self.step_output_emitter()?.send_heartbeat(Some(value))
+    }
+
+    /// Decodes the checkpoint persisted by the previous regular attempt.
+    ///
+    /// `None` means no heartbeat Value is present. To distinguish an encoded JSON null, request an
+    /// optional application type: `last_heartbeat_value::<Option<T>>()` returns `Some(None)` for a
+    /// present null Value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] for an RPC Context or when the persisted Value cannot be decoded
+    /// as `T`.
+    pub fn last_heartbeat_value<T: Value>(&self) -> HandlerResult<Option<T>> {
+        if self.method == InvocationMethod::Rpc {
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "Heartbeat values require a Step Context",
+            ));
+        }
+        self.metadata
+            .last_heartbeat_value
+            .as_ref()
+            .map(value_mapper::decode_handler)
+            .transpose()
     }
 
     /// Returns whether any timer condition completed for this `execute` invocation.
@@ -447,19 +511,18 @@ impl Context {
         self.channel_results_value(channel.name(), PersistenceKind::ChannelMap, Some(instance))
     }
 
-    /// Appends one immediate best-effort Stream message from a Step invocation.
+    /// Appends one best-effort Stream message to the current Worker response stream.
+    ///
+    /// The call returns after the Worker's bounded output buffer accepts the frame. It does not
+    /// wait for Dex or the Stream Store, and a later server-side write failure is not returned to
+    /// the handler. One invocation may append any number of messages to the same Stream.
     ///
     /// # Errors
     ///
-    /// Returns [`HandlerError`] for RPC Contexts, unregistered or duplicate Streams, encoding
-    /// failures, or a failed FlowService write.
+    /// Returns [`HandlerError`] for an RPC Context, an unregistered Stream, a capacity mismatch,
+    /// encoding failure, cancellation, or a closed Worker response stream.
     pub fn write_stream<T: Value>(&mut self, stream: &Stream<T>, value: T) -> HandlerResult<()> {
-        if self.method == InvocationMethod::Rpc {
-            return Err(HandlerError::new(
-                "dex_sdk::HandlerError",
-                "Stream writes require a Step Context",
-            ));
-        }
+        let output_emitter = self.step_output_emitter()?.clone();
         let definition = self
             .flow
             .persistence
@@ -483,31 +546,11 @@ impl Context {
                 ),
             ));
         }
-        if self.stream_writes.contains(&stream.identity()) {
-            return Err(HandlerError::new(
-                "dex_sdk::HandlerError",
-                format!(
-                    "Stream {} was already written by this Step execution",
-                    stream.name()
-                ),
-            ));
-        }
-        let request = WriteStreamRequest {
-            flow_id: self.flow_id().to_string(),
-            flow_type: self.flow.name.to_string(),
+        output_emitter.send_stream_write(StepStreamWrite {
             stream_name: stream.name().to_string(),
             stream_capacity_bytes: stream.stream_capacity_bytes(),
             value: Some(value_mapper::encode_handler(&value)?),
-            idempotency_key: format!("{}#{}", self.run_id(), self.step_execution_id()),
-        };
-        let mut service = self.flow_service.clone();
-        self.runtime_handle
-            .block_on(async move { service.write_stream(request).await })
-            .map_err(|status| {
-                HandlerError::new("tonic::Status", format!("WriteStream failed: {status}"))
-            })?;
-        self.stream_writes.insert(stream.identity());
-        Ok(())
+        })
     }
 
     pub(crate) fn cancellation(&self) -> InvocationCancellation {
@@ -523,6 +566,24 @@ impl Context {
             self.events,
             self.publications,
         )
+    }
+
+    fn step_output_emitter(&self) -> HandlerResult<&StepOutputEmitter> {
+        if self.method == InvocationMethod::Rpc {
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "Step progress requires a Step Context",
+            ));
+        }
+        if self.cancellation.is_cancelled() {
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "Step invocation is canceled",
+            ));
+        }
+        self.output_emitter.as_ref().ok_or_else(|| {
+            HandlerError::new("dex_sdk::HandlerError", "Step output stream is unavailable")
+        })
     }
 
     fn get_attribute_value<T: Value>(
@@ -694,7 +755,7 @@ struct InvocationCancellationInner {
 }
 
 impl InvocationCancellation {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             inner: Arc::new(InvocationCancellationInner {
                 cancelled: AtomicBool::new(false),
@@ -711,7 +772,7 @@ impl InvocationCancellation {
         }
     }
 
-    fn is_cancelled(&self) -> bool {
+    pub(crate) fn is_cancelled(&self) -> bool {
         self.inner.cancelled.load(Ordering::Acquire)
     }
 
@@ -763,17 +824,13 @@ fn require_name(value: &str, kind: &str) -> HandlerResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Context, ContextInput, InvocationMethod};
+    use super::{Context, ContextInput, InvocationCancellation, InvocationMethod};
     use crate::{
         AttributeMap, ChannelMap, Flow, PersistenceSchema, Registry, registry::physical_name,
         value_mapper,
     };
-    use dex_protocol::dex::{
-        ChannelInfo, Context as ProtoContext, Kv, flow_service_client::FlowServiceClient,
-    };
+    use dex_protocol::dex::{ChannelInfo, Context as ProtoContext, Kv};
     use std::collections::HashMap;
-    use tokio::runtime::Runtime;
-    use tonic::transport::Endpoint;
 
     struct MapFlow {
         attributes: AttributeMap<String>,
@@ -801,11 +858,6 @@ mod tests {
         let attributes = AttributeMap::<String>::new("items");
         let channels = ChannelMap::<String>::new("messages");
         let special = "special / key";
-        let runtime = Runtime::new().expect("create test runtime");
-        let flow_service = {
-            let _runtime_guard = runtime.enter();
-            FlowServiceClient::new(Endpoint::from_static("http://127.0.0.1:1").connect_lazy())
-        };
         let mut context = Context::new(
             ContextInput {
                 method: InvocationMethod::Rpc,
@@ -828,8 +880,8 @@ mod tests {
                     (physical_name("messages", "empty"), ChannelInfo { size: 0 }),
                 ]),
             },
-            runtime.handle().clone(),
-            flow_service,
+            None,
+            InvocationCancellation::new(),
         )
         .expect("create RPC Context");
 
@@ -859,5 +911,12 @@ mod tests {
             channels.all_instance_keys(&context).unwrap()
         );
         assert_eq!(2, channels.map_size(&context).unwrap());
+        assert!(context.record_heartbeat().is_err());
+        assert!(
+            context
+                .record_heartbeat_value("checkpoint".to_string())
+                .is_err()
+        );
+        assert!(context.last_heartbeat_value::<String>().is_err());
     }
 }

--- a/sdk-rust/crates/dex-sdk/src/lib.rs
+++ b/sdk-rust/crates/dex-sdk/src/lib.rs
@@ -45,6 +45,7 @@ mod wait;
 mod worker;
 mod worker_dispatcher;
 mod worker_options;
+mod worker_output;
 
 pub use attribute::{Attribute, AttributeIndex, AttributeMap};
 pub use channel::{Channel, ChannelGuard, ChannelMap};

--- a/sdk-rust/crates/dex-sdk/src/step_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/step_options.rs
@@ -110,10 +110,11 @@ impl<Input: Value> StepOptions<Input> {
         self
     }
 
-    /// Enables cooperative cancellation heartbeats for regular `wait_for` and `execute` activities.
+    /// Sets the heartbeat timeout for regular `wait_for` and `execute` activities.
     ///
-    /// Zero disables heartbeats. Positive values must be whole seconds within the int32 range.
-    /// Local activities ignore this option; an asynchronous fallback to regular activity uses it.
+    /// Zero selects the server default of one minute. Positive values must be whole seconds and at
+    /// least the server-configured minimum, which defaults to ten seconds. Local activities ignore
+    /// this option; an asynchronous fallback to a regular activity uses it.
     pub fn heartbeat_timeout(mut self, value: Duration) -> Self {
         self.heartbeat_timeout = Some(value);
         self

--- a/sdk-rust/crates/dex-sdk/src/stream.rs
+++ b/sdk-rust/crates/dex-sdk/src/stream.rs
@@ -64,8 +64,8 @@ impl<T> Stream<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`crate::HandlerError`] for RPC Contexts, duplicate writes, unregistered Streams,
-    /// encoding failures, or a failed FlowService write.
+    /// Returns [`crate::HandlerError`] for RPC Contexts, unregistered Streams, encoding failures,
+    /// cancellation, or a closed Worker output stream. Dex storage failures are not acknowledged.
     pub fn write(&self, context: &mut Context, value: T) -> HandlerResult<()>
     where
         T: Value,
@@ -87,6 +87,6 @@ pub struct StreamMessage<T> {
     pub resume_token: String,
     /// Server-assigned creation time.
     pub created_time: SystemTime,
-    /// Client key or Step-generated runID#stepExecutionID key.
-    pub idempotency_key: String,
+    /// Client-provided source or Step-generated `#stepExecutionID` source.
+    pub source: String,
 }

--- a/sdk-rust/crates/dex-sdk/src/worker.rs
+++ b/sdk-rust/crates/dex-sdk/src/worker.rs
@@ -15,8 +15,8 @@ use dex_protocol::dex::WorkerErrorResponse;
 use dex_protocol::dex::flow_service_client::FlowServiceClient;
 use dex_protocol::dex::worker_service_server::{WorkerService, WorkerServiceServer};
 use dex_protocol::dex::{
-    InvokeExecuteMethodRequest, InvokeExecuteMethodResponse, InvokeWaitForMethodRequest,
-    InvokeWaitForMethodResponse, InvokeWorkerRpcRequest, InvokeWorkerRpcResponse,
+    InvokeExecuteMethodOutput, InvokeExecuteMethodRequest, InvokeWaitForMethodOutput,
+    InvokeWaitForMethodRequest, InvokeWorkerRpcRequest, InvokeWorkerRpcResponse,
     SyncAttributeIndexRequest,
 };
 use prost::Message;
@@ -28,6 +28,7 @@ use tonic::{Code, Request, Response, Status};
 
 use crate::value_hydrator::ValueHydrator;
 use crate::worker_dispatcher::WorkerDispatcher;
+use crate::worker_output::WorkerResponseStream;
 use crate::{BlobCache, HandlerError, Registry, SdkError, SdkResult, WorkerOptions, WorkerTarget};
 
 // Keep worker error status small enough for default gRPC trailer limits after
@@ -122,12 +123,7 @@ impl Worker {
         };
         let attribute_indexes = registry.attribute_indexes().clone();
         let hydrator = ValueHydrator::new(flow_service.clone(), blob_cache);
-        let dispatcher = WorkerDispatcher::new(
-            registry,
-            hydrator,
-            flow_service.clone(),
-            runtime.handle().clone(),
-        );
+        let dispatcher = WorkerDispatcher::new(registry, hydrator);
         let (shutdown, _) = watch::channel(false);
         Ok(Self {
             runtime,
@@ -207,26 +203,30 @@ struct RustWorkerService {
 
 #[tonic::async_trait]
 impl WorkerService for RustWorkerService {
+    type InvokeWaitForMethodStream = WorkerResponseStream<InvokeWaitForMethodOutput>;
+
     async fn invoke_wait_for_method(
         &self,
         request: Request<InvokeWaitForMethodRequest>,
-    ) -> Result<Response<InvokeWaitForMethodResponse>, Status> {
-        self.dispatcher
-            .invoke_wait_for(request.into_inner())
-            .await
-            .map(Response::new)
-            .map_err(worker_status)
+    ) -> Result<Response<Self::InvokeWaitForMethodStream>, Status> {
+        Ok(Response::new(
+            self.dispatcher
+                .invoke_wait_for(request.into_inner())
+                .into_stream(worker_status),
+        ))
     }
+
+    type InvokeExecuteMethodStream = WorkerResponseStream<InvokeExecuteMethodOutput>;
 
     async fn invoke_execute_method(
         &self,
         request: Request<InvokeExecuteMethodRequest>,
-    ) -> Result<Response<InvokeExecuteMethodResponse>, Status> {
-        self.dispatcher
-            .invoke_execute(request.into_inner())
-            .await
-            .map(Response::new)
-            .map_err(worker_status)
+    ) -> Result<Response<Self::InvokeExecuteMethodStream>, Status> {
+        Ok(Response::new(
+            self.dispatcher
+                .invoke_execute(request.into_inner())
+                .into_stream(worker_status),
+        ))
     }
 
     async fn invoke_worker_rpc(

--- a/sdk-rust/crates/dex-sdk/src/worker_dispatcher.rs
+++ b/sdk-rust/crates/dex-sdk/src/worker_dispatcher.rs
@@ -13,17 +13,17 @@ use std::time::Duration;
 use dex_protocol::dex::{
     AttributeWrite, ChannelCondition, ChannelMessage, CloseDecision, CloseDecisionType,
     ConditionCombination as ProtoCombination, ExecuteMethodFailurePolicy,
-    InvokeExecuteMethodRequest, InvokeExecuteMethodResponse, InvokeWaitForMethodRequest,
-    InvokeWaitForMethodResponse, InvokeWorkerRpcRequest, InvokeWorkerRpcResponse, Kv,
-    RetryPolicy as ProtoRetryPolicy, StepDecision as ProtoStepDecision,
-    StepDurability as ProtoStepDurability, StepMovement as ProtoStepMovement,
-    StepOptions as ProtoStepOptions, SubFlowCondition as ProtoSubFlowCondition,
-    SubFlowOptions as ProtoSubFlowOptions, SubFlowReusePolicy as ProtoSubFlowReusePolicy,
-    TimerCondition, WaitForMethodFailurePolicy, WaitingCondition, WaitingConditionType,
-    flow_service_client::FlowServiceClient,
+    InvokeExecuteMethodOutput, InvokeExecuteMethodRequest, InvokeExecuteMethodResponse,
+    InvokeWaitForMethodOutput, InvokeWaitForMethodRequest, InvokeWaitForMethodResponse,
+    InvokeWorkerRpcRequest, InvokeWorkerRpcResponse, Kv, RetryPolicy as ProtoRetryPolicy,
+    StepDecision as ProtoStepDecision, StepDurability as ProtoStepDurability,
+    StepMovement as ProtoStepMovement, StepOptions as ProtoStepOptions,
+    SubFlowCondition as ProtoSubFlowCondition, SubFlowOptions as ProtoSubFlowOptions,
+    SubFlowReusePolicy as ProtoSubFlowReusePolicy, TimerCondition, WaitForMethodFailurePolicy,
+    WaitingCondition, WaitingConditionType, invoke_execute_method_output,
+    invoke_wait_for_method_output,
 };
-use tokio::runtime::Handle;
-use tonic::transport::Channel as TransportChannel;
+use tokio::sync::mpsc;
 
 use crate::context::{Context, ContextInput, InvocationCancellation, InvocationMethod};
 use crate::persistence::PersistenceKind;
@@ -34,6 +34,7 @@ use crate::step_options::ErasedStepOptions;
 use crate::value_hydrator::ValueHydrator;
 use crate::value_mapper;
 use crate::wait::{Condition, ConditionKind, Wait, WaitKind};
+use crate::worker_output::{StepOutputEmitter, WorkerInvocation};
 use crate::{
     HandlerError, HandlerResult, Registry, RetryPolicy, SdkError, StepDurability,
     SubFlowReusePolicy, WaitForFailurePolicy,
@@ -45,28 +46,39 @@ const TIMEOUT_HANDLER_STEP_TYPE: &str = "sys:timeout_handler";
 pub(crate) struct WorkerDispatcher {
     registry: Registry,
     hydrator: ValueHydrator,
-    flow_service: FlowServiceClient<TransportChannel>,
-    runtime_handle: Handle,
 }
 
 impl WorkerDispatcher {
-    pub(crate) fn new(
-        registry: Registry,
-        hydrator: ValueHydrator,
-        flow_service: FlowServiceClient<TransportChannel>,
-        runtime_handle: Handle,
-    ) -> Self {
-        Self {
-            registry,
-            hydrator,
-            flow_service,
-            runtime_handle,
-        }
+    pub(crate) fn new(registry: Registry, hydrator: ValueHydrator) -> Self {
+        Self { registry, hydrator }
     }
 
-    pub(crate) async fn invoke_wait_for(
+    pub(crate) fn invoke_wait_for(
         &self,
         request: InvokeWaitForMethodRequest,
+    ) -> WorkerInvocation<InvokeWaitForMethodOutput> {
+        let (output_emitter, receiver) = StepOutputEmitter::wait_for();
+        let sender = output_emitter.wait_for_sender();
+        let cancellation = InvocationCancellation::new();
+        let producer_cancellation = cancellation.clone();
+        let dispatcher = self.clone();
+        let producer = tokio::spawn(async move {
+            let result = dispatcher
+                .do_invoke_wait_for(request, output_emitter, producer_cancellation.clone())
+                .await
+                .map(|result| InvokeWaitForMethodOutput {
+                    output: Some(invoke_wait_for_method_output::Output::Result(result)),
+                });
+            send_handler_result(sender, producer_cancellation, result).await;
+        });
+        WorkerInvocation::new(receiver, cancellation, producer)
+    }
+
+    async fn do_invoke_wait_for(
+        &self,
+        request: InvokeWaitForMethodRequest,
+        output_emitter: StepOutputEmitter,
+        cancellation: InvocationCancellation,
     ) -> HandlerResult<InvokeWaitForMethodResponse> {
         let request = self.hydrate_wait_for(request).await?;
         let flow = self.registered_flow(&request.flow_type)?;
@@ -95,8 +107,8 @@ impl WorkerDispatcher {
                 condition_results: None,
                 channel_infos: HashMap::new(),
             },
-            self.runtime_handle.clone(),
-            self.flow_service.clone(),
+            Some(output_emitter),
+            cancellation,
         )?;
         let input = request
             .step_input
@@ -121,14 +133,39 @@ impl WorkerDispatcher {
         .await
     }
 
-    pub(crate) async fn invoke_execute(
+    pub(crate) fn invoke_execute(
         &self,
         request: InvokeExecuteMethodRequest,
+    ) -> WorkerInvocation<InvokeExecuteMethodOutput> {
+        let (output_emitter, receiver) = StepOutputEmitter::execute();
+        let sender = output_emitter.execute_sender();
+        let cancellation = InvocationCancellation::new();
+        let producer_cancellation = cancellation.clone();
+        let dispatcher = self.clone();
+        let producer = tokio::spawn(async move {
+            let result = dispatcher
+                .do_invoke_execute(request, output_emitter, producer_cancellation.clone())
+                .await
+                .map(|result| InvokeExecuteMethodOutput {
+                    output: Some(invoke_execute_method_output::Output::Result(result)),
+                });
+            send_handler_result(sender, producer_cancellation, result).await;
+        });
+        WorkerInvocation::new(receiver, cancellation, producer)
+    }
+
+    async fn do_invoke_execute(
+        &self,
+        request: InvokeExecuteMethodRequest,
+        output_emitter: StepOutputEmitter,
+        cancellation: InvocationCancellation,
     ) -> HandlerResult<InvokeExecuteMethodResponse> {
         let request = self.hydrate_execute(request).await?;
         let flow = self.registered_flow(&request.flow_type)?;
         if request.step_type == TIMEOUT_HANDLER_STEP_TYPE {
-            return self.invoke_timeout_handler(request, flow).await;
+            return self
+                .invoke_timeout_handler(request, flow, output_emitter, cancellation)
+                .await;
         }
         let step = flow
             .steps
@@ -155,8 +192,8 @@ impl WorkerDispatcher {
                 condition_results: request.condition_results,
                 channel_infos: HashMap::new(),
             },
-            self.runtime_handle.clone(),
-            self.flow_service.clone(),
+            Some(output_emitter),
+            cancellation,
         )?;
         let input = request
             .step_input
@@ -184,6 +221,8 @@ impl WorkerDispatcher {
         &self,
         request: InvokeExecuteMethodRequest,
         flow: RegisteredFlow,
+        output_emitter: StepOutputEmitter,
+        cancellation: InvocationCancellation,
     ) -> HandlerResult<InvokeExecuteMethodResponse> {
         if request.step_input.is_some() {
             return Err(HandlerError::new(
@@ -212,8 +251,8 @@ impl WorkerDispatcher {
                 condition_results: request.condition_results,
                 channel_infos: HashMap::new(),
             },
-            self.runtime_handle.clone(),
-            self.flow_service.clone(),
+            Some(output_emitter),
+            cancellation,
         )?;
         let cancellation = context.cancellation();
         run_handler(cancellation, move || {
@@ -270,8 +309,8 @@ impl WorkerDispatcher {
                 condition_results: None,
                 channel_infos: request.channel_infos,
             },
-            self.runtime_handle.clone(),
-            self.flow_service.clone(),
+            None,
+            InvocationCancellation::new(),
         )?;
         let input = request
             .input
@@ -417,6 +456,16 @@ impl WorkerDispatcher {
             .flow(flow_type)
             .cloned()
             .map_err(handler_error)
+    }
+}
+
+async fn send_handler_result<Output>(
+    sender: mpsc::Sender<HandlerResult<Output>>,
+    cancellation: InvocationCancellation,
+    result: HandlerResult<Output>,
+) {
+    if sender.send(result).await.is_err() {
+        cancellation.cancel();
     }
 }
 

--- a/sdk-rust/crates/dex-sdk/src/worker_output.rs
+++ b/sdk-rust/crates/dex-sdk/src/worker_output.rs
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use dex_protocol::dex::{
+    InvokeExecuteMethodOutput, InvokeWaitForMethodOutput, StepMethodHeartbeat, StepStreamWrite,
+    Value as ProtoValue, invoke_execute_method_output, invoke_wait_for_method_output,
+};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_stream::Stream;
+use tonic::Status;
+
+use crate::context::InvocationCancellation;
+use crate::{HandlerError, HandlerResult};
+
+const STEP_OUTPUT_CHANNEL_CAPACITY: usize = 1;
+
+#[derive(Clone)]
+pub(crate) enum StepOutputEmitter {
+    WaitFor(mpsc::Sender<HandlerResult<InvokeWaitForMethodOutput>>),
+    Execute(mpsc::Sender<HandlerResult<InvokeExecuteMethodOutput>>),
+}
+
+impl StepOutputEmitter {
+    pub(crate) fn wait_for() -> (
+        Self,
+        mpsc::Receiver<HandlerResult<InvokeWaitForMethodOutput>>,
+    ) {
+        let (sender, receiver) = mpsc::channel(STEP_OUTPUT_CHANNEL_CAPACITY);
+        (Self::WaitFor(sender), receiver)
+    }
+
+    pub(crate) fn execute() -> (
+        Self,
+        mpsc::Receiver<HandlerResult<InvokeExecuteMethodOutput>>,
+    ) {
+        let (sender, receiver) = mpsc::channel(STEP_OUTPUT_CHANNEL_CAPACITY);
+        (Self::Execute(sender), receiver)
+    }
+
+    pub(crate) fn send_heartbeat(&self, value: Option<ProtoValue>) -> HandlerResult<()> {
+        match self {
+            Self::WaitFor(sender) => sender
+                .blocking_send(Ok(InvokeWaitForMethodOutput {
+                    output: Some(invoke_wait_for_method_output::Output::Heartbeat(
+                        StepMethodHeartbeat { value },
+                    )),
+                }))
+                .map_err(output_closed),
+            Self::Execute(sender) => sender
+                .blocking_send(Ok(InvokeExecuteMethodOutput {
+                    output: Some(invoke_execute_method_output::Output::Heartbeat(
+                        StepMethodHeartbeat { value },
+                    )),
+                }))
+                .map_err(output_closed),
+        }
+    }
+
+    pub(crate) fn send_stream_write(&self, write: StepStreamWrite) -> HandlerResult<()> {
+        match self {
+            Self::WaitFor(sender) => sender
+                .blocking_send(Ok(InvokeWaitForMethodOutput {
+                    output: Some(invoke_wait_for_method_output::Output::StreamWrite(write)),
+                }))
+                .map_err(output_closed),
+            Self::Execute(sender) => sender
+                .blocking_send(Ok(InvokeExecuteMethodOutput {
+                    output: Some(invoke_execute_method_output::Output::StreamWrite(write)),
+                }))
+                .map_err(output_closed),
+        }
+    }
+
+    pub(crate) fn wait_for_sender(&self) -> mpsc::Sender<HandlerResult<InvokeWaitForMethodOutput>> {
+        match self {
+            Self::WaitFor(sender) => sender.clone(),
+            Self::Execute(_) => panic!("WaitFor output emitter has the wrong method"),
+        }
+    }
+
+    pub(crate) fn execute_sender(&self) -> mpsc::Sender<HandlerResult<InvokeExecuteMethodOutput>> {
+        match self {
+            Self::Execute(sender) => sender.clone(),
+            Self::WaitFor(_) => panic!("Execute output emitter has the wrong method"),
+        }
+    }
+}
+
+pub(crate) struct WorkerInvocation<Output> {
+    receiver: mpsc::Receiver<HandlerResult<Output>>,
+    cancellation: InvocationCancellation,
+    producer: JoinHandle<()>,
+}
+
+impl<Output> WorkerInvocation<Output> {
+    pub(crate) fn new(
+        receiver: mpsc::Receiver<HandlerResult<Output>>,
+        cancellation: InvocationCancellation,
+        producer: JoinHandle<()>,
+    ) -> Self {
+        Self {
+            receiver,
+            cancellation,
+            producer,
+        }
+    }
+
+    pub(crate) fn into_stream(
+        self,
+        map_error: fn(HandlerError) -> Status,
+    ) -> WorkerResponseStream<Output> {
+        WorkerResponseStream {
+            receiver: self.receiver,
+            cancellation: self.cancellation,
+            producer: self.producer,
+            map_error,
+        }
+    }
+}
+
+pub(crate) struct WorkerResponseStream<Output> {
+    receiver: mpsc::Receiver<HandlerResult<Output>>,
+    cancellation: InvocationCancellation,
+    producer: JoinHandle<()>,
+    map_error: fn(HandlerError) -> Status,
+}
+
+impl<Output> Stream for WorkerResponseStream<Output> {
+    type Item = Result<Output, Status>;
+
+    fn poll_next(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let map_error = self.map_error;
+        Pin::new(&mut self.receiver)
+            .poll_recv(context)
+            .map(|output| output.map(|result| result.map_err(map_error)))
+    }
+}
+
+impl<Output> Drop for WorkerResponseStream<Output> {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
+        self.producer.abort();
+    }
+}
+
+fn output_closed<T>(_: mpsc::error::SendError<T>) -> HandlerError {
+    HandlerError::new("dex_sdk::HandlerError", "Step output stream is closed")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc as std_mpsc;
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn single_slot_channel_applies_backpressure() {
+        let (emitter, mut receiver) = StepOutputEmitter::wait_for();
+        let (sent, observed) = std_mpsc::channel();
+        let producer = std::thread::spawn(move || {
+            emitter.send_heartbeat(None).expect("send first frame");
+            sent.send(1).expect("report first frame");
+            emitter.send_heartbeat(None).expect("send second frame");
+            sent.send(2).expect("report second frame");
+        });
+
+        assert_eq!(1, observed.recv().expect("observe first frame"));
+        assert!(observed.recv_timeout(Duration::from_millis(50)).is_err());
+        receiver
+            .recv()
+            .await
+            .expect("receive first frame")
+            .expect("first frame succeeds");
+        assert_eq!(2, observed.recv().expect("observe second frame"));
+        receiver
+            .recv()
+            .await
+            .expect("receive second frame")
+            .expect("second frame succeeds");
+        producer.join().expect("join producer");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dropped_stream_cancels_and_unblocks_sender() {
+        let (emitter, receiver) = StepOutputEmitter::wait_for();
+        let (sent, observed) = std_mpsc::channel();
+        let sender = std::thread::spawn(move || {
+            emitter.send_heartbeat(None).expect("send first frame");
+            sent.send(()).expect("report first frame");
+            emitter.send_heartbeat(None)
+        });
+        observed.recv().expect("observe first frame");
+
+        let cancellation = InvocationCancellation::new();
+        let producer = tokio::spawn(std::future::pending());
+        let stream = WorkerInvocation::new(receiver, cancellation.clone(), producer)
+            .into_stream(|error| Status::unknown(error.to_string()));
+        drop(stream);
+
+        assert!(cancellation.is_cancelled());
+        assert!(sender.join().expect("join sender").is_err());
+    }
+}

--- a/sdk-rust/crates/dex-sdk/tests/compile_contracts.rs
+++ b/sdk-rust/crates/dex-sdk/tests/compile_contracts.rs
@@ -31,10 +31,16 @@ fn stream_definitions_and_client_calls_compile() {
         context: &mut dex_sdk::Context,
         stream: &dex_sdk::Stream<String>,
     ) -> dex_sdk::SdkResult<()> {
+        let _heartbeat: dex_sdk::HandlerResult<()> = context.record_heartbeat();
+        let _heartbeat_value: dex_sdk::HandlerResult<()> =
+            context.record_heartbeat_value(Some("checkpoint".to_owned()));
+        let _last_heartbeat: dex_sdk::HandlerResult<Option<Option<String>>> =
+            context.last_heartbeat_value::<Option<String>>();
         let _stream_write: dex_sdk::HandlerResult<()> =
             stream.write(context, "checking".to_owned());
-        client.write_stream("flow-1", stream, "client-1", "starting".to_owned())?;
+        client.write_stream("flow-1", stream, "client#source", "starting".to_owned())?;
         let message = client.read_stream("flow-1", stream, "")?;
+        let _source: &str = &message.source;
         let _next = client.read_stream_with_timeout(
             "flow-1",
             stream,

--- a/sdk-rust/crates/dex-sdk/tests/integ.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ.rs
@@ -33,6 +33,10 @@ mod conditional_complete_test;
 mod conditional_complete_workflow;
 #[path = "integ/flow_service_client.rs"]
 mod flow_service_client;
+#[path = "integ/heartbeat_recovery_test.rs"]
+mod heartbeat_recovery_test;
+#[path = "integ/heartbeat_recovery_workflow.rs"]
+mod heartbeat_recovery_workflow;
 #[path = "integ/internal_channel_test.rs"]
 mod internal_channel_test;
 #[path = "integ/internal_channel_waiting_workflow.rs"]

--- a/sdk-rust/crates/dex-sdk/tests/integ/README.md
+++ b/sdk-rust/crates/dex-sdk/tests/integ/README.md
@@ -2,14 +2,15 @@
 
 This suite mirrors `sdk-java/src/test/java/io/superdurable/dex/integ` in
 idiomatic, strongly typed Rust. Each Java integration test and Workflow has a
-corresponding Rust file with the same behavior and assertions. Stream coverage adds
-one SDK-native test and Workflow.
+corresponding Rust file with the same behavior and assertions. SDK-native coverage adds
+Step streaming, heartbeat recovery, and cancellation scenarios.
 
 | Java test | Rust module |
 | --- | --- |
 | `AnyCommandCombinationTest` | `any_command_combination_test.rs` |
 | `BasicTest` | `basic_test.rs` |
 | `ConditionalCompleteTest` | `conditional_complete_test.rs` |
+| Rust heartbeat recovery | `heartbeat_recovery_test.rs` |
 | `InternalChannelTest` | `internal_channel_test.rs` |
 | `NoStartStateTest` | `no_start_state_test.rs` |
 | `PersistenceTest` | `persistence_test.rs` |
@@ -58,3 +59,9 @@ one-to-one Java suite.
 Local contract tests also cover malformed rich details, fallible registration,
 invalid Step-result worker metadata, user-owned Condition IDs, and map
 introspection. Persistence integration covers singleton Attribute equality waits.
+
+Heartbeat recovery verifies typed checkpoints, explicit clearing, JSON null versus an absent Value,
+Stream implicit-heartbeat preservation, and the absence of local-activity details after regular
+fallback. Stream integration interleaves WaitFor and Execute heartbeat frames with repeated Step
+writes, then verifies repeated client sources containing `#` all append. Cancellation coverage uses
+active heartbeat output so blocked synchronous handlers observe response-stream closure promptly.

--- a/sdk-rust/crates/dex-sdk/tests/integ/heartbeat_recovery_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/heartbeat_recovery_test.rs
@@ -1,0 +1,79 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+use std::time::Duration;
+
+use dex_sdk::Registry;
+
+use crate::heartbeat_recovery_workflow::{
+    HEARTBEAT_PROGRESS, HeartbeatRecoveryWorkflow, NoOutputHeartbeatTimeoutWorkflow,
+};
+use crate::support::{DexDevTestEnvironment, flow_id};
+
+#[test]
+#[ignore = "requires dexcli dev"]
+fn test_heartbeat_recovery_and_local_fallback() {
+    let workflow = HeartbeatRecoveryWorkflow::new();
+    let environment = DexDevTestEnvironment::start(Registry::new().register(workflow.clone()));
+    let flow_id = flow_id("rust-heartbeat-recovery");
+    environment
+        .client
+        .start_flow(&workflow, &flow_id, ())
+        .expect("start heartbeat recovery Flow");
+    assert_eq!(
+        "heartbeat-ok",
+        environment
+            .client
+            .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(45))
+            .and_then(|result| result.single_output::<String>())
+            .expect("complete heartbeat recovery Flow")
+    );
+
+    let mut resume_token = String::new();
+    let mut sources = Vec::new();
+    for expected in ["sync-progress", "local-1", "local-2", "local-3"] {
+        let message = environment
+            .client
+            .read_stream_with_timeout(
+                &flow_id,
+                &HEARTBEAT_PROGRESS,
+                &resume_token,
+                Duration::from_secs(30),
+            )
+            .expect("read heartbeat progress");
+        assert_eq!(expected, message.value);
+        assert!(message.source.starts_with('#'));
+        sources.push(message.source);
+        resume_token = message.resume_token;
+    }
+    assert_ne!(sources[0], sources[1]);
+    assert_eq!(sources[1], sources[2]);
+    assert_eq!(sources[2], sources[3]);
+}
+
+#[test]
+#[ignore = "requires dexcli dev"]
+fn test_no_output_handler_reaches_heartbeat_timeout() {
+    let workflow = NoOutputHeartbeatTimeoutWorkflow::new();
+    let environment = DexDevTestEnvironment::start(Registry::new().register(workflow.clone()));
+    let flow_id = flow_id("rust-heartbeat-timeout");
+    environment
+        .client
+        .start_flow(&workflow, &flow_id, ())
+        .expect("start heartbeat timeout Flow");
+    assert_eq!(
+        "heartbeat-timeout",
+        environment
+            .client
+            .wait_for_flow_with_timeout(&flow_id, Duration::from_secs(30))
+            .and_then(|result| result.single_output::<String>())
+            .expect("recover from heartbeat timeout")
+    );
+}

--- a/sdk-rust/crates/dex-sdk/tests/integ/heartbeat_recovery_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/heartbeat_recovery_workflow.rs
@@ -1,0 +1,201 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+use std::sync::LazyLock;
+use std::thread;
+use std::time::Duration;
+
+use dex_sdk::{
+    Context, Flow, HandlerError, HandlerResult, PersistenceSchema, RetryPolicy, Step, StepDecision,
+    StepDurability, StepList, StepOptions, Stream,
+};
+
+pub(crate) static HEARTBEAT_PROGRESS: LazyLock<Stream<String>> =
+    LazyLock::new(|| Stream::new("rust-heartbeat-progress", 1 << 20));
+
+#[derive(Clone)]
+pub(crate) struct HeartbeatRecoveryWorkflow {
+    sync: SyncHeartbeatStep,
+    asynchronous: AsyncHeartbeatStep,
+}
+
+impl HeartbeatRecoveryWorkflow {
+    pub(crate) fn new() -> Self {
+        Self {
+            sync: SyncHeartbeatStep,
+            asynchronous: AsyncHeartbeatStep,
+        }
+    }
+}
+
+impl Flow for HeartbeatRecoveryWorkflow {
+    type StartInput = ();
+
+    fn steps(&self) -> StepList<'_, Self::StartInput> {
+        StepList::start(&self.sync).and(&self.asynchronous)
+    }
+
+    fn persistence(&self) -> PersistenceSchema {
+        PersistenceSchema::new().stream(&HEARTBEAT_PROGRESS)
+    }
+}
+
+#[derive(Clone)]
+struct SyncHeartbeatStep;
+
+impl Step for SyncHeartbeatStep {
+    type Input = ();
+
+    fn execute(&self, context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        match context.attempt() {
+            1 => {
+                require_last_heartbeat(context, None)?;
+                context.record_heartbeat_value(Some("sync-checkpoint".to_string()))?;
+                HEARTBEAT_PROGRESS.write(context, "sync-progress".to_string())?;
+                Err(retry_error("persist typed heartbeat"))
+            }
+            2 => {
+                require_last_heartbeat(context, Some(Some("sync-checkpoint".to_string())))?;
+                context.record_heartbeat()?;
+                Err(retry_error("clear heartbeat"))
+            }
+            3 => {
+                require_last_heartbeat(context, None)?;
+                context.record_heartbeat_value(None::<String>)?;
+                Err(retry_error("persist null heartbeat"))
+            }
+            4 => {
+                require_last_heartbeat(context, Some(None))?;
+                Ok(StepDecision::go_to(&AsyncHeartbeatStep, ()))
+            }
+            attempt => Err(HandlerError::new(
+                "HeartbeatRecoveryFailure",
+                format!("unexpected sync attempt {attempt}"),
+            )),
+        }
+    }
+
+    fn options(&self) -> StepOptions<Self::Input> {
+        retry_options(StepDurability::Sync)
+    }
+}
+
+#[derive(Clone)]
+struct AsyncHeartbeatStep;
+
+impl Step for AsyncHeartbeatStep {
+    type Input = ();
+
+    fn execute(&self, context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        if context.attempt() <= 3 {
+            if context.last_heartbeat_value::<String>()?.is_some() {
+                return Err(retry_error("local heartbeat leaked into retry"));
+            }
+            context.record_heartbeat_value(format!("local-{}", context.attempt()))?;
+            HEARTBEAT_PROGRESS.write(context, format!("local-{}", context.attempt()))?;
+            return Err(retry_error("exercise local retry"));
+        }
+        if context.last_heartbeat_value::<String>()?.is_some() {
+            return Err(retry_error("local heartbeat leaked into regular fallback"));
+        }
+        Ok(StepDecision::graceful_complete("heartbeat-ok".to_string()))
+    }
+
+    fn options(&self) -> StepOptions<Self::Input> {
+        retry_options(StepDurability::Async)
+    }
+}
+
+fn retry_options(durability: StepDurability) -> StepOptions<()> {
+    StepOptions::new()
+        .execute_durability(durability)
+        .heartbeat_timeout(Duration::from_secs(10))
+        .execute_retry(
+            RetryPolicy::new()
+                .initial_interval(Duration::from_secs(1))
+                .maximum_attempts(4)
+                .total_duration(Duration::from_secs(30)),
+        )
+}
+
+fn require_last_heartbeat(
+    context: &Context,
+    expected: Option<Option<String>>,
+) -> HandlerResult<()> {
+    let actual = context.last_heartbeat_value::<Option<String>>()?;
+    if actual == expected {
+        return Ok(());
+    }
+    Err(HandlerError::new(
+        "HeartbeatRecoveryFailure",
+        format!("expected heartbeat {expected:?}, got {actual:?}"),
+    ))
+}
+
+fn retry_error(message: &str) -> HandlerError {
+    HandlerError::new("HeartbeatRecoveryRetry", message)
+}
+
+#[derive(Clone)]
+pub(crate) struct NoOutputHeartbeatTimeoutWorkflow {
+    start: NoOutputHeartbeatStep,
+    recovery: HeartbeatTimeoutRecovery,
+}
+
+impl NoOutputHeartbeatTimeoutWorkflow {
+    pub(crate) fn new() -> Self {
+        Self {
+            start: NoOutputHeartbeatStep,
+            recovery: HeartbeatTimeoutRecovery,
+        }
+    }
+}
+
+impl Flow for NoOutputHeartbeatTimeoutWorkflow {
+    type StartInput = ();
+
+    fn steps(&self) -> StepList<'_, Self::StartInput> {
+        StepList::start(&self.start).and(&self.recovery)
+    }
+}
+
+#[derive(Clone)]
+struct NoOutputHeartbeatStep;
+
+impl Step for NoOutputHeartbeatStep {
+    type Input = ();
+
+    fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        thread::sleep(Duration::from_secs(12));
+        Ok(StepDecision::graceful_complete("late-result".to_string()))
+    }
+
+    fn options(&self) -> StepOptions<Self::Input> {
+        StepOptions::new()
+            .execute_durability(StepDurability::Sync)
+            .execute_method_timeout(Duration::from_secs(20))
+            .heartbeat_timeout(Duration::from_secs(10))
+            .execute_retry(RetryPolicy::new().maximum_attempts(1))
+            .on_execute_failure_proceed_to(&HeartbeatTimeoutRecovery)
+    }
+}
+
+#[derive(Clone)]
+struct HeartbeatTimeoutRecovery;
+
+impl Step for HeartbeatTimeoutRecovery {
+    type Input = ();
+
+    fn execute(&self, _context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
+        Ok(StepDecision::graceful_complete(
+            "heartbeat-timeout".to_string(),
+        ))
+    }
+}

--- a/sdk-rust/crates/dex-sdk/tests/integ/signal_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/signal_test.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use dex_sdk::{Client, GrpcCode, Registry, SdkError, SdkResult, StepExecutionId, TimerId};
 
 use crate::signal_workflow::{FIRST, SignalWorkflow, THIRD};
-use crate::support::{DexDevTestEnvironment, flow_id};
+use crate::support::{DexDevTestEnvironment, flow_id, skip_timer_when_pending};
 
 #[test]
 #[ignore = "requires dexcli dev"]
@@ -37,14 +37,12 @@ fn test_basic_signal_workflow() {
         .client
         .publish_map(&flow_id, &workflow.signal_map, "one", [4])
         .expect("publish mapped signal");
-    environment
-        .client
-        .skip_timer(
-            &flow_id,
-            StepExecutionId::of(&workflow.combination),
-            TimerId::by_condition_id("test-timer-id"),
-        )
-        .expect("skip signal timer");
+    skip_timer_when_pending(
+        &environment.client,
+        &flow_id,
+        StepExecutionId::of(&workflow.combination),
+        TimerId::by_condition_id("test-timer-id"),
+    );
     assert_eq!(
         6,
         environment

--- a/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_test.rs
@@ -98,7 +98,20 @@ fn run_scenario(scenario: CancellationScenario) {
             assert!(state.context_reported_cancellation.load(Ordering::SeqCst));
         }
     }
-    assert_eq!(1, state.blocking_invocations.load(Ordering::SeqCst));
+    let expected_invocations = if matches!(
+        scenario,
+        CancellationScenario::LocalExecute | CancellationScenario::LocalTimeoutFallback
+    ) {
+        2
+    } else {
+        1
+    };
+    assert_eq!(
+        expected_invocations,
+        state.blocking_invocations.load(Ordering::SeqCst),
+        "{}",
+        scenario.name()
+    );
     assert!(!state.recovery_ran.load(Ordering::SeqCst));
     assert_eq!(
         None,

--- a/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/step_cancellation_workflow.rs
@@ -218,12 +218,7 @@ impl Step for CancellationBlockingExecute {
         if self.state.scenario == CancellationScenario::NoHeartbeat {
             thread::sleep(Duration::from_secs(7));
         } else {
-            context.wait_for_cancellation();
-            self.state.handler_canceled.store(true, Ordering::SeqCst);
-            self.state
-                .context_reported_cancellation
-                .store(context.is_cancelled(), Ordering::SeqCst);
-            self.state.cancellation_observed.set();
+            wait_for_stream_cancellation(context, &self.state)?;
         }
         LATE_WRITE.set(context, "late".to_string())?;
         self.state.late_handler_returned.set();
@@ -241,7 +236,7 @@ impl Step for CancellationBlockingExecute {
             self.state.scenario,
             CancellationScenario::HeartbeatExecute | CancellationScenario::LocalTimeoutFallback
         ) {
-            options = options.heartbeat_timeout(Duration::from_secs(2));
+            options = options.heartbeat_timeout(Duration::from_secs(10));
         }
         if matches!(
             self.state.scenario,
@@ -263,12 +258,7 @@ impl Step for CancellationBlockingWaitFor {
     fn wait_for(&self, context: &mut Context, _input: ()) -> HandlerResult<Wait> {
         self.0.blocking_invocations.fetch_add(1, Ordering::SeqCst);
         self.0.blocking_started.set();
-        context.wait_for_cancellation();
-        self.0.handler_canceled.store(true, Ordering::SeqCst);
-        self.0
-            .context_reported_cancellation
-            .store(context.is_cancelled(), Ordering::SeqCst);
-        self.0.cancellation_observed.set();
+        wait_for_stream_cancellation(context, &self.0)?;
         Ok(Wait::skip_immediately())
     }
 
@@ -282,10 +272,31 @@ impl Step for CancellationBlockingWaitFor {
     fn options(&self) -> StepOptions<Self::Input> {
         StepOptions::new()
             .wait_for_method_timeout(Duration::from_secs(15))
-            .heartbeat_timeout(Duration::from_secs(2))
+            .heartbeat_timeout(Duration::from_secs(10))
             .wait_for_failure(WaitForFailurePolicy::Proceed)
             .wait_for_durability(dex_sdk::StepDurability::Sync)
     }
+}
+
+fn wait_for_stream_cancellation(
+    context: &mut Context,
+    state: &CancellationState,
+) -> HandlerResult<()> {
+    while !context.is_cancelled() {
+        if let Err(error) = context.record_heartbeat() {
+            if context.is_cancelled() {
+                break;
+            }
+            return Err(error);
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    state.handler_canceled.store(true, Ordering::SeqCst);
+    state
+        .context_reported_cancellation
+        .store(context.is_cancelled(), Ordering::SeqCst);
+    state.cancellation_observed.set();
+    Ok(())
 }
 
 struct CancellationWinner(Arc<CancellationState>);

--- a/sdk-rust/crates/dex-sdk/tests/integ/stream_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/stream_test.rs
@@ -21,7 +21,7 @@ fn test_stream_round_trip() {
     let workflow = StreamTestWorkflow::new();
     let environment = DexDevTestEnvironment::start(Registry::new().register(workflow.clone()));
     let flow_id = flow_id("stream");
-    let run_id = environment
+    environment
         .client
         .start_flow(&workflow, &flow_id, ())
         .expect("start Stream Flow");
@@ -35,7 +35,7 @@ fn test_stream_round_trip() {
         .write_stream(
             &flow_id,
             &PROGRESS,
-            "client-write",
+            "client#source",
             "client-progress".to_string(),
         )
         .expect("write client Stream message");
@@ -44,31 +44,45 @@ fn test_stream_round_trip() {
         .write_stream(
             &flow_id,
             &PROGRESS,
-            "client-write",
-            "duplicate-ignored".to_string(),
+            "client#source",
+            "client-progress-again".to_string(),
         )
-        .expect("deduplicate client Stream message");
+        .expect("append repeated-source client Stream message");
 
-    let step = environment
-        .client
-        .read_stream_with_timeout(&flow_id, &PROGRESS, "", Duration::from_secs(30))
-        .expect("read Step Stream message");
-    assert_eq!("step-progress", step.value);
-    assert!(!step.resume_token.is_empty());
-    assert!(step.created_time > SystemTime::UNIX_EPOCH);
-    assert!(step.idempotency_key.starts_with(&format!("{run_id}#")));
+    let mut resume_token = String::new();
+    let mut step_source = None;
+    for expected in [
+        "wait-progress-1",
+        "wait-progress-2",
+        "execute-progress-1",
+        "execute-progress-2",
+    ] {
+        let message = environment
+            .client
+            .read_stream_with_timeout(&flow_id, &PROGRESS, &resume_token, Duration::from_secs(30))
+            .expect("read Step Stream message");
+        assert_eq!(expected, message.value);
+        assert!(!message.resume_token.is_empty());
+        assert!(message.created_time > SystemTime::UNIX_EPOCH);
+        assert!(message.source.starts_with('#'));
+        assert!(!message.source[1..].is_empty());
+        if let Some(source) = step_source.as_ref() {
+            assert_eq!(source, &message.source);
+        } else {
+            step_source = Some(message.source.clone());
+        }
+        resume_token = message.resume_token;
+    }
 
-    let client = environment
-        .client
-        .read_stream_with_timeout(
-            &flow_id,
-            &PROGRESS,
-            &step.resume_token,
-            Duration::from_secs(30),
-        )
-        .expect("read client Stream message");
-    assert_eq!("client-progress", client.value);
-    assert_ne!(step.resume_token, client.resume_token);
-    assert!(client.created_time > SystemTime::UNIX_EPOCH);
-    assert_eq!("client-write", client.idempotency_key);
+    for expected in ["client-progress", "client-progress-again"] {
+        let message = environment
+            .client
+            .read_stream_with_timeout(&flow_id, &PROGRESS, &resume_token, Duration::from_secs(30))
+            .expect("read client Stream message");
+        assert_eq!(expected, message.value);
+        assert_ne!(resume_token, message.resume_token);
+        assert!(message.created_time > SystemTime::UNIX_EPOCH);
+        assert_eq!("client#source", message.source);
+        resume_token = message.resume_token;
+    }
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
@@ -11,7 +11,7 @@
 use std::sync::LazyLock;
 
 use dex_sdk::{
-    Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision, StepList, Stream,
+    Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision, StepList, Stream, Wait,
 };
 
 pub(crate) static PROGRESS: LazyLock<Stream<String>> =
@@ -48,8 +48,19 @@ struct StreamTestStep;
 impl Step for StreamTestStep {
     type Input = ();
 
+    fn wait_for(&self, context: &mut Context, _input: ()) -> HandlerResult<Wait> {
+        context.record_heartbeat()?;
+        PROGRESS.write(context, "wait-progress-1".to_string())?;
+        context.record_heartbeat_value("wait-checkpoint".to_string())?;
+        PROGRESS.write(context, "wait-progress-2".to_string())?;
+        Ok(Wait::skip_immediately())
+    }
+
     fn execute(&self, context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
-        PROGRESS.write(context, "step-progress".to_string())?;
+        context.record_heartbeat()?;
+        PROGRESS.write(context, "execute-progress-1".to_string())?;
+        context.record_heartbeat_value("execute-checkpoint".to_string())?;
+        PROGRESS.write(context, "execute-progress-2".to_string())?;
         Ok(StepDecision::graceful_complete(()))
     }
 }

--- a/sdk-rust/crates/dex-sdk/tests/integ/subflow_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/subflow_test.rs
@@ -22,7 +22,7 @@ use crate::subflow_workflow::{
     AbnormalSubFlowParent, AllSubFlowParent, AnySubFlowParent, ContinueAsNewSubFlowParent,
     SingleSubFlowParent, TimerSubFlowParent,
 };
-use crate::support::{DexDevTestEnvironment, flow_id};
+use crate::support::{DexDevTestEnvironment, flow_id, skip_timer_when_pending};
 use crate::timer_workflow::{TimerStep, TimerWorkflow};
 
 #[test]
@@ -150,14 +150,12 @@ fn test_subflow_partial_results_survive_continue_as_new_without_restart() {
         .describe_flow(&completed_id)
         .unwrap()
         .run_id;
-    environment
-        .client
-        .skip_timer(
-            &delayed_id,
-            StepExecutionId::of(&TimerStep),
-            TimerId::by_condition_id("test-timer-id"),
-        )
-        .unwrap();
+    skip_timer_when_pending(
+        &environment.client,
+        &delayed_id,
+        StepExecutionId::of(&TimerStep),
+        TimerId::by_condition_id("test-timer-id"),
+    );
     let output: String = wait(&environment.client, &id).single_output().unwrap();
     assert_eq!(
         vec![completed_id.as_str(), "6", delayed_id.as_str(), "Completed"],
@@ -194,14 +192,12 @@ fn assert_running_reuse(reuse_policy: SubFlowReusePolicy, expects_restart: bool)
         expects_restart.then_some(first_run_id.as_str()),
     );
     assert_eq!(expects_restart, active_run_id != first_run_id);
-    environment
-        .client
-        .skip_timer(
-            &child_id,
-            StepExecutionId::of(&TimerStep),
-            TimerId::by_condition_id("test-timer-id"),
-        )
-        .unwrap();
+    skip_timer_when_pending(
+        &environment.client,
+        &child_id,
+        StepExecutionId::of(&TimerStep),
+        TimerId::by_condition_id("test-timer-id"),
+    );
     let output: String = wait(&environment.client, &id).single_output().unwrap();
     assert_eq!(
         vec![child_id.as_str(), "Completed"],

--- a/sdk-rust/crates/dex-sdk/tests/integ/support.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/support.rs
@@ -14,7 +14,8 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use dex_sdk::{
-    BlobCache, BlobCacheConfig, Client, ClientOptions, Registry, SdkResult, Worker, WorkerOptions,
+    BlobCache, BlobCacheConfig, Client, ClientOptions, GrpcCode, Registry, SdkResult,
+    StepExecutionId, TimerId, Worker, WorkerOptions,
 };
 use tempfile::TempDir;
 
@@ -100,6 +101,32 @@ impl Drop for DexDevTestEnvironment {
 
 pub(crate) fn flow_id(prefix: &str) -> String {
     format!("{prefix}-{}", uuid::Uuid::new_v4())
+}
+
+#[allow(dead_code)]
+pub(crate) fn skip_timer_when_pending(
+    client: &Client,
+    flow_id: &str,
+    step_execution: StepExecutionId,
+    timer: TimerId,
+) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match client.skip_timer(flow_id, step_execution.clone(), timer.clone()) {
+            Ok(()) => return,
+            Err(error)
+                if Instant::now() < deadline
+                    && error.service_error().is_some_and(|service| {
+                        service.code() == GrpcCode::InvalidArgument
+                            && service.detail()
+                                == "requested timer condition does not exist or is not pending"
+                    }) =>
+            {
+                thread::yield_now();
+            }
+            Err(error) => panic!("timer did not become pending: {error}"),
+        }
+    }
 }
 
 fn available_port() -> u16 {


### PR DESCRIPTION
## Summary

- implement WaitFor and Execute tonic server-streaming responses for the synchronous Rust Worker
- add typed heartbeat recording and recovery, bounded single-frame backpressure, cancellation, and fire-and-forget Step Stream writes
- rename external Stream idempotency metadata to source and allow repeated sources, including values containing `#`
- update Rust SDK documentation, compile contracts, transport coverage, and isolated integration scenarios

## Rationale

This stacks Rust SDK support on the server streaming protocol introduced by #417. Step handlers remain synchronous and continue running through `spawn_blocking`, while a capacity-one channel bridges progress frames to tonic without unbounded buffering or another dedicated thread.

## User impact

This is a breaking Rust SDK change. Applications gain explicit heartbeat APIs and repeated Step Stream writes. `Client::write_stream` now accepts source metadata, and `StreamMessage::source` replaces the former idempotency field.

## Validation

- `make copyright-check`
- `make docs-prose-check`
- `make -C sdk-rust fmt`
- `make -C sdk-rust lint`
- `make -C sdk-rust test`
- `make -C sdk-rust docs-check`
- `make -C sdk-rust integration-test` (10 cross-SDK and 78 Rust integration tests)

Stacked on #417.
