### PR TITLE
Add TypeScript SDK Step streaming

### DIFF
--- a/docs/design/plan/typescript-sdk-async-step-handlers.md
+++ b/docs/design/plan/typescript-sdk-async-step-handlers.md
@@ -1,7 +1,7 @@
 # TypeScript SDK: async Step / RPC handlers
 
-Status: proposed
-Audience: implement in a separate worktree (SDK change first, then simplify `examples/typescript`)
+Status: implemented in the SDK; examples cleanup remains separate
+Audience: SDK and examples maintainers
 
 ## Problem
 
@@ -47,6 +47,11 @@ Allow handlers to return a value or a Promise of that value:
 | RPC method body | sync result / `RPCResult` | same, or `Promise` of same |
 
 Keep existing sync handlers valid (no migration required).
+
+Progress-capable Step handlers use `AsyncContext` and must return a Promise.
+`Context` handlers remain valid for synchronous or Promise-returning logic that
+does not record heartbeats. RPC and Flow timeout handlers continue to receive
+`Context` only.
 
 ### Runtime
 

--- a/docs/design/plan/typescript-sdk-step-streaming.md
+++ b/docs/design/plan/typescript-sdk-step-streaming.md
@@ -1,0 +1,124 @@
+# TypeScript SDK Step streaming
+
+Status: implemented
+
+This design records the TypeScript SDK contract for the server-streaming Step
+Worker protocol. WaitFor and Execute use one unary request and a streamed
+response. WorkerRpc remains unary.
+
+## Handler types
+
+`Context` exposes execution metadata, restored heartbeat details, persistence
+operations, and Step Stream writes. It does not expose heartbeat recording.
+Existing handlers may accept `Context` and return either a result or a Promise.
+
+`AsyncContext extends Context` adds:
+
+```typescript
+recordHeartbeat<T>(value: T | undefined, codec?: Codec<T>): Promise<void>
+```
+
+An `AsyncContext` Step handler must return a Promise. The value argument is
+required, so clearing details is visible at the call site:
+
+```typescript
+await context.recordHeartbeat(undefined);
+```
+
+Undefined emits a heartbeat frame without a Value. Null and every other value
+emit a present Value. JSON is the default codec. Scalar or custom values must be
+read with the same codec on a later attempt.
+
+Both Context types expose `hasLastHeartbeatValue()` and
+`getLastHeartbeatValue(codec?)`. The has method preserves proto presence. This
+distinguishes no Value from a present JSON-null Value, even though both decode
+to undefined with the current JSON value mapping.
+
+RPC and Flow timeout handlers never receive the Step output emitter. Attempts
+to write a Step Stream from those Contexts fail locally.
+
+## Output frames
+
+Each invocation owns one emitter around the grpc-js server Writable. Heartbeat
+and Stream calls synchronously enqueue frames on the Node event loop, preserving
+application call order without creating another thread.
+
+`recordHeartbeat` resolves after grpc-js accepts the frame locally. It does not
+wait for Temporal persistence. `Stream.write` returns void after local Stream
+registration checks and encoding. Dex sends no Stream Store acknowledgement.
+
+A successful handler deactivates its Context, writes exactly one result frame,
+and closes the stream. A failed handler deactivates the Context and terminates
+the stream with a Worker status. Result frames never follow failure. Retained
+Contexts cannot emit after success, failure, or cancellation.
+
+The grpc-js cancelled event aborts `Context.cancellationSignal` and immediately
+deactivates the emitter. A late handler result is discarded. Cancellation is
+cooperative: JavaScript code must observe the signal or reach another output
+operation.
+
+## Heartbeat recovery
+
+The dispatcher hydrates `Context.lastHeartbeatValue` before invoking WaitFor or
+Execute. Regular activity retries can inspect it before recording new progress.
+An explicit undefined heartbeat clears existing details. A Stream frame is an
+implicit server heartbeat and reuses the latest explicit state, including an
+empty state; it does not manufacture a new Value.
+
+Local activities ignore heartbeat frames because their backend has no activity
+heartbeat API. They still process Stream frames. A heartbeat emitted during the
+local phase is not available after fallback to a regular activity.
+
+## Stream semantics
+
+A Step method may call `Stream.write` repeatedly for one or several registered
+Streams. Every call emits another frame. Dex supplies `#<stepExecutionID>` as the
+stored source, so WaitFor, Execute, retries, and multiple messages may share it.
+Source is metadata, not an idempotency key.
+
+The external Client API is:
+
+```typescript
+await client.writeStream(flowId, stream, source, value);
+```
+
+Source must be non-empty. Repeated source values and `#` are valid and every
+write appends. Reads expose `StreamMessage.source` unchanged.
+
+## Options and defaults
+
+Durability selection is Step override, then Flow configuration, then sync.
+Failure policy does not affect the default. Retry total duration defaults to
+four hours. A regular attempt defaults to two hours with a one-minute heartbeat
+timeout.
+
+The SDK validates heartbeat timeouts as non-negative whole seconds within int32.
+It does not encode the server minimum. Dex deployments default that minimum to
+ten seconds, while integration deployments may configure two seconds.
+
+Async durability first uses a local-activity schedule-to-close window of at
+most seven seconds and at most three attempts. User-supplied smaller retry
+limits win. Method timeout and heartbeat settings do not apply during this
+phase. Fallback regular activity consumes the remaining retry budget and uses
+the regular timeout defaults.
+
+## Tests
+
+Contract tests cover AsyncContext signatures, required heartbeat arguments,
+Value presence and codecs, restored detail hydration, repeated Stream frames,
+invalid Contexts, failure, cancellation, and two-second option encoding.
+
+SDK integration tests cover WaitFor and Execute progress ordering, multiple
+Streams, duplicate source append behavior, regular retry recovery and clearing,
+Stream implicit heartbeat preservation, heartbeat-driven cancellation, no-output
+timeout behavior, and local fallback without heartbeat recovery.
+
+## Documentation
+
+The SDK README documents application-facing calls and defaults. The integration
+README records runtime coverage. Product documentation and runnable examples
+remain deferred until all language SDK examples use the new protocol.
+
+## UI/UX
+
+N/A: no in-repo web UI changes.

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -174,7 +174,52 @@ Synchronous handlers stay valid — returning a plain `StepDecision` / `Wait` /
 - A long `await client.waitForFlow(...)` holds the current WorkerService call
   until it resolves or times out. Prefer a short timeout plus Step retry (or a
   timer-backed re-check) over one unbounded poll. `executeMethodTimeoutMs` /
-  `waitForMethodTimeoutMs` clock the full async handler duration.
+`waitForMethodTimeoutMs` clock the full async handler duration.
+
+### Step progress and Streams
+
+Annotate a Promise-returning Step handler with `AsyncContext` when it needs to
+record progress. The heartbeat value argument is required. Passing `undefined`
+explicitly sends a heartbeat without a Value and clears previously persisted
+heartbeat details. Passing `null` sends a present JSON-null Value.
+
+```typescript
+async execute(context: AsyncContext, input: ImportInput): Promise<StepDecision> {
+  const restored = context.hasLastHeartbeatValue()
+    ? context.getLastHeartbeatValue(importCheckpointCodec)
+    : undefined;
+
+  for await (const page of remainingPages(restored)) {
+    importedRows.write(context, page.rows);
+    await context.recordHeartbeat(page.checkpoint, importCheckpointCodec);
+  }
+  return gracefulComplete();
+}
+```
+
+Omitting the heartbeat codec uses JSON. Read a restored value with the same
+codec used to record it. `hasLastHeartbeatValue()` distinguishes an absent Value
+from a present JSON-null Value; both decode to `undefined`.
+
+`Stream.write(context, value)` is synchronous and fire-and-forget. It validates
+and encodes locally, then writes a frame to the current WaitFor or Execute gRPC
+response stream. A handler may write any number of messages to the same or
+different Streams. Dex attempts each append in call order, but Stream Store
+failures are not returned to the handler. RPC and Flow timeout Contexts reject
+Step Stream writes.
+
+External writes use `client.writeStream(flowId, stream, source, value)`. Source
+must be non-empty, may contain `#`, and may repeat; every write appends a new
+message. `Client.readStream` returns it as `StreamMessage.source`. Step writes
+use `#<stepExecutionID>` as source metadata.
+
+Step durability defaults to the Flow configuration and then sync. Regular
+attempts default to two hours, heartbeat timeout defaults to one minute, and
+retry total duration defaults to four hours. The SDK accepts non-negative
+whole-second heartbeat timeout values, including two seconds, and leaves the
+deployment-configured minimum to Dex Server. Async durability first uses a
+seven-second local-activity window with at most three attempts; that phase
+ignores method timeouts and heartbeats but still writes Stream messages.
 
 Every TypeScript Flow and Step must return an explicit durable name from
 `getFlowType()` or `getStepType()`. Class names are never used as fallbacks

--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -502,22 +502,21 @@ export class Client {
   }
 
   /**
-   * Appends one typed best-effort Stream message with client idempotency.
+   * Appends one typed best-effort Stream message with source metadata.
    * @typeParam T - Stream message type.
    * @param flowId - Logical Flow instance ID; the Flow need not exist or be active.
    * @param stream - Stream registered in exactly one Flow schema.
-   * @param idempotencyKey - Non-empty key without `#`; retained duplicates are successful no-ops.
+   * @param source - Non-empty source metadata. Repeated values and `#` are allowed.
    * @param value - Typed message to append.
    */
   public async writeStream<T>(
     flowId: string,
     stream: Stream<T>,
-    idempotencyKey: string,
+    source: string,
     value: T,
   ): Promise<void> {
-    requireName(idempotencyKey);
-    if (idempotencyKey.includes("#")) {
-      throw new TypeError("Stream client idempotency key must not contain #");
+    if (source.length === 0) {
+      throw new TypeError("Stream source is required");
     }
     const flow = registeredStream(this.registry, stream as Stream<unknown>);
     await unary<Empty>(
@@ -528,7 +527,7 @@ export class Client {
         streamName: stream.name,
         streamCapacityBytes: BigInt(stream.streamCapacityBytes),
         value: encodeValue(stream.codec, value),
-        idempotencyKey,
+        source,
       }, callback),
     );
   }
@@ -567,7 +566,7 @@ export class Client {
       value: decodeValue(stream.codec, message.value),
       resumeToken: message.resumeToken,
       createdTime: message.createdTime,
-      idempotencyKey: message.idempotencyKey,
+      source: message.source,
     };
   }
 

--- a/sdk-typescript/src/context.ts
+++ b/sdk-typescript/src/context.ts
@@ -38,6 +38,23 @@ export interface Context {
    */
   readonly cancellationSignal: AbortSignal;
   /**
+   * Reports whether a previous regular-activity attempt recorded heartbeat details.
+   * @returns Whether a last heartbeat Value is present.
+   */
+  hasLastHeartbeatValue(): boolean;
+  /**
+   * Decodes heartbeat details recorded by the previous regular-activity attempt.
+   *
+   * The codec must match the one passed to {@link AsyncContext.recordHeartbeat}. When omitted,
+   * values use JSON encoding. Call {@link Context.hasLastHeartbeatValue} to distinguish an absent
+   * Value from a present JSON null value, because both decode to `undefined`.
+   *
+   * @typeParam T - Expected heartbeat value type.
+   * @param codec - Codec used to decode the Value; omitted for JSON.
+   * @returns The decoded value, or `undefined` when no Value is present.
+   */
+  getLastHeartbeatValue<T = unknown>(codec?: Codec<T>): T | undefined;
+  /**
    * Reports whether a Timer made the current Wait ready.
    * @param index - Optional zero-based Timer index; checks any Timer when omitted.
    * @returns Whether the selected Timer fired.
@@ -135,5 +152,27 @@ export interface Context {
    * @param stream - Stream registered by the current Flow type.
    * @param value - Typed message to append.
    */
-  writeStream<T>(stream: Stream<T>, value: T): Promise<void>;
+  writeStream<T>(stream: Stream<T>, value: T): void;
+}
+
+/**
+ * Adds asynchronous progress reporting to a Step invocation Context.
+ *
+ * Annotate an async `waitFor` or `execute` handler with AsyncContext when it records heartbeats.
+ * RPC and Flow timeout handlers receive Context and cannot record Step heartbeats.
+ */
+export interface AsyncContext extends Context {
+  /**
+   * Records heartbeat progress for the current Step method attempt.
+   *
+   * Passing `undefined` explicitly clears persisted heartbeat details. Every other value produces
+   * a present Value; omitted codecs use JSON. The Promise resolves when grpc-js accepts the frame,
+   * not when Temporal persists it. Local activities ignore heartbeat frames.
+   *
+   * @typeParam T - Heartbeat value type.
+   * @param value - Value to persist, or `undefined` to clear existing details.
+   * @param codec - Codec used to encode the Value; omitted for JSON.
+   * @returns A Promise resolved after the Worker accepts the output frame locally.
+   */
+  recordHeartbeat<T>(value: T | undefined, codec?: Codec<T>): Promise<void>;
 }

--- a/sdk-typescript/src/flow.ts
+++ b/sdk-typescript/src/flow.ts
@@ -110,7 +110,7 @@ export class Registry {
 
 export interface RegisteredStep {
   readonly name: string;
-  readonly step: Step<unknown>;
+  readonly step: Step<any>;
   readonly isStartStep: boolean;
 }
 
@@ -223,7 +223,7 @@ function flowType(flow: Flow<any>): string {
   }
 }
 
-function stepType(flowName: string, step: Step<unknown>): string {
+function stepType(flowName: string, step: Step<any>): string {
   if (typeof step.getStepType !== "function") {
     throw new FlowDefinitionError(`Flow ${flowName} Step must implement getStepType`);
   }

--- a/sdk-typescript/src/invocation-context.ts
+++ b/sdk-typescript/src/invocation-context.ts
@@ -7,9 +7,8 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import type { Codec } from "./codec.js";
-import { FlowServiceClient, type WriteStreamRequest } from "./gen/dex.js";
 import { mapAttributeStoreSync } from "./attribute-store-sync.js";
-import type { Context } from "./context.js";
+import type { AsyncContext } from "./context.js";
 import {
   ConditionStatus,
   IndexType as ProtoIndexType,
@@ -20,19 +19,25 @@ import {
   type Context as ProtoContext,
   type IndexConfig,
   type KV,
+  type StepStreamWrite,
   type Value,
 } from "./gen/dex.js";
 import { requireFlowStream, type RegisteredFlow } from "./flow.js";
 import { createFlowResultFromProto, type FlowResult } from "./flow-result.js";
 import { AttributeMap, IndexType, type Attribute } from "./persistence.js";
-import { decodeValue, deletionValue, encodeValue } from "./value-mapper.js";
+import { codecOrJson, decodeValue, deletionValue, encodeValue } from "./value-mapper.js";
 import { requireName } from "./validation.js";
 import { ChannelMap, type Channel } from "./wait.js";
 import type { Stream } from "./stream.js";
 
 export type InvocationMethod = "waitFor" | "execute" | "rpc";
 
-export class InvocationContext implements Context {
+export interface StepOutputEmitter {
+  recordHeartbeat(value: Value | undefined): Promise<void>;
+  writeStream(write: StepStreamWrite): void;
+}
+
+export class InvocationContext implements AsyncContext {
   public readonly flowId: string;
   public readonly runId: string;
   public readonly flowStartedAt: Date;
@@ -50,18 +55,18 @@ export class InvocationContext implements Context {
   private readonly events: KV[] = [];
   private readonly eventNames = new Set<string>();
   private readonly publications: ChannelMessage[] = [];
-  private readonly streamWrites = new Set<Stream<unknown>>();
+  private readonly lastHeartbeatValue: Value | undefined;
 
   public constructor(
     private readonly method: InvocationMethod,
     private readonly flow: RegisteredFlow,
-    private readonly flowService: InstanceType<typeof FlowServiceClient>,
     metadata: ProtoContext | undefined,
     attributes: readonly KV[],
     locals: readonly KV[] = [],
     private readonly conditionResults?: ConditionResults,
     channelInfos: Readonly<Record<string, ChannelInfo>> = {},
     cancellationSignal: AbortSignal = new AbortController().signal,
+    private readonly stepOutput?: StepOutputEmitter,
   ) {
     if (metadata === undefined) {
       throw new TypeError("Worker request Context is required");
@@ -73,34 +78,43 @@ export class InvocationContext implements Context {
     this.fromStepExecutionId = metadata.fromStepExecutionId;
     this.firstAttemptAt = secondsDate(metadata.firstAttemptTimestamp);
     this.attempt = metadata.attempt;
+    this.lastHeartbeatValue = metadata.lastHeartbeatValue;
     this.cancellationSignal = cancellationSignal;
     this.attributes = mapValues("Attribute", attributes);
     this.locals = mapValues("step-execution local", locals);
     this.channelInfos = new Map(Object.entries(channelInfos));
   }
 
-  public async writeStream<T>(stream: Stream<T>, value: T): Promise<void> {
-    if (this.method === "rpc") {
+  public hasLastHeartbeatValue(): boolean {
+    return this.lastHeartbeatValue !== undefined;
+  }
+
+  public getLastHeartbeatValue<T = unknown>(codec?: Codec<T>): T | undefined {
+    if (this.lastHeartbeatValue === undefined) {
+      return undefined;
+    }
+    return decodeValue(codecOrJson(codec), this.lastHeartbeatValue);
+  }
+
+  public recordHeartbeat<T>(value: T | undefined, codec?: Codec<T>): Promise<void> {
+    if (this.stepOutput === undefined) {
+      throw new TypeError("Heartbeats require an async Step Context");
+    }
+    return this.stepOutput.recordHeartbeat(
+      value === undefined ? undefined : encodeValue(codecOrJson(codec), value),
+    );
+  }
+
+  public writeStream<T>(stream: Stream<T>, value: T): void {
+    if (this.stepOutput === undefined) {
       throw new TypeError("Stream writes require a Step Context");
     }
     requireFlowStream(this.flow, stream as Stream<unknown>);
-    if (this.streamWrites.has(stream as Stream<unknown>)) {
-      throw new TypeError(`Stream ${stream.name} was already written by this Step execution`);
-    }
-    this.streamWrites.add(stream as Stream<unknown>);
-    try {
-      await writeStream(this.flowService, {
-        flowId: this.flowId,
-        flowType: this.flow.name,
-        streamName: stream.name,
-        streamCapacityBytes: BigInt(stream.streamCapacityBytes),
-        value: encodeValue(stream.codec, value),
-        idempotencyKey: `${this.runId}#${this.stepExecutionId}`,
-      });
-    } catch (failure) {
-      this.streamWrites.delete(stream as Stream<unknown>);
-      throw failure;
-    }
+    this.stepOutput.writeStream({
+      streamName: stream.name,
+      streamCapacityBytes: BigInt(stream.streamCapacityBytes),
+      value: encodeValue(stream.codec, value),
+    });
   }
 
   public hasTimerFired(index?: number): boolean {
@@ -296,21 +310,6 @@ export class InvocationContext implements Context {
       throw new TypeError(`persistence definition does not belong to Flow: ${definition.name}`);
     }
   }
-}
-
-function writeStream(
-  service: InstanceType<typeof FlowServiceClient>,
-  request: WriteStreamRequest,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    service.writeStream(request, (error) => {
-      if (error !== null) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
 }
 
 function definitionName(

--- a/sdk-typescript/src/rpc.ts
+++ b/sdk-typescript/src/rpc.ts
@@ -21,7 +21,7 @@ export interface RPCResult<Output> {
   /** Typed application result. */
   readonly output: Output;
   /** Step movements applied atomically with handler persistence writes. */
-  readonly nextSteps?: readonly StepMovement<unknown>[];
+  readonly nextSteps?: readonly StepMovement<any>[];
   /** Registered Step types canceled before `nextSteps` are scheduled. */
   readonly cancelingSteps?: readonly StepClass<any>[];
 }

--- a/sdk-typescript/src/step.ts
+++ b/sdk-typescript/src/step.ts
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import type { Codec } from "./codec.js";
-import type { Context } from "./context.js";
+import type { AsyncContext, Context } from "./context.js";
 import type { AttributeLock } from "./persistence.js";
 import type { Channel, ChannelMap, Wait } from "./wait.js";
 
@@ -26,7 +26,7 @@ export interface RetryPolicy {
   readonly maximumIntervalMs?: number;
   /** Total attempt limit including the initial call. */
   readonly maximumAttempts?: number;
-  /** Overall elapsed-time limit in milliseconds. */
+  /** Overall elapsed-time limit in milliseconds; defaults to four hours when omitted. */
   readonly totalDurationMs?: number;
 }
 
@@ -57,11 +57,11 @@ export const ExecuteFailure = Object.freeze({
 
 /** Configures timeouts, retries, durability, locks, and failure routing for a Step. */
 export interface StepOptions {
-  /** Maximum duration of one `waitFor` attempt in milliseconds. */
+  /** Regular `waitFor` attempt limit in milliseconds; defaults to two hours. */
   readonly waitForMethodTimeoutMs?: number;
-  /** Maximum duration of one `execute` attempt in milliseconds. */
+  /** Regular `execute` attempt limit in milliseconds; defaults to two hours. */
   readonly executeMethodTimeoutMs?: number;
-  /** Regular-activity heartbeat in milliseconds; must represent whole seconds. */
+  /** Regular heartbeat timeout in milliseconds; requires whole seconds and defaults to one minute. */
   readonly heartbeatTimeoutMs?: number;
   /** Optional retry policy for `waitFor`. */
   readonly waitForRetry?: RetryPolicy;
@@ -69,9 +69,9 @@ export interface StepOptions {
   readonly executeRetry?: RetryPolicy;
   /** Behavior after all `waitFor` attempts fail. */
   readonly waitForFailure?: WaitForFailurePolicy;
-  /** Durability used for the `waitFor` result. */
+  /** WaitFor durability override; otherwise uses Flow configuration, then sync. */
   readonly waitForDurability?: StepDurability;
-  /** Durability used for the `execute` result. */
+  /** Execute durability override; otherwise uses Flow configuration, then sync. */
   readonly executeDurability?: StepDurability;
   /** Attribute locks held during `waitFor`. */
   readonly waitForLockAttributes?: readonly AttributeLock[];
@@ -117,19 +117,25 @@ export interface Step<Input> {
   getStepOptions?(): StepOptions | undefined;
   /**
    * Describes durable conditions required before execution.
+   * Async handlers that record heartbeats must accept AsyncContext and return a Promise.
    * @param context - Current execution metadata and persistence operations.
    * @param input - Decoded Step input.
    * @returns A Wait or promise resolving to one.
    */
-  waitFor?(context: Context, input: Input): Wait | Promise<Wait>;
+  waitFor?: StepHandler<Input, Wait>;
   /**
    * Runs application logic and produces the next durable decision.
+   * Async handlers that record heartbeats must accept AsyncContext and return a Promise.
    * @param context - Current execution metadata and persistence operations.
    * @param input - Decoded Step input.
    * @returns A StepDecision or promise resolving to one.
    */
-  execute(context: Context, input: Input): StepDecision | Promise<StepDecision>;
+  execute: StepHandler<Input, StepDecision>;
 }
+
+type StepHandler<Input, Output> =
+  | ((context: Context, input: Input) => Output | Promise<Output>)
+  | ((context: AsyncContext, input: Input) => Promise<Output>);
 
 /**
  * Identifies one registered Step implementation by its runtime class.
@@ -143,7 +149,7 @@ interface StartStepDefinition<StartInput> {
 }
 
 interface NonStartStepDefinition {
-  readonly step: Step<unknown>;
+  readonly step: Step<any>;
   readonly isStartStep: false;
 }
 
@@ -181,7 +187,7 @@ export class StepList<StartInput> {
    * @returns A StepList with exactly one starting Step.
    */
   public static startStep<StartInput>(step: Step<StartInput>): StepList<StartInput> {
-    return new StepList([{ step: step as Step<unknown>, isStartStep: true }]);
+    return new StepList([{ step: step as Step<any>, isStartStep: true }]);
   }
 
   /**
@@ -193,7 +199,7 @@ export class StepList<StartInput> {
   public static withoutStartStep<StartInput = never>(
     ...steps: readonly Step<any>[]
   ): StepList<StartInput> {
-    return new StepList(steps.map((step) => ({ step: step as Step<unknown>, isStartStep: false })));
+    return new StepList(steps.map((step) => ({ step: step as Step<any>, isStartStep: false })));
   }
 
   /**
@@ -204,7 +210,7 @@ export class StepList<StartInput> {
   public otherSteps(...steps: readonly Step<any>[]): StepList<StartInput> {
     return new StepList([
       ...this.definitions,
-      ...steps.map((step) => ({ step: step as Step<unknown>, isStartStep: false as const })),
+      ...steps.map((step) => ({ step: step as Step<any>, isStartStep: false as const })),
     ]);
   }
 
@@ -263,7 +269,7 @@ export type StepDecision = (
       /** Schedules next Step movements. */
       kind: "next";
       /** Ordered destination movements. */
-      movements: readonly StepMovement<unknown>[];
+      movements: readonly StepMovement<any>[];
     }>
   | Readonly<{
       /** Requests graceful or immediate successful completion. */
@@ -277,7 +283,7 @@ export type StepDecision = (
       /** Codec-supported Flow result. */
       output: unknown;
       /** Movement scheduled when any selected Channel is non-empty. */
-      fallback: StepMovement<unknown>;
+      fallback: StepMovement<any>;
       /** Registered Channels inspected for emptiness. */
       channels: readonly (Channel<unknown> | ChannelMap<unknown>)[];
     }>
@@ -307,7 +313,7 @@ export const goTo = <Input>(step: StepClass<Input>, input: Input): StepDecision 
  * @param movements - Typed movements applied in argument order.
  * @returns A next decision containing every movement.
  */
-export const goToMany = (...movements: readonly StepMovement<unknown>[]): StepDecision => ({
+export const goToMany = (...movements: readonly StepMovement<any>[]): StepDecision => ({
   kind: "next",
   movements,
 });
@@ -338,7 +344,7 @@ export const forceComplete = (output?: unknown): StepDecision => ({ kind: "force
  */
 export const forceCompleteIfChannelsEmpty = (
   output: unknown,
-  fallback: StepMovement<unknown>,
+  fallback: StepMovement<any>,
   ...channels: readonly (Channel<unknown> | ChannelMap<unknown>)[]
 ): StepDecision => ({ kind: "forceCompleteIfChannelsEmpty", output, fallback, channels });
 

--- a/sdk-typescript/src/stream.ts
+++ b/sdk-typescript/src/stream.ts
@@ -35,12 +35,14 @@ export class Stream<T> {
   /**
    * Appends one message immediately from the current Step execution.
    *
-   * A Step execution may write once per Stream. Retries reuse the same server idempotency key.
+   * The write emits a fire-and-forget frame on the current Worker response stream. One Step method
+   * invocation may write any number of messages to the same or different Streams. Dex Stream Store
+   * failures are not returned to the handler; local validation and encoding errors still throw.
    * @param context - Current Step Context; RPC Contexts are rejected.
    * @param value - Typed message to append.
    */
-  public async write(context: Context, value: T): Promise<void> {
-    await context.writeStream(this, value);
+  public write(context: Context, value: T): void {
+    context.writeStream(this, value);
   }
 }
 
@@ -55,6 +57,6 @@ export interface StreamMessage<T> {
   readonly resumeToken: string;
   /** Server-assigned UTC creation time. */
   readonly createdTime: Date;
-  /** Client key or Step-generated runID#stepExecutionID key. */
-  readonly idempotencyKey: string;
+  /** Client-supplied source or Step-generated `#stepExecutionID` source. */
+  readonly source: string;
 }

--- a/sdk-typescript/src/worker-dispatcher.ts
+++ b/sdk-typescript/src/worker-dispatcher.ts
@@ -25,7 +25,6 @@ import {
   FlowRetryPolicy,
   FlowTimeoutPolicy as ProtoFlowTimeoutPolicy,
   FlowConfig as ProtoFlowConfig,
-  FlowServiceClient,
   ActiveStepSearchMode as ProtoActiveStepSearchMode,
   StepDurability as ProtoStepDurability,
   IndexType as ProtoIndexType,
@@ -52,7 +51,7 @@ import {
   type RegisteredStep,
   type Registry,
 } from "./flow.js";
-import { InvocationContext } from "./invocation-context.js";
+import { InvocationContext, type StepOutputEmitter } from "./invocation-context.js";
 import { Attribute, AttributeMap, IndexType } from "./persistence.js";
 import { mapAttributeStoreNames, mapAttributeStoreSync } from "./attribute-store-sync.js";
 import { ActiveStepSearchMode, FlowTimeoutPolicy, type FlowConfig } from "./options.js";
@@ -81,12 +80,12 @@ export class WorkerDispatcher {
   public constructor(
     private readonly registry: Registry,
     private readonly hydrator: ValueHydrator,
-    private readonly flowService: InstanceType<typeof FlowServiceClient>,
   ) {}
 
   public async invokeWaitFor(
     original: InvokeWaitForMethodRequest,
     cancellationSignal: AbortSignal = new AbortController().signal,
+    stepOutput?: StepOutputEmitter,
   ): Promise<InvokeWaitForMethodResponse> {
     const request = await this.hydrateWaitFor(original);
     cancellationSignal.throwIfAborted();
@@ -95,13 +94,13 @@ export class WorkerDispatcher {
     const context = new InvocationContext(
       "waitFor",
       flow,
-      this.flowService,
       request.context,
       request.attributes,
       [],
       undefined,
       {},
       cancellationSignal,
+      stepOutput,
     );
     const input = decodeValue(
       codecOrJson(step.step.inputCodec),
@@ -127,6 +126,7 @@ export class WorkerDispatcher {
   public async invokeExecute(
     original: InvokeExecuteMethodRequest,
     cancellationSignal: AbortSignal = new AbortController().signal,
+    stepOutput?: StepOutputEmitter,
   ): Promise<InvokeExecuteMethodResponse> {
     const request = await this.hydrateExecute(original);
     cancellationSignal.throwIfAborted();
@@ -138,13 +138,13 @@ export class WorkerDispatcher {
     const context = new InvocationContext(
       "execute",
       flow,
-      this.flowService,
       request.context,
       request.attributes,
       request.stepExeLocals,
       request.conditionResults,
       {},
       cancellationSignal,
+      stepOutput,
     );
     const input = decodeValue(
       codecOrJson(step.step.inputCodec),
@@ -179,7 +179,6 @@ export class WorkerDispatcher {
       const context = new InvocationContext(
         "execute",
         flow,
-        this.flowService,
         request.context,
         request.attributes,
         request.stepExeLocals,
@@ -211,7 +210,6 @@ export class WorkerDispatcher {
     const context = new InvocationContext(
       "rpc",
       flow,
-      this.flowService,
       request.context,
       request.attributes,
       [],
@@ -240,20 +238,29 @@ export class WorkerDispatcher {
   private async hydrateWaitFor(
     request: InvokeWaitForMethodRequest,
   ): Promise<InvokeWaitForMethodRequest> {
+    const lastHeartbeatValue = request.context?.lastHeartbeatValue;
+    const hasLastHeartbeatValue = lastHeartbeatValue !== undefined;
     const values = await this.hydrator.hydrateAll([
+      ...(hasLastHeartbeatValue ? [lastHeartbeatValue] : []),
       request.stepInput,
       ...request.attributes.map((entry) => entry.value),
     ]);
+    const offset = hasLastHeartbeatValue ? 1 : 0;
     return {
       ...request,
-      stepInput: values[0],
-      attributes: replaceEntryValues(request.attributes, values.slice(1)),
+      context: hasLastHeartbeatValue
+        ? { ...request.context!, lastHeartbeatValue: values[0] }
+        : request.context,
+      stepInput: values[offset],
+      attributes: replaceEntryValues(request.attributes, values.slice(offset + 1)),
     };
   }
 
   private async hydrateExecute(
     request: InvokeExecuteMethodRequest,
   ): Promise<InvokeExecuteMethodRequest> {
+    const lastHeartbeatValue = request.context?.lastHeartbeatValue;
+    const hasLastHeartbeatValue = lastHeartbeatValue !== undefined;
     const channelValues = request.conditionResults?.channelResults.flatMap(
       (result) => result.values,
     ) ?? [];
@@ -262,13 +269,15 @@ export class WorkerDispatcher {
     ) ?? [];
     const hasInput = request.stepInput !== undefined;
     const values = await this.hydrator.hydrateAll([
+      ...(hasLastHeartbeatValue ? [lastHeartbeatValue] : []),
       ...(hasInput ? [request.stepInput] : []),
       ...request.attributes.map((entry) => entry.value),
       ...request.stepExeLocals.map((entry) => entry.value),
       ...channelValues,
       ...subFlowValues,
     ]);
-    let offset = hasInput ? 1 : 0;
+    let offset = hasLastHeartbeatValue ? 1 : 0;
+    const stepInput = hasInput ? values[offset++] : undefined;
     const attributes = replaceEntryValues(
       request.attributes,
       values.slice(offset, (offset += request.attributes.length)),
@@ -283,7 +292,10 @@ export class WorkerDispatcher {
     );
     return {
       ...request,
-      stepInput: hasInput ? values[0] : undefined,
+      context: hasLastHeartbeatValue
+        ? { ...request.context!, lastHeartbeatValue: values[0] }
+        : request.context,
+      stepInput,
       attributes,
       stepExeLocals,
       conditionResults,
@@ -323,7 +335,7 @@ function invokeRPC(
 function rpcResult(
   rpc: RegisteredRPC,
   returned: unknown,
-): { output: unknown; nextSteps?: readonly StepMovement<unknown>[] } | undefined {
+): { output: unknown; nextSteps?: readonly StepMovement<any>[] } | undefined {
   if (returned === undefined) {
     if (rpc.options.outputCodec !== undefined) {
       throw new TypeError(`function RPC ${rpc.name} must return RPCResult`);
@@ -337,7 +349,7 @@ function rpcResult(
         : `function RPC ${rpc.name} must return RPCResult`,
     );
   }
-  return returned as { output: unknown; nextSteps?: readonly StepMovement<unknown>[] };
+  return returned as { output: unknown; nextSteps?: readonly StepMovement<any>[] };
 }
 
 function mapWait(
@@ -478,7 +490,7 @@ function mapCancellationSteps(
 function rpcDecision(
   flow: RegisteredFlow,
   result: {
-    nextSteps?: readonly StepMovement<unknown>[];
+    nextSteps?: readonly StepMovement<any>[];
     cancelingSteps?: readonly StepClass<any>[];
   }
     | undefined,
@@ -496,12 +508,12 @@ function rpcDecision(
 
 function mapMovements(
   flow: RegisteredFlow,
-  movements: readonly StepMovement<unknown>[],
+  movements: readonly StepMovement<any>[],
 ): ProtoStepMovement[] {
   return movements.map((movement) => mapMovement(flow, movement));
 }
 
-function mapMovement(flow: RegisteredFlow, movement: StepMovement<unknown>): ProtoStepMovement {
+function mapMovement(flow: RegisteredFlow, movement: StepMovement<any>): ProtoStepMovement {
   const target = flow.stepsByClass.get(movement.step);
   if (target === undefined) {
     throw new TypeError("Step movement target does not belong to Flow");

--- a/sdk-typescript/src/worker.ts
+++ b/sdk-typescript/src/worker.ts
@@ -11,6 +11,7 @@ import {
   ServerCredentials,
   Metadata,
   credentials,
+  type ServerWritableStream,
   type ServerUnaryCall,
   type sendUnaryData,
 } from "@grpc/grpc-js";
@@ -18,6 +19,8 @@ import {
 import type { BlobCache } from "./blob-cache.js";
 import {
   FlowServiceClient,
+  InvokeExecuteMethodOutput,
+  InvokeWaitForMethodOutput,
   WorkerServiceService,
   type InvokeExecuteMethodRequest,
   type InvokeExecuteMethodResponse,
@@ -25,10 +28,13 @@ import {
   type InvokeWaitForMethodResponse,
   type InvokeWorkerRPCRequest,
   type InvokeWorkerRPCResponse,
+  type StepStreamWrite,
+  type Value,
   type WorkerServiceServer,
 } from "./gen/dex.js";
 import { workerServiceError } from "./grpc-status.js";
 import { registeredAttributeIndexes, type Registry } from "./flow.js";
+import type { StepOutputEmitter } from "./invocation-context.js";
 import type { WorkerOptions, WorkerTarget } from "./options.js";
 import { ValueHydrator } from "./value-mapper.js";
 import { WorkerDispatcher } from "./worker-dispatcher.js";
@@ -78,7 +84,6 @@ export class Worker {
     const dispatcher = new WorkerDispatcher(
       registry,
       new ValueHydrator(this.flowService, blobCache),
-      this.flowService,
     );
     this.server.addService(WorkerServiceService, workerService(dispatcher));
     this.stopped = new Promise((resolve) => {
@@ -167,17 +172,124 @@ function syncAttributeIndexes(
 
 function workerService(dispatcher: WorkerDispatcher): WorkerServiceServer {
   return {
-    invokeWaitForMethod(call, callback) {
-      invoke(call, (signal) => dispatcher.invokeWaitFor(call.request, signal), callback);
+    invokeWaitForMethod(call) {
+      invokeStep(
+        call,
+        (signal, output) => dispatcher.invokeWaitFor(call.request, signal, output),
+        waitForOutput,
+      );
     },
-    invokeExecuteMethod(call, callback) {
-      invoke(call, (signal) => dispatcher.invokeExecute(call.request, signal), callback);
+    invokeExecuteMethod(call) {
+      invokeStep(
+        call,
+        (signal, output) => dispatcher.invokeExecute(call.request, signal, output),
+        executeOutput,
+      );
     },
     invokeWorkerRpc(call, callback) {
       invoke(call, (signal) => dispatcher.invokeRPC(call.request, signal), callback);
     },
   };
 }
+
+interface StepOutputFactory<Response, Output> {
+  heartbeat(value: Value | undefined): Output;
+  streamWrite(write: StepStreamWrite): Output;
+  result(response: Response): Output;
+}
+
+class GrpcStepOutputEmitter<Request, Response, Output> implements StepOutputEmitter {
+  private isActive = true;
+
+  public constructor(
+    private readonly call: ServerWritableStream<Request, Output>,
+    private readonly outputs: StepOutputFactory<Response, Output>,
+  ) {}
+
+  public recordHeartbeat(value: Value | undefined): Promise<void> {
+    this.write(this.outputs.heartbeat(value));
+    return Promise.resolve();
+  }
+
+  public writeStream(write: StepStreamWrite): void {
+    this.write(this.outputs.streamWrite(write));
+  }
+
+  public finish(response: Response): void {
+    if (!this.isActive) {
+      return;
+    }
+    this.isActive = false;
+    this.call.write(this.outputs.result(response));
+    this.call.end();
+  }
+
+  public fail(failure: unknown): void {
+    if (!this.isActive) {
+      return;
+    }
+    this.isActive = false;
+    this.call.emit("error", workerServiceError(failure));
+  }
+
+  public cancel(): void {
+    this.isActive = false;
+  }
+
+  private write(output: Output): void {
+    if (!this.isActive || this.call.cancelled) {
+      throw new Error("Step invocation is no longer active");
+    }
+    this.call.write(output);
+  }
+}
+
+function invokeStep<Request, Response, Output>(
+  call: ServerWritableStream<Request, Output>,
+  invocation: (signal: AbortSignal, output: StepOutputEmitter) => Promise<Response>,
+  outputs: StepOutputFactory<Response, Output>,
+): void {
+  const controller = new AbortController();
+  const emitter = new GrpcStepOutputEmitter(call, outputs);
+  const cancel = (): void => {
+    controller.abort();
+    emitter.cancel();
+  };
+  call.once("cancelled", cancel);
+  if (call.cancelled) {
+    cancel();
+  }
+  invocation(controller.signal, emitter)
+    .then(
+      (response) => emitter.finish(response),
+      (failure: unknown) => emitter.fail(failure),
+    )
+    .finally(() => call.off("cancelled", cancel));
+}
+
+const waitForOutput: StepOutputFactory<InvokeWaitForMethodResponse, InvokeWaitForMethodOutput> = {
+  heartbeat: (value) => InvokeWaitForMethodOutput.create({
+    output: { $case: "heartbeat", value: { value } },
+  }),
+  streamWrite: (write) => InvokeWaitForMethodOutput.create({
+    output: { $case: "streamWrite", value: write },
+  }),
+  result: (response) => InvokeWaitForMethodOutput.create({
+    output: { $case: "result", value: response },
+  }),
+};
+
+const executeOutput: StepOutputFactory<InvokeExecuteMethodResponse, InvokeExecuteMethodOutput> = {
+  heartbeat: (value) => InvokeExecuteMethodOutput.create({
+    output: { $case: "heartbeat", value: { value } },
+  }),
+  streamWrite: (write) => InvokeExecuteMethodOutput.create({
+    output: { $case: "streamWrite", value: write },
+  }),
+  result: (response) => InvokeExecuteMethodOutput.create({
+    output: { $case: "result", value: response },
+  }),
+};
 
 function invoke<Request, Response>(
   call: ServerUnaryCall<Request, Response>,

--- a/sdk-typescript/test/client.integration.test.ts
+++ b/sdk-typescript/test/client.integration.test.ts
@@ -70,6 +70,10 @@ class Start implements Step<Input> {
     return "Start";
   }
 
+  public getStepOptions() {
+    return { heartbeatTimeoutMs: 2_000 };
+  }
+
   public execute(_context: Context, _input: Input): StepDecision {
     return { kind: "gracefulComplete", output: undefined };
   }
@@ -125,7 +129,7 @@ test("Client maps typed calls and hydrates blob-backed outputs", async () => {
           value: Value.create({ kind: { $case: "stringValue", value: "working" } }),
           resumeToken: "resume-1",
           createdTime: new Date("2026-08-27T12:00:00.000Z"),
-          idempotencyKey: "client-1",
+          source: "client-1",
         },
       });
     },
@@ -202,8 +206,9 @@ test("Client maps typed calls and hydrates blob-backed outputs", async () => {
     assert.equal(message.value, "working");
     assert.equal(message.resumeToken, "resume-1");
     assert.equal(message.createdTime.toISOString(), "2026-08-27T12:00:00.000Z");
-    assert.equal(message.idempotencyKey, "client-1");
-    await assert.rejects(client.writeStream("flow-1", thinking, "bad#key", "ignored"), /must not contain/);
+    assert.equal(message.source, "client-1");
+    await client.writeStream("flow-1", thinking, "source#with-delimiter", "accepted");
+    await assert.rejects(client.writeStream("flow-1", thinking, "", "ignored"), /source is required/);
     const result = await client.waitForFlow("flow-1");
     assert.equal(result.completions.length, 2);
     assert.equal(result.completions[0]?.stepType, "Start");
@@ -222,14 +227,15 @@ test("Client maps typed calls and hydrates blob-backed outputs", async () => {
     assert.equal(failed.completions[1]?.decode(stringCodec), "done");
     assert.equal(requests.start?.flowType, "TestFlow");
     assert.equal(requests.start?.startStepType, "Start");
+    assert.equal(requests.start?.stepOptions?.heartbeatTimeoutSeconds, 2);
     assert.equal(requests.rpc?.rpcName, "accept");
     assert.deepEqual(requests.writeStream, {
       flowId: "flow-1",
       flowType: "TestFlow",
       streamName: "thinking",
       streamCapacityBytes: 1_048_576n,
-      value: Value.create({ kind: { $case: "stringValue", value: "starting" } }),
-      idempotencyKey: "client-1",
+      value: Value.create({ kind: { $case: "stringValue", value: "accepted" } }),
+      source: "source#with-delimiter",
     });
     assert.equal(requests.readStream?.flowType, "TestFlow");
     assert.equal(requests.readStream?.resumeToken, "previous");

--- a/sdk-typescript/test/contracts.test.ts
+++ b/sdk-typescript/test/contracts.test.ts
@@ -34,6 +34,7 @@ import {
   rpc,
   stringCodec,
   type BlobCache,
+  type AsyncContext,
   type Context,
   type Flow,
   type FlowConfig,
@@ -47,11 +48,11 @@ import {
 } from "../src/attribute-store-sync.js";
 import {
   Context as ProtoContext,
-  FlowServiceClient,
   InvokeExecuteMethodRequest,
   InvokeWaitForMethodRequest,
   InvokeWorkerRPCRequest,
-  type WriteStreamRequest,
+  type StepStreamWrite,
+  type Value,
 } from "../src/gen/dex.js";
 import { codecOrJson, encodeValue, type ValueHydrator } from "../src/value-mapper.js";
 import { WorkerDispatcher } from "../src/worker-dispatcher.js";
@@ -61,8 +62,6 @@ import { InvocationContext } from "../src/invocation-context.js";
 interface OrderInput {
   readonly orderId: string;
 }
-
-const testFlowService = {} as InstanceType<typeof FlowServiceClient>;
 
 interface OrderOutput {
   readonly accepted: boolean;
@@ -250,7 +249,7 @@ test("object Step and RPC omit codecs and still encode JSON", async () => {
   const hydrator = {
     hydrateAll: async (values: readonly unknown[]) => values,
   } as unknown as ValueHydrator;
-  const dispatcher = new WorkerDispatcher(new Registry([flow]), hydrator, testFlowService);
+  const dispatcher = new WorkerDispatcher(new Registry([flow]), hydrator);
   const executed = await dispatcher.invokeExecute(
     InvokeExecuteMethodRequest.create({
       context: ProtoContext.create(),
@@ -363,7 +362,7 @@ test("invalid Step results include Flow and Step context", async () => {
   const hydrator = {
     hydrateAll: async (values: readonly unknown[]) => values,
   } as unknown as ValueHydrator;
-  const dispatcher = new WorkerDispatcher(new Registry([flow]), hydrator, testFlowService);
+  const dispatcher = new WorkerDispatcher(new Registry([flow]), hydrator);
   const invocation = dispatcher.invokeExecute(
     InvokeExecuteMethodRequest.create({
       context: ProtoContext.create(),
@@ -437,7 +436,7 @@ test("Worker maps only user-provided Condition IDs", async () => {
   const hydrator = {
     hydrateAll: async (values: readonly unknown[]) => values,
   } as unknown as ValueHydrator;
-  const dispatcher = new WorkerDispatcher(new Registry([flow]), hydrator, testFlowService);
+  const dispatcher = new WorkerDispatcher(new Registry([flow]), hydrator);
   const invoke = (input: string) =>
     dispatcher.invokeWaitFor(
       InvokeWaitForMethodRequest.create({
@@ -464,8 +463,18 @@ test("Worker maps only user-provided Condition IDs", async () => {
   assert.throws(() => conditionChannel.forOne(""), /must not be empty/);
 });
 
-test("Step Stream writes use the Step execution idempotency key", async () => {
+test("Step Stream writes emit every message on the active invocation", async () => {
   const thinking = new Stream("thinking", stringCodec, 1_048_576);
+  const broken = new Stream("broken", {
+    typeName: "broken",
+    wireKind: "string",
+    encode() {
+      throw new Error("cannot encode");
+    },
+    decode() {
+      return "unused";
+    },
+  }, 1_048_576);
   class StreamStep implements Step<string> {
     public readonly inputCodec = stringCodec;
 
@@ -473,8 +482,9 @@ test("Step Stream writes use the Step execution idempotency key", async () => {
       return "StreamStep";
     }
 
-    public async execute(context: Context, input: string): Promise<StepDecision> {
-      await thinking.write(context, input);
+    public execute(context: Context, input: string): StepDecision {
+      thinking.write(context, input);
+      thinking.write(context, `${input}-again`);
       return gracefulComplete(input);
     }
   }
@@ -490,21 +500,22 @@ test("Step Stream writes use the Step execution idempotency key", async () => {
     }
 
     public getPersistenceSchema() {
-      return { streams: [thinking] };
+      return { streams: [thinking, broken] };
     }
   }
-  let written: WriteStreamRequest | undefined;
-  const flowService = {
-    writeStream(request: WriteStreamRequest, callback: (error: Error | null) => void) {
-      written = request;
-      callback(null);
+  const writes: StepStreamWrite[] = [];
+  const output = {
+    recordHeartbeat: async () => {},
+    writeStream(write: StepStreamWrite) {
+      writes.push(write);
     },
-  } as unknown as InstanceType<typeof FlowServiceClient>;
+  };
   const flow = new StreamFlow();
   const hydrator = {
     hydrateAll: async (values: readonly unknown[]) => values,
   } as unknown as ValueHydrator;
-  const dispatcher = new WorkerDispatcher(new Registry([flow]), hydrator, flowService);
+  const registry = new Registry([flow]);
+  const dispatcher = new WorkerDispatcher(registry, hydrator);
   await dispatcher.invokeExecute(
     InvokeExecuteMethodRequest.create({
       context: ProtoContext.create({
@@ -518,16 +529,143 @@ test("Step Stream writes use the Step execution idempotency key", async () => {
       attributes: [],
       stepExeLocals: [],
     }),
+    new AbortController().signal,
+    output,
   );
-  assert.deepEqual(written, {
-    flowId: "flow-1",
-    flowType: "StreamFlow",
-    streamName: "thinking",
-    streamCapacityBytes: 1_048_576n,
-    value: encodeValue(stringCodec, "checking"),
-    idempotencyKey: "run-1#step-1",
-  });
+  assert.deepEqual(writes, [
+    {
+      streamName: "thinking",
+      streamCapacityBytes: 1_048_576n,
+      value: encodeValue(stringCodec, "checking"),
+    },
+    {
+      streamName: "thinking",
+      streamCapacityBytes: 1_048_576n,
+      value: encodeValue(stringCodec, "checking-again"),
+    },
+  ]);
+
+  const direct = new InvocationContext(
+    "execute",
+    registeredFlowByName(registry, flow.getFlowType()),
+    ProtoContext.create(),
+    [],
+    [],
+    undefined,
+    {},
+    new AbortController().signal,
+    output,
+  );
+  assert.throws(() => broken.write(direct, "value"), ValueMappingError);
+  assert.throws(
+    () => new Stream("unregistered", stringCodec, 1_024).write(direct, "value"),
+    /does not register/,
+  );
+  const rpc = new InvocationContext(
+    "rpc",
+    registeredFlowByName(registry, flow.getFlowType()),
+    ProtoContext.create(),
+    [],
+  );
+  assert.throws(() => thinking.write(rpc, "value"), /require a Step Context/);
+  assert.throws(() => void rpc.recordHeartbeat("value"), /require an async Step Context/);
 });
+
+test("Async Step Context preserves heartbeat Value presence and codecs", async () => {
+  const observed: Array<{ hasValue: boolean; value: unknown }> = [];
+  class HeartbeatStep implements Step<string> {
+    public readonly inputCodec = stringCodec;
+
+    public getStepType(): string {
+      return "HeartbeatStep";
+    }
+
+    public async execute(context: AsyncContext, input: string): Promise<StepDecision> {
+      observed.push({
+        hasValue: context.hasLastHeartbeatValue(),
+        value: input === "string"
+          ? context.getLastHeartbeatValue(stringCodec)
+          : context.getLastHeartbeatValue(),
+      });
+      await context.recordHeartbeat({ input });
+      await context.recordHeartbeat(input, stringCodec);
+      await context.recordHeartbeat(null);
+      await context.recordHeartbeat(undefined);
+      if (input === "unreachable") {
+        // @ts-expect-error The heartbeat value is required, including when explicitly undefined.
+        await context.recordHeartbeat();
+      }
+      return gracefulComplete(input);
+    }
+  }
+  class HeartbeatFlow implements Flow<string> {
+    public readonly start = new HeartbeatStep();
+
+    public getFlowType(): string {
+      return "HeartbeatFlow";
+    }
+
+    public getSteps(): StepList<string> {
+      return StepList.startStep(this.start);
+    }
+  }
+  const heartbeats: Array<Value | undefined> = [];
+  const output = {
+    recordHeartbeat(value: Value | undefined): Promise<void> {
+      heartbeats.push(value);
+      return Promise.resolve();
+    },
+    writeStream(_write: StepStreamWrite): void {},
+  };
+  const flow = new HeartbeatFlow();
+  const hydrator = {
+    hydrateAll: async (values: readonly unknown[]) => values,
+  } as unknown as ValueHydrator;
+  const dispatcher = new WorkerDispatcher(new Registry([flow]), hydrator);
+  const invoke = async (input: string, lastHeartbeatValue?: Value): Promise<void> => {
+    await dispatcher.invokeExecute(
+      InvokeExecuteMethodRequest.create({
+        context: ProtoContext.create({ lastHeartbeatValue }),
+        flowType: flow.getFlowType(),
+        stepType: flow.start.getStepType(),
+        stepInput: encodeValue(stringCodec, input),
+        attributes: [],
+        stepExeLocals: [],
+      }),
+      new AbortController().signal,
+      output,
+    );
+  };
+
+  await invoke("absent");
+  await invoke("string", encodeValue(stringCodec, "restored"));
+  await invoke("null", encodeValue(codecOrJson(), null));
+  assert.deepEqual(observed, [
+    { hasValue: false, value: undefined },
+    { hasValue: true, value: "restored" },
+    { hasValue: true, value: undefined },
+  ]);
+  assert.equal(heartbeats.length, 12);
+  for (let offset = 0; offset < heartbeats.length; offset += 4) {
+    assert.equal(heartbeats[offset]?.kind?.$case, "objValue");
+    assert.equal(heartbeats[offset + 1]?.kind?.$case, "stringValue");
+    assert.equal(heartbeats[offset + 2]?.kind?.$case, "objValue");
+    assert.equal(heartbeats[offset + 3], undefined);
+  }
+});
+
+class UnsupportedSynchronousHeartbeatStep implements Step<string> {
+  public getStepType(): string {
+    return "UnsupportedSynchronousHeartbeatStep";
+  }
+
+  // @ts-expect-error AsyncContext handlers must return a Promise.
+  public execute(_context: AsyncContext, input: string): StepDecision {
+    return gracefulComplete(input);
+  }
+}
+
+void UnsupportedSynchronousHeartbeatStep;
 
 test("map introspection tracks buffered changes", () => {
   const attributes = new AttributeMap("items", stringCodec);
@@ -554,7 +692,6 @@ test("map introspection tracks buffered changes", () => {
   const context = new InvocationContext(
     "rpc",
     registeredFlowByName(registry, "MapFlow"),
-    testFlowService,
     ProtoContext.create(),
     [
       { key: physical("items", special), value: encodeValue(stringCodec, "initial") },

--- a/sdk-typescript/test/integ/README.md
+++ b/sdk-typescript/test/integ/README.md
@@ -35,7 +35,8 @@ Full integration verification:
   `mixed_sync_async_flow.ts` exercise both styles on one Worker.
 - Persistence integration covers singleton Attribute equality waits; local
   contracts cover Condition IDs and buffered map introspection.
-- Stream integration is pending the server-streaming Worker API update.
+- Step streaming covers repeated and cross-Stream writes, duplicate source
+  metadata, heartbeat detail recovery and clearing, and local-activity fallback.
 
 ## Error coverage
 

--- a/sdk-typescript/test/integ/core.integration.test.ts
+++ b/sdk-typescript/test/integ/core.integration.test.ts
@@ -25,7 +25,7 @@ import { BasicInternalChannelFlow } from "./basic_internal_channel_flow.js";
 import { ConditionalCompleteFlow } from "./conditional_complete_flow.js";
 import { DeadEndFlow } from "./dead_end_flow.js";
 import { ExecuteOnlyFlow } from "./execute_only_flow.js";
-import { expectError, flowId, withEnvironment } from "./environment.js";
+import { expectError, flowId, skipTimerWhenPending, withEnvironment } from "./environment.js";
 import { NoStartFlow } from "./no_start_flow.js";
 import { NoStateFlow } from "./no_state_flow.js";
 import { SignalFlow } from "./signal_flow.js";
@@ -124,7 +124,8 @@ test("signals, mapped signals, and skipped timer form one combination", async ()
     await client.publish(id, flow.first, 2, 3, 5);
     await client.publish(id, flow.third, undefined);
     await client.publish(id, flow.signalMap, "one", 4);
-    await client.skipTimer(
+    await skipTimerWhenPending(
+      client,
       id,
       StepExecutionId.of("SignalCombinationStep"),
       TimerId.byConditionId("test-timer-id"),

--- a/sdk-typescript/test/integ/environment.ts
+++ b/sdk-typescript/test/integ/environment.ts
@@ -17,10 +17,13 @@ import { join } from "node:path";
 
 import {
   Client,
+  DexServiceError,
   Registry,
   Worker,
   openBlobCache,
   type Flow,
+  type StepExecutionId,
+  type TimerId,
 } from "../../src/index.js";
 
 export interface TestEnvironment {
@@ -73,6 +76,30 @@ export async function withEnvironment(
 
 export function flowId(prefix: string): string {
   return `${prefix}-${randomUUID()}`;
+}
+
+export async function skipTimerWhenPending(
+  client: Client,
+  id: string,
+  stepExecutionId: StepExecutionId,
+  timerId: TimerId,
+): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      await client.skipTimer(id, stepExecutionId, timerId);
+      return;
+    } catch (failure) {
+      if (
+        !(failure instanceof DexServiceError) ||
+        failure.detail !== "requested timer condition does not exist or is not pending"
+      ) {
+        throw failure;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timer did not become pending for ${id}`);
 }
 
 export async function expectError<Failure extends Error>(

--- a/sdk-typescript/test/integ/step-cancellation.integration.test.ts
+++ b/sdk-typescript/test/integ/step-cancellation.integration.test.ts
@@ -60,7 +60,10 @@ for (const scenario of cancellationScenarios) {
         assert.equal(flow.handlerCanceled, true);
         assert.equal(flow.contextReportedCancellation, true);
       }
-      assert.equal(flow.blockingInvocations, 1);
+      assert.equal(
+        flow.blockingInvocations,
+        scenario === "local-execute" || scenario === "local-timeout-fallback" ? 2 : 1,
+      );
       assert.equal(flow.recoveryRan, false);
       assert.equal(await client.getAttribute(id, flow.lateWrite), undefined);
     });

--- a/sdk-typescript/test/integ/step-heartbeat.integration.test.ts
+++ b/sdk-typescript/test/integ/step-heartbeat.integration.test.ts
@@ -1,0 +1,73 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { stringCodec } from "../../src/index.js";
+import { flowId, withEnvironment } from "./environment.js";
+import {
+  StepHeartbeatFlow,
+  type HeartbeatScenario,
+} from "./step_heartbeat_flow.js";
+
+test("regular retries restore heartbeat presence and preserve details across Stream writes", async () => {
+  const flow = new StepHeartbeatFlow();
+  await withEnvironment([flow], async ({ client }) => {
+    for (const scenario of ["value", "clear", "null", "stream"] as const) {
+      flow.scenario = scenario;
+      const id = flowId(`typescript-heartbeat-${scenario}`);
+      await client.startFlow(flow, id, scenario);
+      assert.equal(
+        await client.waitForFlow(id, 30_000).then((result) => result.singleOutput(stringCodec)),
+        scenario,
+      );
+      if (scenario === "stream") {
+        const first = await client.readStream(id, flow.progress, "", 30_000);
+        const second = await client.readStream(id, flow.progress, first.resumeToken, 30_000);
+        assert.equal(first.value, "stream-after-heartbeat-1");
+        assert.equal(second.value, "stream-after-heartbeat-2");
+        assert.equal(first.source, second.source);
+      }
+    }
+  });
+});
+
+test("async local attempts write Streams without restoring heartbeat into fallback", async () => {
+  const flow = new StepHeartbeatFlow();
+  flow.scenario = "local";
+  await withEnvironment([flow], async ({ client }) => {
+    const id = flowId("typescript-heartbeat-local");
+    await client.startFlow(flow, id, "local" satisfies HeartbeatScenario);
+    assert.equal(
+      await client.waitForFlow(id, 30_000).then((result) => result.singleOutput(stringCodec)),
+      "local",
+    );
+    let resumeToken = "";
+    let source = "";
+    for (let invocation = 1; invocation <= 4; invocation += 1) {
+      const message = await client.readStream(id, flow.progress, resumeToken, 30_000);
+      assert.equal(message.value, `local-stream-${invocation}`);
+      source ||= message.source;
+      assert.equal(message.source, source);
+      resumeToken = message.resumeToken;
+    }
+  });
+});
+
+test("regular Step without progress frames reaches heartbeat timeout", async () => {
+  const flow = new StepHeartbeatFlow();
+  flow.scenario = "timeout";
+  await withEnvironment([flow], async ({ client }) => {
+    const id = flowId("typescript-heartbeat-timeout");
+    await client.startFlow(flow, id, "timeout" satisfies HeartbeatScenario);
+    assert.equal((await client.waitForFlow(id, 30_000)).status, "failed");
+  });
+});

--- a/sdk-typescript/test/integ/step_cancellation_flow.ts
+++ b/sdk-typescript/test/integ/step_cancellation_flow.ts
@@ -24,6 +24,7 @@ import {
   voidCodec,
   withCancelingSiblingSteps,
   withCancelingSteps,
+  type AsyncContext,
   type Context,
   type Flow,
   type PersistenceSchema,
@@ -95,7 +96,7 @@ class CancellationBlockingExecute implements Step<void> {
       ...(
         this.flow.scenario === "heartbeat-execute" ||
           this.flow.scenario === "local-timeout-fallback"
-          ? { heartbeatTimeoutMs: 2_000 }
+          ? { heartbeatTimeoutMs: 10_000 }
           : {}
       ),
       executeDurability:
@@ -107,12 +108,17 @@ class CancellationBlockingExecute implements Step<void> {
     };
   }
 
-  public async execute(context: Context, _input: void): Promise<StepDecision> {
+  public async execute(context: AsyncContext, _input: void): Promise<StepDecision> {
     this.flow.blockingInvocations += 1;
     this.flow.markBlockingStarted();
     try {
       if (this.flow.scenario === "no-heartbeat") {
         await delay(7_000);
+      } else if (
+        this.flow.scenario === "heartbeat-execute" ||
+        this.flow.scenario === "local-timeout-fallback"
+      ) {
+        await delayWithHeartbeats(context, 10_000);
       } else {
         await delay(10_000, context.cancellationSignal);
       }
@@ -142,17 +148,17 @@ class CancellationBlockingWaitFor implements Step<void> {
   public getStepOptions(): StepOptions {
     return {
       waitForMethodTimeoutMs: 15_000,
-      heartbeatTimeoutMs: 2_000,
+      heartbeatTimeoutMs: 10_000,
       waitForFailure: "proceed",
       waitForDurability: "sync",
     };
   }
 
-  public async waitFor(context: Context, _input: void): Promise<Wait> {
+  public async waitFor(context: AsyncContext, _input: void): Promise<Wait> {
     this.flow.blockingInvocations += 1;
     this.flow.markBlockingStarted();
     try {
-      await delay(10_000, context.cancellationSignal);
+      await delayWithHeartbeats(context, 10_000);
     } catch (failure) {
       if (!context.cancellationSignal.aborted) {
         throw failure;
@@ -408,4 +414,12 @@ function delay(milliseconds: number, signal?: AbortSignal): Promise<void> {
     }
     signal.addEventListener("abort", abort, { once: true });
   });
+}
+
+async function delayWithHeartbeats(context: AsyncContext, milliseconds: number): Promise<void> {
+  const deadline = Date.now() + milliseconds;
+  while (Date.now() < deadline) {
+    await context.recordHeartbeat({ attempt: context.attempt });
+    await delay(Math.min(500, deadline - Date.now()), context.cancellationSignal);
+  }
 }

--- a/sdk-typescript/test/integ/step_heartbeat_flow.ts
+++ b/sdk-typescript/test/integ/step_heartbeat_flow.ts
@@ -1,0 +1,150 @@
+// Portions of this file are derived from indeedeng/iwf-java-sdk.
+// Those portions are licensed under the Apache License, Version 2.0.
+// See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+//
+// Modifications Copyright (c) 2026 Super Durable, Inc.
+//
+// Modifications are licensed under the Super Durable Source License 1.0.
+// Third-Party Materials remain under the Apache License, Version 2.0.
+// See LICENSE and LEGACY_NOTICES.md.
+
+import {
+  StepList,
+  Stream,
+  gracefulComplete,
+  stringCodec,
+  type AsyncContext,
+  type Codec,
+  type Flow,
+  type PersistenceSchema,
+  type Step,
+  type StepDecision,
+  type StepOptions,
+} from "../../src/index.js";
+
+export type HeartbeatScenario = "value" | "clear" | "null" | "stream" | "local" | "timeout";
+
+class StepHeartbeatStep implements Step<HeartbeatScenario> {
+  public readonly inputCodec = stringCodec as Codec<HeartbeatScenario>;
+
+  public constructor(private readonly flow: StepHeartbeatFlow) {}
+
+  public getStepType(): string {
+    return "TypeScriptStepHeartbeat";
+  }
+
+  public getStepOptions(): StepOptions {
+    return {
+      heartbeatTimeoutMs: 10_000,
+      executeDurability: this.flow.scenario === "local" ? "async" : "sync",
+      ...(this.flow.scenario === "timeout" ? { executeMethodTimeoutMs: 20_000 } : {}),
+      executeRetry: {
+        initialIntervalMs: 1_000,
+        maximumAttempts: this.flow.scenario === "local"
+          ? 4
+          : this.flow.scenario === "timeout"
+            ? 1
+            : 2,
+        totalDurationMs: 30_000,
+      },
+    };
+  }
+
+  public async execute(
+    context: AsyncContext,
+    scenario: HeartbeatScenario,
+  ): Promise<StepDecision> {
+    if (scenario === "local") {
+      return this.executeLocal(context);
+    }
+    if (scenario === "timeout") {
+      await new Promise((resolve) => setTimeout(resolve, 12_000));
+      return gracefulComplete("unexpected");
+    }
+    if (context.attempt === 1) {
+      await this.recordFirstAttempt(context, scenario);
+      throw new Error(`retry ${scenario} after heartbeat`);
+    }
+    this.verifyRestoredHeartbeat(context, scenario);
+    return gracefulComplete(scenario);
+  }
+
+  private async executeLocal(context: AsyncContext): Promise<StepDecision> {
+    const invocation = (this.flow.localInvocations.get(context.flowId) ?? 0) + 1;
+    this.flow.localInvocations.set(context.flowId, invocation);
+    await context.recordHeartbeat(`local-${invocation}`, stringCodec);
+    this.flow.progress.write(context, `local-stream-${invocation}`);
+    if (invocation < 4) {
+      throw new Error(`local attempt ${invocation}`);
+    }
+    if (context.hasLastHeartbeatValue()) {
+      throw new Error("local heartbeat leaked into regular fallback");
+    }
+    return gracefulComplete("local");
+  }
+
+  private async recordFirstAttempt(
+    context: AsyncContext,
+    scenario: Exclude<HeartbeatScenario, "local" | "timeout">,
+  ): Promise<void> {
+    if (scenario === "clear") {
+      await context.recordHeartbeat("discarded", stringCodec);
+      await context.recordHeartbeat(undefined);
+      return;
+    }
+    if (scenario === "null") {
+      await context.recordHeartbeat(null);
+      return;
+    }
+    const value = scenario === "stream" ? "stream-heartbeat" : "restored-heartbeat";
+    await context.recordHeartbeat(value, stringCodec);
+    if (scenario === "stream") {
+      this.flow.progress.write(context, "stream-after-heartbeat-1");
+      this.flow.progress.write(context, "stream-after-heartbeat-2");
+    }
+  }
+
+  private verifyRestoredHeartbeat(
+    context: AsyncContext,
+    scenario: Exclude<HeartbeatScenario, "local" | "timeout">,
+  ): void {
+    if (scenario === "clear") {
+      if (context.hasLastHeartbeatValue()) {
+        throw new Error("explicit undefined heartbeat was not cleared");
+      }
+      return;
+    }
+    if (!context.hasLastHeartbeatValue()) {
+      throw new Error(`${scenario} heartbeat Value was not restored`);
+    }
+    if (scenario === "null") {
+      if (context.getLastHeartbeatValue() !== undefined) {
+        throw new Error("JSON null heartbeat decoded unexpectedly");
+      }
+      return;
+    }
+    const expected = scenario === "stream" ? "stream-heartbeat" : "restored-heartbeat";
+    if (context.getLastHeartbeatValue(stringCodec) !== expected) {
+      throw new Error(`${scenario} heartbeat Value changed during retry`);
+    }
+  }
+}
+
+export class StepHeartbeatFlow implements Flow<HeartbeatScenario> {
+  public readonly progress = new Stream("typescript-heartbeat-progress", stringCodec, 1 << 20);
+  public readonly localInvocations = new Map<string, number>();
+  public scenario: HeartbeatScenario = "value";
+  private readonly start = new StepHeartbeatStep(this);
+
+  public getFlowType(): string {
+    return "TypeScriptStepHeartbeatFlow";
+  }
+
+  public getSteps(): StepList<HeartbeatScenario> {
+    return StepList.startStep(this.start);
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return { streams: [this.progress] };
+  }
+}

--- a/sdk-typescript/test/integ/stream.integration.test.ts
+++ b/sdk-typescript/test/integ/stream.integration.test.ts
@@ -14,26 +14,59 @@ import test from "node:test";
 import { flowId, withEnvironment } from "./environment.js";
 import { StreamTestFlow } from "./stream_flow.js";
 
-test("Stream messages round-trip through Dex with resume metadata and idempotency", async () => {
+test("Stream messages retain duplicate sources and Step source metadata", async () => {
   const flow = new StreamTestFlow();
   await withEnvironment([flow], async ({ client }) => {
     const id = flowId("stream");
-    const runId = await client.startFlow(flow, id, undefined);
+    await client.startFlow(flow, id, undefined);
     await client.waitForFlow(id, 30_000);
 
-    await client.writeStream(id, flow.progress, "client-write", "client-progress");
-    await client.writeStream(id, flow.progress, "client-write", "duplicate-ignored");
+    await client.writeStream(id, flow.progress, "client#write", "client-progress");
+    await client.writeStream(id, flow.progress, "client#write", "duplicate-source");
 
-    const step = await client.readStream(id, flow.progress, "", 30_000);
-    assert.equal(step.value, "step-progress");
-    assert.notEqual(step.resumeToken, "");
-    assert.ok(step.createdTime.getTime() > 0);
-    assert.ok(step.idempotencyKey.startsWith(`${runId}#`));
+    let resumeToken = "";
+    let stepSource = "";
+    for (const expected of [
+      "wait-progress-1",
+      "wait-progress-2",
+      "execute-progress-1",
+      "execute-progress-2",
+    ]) {
+      const message = await client.readStream(id, flow.progress, resumeToken, 30_000);
+      assert.equal(message.value, expected);
+      assert.notEqual(message.resumeToken, resumeToken);
+      assert.ok(message.createdTime.getTime() > 0);
+      assert.ok(message.source.startsWith("#"));
+      stepSource ||= message.source;
+      assert.equal(message.source, stepSource);
+      resumeToken = message.resumeToken;
+    }
 
-    const clientMessage = await client.readStream(id, flow.progress, step.resumeToken, 30_000);
+    const waitDetails = await client.readStream(id, flow.details, "", 30_000);
+    const executeDetails = await client.readStream(
+      id,
+      flow.details,
+      waitDetails.resumeToken,
+      30_000,
+    );
+    assert.equal(waitDetails.value, "wait-details");
+    assert.equal(executeDetails.value, "execute-details");
+    assert.equal(waitDetails.source, stepSource);
+    assert.equal(executeDetails.source, stepSource);
+
+    const clientMessage = await client.readStream(id, flow.progress, resumeToken, 30_000);
     assert.equal(clientMessage.value, "client-progress");
-    assert.notEqual(clientMessage.resumeToken, step.resumeToken);
+    assert.notEqual(clientMessage.resumeToken, resumeToken);
     assert.ok(clientMessage.createdTime.getTime() > 0);
-    assert.equal(clientMessage.idempotencyKey, "client-write");
+    assert.equal(clientMessage.source, "client#write");
+
+    const duplicateSource = await client.readStream(
+      id,
+      flow.progress,
+      clientMessage.resumeToken,
+      30_000,
+    );
+    assert.equal(duplicateSource.value, "duplicate-source");
+    assert.equal(duplicateSource.source, "client#write");
   });
 });

--- a/sdk-typescript/test/integ/stream_flow.ts
+++ b/sdk-typescript/test/integ/stream_flow.ts
@@ -11,10 +11,11 @@
 import {
   StepList,
   Stream,
+  Wait,
   gracefulComplete,
   stringCodec,
   voidCodec,
-  type Context,
+  type AsyncContext,
   type Flow,
   type PersistenceSchema,
   type Step,
@@ -24,21 +25,40 @@ import {
 class StreamTestStep implements Step<void> {
   public readonly inputCodec = voidCodec;
 
-  public constructor(private readonly progress: Stream<string>) {}
+  public constructor(
+    private readonly progress: Stream<string>,
+    private readonly details: Stream<string>,
+  ) {}
 
   public getStepType(): string {
     return "StreamTestStep";
   }
 
-  public async execute(context: Context, _input: void): Promise<StepDecision> {
-    await this.progress.write(context, "step-progress");
+  public getStepOptions() {
+    return { heartbeatTimeoutMs: 10_000 };
+  }
+
+  public async waitFor(context: AsyncContext, _input: void): Promise<Wait> {
+    await context.recordHeartbeat("wait-for", stringCodec);
+    this.progress.write(context, "wait-progress-1");
+    this.progress.write(context, "wait-progress-2");
+    this.details.write(context, "wait-details");
+    return Wait.skipImmediately();
+  }
+
+  public async execute(context: AsyncContext, _input: void): Promise<StepDecision> {
+    await context.recordHeartbeat({ phase: "execute" });
+    this.progress.write(context, "execute-progress-1");
+    this.details.write(context, "execute-details");
+    this.progress.write(context, "execute-progress-2");
     return gracefulComplete();
   }
 }
 
 export class StreamTestFlow implements Flow<void> {
   public readonly progress = new Stream("stream-test-progress", stringCodec, 1 << 20);
-  private readonly start = new StreamTestStep(this.progress);
+  public readonly details = new Stream("stream-test-details", stringCodec, 1 << 20);
+  private readonly start = new StreamTestStep(this.progress, this.details);
 
   public getFlowType(): string {
     return "StreamTestFlow";
@@ -49,6 +69,6 @@ export class StreamTestFlow implements Flow<void> {
   }
 
   public getPersistenceSchema(): PersistenceSchema {
-    return { streams: [this.progress] };
+    return { streams: [this.progress, this.details] };
   }
 }

--- a/sdk-typescript/test/integ/subflow.integration.test.ts
+++ b/sdk-typescript/test/integ/subflow.integration.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../../src/index.js";
 import { AbnormalExitFlow } from "./abnormal_exit_flow.js";
 import { BasicFlow } from "./basic_flow.js";
-import { flowId, withEnvironment } from "./environment.js";
+import { flowId, skipTimerWhenPending, withEnvironment } from "./environment.js";
 import {
   AllSubFlowParent,
   AnySubFlowParent,
@@ -108,7 +108,8 @@ test("SubFlow partial results survive continue-as-new without restart", async ()
     });
     await awaitDifferentRun(client, id, firstParentRunId);
     const completedRunId = (await client.describeFlow(completedId)).runId;
-    await client.skipTimer(
+    await skipTimerWhenPending(
+      client,
       delayedId,
       StepExecutionId.of("TimerStep"),
       TimerId.byConditionId("test-timer-id"),
@@ -133,7 +134,8 @@ async function assertRunningReuse(
     await client.timeTravel(id, { type: TimeTravelType.BEGINNING, reason: "verify SubFlow running reuse" });
     const activeRunId = await awaitRunning(client, childId, expectsRestart ? firstRunId : undefined);
     assert.equal(activeRunId !== firstRunId, expectsRestart);
-    await client.skipTimer(
+    await skipTimerWhenPending(
+      client,
       childId,
       StepExecutionId.of("TimerStep"),
       TimerId.byConditionId("test-timer-id"),

--- a/sdk-typescript/test/worker.integration.test.ts
+++ b/sdk-typescript/test/worker.integration.test.ts
@@ -13,7 +13,10 @@ import test from "node:test";
 import {
   Server,
   ServerCredentials,
+  credentials,
   status as grpcStatus,
+  type ClientReadableStream,
+  type ServiceError,
   type sendUnaryData,
 } from "@grpc/grpc-js";
 
@@ -22,18 +25,30 @@ import {
   IndexType,
   Registry,
   StepList,
+  Stream,
+  Wait,
   Worker,
+  gracefulComplete,
   stringCodec,
+  type AsyncContext,
   type BlobCache,
   type Flow,
+  type PersistenceSchema,
+  type Step,
+  type StepDecision,
 } from "../src/index.js";
 import {
+  Context as ProtoContext,
   FlowServiceService,
   IndexType as ProtoIndexType,
+  InvokeExecuteMethodRequest,
+  InvokeWaitForMethodRequest,
+  WorkerServiceClient,
   type FlowServiceServer,
   type SyncAttributeIndexRequest,
   type SyncAttributeIndexResponse,
 } from "../src/gen/dex.js";
+import { encodeValue } from "../src/value-mapper.js";
 
 class IndexedFlow implements Flow {
   private readonly status = new Attribute(
@@ -109,6 +124,179 @@ test("Worker sync failure keeps its port closed", async () => {
     await shutdown(flowServer);
   }
 });
+
+test("Worker streams ordered Step progress and exactly one result", async () => {
+  const workerPort = await availablePort();
+  const flowServer = new Server();
+  flowServer.addService(FlowServiceService, {
+    syncAttributeIndexes(_call, callback: sendUnaryData<SyncAttributeIndexResponse>) {
+      callback(null, {});
+    },
+  } as Partial<FlowServiceServer> as FlowServiceServer);
+  const flowPort = await bind(flowServer);
+  const flow = new StreamingWorkerFlow();
+  const worker = new Worker(new Registry([flow]), new MemoryBlobCache(), {
+    bindAddress: `127.0.0.1:${workerPort}`,
+    serverAddress: `127.0.0.1:${flowPort}`,
+  });
+  const client = new WorkerServiceClient(
+    `127.0.0.1:${workerPort}`,
+    credentials.createInsecure(),
+  );
+  try {
+    await worker.start();
+    const waitFor = await observeStream(client.invokeWaitForMethod(
+      InvokeWaitForMethodRequest.create({
+        context: ProtoContext.create({ flowId: "flow-1", stepExecutionId: "step-1" }),
+        flowType: flow.getFlowType(),
+        stepType: flow.start.getStepType(),
+        stepInput: encodeValue(stringCodec, "wait"),
+        attributes: [],
+      }),
+    ));
+    assert.equal(waitFor.error, undefined);
+    assert.deepEqual(waitFor.outputs.map((output) => output.output?.$case), [
+      "heartbeat",
+      "streamWrite",
+      "streamWrite",
+      "result",
+    ]);
+
+    const execute = await observeStream(client.invokeExecuteMethod(executeRequest(flow, "success")));
+    assert.equal(execute.error, undefined);
+    assert.deepEqual(execute.outputs.map((output) => output.output?.$case), [
+      "heartbeat",
+      "streamWrite",
+      "heartbeat",
+      "streamWrite",
+      "result",
+    ]);
+    assert.equal(
+      execute.outputs.filter((output) => output.output?.$case === "result").length,
+      1,
+    );
+    assert.equal(execute.outputs[2]?.output?.$case, "heartbeat");
+    if (execute.outputs[2]?.output?.$case === "heartbeat") {
+      assert.equal(execute.outputs[2].output.value.value, undefined);
+    }
+    assert.throws(() => flow.progress.write(flow.completedContext!, "late"), /no longer active/);
+    assert.throws(() => void flow.completedContext!.recordHeartbeat("late"), /no longer active/);
+
+    const failed = await observeStream(client.invokeExecuteMethod(executeRequest(flow, "failure")));
+    assert.notEqual(failed.error, undefined);
+    assert.deepEqual(failed.outputs.map((output) => output.output?.$case), ["heartbeat"]);
+
+    const cancelledCall = client.invokeExecuteMethod(executeRequest(flow, "cancel"));
+    const cancelled = observeStream(cancelledCall, () => cancelledCall.cancel());
+    const cancelledResult = await cancelled;
+    assert.notEqual(cancelledResult.error, undefined);
+    assert.deepEqual(cancelledResult.outputs.map((output) => output.output?.$case), ["heartbeat"]);
+  } finally {
+    client.close();
+    await worker.close();
+    await shutdown(flowServer);
+  }
+});
+
+class StreamingWorkerStep implements Step<string> {
+  public readonly inputCodec = stringCodec;
+
+  public constructor(
+    private readonly flow: StreamingWorkerFlow,
+    private readonly progress: Stream<string>,
+  ) {}
+
+  public getStepType(): string {
+    return "StreamingWorkerStep";
+  }
+
+  public async waitFor(context: AsyncContext, _input: string): Promise<Wait> {
+    await context.recordHeartbeat("waiting", stringCodec);
+    this.progress.write(context, "wait-1");
+    this.progress.write(context, "wait-2");
+    return Wait.skipImmediately();
+  }
+
+  public async execute(context: AsyncContext, input: string): Promise<StepDecision> {
+    await context.recordHeartbeat({ input });
+    if (input === "failure") {
+      throw new Error("handler failed after progress");
+    }
+    if (input === "cancel") {
+      await aborted(context.cancellationSignal);
+      return gracefulComplete(input);
+    }
+    this.progress.write(context, "execute-1");
+    await context.recordHeartbeat(undefined);
+    this.progress.write(context, "execute-2");
+    this.flow.completedContext = context;
+    return gracefulComplete(input);
+  }
+}
+
+class StreamingWorkerFlow implements Flow<string> {
+  public readonly progress = new Stream("worker-progress", stringCodec, 1 << 20);
+  public readonly start = new StreamingWorkerStep(this, this.progress);
+  public completedContext: AsyncContext | undefined;
+
+  public getFlowType(): string {
+    return "StreamingWorkerFlow";
+  }
+
+  public getSteps(): StepList<string> {
+    return StepList.startStep(this.start);
+  }
+
+  public getPersistenceSchema(): PersistenceSchema {
+    return { streams: [this.progress] };
+  }
+}
+
+function executeRequest(flow: StreamingWorkerFlow, input: string): InvokeExecuteMethodRequest {
+  return InvokeExecuteMethodRequest.create({
+    context: ProtoContext.create({ flowId: "flow-1", stepExecutionId: "step-1" }),
+    flowType: flow.getFlowType(),
+    stepType: flow.start.getStepType(),
+    stepInput: encodeValue(stringCodec, input),
+    attributes: [],
+    stepExeLocals: [],
+  });
+}
+
+function observeStream<Output>(
+  call: ClientReadableStream<Output>,
+  afterFirstOutput?: () => void,
+): Promise<{ outputs: Output[]; error: ServiceError | undefined }> {
+  return new Promise((resolve) => {
+    const outputs: Output[] = [];
+    let isSettled = false;
+    const settle = (error?: ServiceError): void => {
+      if (isSettled) {
+        return;
+      }
+      isSettled = true;
+      resolve({ outputs, error });
+    };
+    call.on("data", (output: Output) => {
+      outputs.push(output);
+      if (outputs.length === 1) {
+        afterFirstOutput?.();
+      }
+    });
+    call.on("error", settle);
+    call.on("end", () => settle());
+  });
+}
+
+function aborted(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
 
 class MemoryBlobCache implements BlobCache {
   public readonly config = { directory: "memory", maxBytes: 1_024 };


### PR DESCRIPTION
## Summary

- add `AsyncContext.recordHeartbeat(value, codec?)` and restore heartbeat details through `Context`
- stream WaitFor and Execute Worker responses through grpc-js while keeping WorkerRpc unary
- make Step `Stream.write` synchronous and fire-and-forget with repeated message support
- rename external Stream idempotency metadata to repeatable `source`
- cover result framing, cancellation, retries, heartbeat presence, implicit Stream heartbeats, and local fallback

## Rationale and user impact

This is stacked on #417 and implements its breaking Worker protocol in the TypeScript SDK. Async Step handlers can explicitly report progress, repeated Stream writes no longer call FlowService, and retained heartbeat details are available on retry. Existing Context-based sync and async handlers continue to compile when they do not need heartbeat recording.

## Validation

- `npm run docs:check`
- `npm run typecheck`
- `npm test` — 24/24 passing
- `npm run coverage:integration` — 92/92 passing
- `make generated-code-check`
- `make copyright-check`

## Stack

- Base server PR: #417
