### PR TITLE
Add Java SDK Step streaming

### DIFF
--- a/docs/design/plan/java-sdk-step-streaming.md
+++ b/docs/design/plan/java-sdk-step-streaming.md
@@ -1,0 +1,58 @@
+# Java SDK Step Worker streaming
+
+This design applies the Step Worker server-streaming protocol to the synchronous
+Java SDK. **InvokeWaitForMethod** and **InvokeExecuteMethod** stream progress and
+one final result. **InvokeWorkerRPC** remains unary.
+
+## Handler and transport model
+
+Java Step signatures remain ordinary synchronous methods. The handler runs on
+the existing bounded Worker executor. Calls to **Context.recordHeartbeat** and
+**Stream.write** synchronously encode and send one response frame from that same
+thread. The SDK adds no generator, queue, or streaming thread.
+
+The Worker sends frames in application call order. After the handler returns,
+it sends exactly one result and completes the response stream. A handler,
+encoding, or transport failure ends the RPC with an error and no result; progress
+already delivered to Dex is not retracted. gRPC cancellation is checked before
+every progress or result frame and continues to interrupt the handler task.
+
+Flow timeout handlers use the Execute stream and may emit progress. RPC Contexts
+reject heartbeat and Stream operations because **InvokeWorkerRPC** is unary.
+
+## Heartbeat context
+
+**recordHeartbeat(value)** emits a heartbeat with a Dex Value when value is
+nonnull. **recordHeartbeat(null)** emits a heartbeat without a Value. The server
+therefore clears the current heartbeat details, and a later Stream implicit
+heartbeat also carries no details.
+
+**hasLastHeartbeatValue** reports whether a regular activity retry supplied
+details. **getLastHeartbeatValue(Class)** decodes those details or returns null
+when they are absent. The SDK hydrates blob-backed heartbeat Values before the
+handler runs. Local activity heartbeat frames are emitted by the Worker but are
+ignored by the server and never reach fallback context.
+
+## Stream behavior
+
+**Stream.write** emits a fire-and-forget **StepStreamWrite** frame. It does not
+call FlowService.WriteStream, wait for an acknowledgement, or restrict repeated
+writes. The server assigns `#<stepExecutionID>` as source metadata and treats
+Store failures as observable best-effort loss.
+
+External **Client.writeStream** remains unary. Its third argument is **source**,
+which must be nonblank, may contain `#`, and may repeat. Every call appends.
+**StreamMessage.getSource** returns the metadata without interpreting it as an
+identity.
+
+## Defaults
+
+Durability precedence is Step method, Flow configuration, then SYNC; failure
+policy does not change it. Step retry duration defaults to four hours. Regular
+attempt and heartbeat timeouts default to two hours and one minute. Zero
+heartbeat timeout selects the default; explicit values must satisfy the
+server-configured minimum, normally ten seconds.
+
+ASYNC uses at most seven seconds and three attempts in the local phase, subject
+to smaller user retry limits. Local execution ignores method and heartbeat
+timeouts. Fallback applies the regular defaults and the remaining retry budget.

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -76,6 +76,49 @@ activities share maximum attempts, total duration, and 1-based attempt numbers.
 Fallback starts immediately; later regular retries continue the backoff
 sequence at the cumulative attempt.
 
+Dex defaults Step methods to SYNC durability, a four-hour retry duration, a
+two-hour regular attempt timeout, and a one-minute heartbeat timeout. A Step
+method durability override wins over `FlowConfig.stepDurability(...)`, which
+wins over SYNC. Failure policies do not change that order. ASYNC first uses a
+local activity for at most seven seconds and three attempts; the local phase
+ignores method and heartbeat timeouts before regular-activity fallback.
+
+### Step progress and Streams
+
+Dex does not heartbeat a Step automatically. Long-running handlers should emit
+progress before the configured heartbeat timeout:
+
+```java
+@Override
+public StepDecision execute(Context context, Batch batch) {
+    int start = context.hasLastHeartbeatValue()
+            ? context.getLastHeartbeatValue(Integer.class)
+            : 0;
+    for (int index = start; index < batch.items().size(); index++) {
+        process(batch.items().get(index));
+        context.recordHeartbeat(index + 1);
+        progress.write(context, "processed " + (index + 1));
+    }
+    return StepDecision.gracefulComplete();
+}
+```
+
+`recordHeartbeat(value)` persists a nonnull checkpoint for a later regular
+activity attempt. `recordHeartbeat(null)` sends a heartbeat without details and
+clears the current checkpoint. ASYNC local activities ignore heartbeat frames.
+A Stream write is an implicit heartbeat that preserves the latest explicit
+heartbeat details.
+
+Step Stream writes travel on the Worker response stream and are fire-and-forget.
+One handler may write the same Stream any number of times. Dex assigns
+`#<stepExecutionID>` as source metadata. Storage rejection does not fail the
+handler, although local validation, serialization, and Worker transport errors
+can still fail it.
+
+`Client.writeStream(flowId, stream, source, value)` appends on every call.
+Sources are required metadata, may repeat, and may contain `#`. Read them with
+`StreamMessage.getSource()`; they do not provide deduplication.
+
 ### Soft Flow timeout
 
 Override `Flow.handleTimeout` to make a positive timeout use handler policy by

--- a/sdk-java/src/main/java/io/superdurable/dex/Client.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Client.java
@@ -148,7 +148,7 @@ public final class Client implements AutoCloseable {
                 .build();
         this.service = FlowServiceGrpc.newBlockingStub(channel);
         this.hydrator = new ValueHydrator(service, blobCache);
-        this.mappings = new WorkerDispatcher(registry, values, hydrator, service);
+        this.mappings = new WorkerDispatcher(registry, values, hydrator);
     }
 
     Registry getRegistry() {
@@ -578,27 +578,26 @@ public final class Client implements AutoCloseable {
     }
 
     /**
-     * Appends one typed best-effort Stream message with client idempotency.
+     * Appends one typed best-effort Stream message with producer metadata.
+     *
+     * <p>Each call appends a new message. The source is informational and may be reused, including
+     * by concurrent producers. A source may contain {@code #}.
      *
      * @param flowId the logical Flow instance ID; the Flow need not exist or be active
      * @param stream the exact Stream registered in one Flow schema
-     * @param idempotencyKey the nonblank key without {@code #}
+     * @param source the nonblank producer description returned with the message
      * @param value the typed message to append
      * @param <T> the Stream message type
      * @throws FlowDefinitionException if the Stream is not registered
-     * @throws IllegalArgumentException if an ID is invalid or the key contains {@code #}
+     * @throws IllegalArgumentException if the Flow ID or source is invalid
      * @throws DexServiceException if Dex cannot append the message
      */
     public <T> void writeStream(
             final String flowId,
             final Stream<T> stream,
-            final String idempotencyKey,
+            final String source,
             final T value) {
-        final String key = Attribute.requireName(idempotencyKey);
-        if (key.indexOf('#') >= 0) {
-            throw new IllegalArgumentException(
-                    "Stream client idempotency key must not contain #");
-        }
+        final String validatedSource = Attribute.requireName(source);
         final Registry.RegisteredFlow flow = registry.getFlow(stream);
         call(() -> service.writeStream(WriteStreamRequest.newBuilder()
                 .setFlowId(Attribute.requireName(flowId))
@@ -606,7 +605,7 @@ public final class Client implements AutoCloseable {
                 .setStreamName(stream.getStreamName())
                 .setStreamCapacityBytes(stream.getStreamCapacityBytes())
                 .setValue(values.encode(value))
-                .setIdempotencyKey(key)
+                .setSource(validatedSource)
                 .build()));
     }
 
@@ -668,7 +667,7 @@ public final class Client implements AutoCloseable {
                 value,
                 response.getMessage().getResumeToken(),
                 instant(response.getMessage().getCreatedTime()),
-                response.getMessage().getIdempotencyKey());
+                response.getMessage().getSource());
     }
 
     /**

--- a/sdk-java/src/main/java/io/superdurable/dex/Context.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Context.java
@@ -131,6 +131,54 @@ public interface Context {
     boolean waitForMethodFailed();
 
     /**
+     * Sends a best-effort heartbeat for the current Step method attempt.
+     *
+     * <p>Dex persists a nonnull value with the activity heartbeat and supplies it to a later
+     * attempt through {@link #getLastHeartbeatValue}. Passing {@code null} sends a heartbeat
+     * without details, clearing any value previously reported during the current attempt. A Stream
+     * write also acts as a heartbeat and preserves the most recently reported details. Heartbeats
+     * are ignored while an asynchronous Step runs as a local activity. This method sends directly
+     * on the invocation's response stream and must be called only from the handler thread.
+     *
+     * <pre>{@code
+     * public StepDecision execute(Context context, Batch input) {
+     *     for (int index = 0; index < input.items().size(); index++) {
+     *         process(input.items().get(index));
+     *         context.recordHeartbeat(index + 1);
+     *     }
+     *     return StepDecision.gracefulComplete();
+     * }
+     * }</pre>
+     *
+     * @param value the checkpoint to persist, or {@code null} to send no heartbeat details
+     * @throws IllegalStateException if called from an RPC
+     * @throws io.grpc.StatusRuntimeException if the invocation is canceled or transport fails
+     * @throws io.superdurable.dex.exceptions.ValueMappingException if a nonnull value cannot be
+     *     encoded
+     */
+    void recordHeartbeat(Object value);
+
+    /**
+     * Reports whether Dex restored heartbeat details from an earlier attempt.
+     *
+     * @return {@code true} when {@link #getLastHeartbeatValue} can decode a restored value
+     */
+    boolean hasLastHeartbeatValue();
+
+    /**
+     * Decodes heartbeat details restored from an earlier attempt.
+     *
+     * <p>Call {@link #hasLastHeartbeatValue} to distinguish an absent checkpoint. Values passed
+     * with a {@link Class} must use concrete, non-parameterized types.
+     *
+     * @param valueType the concrete Java class used to decode the checkpoint
+     * @param <T> the checkpoint type
+     * @return the decoded checkpoint, or {@code null} when no checkpoint was restored
+     * @throws io.superdurable.dex.exceptions.ValueMappingException if the value cannot be decoded
+     */
+    <T> T getLastHeartbeatValue(Class<T> valueType);
+
+    /**
      * Stores a value scoped to the current Step execution.
      *
      * <p>Step-execution locals allow {@link Step#waitFor} to pass durable data to
@@ -274,9 +322,16 @@ public interface Context {
     /**
      * Appends one immediate best-effort Stream message.
      *
+     * <p>The write emits a frame on the current Step method response stream and does not wait for
+     * storage acknowledgement. Multiple writes to the same Stream are allowed. Dex may discard a
+     * message when its Stream Store is unavailable or rejects the write.
+     *
      * @param stream the Stream registered by the current Flow
      * @param value the typed message to append
      * @param <T> the Stream message type
+     * @throws IllegalStateException if called from an RPC
+     * @throws io.grpc.StatusRuntimeException if the invocation is canceled or transport fails
+     * @throws io.superdurable.dex.exceptions.ValueMappingException if the value cannot be encoded
      */
     <T> void writeStream(Stream<T> stream, T value);
 }

--- a/sdk-java/src/main/java/io/superdurable/dex/FlowConfig.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/FlowConfig.java
@@ -131,12 +131,9 @@ public final class FlowConfig {
         /**
          * Sets the normal default durability for Step methods in this Flow.
          *
-         * <p>The server default is {@link StepDurability#ASYNC}, which lowers latency and increases
-         * server throughput by allowing result persistence to be batched. A method-level setting in
-         * {@link StepOptions} takes precedence. This Flow-wide setting does not override Dex's safer
-         * {@link StepDurability#SYNC} choice when a wait-for or execute failure policy proceeds.
-         * Applications may override that choice only in the relevant Step options after considering
-         * the replay tradeoff described by {@link StepDurability}.
+         * <p>The server default is {@link StepDurability#SYNC}. A method-level setting in
+         * {@link StepOptions} takes precedence over this Flow-wide value. Failure policies do not
+         * change that ordering or the selected default.
          *
          * @param value the durability mode, or {@code null} for the server default
          * @return this builder

--- a/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
@@ -23,10 +23,10 @@ import io.superdurable.gen.ConditionResults;
 import io.superdurable.gen.ConditionStatus;
 import io.superdurable.gen.KV;
 import io.superdurable.gen.FlowResult;
-import io.superdurable.gen.FlowServiceGrpc;
+import io.superdurable.gen.StepMethodHeartbeat;
+import io.superdurable.gen.StepStreamWrite;
 import io.superdurable.gen.TimerResult;
 import io.superdurable.gen.Value;
-import io.superdurable.gen.WriteStreamRequest;
 
 import java.time.Instant;
 import java.io.UnsupportedEncodingException;
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,7 +51,7 @@ final class InvocationContext implements Context {
     private final Registry.RegisteredFlow flow;
     private final io.superdurable.gen.Context metadata;
     private final ValueMapper values;
-    private final FlowServiceGrpc.FlowServiceBlockingStub flowService;
+    private final StepOutputEmitter stepOutputEmitter;
     private final Map<String, Value> attributes;
     private final Map<String, Value> locals;
     private final ConditionResults conditionResults;
@@ -63,15 +62,12 @@ final class InvocationContext implements Context {
     private final List<KV> events = new ArrayList<KV>();
     private final Set<String> eventNames = new HashSet<String>();
     private final List<ChannelMessage> publications = new ArrayList<ChannelMessage>();
-    private final Set<Stream<?>> streamWrites = Collections.newSetFromMap(
-            new IdentityHashMap<Stream<?>, Boolean>());
-
     InvocationContext(
             final Method method,
             final Registry.RegisteredFlow flow,
             final io.superdurable.gen.Context metadata,
             final ValueMapper values,
-            final FlowServiceGrpc.FlowServiceBlockingStub flowService,
+            final StepOutputEmitter stepOutputEmitter,
             final List<KV> attributes,
             final List<KV> locals,
             final ConditionResults conditionResults,
@@ -83,7 +79,7 @@ final class InvocationContext implements Context {
         this.flow = flow;
         this.metadata = metadata;
         this.values = values;
-        this.flowService = flowService;
+        this.stepOutputEmitter = stepOutputEmitter;
         this.attributes = mapValues("Attribute", attributes);
         this.locals = mapValues("step-execution local", locals);
         this.conditionResults = conditionResults;
@@ -168,25 +164,46 @@ final class InvocationContext implements Context {
     }
 
     @Override
+    public void recordHeartbeat(final Object value) {
+        requireStepOutput("Heartbeats");
+        final StepMethodHeartbeat.Builder heartbeat = StepMethodHeartbeat.newBuilder();
+        if (value != null) {
+            heartbeat.setValue(values.encode(value));
+        }
+        stepOutputEmitter.emitHeartbeat(heartbeat.build());
+    }
+
+    @Override
+    public boolean hasLastHeartbeatValue() {
+        return metadata.hasLastHeartbeatValue();
+    }
+
+    @Override
+    public <T> T getLastHeartbeatValue(final Class<T> valueType) {
+        if (!metadata.hasLastHeartbeatValue()) {
+            return null;
+        }
+        return values.decode(metadata.getLastHeartbeatValue(), valueType);
+    }
+
+    @Override
     public <T> void writeStream(final Stream<T> stream, final T value) {
-        if (method == Method.RPC) {
-            throw new IllegalStateException("Stream writes require a Step Context");
-        }
+        requireStepOutput("Stream writes");
         requireRegistered(stream);
-        if (streamWrites.contains(stream)) {
-            throw new IllegalStateException(
-                    "Stream " + stream.getStreamName()
-                            + " was already written by this Step execution");
-        }
-        flowService.writeStream(WriteStreamRequest.newBuilder()
-                .setFlowId(getFlowId())
-                .setFlowType(flow.getName())
+        stepOutputEmitter.emitStreamWrite(StepStreamWrite.newBuilder()
                 .setStreamName(stream.getStreamName())
                 .setStreamCapacityBytes(stream.getStreamCapacityBytes())
                 .setValue(values.encode(value))
-                .setIdempotencyKey(getRunId() + "#" + getStepExecutionId())
                 .build());
-        streamWrites.add(stream);
+    }
+
+    private void requireStepOutput(final String operation) {
+        if (method == Method.RPC) {
+            throw new IllegalStateException(operation + " require a Step Context");
+        }
+        if (stepOutputEmitter == null) {
+            throw new IllegalStateException("Step output emitter is required");
+        }
     }
 
     io.superdurable.dex.FlowResult subFlowResult(final int index) {

--- a/sdk-java/src/main/java/io/superdurable/dex/JavaWorkerService.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/JavaWorkerService.java
@@ -16,12 +16,16 @@ import io.grpc.Status;
 import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
 import io.superdurable.dex.exceptions.RetryAfterException;
+import io.superdurable.gen.InvokeExecuteMethodOutput;
 import io.superdurable.gen.InvokeExecuteMethodRequest;
 import io.superdurable.gen.InvokeExecuteMethodResponse;
+import io.superdurable.gen.InvokeWaitForMethodOutput;
 import io.superdurable.gen.InvokeWaitForMethodRequest;
 import io.superdurable.gen.InvokeWaitForMethodResponse;
 import io.superdurable.gen.InvokeWorkerRPCRequest;
 import io.superdurable.gen.InvokeWorkerRPCResponse;
+import io.superdurable.gen.StepMethodHeartbeat;
+import io.superdurable.gen.StepStreamWrite;
 import io.superdurable.gen.WorkerErrorResponse;
 import io.superdurable.gen.WorkerServiceGrpc;
 
@@ -59,27 +63,29 @@ final class JavaWorkerService extends WorkerServiceGrpc.WorkerServiceImplBase {
     @Override
     public void invokeWaitForMethod(
             final InvokeWaitForMethodRequest request,
-            final StreamObserver<InvokeWaitForMethodResponse> observer) {
-        submit(observer, () -> dispatcher.invokeWaitFor(request));
+            final StreamObserver<InvokeWaitForMethodOutput> observer) {
+        final WaitForOutputEmitter emitter = new WaitForOutputEmitter(observer);
+        submit(observer, () -> emitter.emitResult(dispatcher.invokeWaitFor(request, emitter)));
     }
 
     @Override
     public void invokeExecuteMethod(
             final InvokeExecuteMethodRequest request,
-            final StreamObserver<InvokeExecuteMethodResponse> observer) {
-        submit(observer, () -> dispatcher.invokeExecute(request));
+            final StreamObserver<InvokeExecuteMethodOutput> observer) {
+        final ExecuteOutputEmitter emitter = new ExecuteOutputEmitter(observer);
+        submit(observer, () -> emitter.emitResult(dispatcher.invokeExecute(request, emitter)));
     }
 
     @Override
     public void invokeWorkerRPC(
             final InvokeWorkerRPCRequest request,
             final StreamObserver<InvokeWorkerRPCResponse> observer) {
-        submit(observer, () -> dispatcher.invokeRpc(request));
+        submit(observer, () -> emit(observer, dispatcher.invokeRpc(request)));
     }
 
-    private <Response> void submit(
-            final StreamObserver<Response> observer,
-            final Invocation<Response> invocation) {
+    private void submit(
+            final StreamObserver<?> observer,
+            final Invocation invocation) {
         final Context requestContext = Context.current();
         final HandlerCancellation cancellation = new HandlerCancellation(requestContext);
         final Runnable task = requestContext.wrap(() -> {
@@ -100,11 +106,11 @@ final class JavaWorkerService extends WorkerServiceGrpc.WorkerServiceImplBase {
         }
     }
 
-    private <Response> void invoke(
-            final StreamObserver<Response> observer,
-            final Invocation<Response> invocation) {
+    private void invoke(
+            final StreamObserver<?> observer,
+            final Invocation invocation) {
         try {
-            observer.onNext(invocation.invoke());
+            invocation.invoke();
             observer.onCompleted();
         } catch (Throwable failure) {
             if (Context.current().isCancelled()) {
@@ -163,8 +169,83 @@ final class JavaWorkerService extends WorkerServiceGrpc.WorkerServiceImplBase {
                 + new String(STACK_TRACE_TRUNCATION_MARKER, StandardCharsets.UTF_8);
     }
 
-    private interface Invocation<Response> {
-        Response invoke() throws Throwable;
+    private static <Response> void emit(
+            final StreamObserver<Response> observer,
+            final Response response) {
+        try {
+            requireActiveInvocation();
+            observer.onNext(response);
+        } catch (RuntimeException failure) {
+            if (Context.current().isCancelled()) {
+                Thread.currentThread().interrupt();
+            }
+            throw failure;
+        }
+    }
+
+    private static void requireActiveInvocation() {
+        if (Context.current().isCancelled()) {
+            Thread.currentThread().interrupt();
+            throw Status.CANCELLED
+                    .withDescription("Java Worker invocation canceled")
+                    .asRuntimeException();
+        }
+    }
+
+    private interface Invocation {
+        void invoke() throws Throwable;
+    }
+
+    private static final class WaitForOutputEmitter implements StepOutputEmitter {
+        private final StreamObserver<InvokeWaitForMethodOutput> observer;
+
+        private WaitForOutputEmitter(final StreamObserver<InvokeWaitForMethodOutput> observer) {
+            this.observer = observer;
+        }
+
+        @Override
+        public void emitHeartbeat(final StepMethodHeartbeat heartbeat) {
+            emit(observer, InvokeWaitForMethodOutput.newBuilder()
+                    .setHeartbeat(heartbeat)
+                    .build());
+        }
+
+        @Override
+        public void emitStreamWrite(final StepStreamWrite streamWrite) {
+            emit(observer, InvokeWaitForMethodOutput.newBuilder()
+                    .setStreamWrite(streamWrite)
+                    .build());
+        }
+
+        private void emitResult(final InvokeWaitForMethodResponse result) {
+            emit(observer, InvokeWaitForMethodOutput.newBuilder().setResult(result).build());
+        }
+    }
+
+    private static final class ExecuteOutputEmitter implements StepOutputEmitter {
+        private final StreamObserver<InvokeExecuteMethodOutput> observer;
+
+        private ExecuteOutputEmitter(final StreamObserver<InvokeExecuteMethodOutput> observer) {
+            this.observer = observer;
+        }
+
+        @Override
+        public void emitHeartbeat(final StepMethodHeartbeat heartbeat) {
+            emit(observer, InvokeExecuteMethodOutput.newBuilder()
+                    .setHeartbeat(heartbeat)
+                    .build());
+        }
+
+        @Override
+        public void emitStreamWrite(final StepStreamWrite streamWrite) {
+            emit(observer, InvokeExecuteMethodOutput.newBuilder()
+                    .setStreamWrite(streamWrite)
+                    .build());
+        }
+
+        private void emitResult(final InvokeExecuteMethodResponse result) {
+            emit(observer, InvokeExecuteMethodOutput.newBuilder().setResult(result).build());
+        }
     }
 
     private static final class HandlerCancellation implements Context.CancellationListener {

--- a/sdk-java/src/main/java/io/superdurable/dex/RetryPolicy.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/RetryPolicy.java
@@ -20,7 +20,9 @@ import java.time.Duration;
  * {@link java.time.Duration}; the receiving API determines whether subsecond precision is accepted.
  * With asynchronous Step durability, local and regular execution share the same attempt and elapsed
  * duration budgets. Fallback starts immediately, while later regular retries continue the cumulative
- * exponential-backoff sequence.
+ * exponential-backoff sequence. Step retry total duration defaults to four hours. The asynchronous
+ * local phase uses at most seven seconds and three attempts before fallback; smaller user limits
+ * still apply.
  *
  * <pre>{@code
  * RetryPolicy retry = RetryPolicy.newBuilder()
@@ -132,6 +134,9 @@ public final class RetryPolicy {
 
         /**
          * Limits the total elapsed retry duration.
+         *
+         * <p>Step method retries default to four hours when this value is unset. An explicit value
+         * may be shorter or longer.
          *
          * @param value the total retry duration, or {@code null} for the server default
          * @return this builder

--- a/sdk-java/src/main/java/io/superdurable/dex/StepDurability.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StepDurability.java
@@ -25,24 +25,14 @@ package io.superdurable.dex;
  * it closes the asynchronous result-loss window. It does not provide exactly-once execution, so Step
  * methods must still be safe to retry.
  *
- * <p>The server default for ordinary Step methods is {@link #ASYNC}. Use
- * {@link FlowConfig.Builder#stepDurability} to change the default for a Flow. Use
+ * <p>The server default for Step methods is {@link #SYNC}. Use
+ * {@link FlowConfig.Builder#stepDurability} to override the default for a Flow. Use
  * {@link StepOptions.Builder#waitForDurability} or
  * {@link StepOptions.Builder#executeDurability} to override one method on a specific Step; these
  * method-level choices take precedence over the Flow configuration.
  *
- * <p>Failure policies use a safer server default. When
- * {@link StepOptions.Builder#waitForFailure} allows execution to proceed after a wait-for failure,
- * or {@link StepOptions.Builder#onExecuteFailureProceedTo} routes an execute failure to a recovery
- * Step, Dex defaults to {@link #SYNC} for the affected method. A Flow-wide durability setting does not
- * override that server choice. The application may still select {@link #ASYNC} explicitly in the
- * relevant {@link StepOptions} when its business semantics accept the replay risk.
- *
- * <p>With asynchronous persistence on a failure-policy path, an extreme failure after execution or
- * recovery has begun can cause Dex to resume from the earlier method and invoke it again. That replay
- * is often harmless for idempotent Steps, but it may violate business expectations after recovery
- * logic has already run. Requiring a method-level override makes this tradeoff an explicit application
- * decision rather than an accidental consequence of the Flow default.
+ * <p>Wait-for and execute failure policies do not change this precedence. A Flow-wide asynchronous
+ * default therefore applies to methods with failure policies unless the Step method overrides it.
  *
  * <pre>{@code
  * FlowConfig fastByDefault = FlowConfig.newBuilder()
@@ -61,12 +51,10 @@ package io.superdurable.dex;
  */
 public enum StepDurability {
     /**
-     * Uses the applicable Flow configuration or the server's failure-policy safety choice.
+     * Uses the applicable Flow configuration or the synchronous server default.
      *
-     * <p>For an ordinary Step method with no Flow-level override, this resolves to the server default,
-     * which is {@link #ASYNC}. For a method using a proceed-on-failure policy, Dex instead defaults to
-     * {@link #SYNC}; only an explicit method-level choice in {@link StepOptions} overrides that safety
-     * choice.
+     * <p>A method-level DEFAULT defers to {@link FlowConfig}. Without a Flow override, it resolves to
+     * {@link #SYNC}. Failure policies do not change the result.
      */
     DEFAULT,
 
@@ -82,9 +70,10 @@ public enum StepDurability {
     /**
      * Allows Dex to advance before the completed method result is durably recorded.
      *
-     * <p>This is the server default. It lowers latency and improves server throughput through batched
-     * persistence, while accepting that an extreme failure may lose an unpersisted result and cause
-     * the Step method to execute again.
+     * <p>This lowers latency and improves server throughput through batched persistence, while
+     * accepting that an extreme failure may lose an unpersisted result and cause the Step method to
+     * execute again. Dex first uses a local activity for at most seven seconds and three attempts,
+     * then falls back to a regular activity using the remaining retry budget.
      */
     ASYNC
 }

--- a/sdk-java/src/main/java/io/superdurable/dex/StepOptions.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StepOptions.java
@@ -143,6 +143,10 @@ public final class StepOptions {
         /**
          * Sets the maximum duration of one wait-for method attempt.
          *
+         * <p>A regular activity attempt defaults to two hours. An asynchronous local activity
+         * ignores this setting during its seven-second optimization window; fallback regular
+         * activity attempts apply it.
+         *
          * @param value the method timeout, or {@code null} for the server default
          * @return this builder
          */
@@ -153,6 +157,10 @@ public final class StepOptions {
 
         /**
          * Sets the maximum duration of one execute method attempt.
+         *
+         * <p>A regular activity attempt defaults to two hours. An asynchronous local activity
+         * ignores this setting during its seven-second optimization window; fallback regular
+         * activity attempts apply it.
          *
          * @param value the method timeout, or {@code null} for the server default
          * @return this builder
@@ -165,15 +173,15 @@ public final class StepOptions {
         /**
          * Sets the heartbeat timeout for regular wait-for and execute activities.
          *
-         * <p>Dex automatically heartbeats while the Java handler is running so cancellation reaches
-         * the worker promptly. Local activities ignore this setting; an asynchronous local activity
-         * that falls back to a regular activity uses it. {@code null} and {@link Duration#ZERO}
-         * disable heartbeats. Positive values must be whole seconds within the signed int32 range.
-         * Once cancellation reaches the Java Worker, Dex interrupts the handler thread. CPU-bound or
-         * batch-oriented handlers may additionally check {@link Context#isCancellationRequested()}
-         * at natural work boundaries.
+         * <p>Dex sends no automatic heartbeat. Application code must call
+         * {@link Context#recordHeartbeat} or write a {@link Stream} often enough to make progress.
+         * {@code null} and {@link Duration#ZERO} use the one-minute server default. Explicit values
+         * must be whole seconds within the signed int32 range and satisfy the server-configured
+         * minimum, which defaults to ten seconds. Local activities ignore this setting; a fallback
+         * regular activity applies it. Once cancellation reaches the Java Worker, Dex interrupts the
+         * handler thread.
          *
-         * @param value the regular activity heartbeat timeout, or {@code null} to disable it
+         * @param value the regular activity heartbeat timeout, or {@code null} for one minute
          * @return this builder
          */
         public Builder heartbeatTimeout(final Duration value) {
@@ -206,12 +214,8 @@ public final class StepOptions {
         /**
          * Sets the action taken after wait-for retries are exhausted.
          *
-         * <p>When {@link WaitForFailurePolicy#PROCEED} is selected, Dex defaults to
-         * {@link StepDurability#SYNC} for the wait-for method so the recorded failure is not lost after
-         * the execute method begins. The Flow-wide durability setting does not override this safety
-         * choice. The application may still choose {@link StepDurability#ASYNC} explicitly through
-         * {@link #waitForDurability} when it accepts that an extreme failure can cause the wait-for
-         * method to run again after execution has already begun.
+         * <p>This policy does not change durability selection. The method override takes precedence
+         * over {@link FlowConfig}'s default, followed by the synchronous server default.
          *
          * @param value the failure policy; the default is {@link WaitForFailurePolicy#FAIL_FLOW}
          * @return this builder
@@ -227,11 +231,8 @@ public final class StepOptions {
          * <p>The recovery Step receives {@code null} input. Its input type should therefore accept
          * {@code null}, commonly {@link Void}.
          *
-         * <p>Dex defaults to {@link StepDurability#SYNC} for the execute method that owns this policy. The
-         * Flow-wide durability setting does not override this safety choice. The application may still
-         * select {@link StepDurability#ASYNC} explicitly through {@link #executeDurability} when it
-         * accepts that an extreme failure after the recovery Step begins can cause Dex to execute the
-         * earlier Step again.
+         * <p>This policy does not change durability selection. The method override takes precedence
+         * over {@link FlowConfig}'s default, followed by the synchronous server default.
          *
          * @param stepClass the nonnull recovery Step class
          * @param <I> the recovery Step input type
@@ -269,12 +270,9 @@ public final class StepOptions {
         /**
          * Overrides durability for this Step's wait-for method result.
          *
-         * <p>This method-level value takes precedence over {@link FlowConfig}'s default and Dex's
-         * {@link StepDurability#SYNC} default when {@link #waitForFailure} selects
-         * {@link WaitForFailurePolicy#PROCEED}. Asynchronous durability reduces latency and improves
-         * server persistence batching, but an unpersisted result can be lost during an extreme failure
-         * and the wait-for method can run again after execution has already begun. See
-         * {@link StepDurability} for the full tradeoff.
+         * <p>This method-level value takes precedence over {@link FlowConfig}'s default and the
+         * synchronous server default. Failure policy does not alter that ordering. See
+         * {@link StepDurability} for the asynchronous replay tradeoff.
          *
          * @param value the durability mode; the default is {@link StepDurability#DEFAULT}
          * @return this builder
@@ -287,12 +285,9 @@ public final class StepOptions {
         /**
          * Overrides durability for this Step's execute method result.
          *
-         * <p>This method-level value takes precedence over {@link FlowConfig}'s default and Dex's
-         * {@link StepDurability#SYNC} default when this builder also uses
-         * {@link #onExecuteFailureProceedTo(Class)}. The application may choose
-         * {@link StepDurability#ASYNC} when it accepts that an extreme failure after recovery begins
-         * can cause the earlier Step to execute again. See {@link StepDurability} for latency and
-         * throughput details.
+         * <p>This method-level value takes precedence over {@link FlowConfig}'s default and the
+         * synchronous server default. Failure policy does not alter that ordering. See
+         * {@link StepDurability} for the asynchronous replay tradeoff.
          *
          * @param value the durability mode; the default is {@link StepDurability#DEFAULT}
          * @return this builder

--- a/sdk-java/src/main/java/io/superdurable/dex/StepOutputEmitter.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StepOutputEmitter.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Licensed under the Super Durable Source License 1.0.
+ * You may not use this file except in compliance with the License.
+ * See the LICENSE file in the repository root.
+ *
+ * SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+ */
+
+package io.superdurable.dex;
+
+import io.superdurable.gen.StepMethodHeartbeat;
+import io.superdurable.gen.StepStreamWrite;
+
+interface StepOutputEmitter {
+    void emitHeartbeat(StepMethodHeartbeat heartbeat);
+
+    void emitStreamWrite(StepStreamWrite streamWrite);
+}

--- a/sdk-java/src/main/java/io/superdurable/dex/Stream.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Stream.java
@@ -58,8 +58,15 @@ public final class Stream<T> extends PersistenceDefinition {
     /**
      * Appends one message immediately from the current Step execution.
      *
+     * <p>This method sends a fire-and-forget frame to Dex. It may be called repeatedly for the same
+     * Stream. Each frame also acts as an implicit activity heartbeat. Storage failures do not fail
+     * the Step, but local validation, serialization, or transport failures may throw.
+     *
      * @param context the current Step Context; RPC Contexts are rejected
      * @param value the typed message to append
+     * @throws IllegalStateException if the Context belongs to an RPC
+     * @throws io.grpc.StatusRuntimeException if the Step invocation is canceled or transport fails
+     * @throws io.superdurable.dex.exceptions.ValueMappingException if the value cannot be encoded
      */
     public void write(final Context context, final T value) {
         context.writeStream(this, value);

--- a/sdk-java/src/main/java/io/superdurable/dex/StreamMessage.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StreamMessage.java
@@ -21,17 +21,17 @@ public final class StreamMessage<T> {
     private final T value;
     private final String resumeToken;
     private final Instant createdTime;
-    private final String idempotencyKey;
+    private final String source;
 
     StreamMessage(
             final T value,
             final String resumeToken,
             final Instant createdTime,
-            final String idempotencyKey) {
+            final String source) {
         this.value = value;
         this.resumeToken = resumeToken;
         this.createdTime = createdTime;
-        this.idempotencyKey = idempotencyKey;
+        this.source = source;
     }
 
     /**
@@ -62,11 +62,14 @@ public final class StreamMessage<T> {
     }
 
     /**
-     * Returns the producer idempotency key.
+     * Returns the producer metadata supplied when the message was appended.
      *
-     * @return the client or generated Step key
+     * <p>Step writes use {@code #<stepExecutionID>}. Client writes use the source supplied to
+     * {@link Client#writeStream}. Sources are not unique and carry no deduplication semantics.
+     *
+     * @return the message source
      */
-    public String getIdempotencyKey() {
-        return idempotencyKey;
+    public String getSource() {
+        return source;
     }
 }

--- a/sdk-java/src/main/java/io/superdurable/dex/ValueHydrator.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/ValueHydrator.java
@@ -88,12 +88,19 @@ final class ValueHydrator {
     InvokeWaitForMethodRequest hydrate(final InvokeWaitForMethodRequest request) {
         final List<Value> source = new ArrayList<Value>();
         source.add(request.getStepInput());
+        if (request.getContext().hasLastHeartbeatValue()) {
+            source.add(request.getContext().getLastHeartbeatValue());
+        }
         addValues(source, request.getAttributesList());
         final List<Value> hydrated = hydrateAll(source);
         int index = 0;
         final InvokeWaitForMethodRequest.Builder builder = request.toBuilder()
                 .setStepInput(hydrated.get(index++))
                 .clearAttributes();
+        if (request.getContext().hasLastHeartbeatValue()) {
+            builder.setContext(request.getContext().toBuilder()
+                    .setLastHeartbeatValue(hydrated.get(index++)));
+        }
         for (KV entry : request.getAttributesList()) {
             builder.addAttributes(entry.toBuilder().setValue(hydrated.get(index++)));
         }
@@ -104,6 +111,9 @@ final class ValueHydrator {
         final List<Value> source = new ArrayList<Value>();
         if (request.hasStepInput()) {
             source.add(request.getStepInput());
+        }
+        if (request.getContext().hasLastHeartbeatValue()) {
+            source.add(request.getContext().getLastHeartbeatValue());
         }
         addValues(source, request.getAttributesList());
         addValues(source, request.getStepExeLocalsList());
@@ -119,6 +129,10 @@ final class ValueHydrator {
                 .clearStepExeLocals();
         if (request.hasStepInput()) {
             builder.setStepInput(hydrated.get(index++));
+        }
+        if (request.getContext().hasLastHeartbeatValue()) {
+            builder.setContext(request.getContext().toBuilder()
+                    .setLastHeartbeatValue(hydrated.get(index++)));
         }
         for (KV entry : request.getAttributesList()) {
             builder.addAttributes(entry.toBuilder().setValue(hydrated.get(index++)));

--- a/sdk-java/src/main/java/io/superdurable/dex/WaitForFailurePolicy.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/WaitForFailurePolicy.java
@@ -15,11 +15,9 @@ package io.superdurable.dex;
  *
  * <p>Set this value with {@link StepOptions.Builder#waitForFailure}. Proceeding calls
  * {@link Step#execute(Context, Object)} after the wait-for failure, allowing user code to inspect
- * {@link Context#waitForMethodFailed()} and recover explicitly. Dex defaults to
- * {@link StepDurability#SYNC} for a wait-for method using {@link #PROCEED}; a Flow-wide durability
- * setting does not override that safety choice. Applications may explicitly select
- * {@link StepDurability#ASYNC} with {@link StepOptions.Builder#waitForDurability} when they accept
- * the possibility that the wait-for method can run again after execute has already begun.
+ * {@link Context#waitForMethodFailed()} and recover explicitly. This policy does not change
+ * durability selection: a method override takes precedence over the Flow configuration, followed by
+ * the synchronous server default.
  */
 public enum WaitForFailurePolicy {
     /** Fails the Flow when the wait-for method cannot complete. */
@@ -28,8 +26,7 @@ public enum WaitForFailurePolicy {
     /**
      * Continues to the execute method after recording the wait-for failure.
      *
-     * <p>Dex defaults to synchronous durability for this failure transition unless the application
-     * explicitly selects a different wait-for durability in {@link StepOptions}.
+     * <p>Durability follows the normal method, Flow, and server-default precedence.
      */
     PROCEED
 }

--- a/sdk-java/src/main/java/io/superdurable/dex/Worker.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Worker.java
@@ -103,8 +103,7 @@ public final class Worker implements AutoCloseable {
         final WorkerDispatcher dispatcher = new WorkerDispatcher(
                 registry,
                 values,
-                new ValueHydrator(flowService, blobCache),
-                flowService);
+                new ValueHydrator(flowService, blobCache));
         this.workerService = new JavaWorkerService(
                 dispatcher,
                 handlers,

--- a/sdk-java/src/main/java/io/superdurable/dex/WorkerDispatcher.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/WorkerDispatcher.java
@@ -22,7 +22,6 @@ import io.superdurable.gen.CloseDecision;
 import io.superdurable.gen.CloseDecisionType;
 import io.superdurable.gen.ConditionCombination;
 import io.superdurable.gen.ExecuteMethodFailurePolicy;
-import io.superdurable.gen.FlowServiceGrpc;
 import io.superdurable.gen.InvokeExecuteMethodRequest;
 import io.superdurable.gen.InvokeExecuteMethodResponse;
 import io.superdurable.gen.InvokeWaitForMethodRequest;
@@ -52,20 +51,19 @@ final class WorkerDispatcher {
     private final Registry registry;
     private final ValueMapper values;
     private final ValueHydrator hydrator;
-    private final FlowServiceGrpc.FlowServiceBlockingStub flowService;
 
     WorkerDispatcher(
             final Registry registry,
             final ValueMapper values,
-            final ValueHydrator hydrator,
-            final FlowServiceGrpc.FlowServiceBlockingStub flowService) {
+            final ValueHydrator hydrator) {
         this.registry = registry;
         this.values = values;
         this.hydrator = hydrator;
-        this.flowService = flowService;
     }
 
-    InvokeWaitForMethodResponse invokeWaitFor(final InvokeWaitForMethodRequest original) {
+    InvokeWaitForMethodResponse invokeWaitFor(
+            final InvokeWaitForMethodRequest original,
+            final StepOutputEmitter stepOutputEmitter) {
         final InvokeWaitForMethodRequest request = hydrator.hydrate(original);
         final Registry.RegisteredFlow flow = registry.getFlow(request.getFlowType());
         final Registry.RegisteredStep step = flow.getStep(request.getStepType());
@@ -74,7 +72,7 @@ final class WorkerDispatcher {
                 flow,
                 request.getContext(),
                 values,
-                flowService,
+                stepOutputEmitter,
                 request.getAttributesList(),
                 null,
                 null,
@@ -95,11 +93,13 @@ final class WorkerDispatcher {
         return response.build();
     }
 
-    InvokeExecuteMethodResponse invokeExecute(final InvokeExecuteMethodRequest original) {
+    InvokeExecuteMethodResponse invokeExecute(
+            final InvokeExecuteMethodRequest original,
+            final StepOutputEmitter stepOutputEmitter) {
         final InvokeExecuteMethodRequest request = hydrator.hydrate(original);
         final Registry.RegisteredFlow flow = registry.getFlow(request.getFlowType());
         if (TIMEOUT_HANDLER_STEP_TYPE.equals(request.getStepType())) {
-            return invokeTimeoutHandler(request, flow);
+            return invokeTimeoutHandler(request, flow, stepOutputEmitter);
         }
         final Registry.RegisteredStep step = flow.getStep(request.getStepType());
         final InvocationContext context = new InvocationContext(
@@ -107,7 +107,7 @@ final class WorkerDispatcher {
                 flow,
                 request.getContext(),
                 values,
-                flowService,
+                stepOutputEmitter,
                 request.getAttributesList(),
                 request.getStepExeLocalsList(),
                 request.hasConditionResults() ? request.getConditionResults() : null,
@@ -125,7 +125,8 @@ final class WorkerDispatcher {
 
     private InvokeExecuteMethodResponse invokeTimeoutHandler(
             final InvokeExecuteMethodRequest request,
-            final Registry.RegisteredFlow flow) {
+            final Registry.RegisteredFlow flow,
+            final StepOutputEmitter stepOutputEmitter) {
         if (request.hasStepInput()) {
             throw new InvalidStepResultException("Flow timeout handler must not receive input");
         }
@@ -138,7 +139,7 @@ final class WorkerDispatcher {
                 flow,
                 request.getContext(),
                 values,
-                flowService,
+                stepOutputEmitter,
                 request.getAttributesList(),
                 request.getStepExeLocalsList(),
                 request.hasConditionResults() ? request.getConditionResults() : null,
@@ -165,7 +166,7 @@ final class WorkerDispatcher {
                 flow,
                 request.getContext(),
                 values,
-                flowService,
+                null,
                 request.getAttributesList(),
                 null,
                 null,

--- a/sdk-java/src/test/java/io/superdurable/dex/ClientExceptionIntegrationTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/ClientExceptionIntegrationTest.java
@@ -179,16 +179,15 @@ final class ClientExceptionIntegrationTest {
         assertEquals("StreamFlow", flowService.writeStreamRequest.getFlowType());
         assertEquals("thinking", flowService.writeStreamRequest.getStreamName());
         assertEquals(1_048_576, flowService.writeStreamRequest.getStreamCapacityBytes());
-        assertEquals("client-1", flowService.writeStreamRequest.getIdempotencyKey());
+        assertEquals("client-1", flowService.writeStreamRequest.getSource());
         assertEquals("previous", flowService.readStreamRequest.getResumeToken());
         assertEquals(2, flowService.readStreamRequest.getWaitTimeSeconds());
         assertEquals("working", message.getValue());
         assertEquals("resume-1", message.getResumeToken());
         assertEquals(java.time.Instant.parse("2026-08-27T12:00:00Z"), message.getCreatedTime());
-        assertEquals("client-1", message.getIdempotencyKey());
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> client.writeStream("flow-1", THINKING, "bad#key", "ignored"));
+        assertEquals("client-1", message.getSource());
+        client.writeStream("flow-1", THINKING, "producer#partition", "allowed");
+        assertEquals("producer#partition", flowService.writeStreamRequest.getSource());
     }
 
     @Test
@@ -257,7 +256,7 @@ final class ClientExceptionIntegrationTest {
                             .setResumeToken("resume-1")
                             .setCreatedTime(com.google.protobuf.Timestamp.newBuilder()
                                     .setSeconds(1_787_832_000L))
-                            .setIdempotencyKey("client-1"))
+                            .setSource("client-1"))
                     .build());
             observer.onCompleted();
         }

--- a/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
@@ -15,8 +15,6 @@
 package io.superdurable.dex;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.protobuf.Empty;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Server;
@@ -31,8 +29,10 @@ import io.superdurable.dex.exceptions.RetryAfterException;
 import io.superdurable.gen.CloseDecisionType;
 import io.superdurable.gen.ChannelInfo;
 import io.superdurable.gen.FlowServiceGrpc;
+import io.superdurable.gen.InvokeExecuteMethodOutput;
 import io.superdurable.gen.InvokeExecuteMethodRequest;
 import io.superdurable.gen.InvokeExecuteMethodResponse;
+import io.superdurable.gen.InvokeWaitForMethodOutput;
 import io.superdurable.gen.InvokeWaitForMethodRequest;
 import io.superdurable.gen.InvokeWaitForMethodResponse;
 import io.superdurable.gen.InvokeWorkerRPCRequest;
@@ -45,7 +45,6 @@ import io.superdurable.gen.SyncAttributeIndexResponse;
 import io.superdurable.gen.Value;
 import io.superdurable.gen.WorkerServiceGrpc;
 import io.superdurable.gen.WorkerErrorResponse;
-import io.superdurable.gen.WriteStreamRequest;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -54,9 +53,12 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
@@ -89,12 +91,12 @@ final class WorkerServiceIntegrationTest {
         final BridgeFlow flow = new BridgeFlow();
         final RunningWorker running = startWorker(flow, new TestBlobCache(), null);
         try {
-            final InvokeWaitForMethodResponse wait = running.client.invokeWaitForMethod(
-                    waitRequest(concrete("hello")));
+            final InvokeWaitForMethodResponse wait = invokeWaitFor(
+                    running, waitRequest(concrete("hello")));
             assertFalse(wait.hasWaitingCondition());
 
-            final InvokeExecuteMethodResponse execute = running.client.invokeExecuteMethod(
-                    executeRequest(concrete("hello")));
+            final InvokeExecuteMethodResponse execute = invokeExecute(
+                    running, executeRequest(concrete("hello")));
             assertEquals(
                     CloseDecisionType.CLOSE_DECISION_TYPE_GRACEFUL_COMPLETE,
                     execute.getStepDecision().getCloseDecision().getCloseDecisionType());
@@ -112,17 +114,77 @@ final class WorkerServiceIntegrationTest {
     }
 
     @Test
-    void stepStreamWritesUseExecutionIdempotencyKey() throws Exception {
+    void streamsStepProgressFramesInCallOrder() throws Exception {
         final RunningWorker running = startWorker(new BridgeFlow(), new TestBlobCache(), null);
         try {
-            running.client.invokeExecuteMethod(executeRequest(concrete("stream")));
-            final WriteStreamRequest request = running.writeStreamRequest.get();
-            assertEquals("flow-1", request.getFlowId());
-            assertEquals("BridgeFlow", request.getFlowType());
-            assertEquals("thinking", request.getStreamName());
-            assertEquals(1_048_576, request.getStreamCapacityBytes());
-            assertEquals("run-1#step-1", request.getIdempotencyKey());
-            assertEquals("stream", request.getValue().getStringValue());
+            final List<InvokeExecuteMethodOutput> execute = collectExecuteOutputs(
+                    running, executeRequest(concrete("progress")));
+            assertEquals(6, execute.size());
+            assertEquals("checkpoint", execute.get(0).getHeartbeat().getValue().getStringValue());
+            assertEquals("thinking", execute.get(1).getStreamWrite().getStreamName());
+            assertEquals("first", execute.get(1).getStreamWrite().getValue().getStringValue());
+            assertEquals("thinking", execute.get(2).getStreamWrite().getStreamName());
+            assertEquals("second", execute.get(2).getStreamWrite().getValue().getStringValue());
+            assertFalse(execute.get(3).getHeartbeat().hasValue());
+            assertEquals("findings", execute.get(4).getStreamWrite().getStreamName());
+            assertEquals("third", execute.get(4).getStreamWrite().getValue().getStringValue());
+            assertTrue(execute.get(5).hasResult());
+
+            final List<InvokeWaitForMethodOutput> wait = collectWaitForOutputs(
+                    running, waitRequest(concrete("progress")));
+            assertEquals(3, wait.size());
+            assertEquals("wait-checkpoint", wait.get(0).getHeartbeat()
+                    .getValue().getStringValue());
+            assertEquals("thinking", wait.get(1).getStreamWrite().getStreamName());
+            assertTrue(wait.get(2).hasResult());
+        } finally {
+            running.close();
+        }
+    }
+
+    @Test
+    void preservesProgressBeforeHandlerFailureWithoutSendingResult() throws Exception {
+        final RunningWorker running = startWorker(new BridgeFlow(), new TestBlobCache(), null);
+        try {
+            final Iterator<InvokeExecuteMethodOutput> outputs =
+                    running.client.invokeExecuteMethod(
+                            executeRequest(concrete("progress-fail")));
+            assertTrue(outputs.hasNext());
+            assertTrue(outputs.next().hasHeartbeat());
+            assertTrue(outputs.hasNext());
+            assertTrue(outputs.next().hasStreamWrite());
+            assertThrows(StatusRuntimeException.class, outputs::hasNext);
+        } finally {
+            running.close();
+        }
+    }
+
+    @Test
+    void restoresHeartbeatDetailsAndRejectsProgressFromRpcContext() throws Exception {
+        final RunningWorker running = startWorker(new BridgeFlow(), new TestBlobCache(), null);
+        try {
+            assertEquals(
+                    "absent",
+                    invokeExecute(running, executeRequest(concrete("read-heartbeat")))
+                            .getStepDecision().getCloseDecision()
+                            .getCloseInput().getStringValue());
+            final InvokeExecuteMethodRequest restored = executeRequest(concrete("read-heartbeat"))
+                    .toBuilder()
+                    .setContext(context().toBuilder()
+                            .setLastHeartbeatValue(concrete("restored")))
+                    .build();
+            assertEquals(
+                    "restored",
+                    invokeExecute(running, restored)
+                            .getStepDecision().getCloseDecision()
+                            .getCloseInput().getStringValue());
+
+            assertThrows(
+                    StatusRuntimeException.class,
+                    () -> running.client.invokeWorkerRPC(rpcRequest("rpc-heartbeat")));
+            assertThrows(
+                    StatusRuntimeException.class,
+                    () -> running.client.invokeWorkerRPC(rpcRequest("rpc-stream")));
         } finally {
             running.close();
         }
@@ -132,15 +194,15 @@ final class WorkerServiceIntegrationTest {
     void mapsConditionIdsWithoutInternalValues() throws Exception {
         final RunningWorker running = startWorker(new BridgeFlow(), new TestBlobCache(), null);
         try {
-            final InvokeWaitForMethodResponse unnamed = running.client.invokeWaitForMethod(
-                    waitRequest(concrete("unnamed")));
+            final InvokeWaitForMethodResponse unnamed = invokeWaitFor(
+                    running, waitRequest(concrete("unnamed")));
             assertEquals("", unnamed.getWaitingCondition()
                     .getTimerConditions(0).getConditionId());
             assertEquals("", unnamed.getWaitingCondition()
                     .getChannelConditions(0).getConditionId());
 
-            final InvokeWaitForMethodResponse reused = running.client.invokeWaitForMethod(
-                    waitRequest(concrete("reused")));
+            final InvokeWaitForMethodResponse reused = invokeWaitFor(
+                    running, waitRequest(concrete("reused")));
             assertEquals(
                     "__dex_internal_condition_0",
                     reused.getWaitingCondition().getChannelConditions(0).getConditionId());
@@ -150,15 +212,15 @@ final class WorkerServiceIntegrationTest {
 
             assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeWaitForMethod(
+                    () -> invokeWaitFor(running,
                             waitRequest(concrete("missing-combination-id"))));
             assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeWaitForMethod(
+                    () -> invokeWaitFor(running,
                             waitRequest(concrete("duplicate-id"))));
             assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeWaitForMethod(
+                    () -> invokeWaitFor(running,
                             waitRequest(concrete("empty-id"))));
         } finally {
             running.close();
@@ -230,7 +292,7 @@ final class WorkerServiceIntegrationTest {
         try {
             final StatusRuntimeException failure = assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeExecuteMethod(executeRequest(concrete("fail"))));
+                    () -> invokeExecute(running, executeRequest(concrete("fail"))));
             assertEquals(Status.Code.INTERNAL, failure.getStatus().getCode());
             final com.google.rpc.Status status = StatusProto.fromThrowable(failure);
             final WorkerErrorResponse details = status.getDetails(0)
@@ -250,7 +312,7 @@ final class WorkerServiceIntegrationTest {
         try {
             final StatusRuntimeException failure = assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeExecuteMethod(
+                    () -> invokeExecute(running,
                             executeRequest(concrete("retry-after"))));
             final WorkerErrorResponse details = StatusProto.fromThrowable(failure)
                     .getDetails(0)
@@ -362,7 +424,7 @@ final class WorkerServiceIntegrationTest {
         try {
             final StatusRuntimeException failure = assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeExecuteMethod(executeRequest(concrete("fail"))));
+                    () -> invokeExecute(running, executeRequest(concrete("fail"))));
             assertEquals(Status.Code.FAILED_PRECONDITION, failure.getStatus().getCode());
         } finally {
             running.close();
@@ -375,7 +437,7 @@ final class WorkerServiceIntegrationTest {
         try {
             final StatusRuntimeException failure = assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeExecuteMethod(executeRequest(concrete("large"))));
+                    () -> invokeExecute(running, executeRequest(concrete("large"))));
             final WorkerErrorResponse details = StatusProto.fromThrowable(failure)
                     .getDetails(0)
                     .unpack(WorkerErrorResponse.class);
@@ -394,7 +456,7 @@ final class WorkerServiceIntegrationTest {
         try {
             final StatusRuntimeException failure = assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeExecuteMethod(executeRequest(concrete("invalid"))));
+                    () -> invokeExecute(running, executeRequest(concrete("invalid"))));
             final com.google.rpc.Status status = StatusProto.fromThrowable(failure);
             final WorkerErrorResponse details = status.getDetails(0)
                     .unpack(WorkerErrorResponse.class);
@@ -411,8 +473,8 @@ final class WorkerServiceIntegrationTest {
         final BridgeFlow flow = new BridgeFlow();
         final RunningWorker running = startWorker(flow, new TestBlobCache(), null);
         try {
-            final InvokeExecuteMethodResponse cancellation = running.client.invokeExecuteMethod(
-                    executeRequest(concrete("cancel")));
+            final InvokeExecuteMethodResponse cancellation = invokeExecute(
+                    running, executeRequest(concrete("cancel")));
             assertEquals(
                     Collections.singletonList("BridgeOtherStep"),
                     cancellation.getStepDecision().getCancelStepTypesList());
@@ -433,8 +495,8 @@ final class WorkerServiceIntegrationTest {
                     rpcCancellation.getStepDecision().getNextSteps(0).getStepType());
             assertTrue(flow.baseRpcResult.get().getCancelingSteps().isEmpty());
 
-            final InvokeExecuteMethodResponse heartbeat = running.client.invokeExecuteMethod(
-                    executeRequest(concrete("heartbeat")));
+            final InvokeExecuteMethodResponse heartbeat = invokeExecute(
+                    running, executeRequest(concrete("heartbeat")));
             assertEquals(
                     10,
                     heartbeat.getStepDecision()
@@ -442,8 +504,8 @@ final class WorkerServiceIntegrationTest {
                             .getStepOptions()
                             .getHeartbeatTimeoutSeconds());
 
-            final InvokeExecuteMethodResponse disabled = running.client.invokeExecuteMethod(
-                    executeRequest(concrete("heartbeat-zero")));
+            final InvokeExecuteMethodResponse disabled = invokeExecute(
+                    running, executeRequest(concrete("heartbeat-zero")));
             assertEquals(
                     0,
                     disabled.getStepDecision()
@@ -453,23 +515,23 @@ final class WorkerServiceIntegrationTest {
 
             assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeExecuteMethod(
+                    () -> invokeExecute(running,
                             executeRequest(concrete("cancel-foreign"))));
             assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeExecuteMethod(
+                    () -> invokeExecute(running,
                             executeRequest(concrete("cancel-null"))));
             assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeExecuteMethod(
+                    () -> invokeExecute(running,
                             executeRequest(concrete("heartbeat-fraction"))));
             assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeExecuteMethod(
+                    () -> invokeExecute(running,
                             executeRequest(concrete("heartbeat-negative"))));
             assertThrows(
                     StatusRuntimeException.class,
-                    () -> running.client.invokeExecuteMethod(
+                    () -> invokeExecute(running,
                             executeRequest(concrete("heartbeat-overflow"))));
             assertThrows(
                     StatusRuntimeException.class,
@@ -487,13 +549,28 @@ final class WorkerServiceIntegrationTest {
         final BridgeFlow flow = new BridgeFlow();
         final RunningWorker running = startWorker(flow, new TestBlobCache(), null);
         try {
-            final ListenableFuture<InvokeExecuteMethodResponse> response =
-                    WorkerServiceGrpc.newFutureStub(running.channel)
-                            .withWaitForReady()
-                            .withDeadlineAfter(10, TimeUnit.SECONDS)
-                            .invokeExecuteMethod(executeRequest(concrete("block")));
+            final io.grpc.Context.CancellableContext invocation =
+                    io.grpc.Context.current().withCancellation();
+            invocation.run(() -> WorkerServiceGrpc.newStub(running.channel)
+                    .withWaitForReady()
+                    .withDeadlineAfter(10, TimeUnit.SECONDS)
+                    .invokeExecuteMethod(
+                            executeRequest(concrete("block")),
+                            new StreamObserver<InvokeExecuteMethodOutput>() {
+                                @Override
+                                public void onNext(final InvokeExecuteMethodOutput output) {
+                                }
+
+                                @Override
+                                public void onError(final Throwable failure) {
+                                }
+
+                                @Override
+                                public void onCompleted() {
+                                }
+                            }));
             assertTrue(flow.start.blockStarted.await(5, TimeUnit.SECONDS));
-            response.cancel(true);
+            invocation.cancel(null);
             assertTrue(flow.start.cancellationObserved.await(5, TimeUnit.SECONDS));
             assertTrue(flow.start.contextReportedCancellation.get());
         } finally {
@@ -542,14 +619,26 @@ final class WorkerServiceIntegrationTest {
         try {
             assertEquals(
                     "hydrated",
-                    running.client.invokeExecuteMethod(executeRequest(blob))
+                    invokeExecute(running, executeRequest(blob))
                             .getStepDecision()
                             .getCloseDecision()
                             .getCloseInput()
                             .getStringValue());
             assertEquals(
                     "hydrated",
-                    running.client.invokeExecuteMethod(executeRequest(blob))
+                    invokeExecute(running, executeRequest(blob))
+                            .getStepDecision()
+                            .getCloseDecision()
+                            .getCloseInput()
+                            .getStringValue());
+            final InvokeExecuteMethodRequest heartbeat = executeRequest(
+                    concrete("read-heartbeat"))
+                    .toBuilder()
+                    .setContext(context().toBuilder().setLastHeartbeatValue(blob))
+                    .build();
+            assertEquals(
+                    "hydrated",
+                    invokeExecute(running, heartbeat)
                             .getStepDecision()
                             .getCloseDecision()
                             .getCloseInput()
@@ -579,8 +668,6 @@ final class WorkerServiceIntegrationTest {
                 new AtomicReference<SyncAttributeIndexRequest>();
         final AtomicReference<Boolean> listeningDuringSync =
                 new AtomicReference<Boolean>();
-        final AtomicReference<WriteStreamRequest> writeStreamRequest =
-                new AtomicReference<WriteStreamRequest>();
         final Server ownedFlowServer;
         final String effectiveServerAddress;
         if (serverAddress == null) {
@@ -599,15 +686,6 @@ final class WorkerServiceIntegrationTest {
                                 listeningDuringSync.set(Boolean.FALSE);
                             }
                             observer.onNext(SyncAttributeIndexResponse.getDefaultInstance());
-                            observer.onCompleted();
-                        }
-
-                        @Override
-                        public void writeStream(
-                                final WriteStreamRequest request,
-                                final StreamObserver<Empty> observer) {
-                            writeStreamRequest.set(request);
-                            observer.onNext(Empty.getDefaultInstance());
                             observer.onCompleted();
                         }
                     })
@@ -654,8 +732,7 @@ final class WorkerServiceIntegrationTest {
                 client,
                 ownedFlowServer,
                 syncRequest,
-                listeningDuringSync,
-                writeStreamRequest);
+                listeningDuringSync);
     }
 
     private static InvokeWaitForMethodRequest waitRequest(final Value input) {
@@ -700,13 +777,54 @@ final class WorkerServiceIntegrationTest {
         return Value.newBuilder().setStringValue(value).build();
     }
 
+    private static InvokeWaitForMethodResponse invokeWaitFor(
+            final RunningWorker running,
+            final InvokeWaitForMethodRequest request) {
+        final List<InvokeWaitForMethodOutput> outputs = collectWaitForOutputs(running, request);
+        assertTrue(outputs.get(outputs.size() - 1).hasResult());
+        return outputs.get(outputs.size() - 1).getResult();
+    }
+
+    private static List<InvokeWaitForMethodOutput> collectWaitForOutputs(
+            final RunningWorker running,
+            final InvokeWaitForMethodRequest request) {
+        final List<InvokeWaitForMethodOutput> outputs = new ArrayList<InvokeWaitForMethodOutput>();
+        final Iterator<InvokeWaitForMethodOutput> iterator =
+                running.client.invokeWaitForMethod(request);
+        while (iterator.hasNext()) {
+            outputs.add(iterator.next());
+        }
+        return outputs;
+    }
+
+    private static InvokeExecuteMethodResponse invokeExecute(
+            final RunningWorker running,
+            final InvokeExecuteMethodRequest request) {
+        final List<InvokeExecuteMethodOutput> outputs = collectExecuteOutputs(running, request);
+        assertTrue(outputs.get(outputs.size() - 1).hasResult());
+        return outputs.get(outputs.size() - 1).getResult();
+    }
+
+    private static List<InvokeExecuteMethodOutput> collectExecuteOutputs(
+            final RunningWorker running,
+            final InvokeExecuteMethodRequest request) {
+        final List<InvokeExecuteMethodOutput> outputs =
+                new ArrayList<InvokeExecuteMethodOutput>();
+        final Iterator<InvokeExecuteMethodOutput> iterator =
+                running.client.invokeExecuteMethod(request);
+        while (iterator.hasNext()) {
+            outputs.add(iterator.next());
+        }
+        return outputs;
+    }
+
     private static void assertWorkerFailure(
             final RunningWorker running,
             final String input,
             final Class<? extends Throwable> expectedType) throws Exception {
         final StatusRuntimeException failure = assertThrows(
                 StatusRuntimeException.class,
-                () -> running.client.invokeExecuteMethod(executeRequest(concrete(input))));
+                () -> invokeExecute(running, executeRequest(concrete(input))));
         assertEquals(Status.Code.INTERNAL, failure.getStatus().getCode());
         final WorkerErrorResponse details = StatusProto.fromThrowable(failure)
                 .getDetails(0)
@@ -745,7 +863,6 @@ final class WorkerServiceIntegrationTest {
         private final Server ownedFlowServer;
         private final AtomicReference<SyncAttributeIndexRequest> syncRequest;
         private final AtomicReference<Boolean> listeningDuringSync;
-        private final AtomicReference<WriteStreamRequest> writeStreamRequest;
 
         private RunningWorker(
                 final Worker worker,
@@ -755,8 +872,7 @@ final class WorkerServiceIntegrationTest {
                 final WorkerServiceGrpc.WorkerServiceBlockingStub client,
                 final Server ownedFlowServer,
                 final AtomicReference<SyncAttributeIndexRequest> syncRequest,
-                final AtomicReference<Boolean> listeningDuringSync,
-                final AtomicReference<WriteStreamRequest> writeStreamRequest) {
+                final AtomicReference<Boolean> listeningDuringSync) {
             this.worker = worker;
             this.workerThread = workerThread;
             this.workerFailure = workerFailure;
@@ -765,7 +881,6 @@ final class WorkerServiceIntegrationTest {
             this.ownedFlowServer = ownedFlowServer;
             this.syncRequest = syncRequest;
             this.listeningDuringSync = listeningDuringSync;
-            this.writeStreamRequest = writeStreamRequest;
         }
 
         @Override
@@ -784,8 +899,10 @@ final class WorkerServiceIntegrationTest {
         private final Channel<Void> commands = Channel.define("commands", Void.class);
         private final Stream<String> thinking =
                 Stream.define("thinking", String.class, 1_048_576);
+        private final Stream<String> findings =
+                Stream.define("findings", String.class, 1_048_576);
         private final BridgeOtherStep other = new BridgeOtherStep();
-        private final BridgeStep start = new BridgeStep(commands, thinking);
+        private final BridgeStep start = new BridgeStep(commands, thinking, findings);
         private final Attribute<String> status = Attribute.define(
                 "status",
                 String.class,
@@ -811,6 +928,12 @@ final class WorkerServiceIntegrationTest {
 
         @RPC
         public RPCResult<String> cancellationRpc(final Context context, final String input) {
+            if ("rpc-heartbeat".equals(input)) {
+                context.recordHeartbeat("invalid");
+            }
+            if ("rpc-stream".equals(input)) {
+                thinking.write(context, "invalid");
+            }
             if ("cancel-foreign".equals(input)) {
                 return RPCResult.of(input)
                         .withCancelingSteps(ForeignBridgeStep.class);
@@ -829,7 +952,7 @@ final class WorkerServiceIntegrationTest {
 
         @Override
         public PersistenceSchema getPersistenceSchema() {
-            return PersistenceSchema.of(status, commands, thinking);
+            return PersistenceSchema.of(status, commands, thinking, findings);
         }
     }
 
@@ -843,12 +966,15 @@ final class WorkerServiceIntegrationTest {
         private final CountDownLatch cancellationObserved = new CountDownLatch(1);
         private final Channel<Void> commands;
         private final Stream<String> thinking;
+        private final Stream<String> findings;
 
         private BridgeStep(
                 final Channel<Void> commands,
-                final Stream<String> thinking) {
+                final Stream<String> thinking,
+                final Stream<String> findings) {
             this.commands = commands;
             this.thinking = thinking;
+            this.findings = findings;
         }
 
         @Override
@@ -863,6 +989,11 @@ final class WorkerServiceIntegrationTest {
 
         @Override
         public Wait waitFor(final Context context, final String input) {
+            if ("progress".equals(input)) {
+                context.recordHeartbeat("wait-checkpoint");
+                thinking.write(context, "wait-stream");
+                return Wait.skipImmediately();
+            }
             if ("unnamed".equals(input)) {
                 return Wait.allOf(
                         Timer.byDuration(java.time.Duration.ofSeconds(1)),
@@ -890,8 +1021,22 @@ final class WorkerServiceIntegrationTest {
 
         @Override
         public StepDecision execute(final Context context, final String input) {
-            if ("stream".equals(input)) {
-                thinking.write(context, input);
+            if ("progress-fail".equals(input)) {
+                context.recordHeartbeat("before-failure");
+                thinking.write(context, "before-failure");
+                throw new BridgeFailureException("failure after progress");
+            }
+            if ("progress".equals(input)) {
+                context.recordHeartbeat("checkpoint");
+                thinking.write(context, "first");
+                thinking.write(context, "second");
+                context.recordHeartbeat(null);
+                findings.write(context, "third");
+            }
+            if ("read-heartbeat".equals(input)) {
+                return StepDecision.gracefulComplete(context.hasLastHeartbeatValue()
+                        ? context.getLastHeartbeatValue(String.class)
+                        : "absent");
             }
             handlerThread.set(Thread.currentThread().getName());
             if ("fail".equals(input)) {

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/BasicTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/BasicTest.java
@@ -523,7 +523,8 @@ public final class BasicTest {
                 assertEquals(firstChildRunId, activeChildRunId);
             }
 
-            environment.client().skipTimer(
+            IntegrationTestWaits.skipTimerWhenRegistered(
+                    environment.client(),
                     childFlowId,
                     StepExecutionId.of("TimerStep"),
                     TimerId.byConditionId("test-timer-id"));

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/HeartbeatTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/HeartbeatTest.java
@@ -1,0 +1,76 @@
+/*
+ * Portions of this file are derived from indeedeng/iwf-java-sdk.
+ * Those portions are licensed under the Apache License, Version 2.0.
+ * See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+ *
+ * Modifications Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Modifications are licensed under the Super Durable Source License 1.0.
+ * Third-Party Materials remain under the Apache License, Version 2.0.
+ * See LICENSE and LEGACY_NOTICES.md.
+ */
+
+package io.superdurable.dex.integ;
+
+import io.superdurable.dex.FlowResult;
+import io.superdurable.dex.StreamMessage;
+import io.superdurable.dex.testing.DexDevTestEnvironment;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("dex-dev")
+public final class HeartbeatTest {
+    @TempDir
+    Path cacheDirectory;
+
+    @Test
+    void testRetryRestoresHeartbeatValue() throws Exception {
+        assertHeartbeatRetry(HeartbeatTestWorkflow.Scenario.RESTORE_VALUE, "restored");
+    }
+
+    @Test
+    void testNullHeartbeatAndStreamPreserveClearedDetails() throws Exception {
+        assertHeartbeatRetry(HeartbeatTestWorkflow.Scenario.CLEAR_VALUE, "cleared");
+    }
+
+    @Test
+    void testLocalHeartbeatIsIgnoredWhileStreamIsWritten() throws Exception {
+        assertHeartbeatRetry(
+                HeartbeatTestWorkflow.Scenario.LOCAL_IGNORES_VALUE,
+                "local-ignored");
+    }
+
+    private void assertHeartbeatRetry(
+            final HeartbeatTestWorkflow.Scenario scenario,
+            final String expectedOutput) throws Exception {
+        final HeartbeatTestWorkflow workflow = new HeartbeatTestWorkflow(scenario);
+        try (DexDevTestEnvironment environment = DexDevTestEnvironment.start(
+                cacheDirectory,
+                workflow)) {
+            final String flowId = "heartbeat-" + UUID.randomUUID();
+            environment.client().startFlow(workflow, flowId, null);
+            final FlowResult result = environment.client()
+                    .waitForFlow(flowId, Duration.ofSeconds(30));
+            assertEquals(expectedOutput, result.getSingleOutput(String.class));
+
+            final StreamMessage<String> progress = environment.client().readStream(
+                    flowId,
+                    workflow.progress,
+                    "",
+                    Duration.ofSeconds(30));
+            final String expectedProgress = scenario
+                    == HeartbeatTestWorkflow.Scenario.LOCAL_IGNORES_VALUE
+                    ? "local-attempt-1"
+                    : "attempt-one";
+            assertEquals(expectedProgress, progress.getValue());
+            assertEquals("#HeartbeatStep-1", progress.getSource());
+        }
+    }
+}

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/HeartbeatTestWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/HeartbeatTestWorkflow.java
@@ -1,0 +1,109 @@
+/*
+ * Portions of this file are derived from indeedeng/iwf-java-sdk.
+ * Those portions are licensed under the Apache License, Version 2.0.
+ * See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+ *
+ * Modifications Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Modifications are licensed under the Super Durable Source License 1.0.
+ * Third-Party Materials remain under the Apache License, Version 2.0.
+ * See LICENSE and LEGACY_NOTICES.md.
+ */
+
+package io.superdurable.dex.integ;
+
+import io.superdurable.dex.Context;
+import io.superdurable.dex.Flow;
+import io.superdurable.dex.PersistenceSchema;
+import io.superdurable.dex.RetryPolicy;
+import io.superdurable.dex.Step;
+import io.superdurable.dex.StepDecision;
+import io.superdurable.dex.StepDurability;
+import io.superdurable.dex.StepList;
+import io.superdurable.dex.StepOptions;
+import io.superdurable.dex.Stream;
+
+import java.time.Duration;
+
+final class HeartbeatTestWorkflow implements Flow<Void> {
+    enum Scenario {
+        RESTORE_VALUE,
+        CLEAR_VALUE,
+        LOCAL_IGNORES_VALUE
+    }
+
+    final Stream<String> progress = Stream.define("heartbeat-progress", String.class, 1L << 20);
+    private final HeartbeatStep start = new HeartbeatStep();
+    private final Scenario scenario;
+
+    HeartbeatTestWorkflow(final Scenario scenario) {
+        this.scenario = scenario;
+    }
+
+    @Override
+    public StepList<Void> getSteps() {
+        return StepList.startStep(start);
+    }
+
+    @Override
+    public PersistenceSchema getPersistenceSchema() {
+        return PersistenceSchema.of(progress);
+    }
+
+    final class HeartbeatStep implements Step<Void> {
+        @Override
+        public Class<Void> getInputType() {
+            return Void.class;
+        }
+
+        @Override
+        public StepDecision execute(final Context context, final Void input) {
+            if (scenario == Scenario.LOCAL_IGNORES_VALUE) {
+                if (context.getAttempt() <= 3) {
+                    context.recordHeartbeat("local-checkpoint");
+                    progress.write(context, "local-attempt-" + context.getAttempt());
+                    throw new IllegalStateException("retry local activity");
+                }
+                if (context.hasLastHeartbeatValue()) {
+                    throw new IllegalStateException("local heartbeat reached fallback");
+                }
+                return StepDecision.gracefulComplete("local-ignored");
+            }
+            if (context.getAttempt() == 1) {
+                context.recordHeartbeat("checkpoint");
+                if (scenario == Scenario.CLEAR_VALUE) {
+                    context.recordHeartbeat(null);
+                }
+                progress.write(context, "attempt-one");
+                throw new IllegalStateException("retry after heartbeat");
+            }
+            if (scenario == Scenario.RESTORE_VALUE) {
+                if (!context.hasLastHeartbeatValue()
+                        || !"checkpoint".equals(
+                                context.getLastHeartbeatValue(String.class))) {
+                    throw new IllegalStateException("heartbeat value was not restored");
+                }
+                return StepDecision.gracefulComplete("restored");
+            }
+            if (context.hasLastHeartbeatValue()) {
+                throw new IllegalStateException("cleared heartbeat value was restored");
+            }
+            return StepDecision.gracefulComplete("cleared");
+        }
+
+        @Override
+        public StepOptions getStepOptions() {
+            final StepOptions.Builder options = StepOptions.newBuilder()
+                    .heartbeatTimeout(Duration.ofSeconds(10))
+                    .executeRetry(RetryPolicy.newBuilder()
+                            .initialInterval(Duration.ofSeconds(1))
+                            .maximumAttempts(scenario == Scenario.LOCAL_IGNORES_VALUE ? 4 : 2)
+                            .totalDuration(Duration.ofSeconds(30))
+                            .build());
+            if (scenario == Scenario.LOCAL_IGNORES_VALUE) {
+                options.executeDurability(StepDurability.ASYNC);
+            }
+            return options.build();
+        }
+    }
+}

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/IntegrationTestWaits.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/IntegrationTestWaits.java
@@ -1,0 +1,48 @@
+/*
+ * Portions of this file are derived from indeedeng/iwf-java-sdk.
+ * Those portions are licensed under the Apache License, Version 2.0.
+ * See LICENSES/Apache-2.0.txt and LEGACY_NOTICES.md.
+ *
+ * Modifications Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Modifications are licensed under the Super Durable Source License 1.0.
+ * Third-Party Materials remain under the Apache License, Version 2.0.
+ * See LICENSE and LEGACY_NOTICES.md.
+ */
+
+package io.superdurable.dex.integ;
+
+import io.superdurable.dex.Client;
+import io.superdurable.dex.StepExecutionId;
+import io.superdurable.dex.TimerId;
+import io.superdurable.dex.exceptions.DexServiceException;
+
+import java.time.Duration;
+
+final class IntegrationTestWaits {
+    private IntegrationTestWaits() {
+    }
+
+    static void skipTimerWhenRegistered(
+            final Client client,
+            final String flowId,
+            final StepExecutionId stepExecutionId,
+            final TimerId timerId) {
+        final long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
+        DexServiceException lastFailure = null;
+        while (System.nanoTime() < deadline) {
+            try {
+                client.skipTimer(flowId, stepExecutionId, timerId);
+                return;
+            } catch (DexServiceException failure) {
+                if (!failure.getDetail().contains(
+                        "timer condition does not exist or is not pending")) {
+                    throw failure;
+                }
+                lastFailure = failure;
+                Thread.yield();
+            }
+        }
+        throw new AssertionError("timer condition was not registered", lastFailure);
+    }
+}

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/SignalTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/SignalTest.java
@@ -45,7 +45,8 @@ public final class SignalTest {
             environment.client().publish(flowId, WORKFLOW.first, 2, 3, 5);
             environment.client().publish(flowId, WORKFLOW.third, (Void) null);
             environment.client().publish(flowId, WORKFLOW.signalMap, "one", 4);
-            environment.client().skipTimer(
+            IntegrationTestWaits.skipTimerWhenRegistered(
+                    environment.client(),
                     flowId,
                     StepExecutionId.of("SignalCombinationStep"),
                     TimerId.byConditionId("test-timer-id"));

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationTest.java
@@ -52,7 +52,7 @@ public final class StepCancellationTest {
     }
 
     @Test
-    void testLocalActivityCancellationInterruptsWithoutFallback() throws Exception {
+    void testLocalHeartbeatIsIgnoredUntilRegularFallback() throws Exception {
         final StepCancellationWorkflow workflow = new StepCancellationWorkflow(
                 StepCancellationWorkflow.Scenario.LOCAL_EXECUTE);
         try (DexDevTestEnvironment environment = DexDevTestEnvironment.start(
@@ -63,19 +63,19 @@ public final class StepCancellationTest {
             environment.client().waitForStepCompletion(
                     flowId,
                     StepExecutionId.of(workflow.canceledStepType()),
-                    CANCELLATION_TIMEOUT);
-            assertTrue(workflow.awaitCancellation(CANCELLATION_TIMEOUT));
+                    FLOW_TIMEOUT);
+            assertTrue(workflow.awaitCancellation(FLOW_TIMEOUT));
             assertCompleted(environment, flowId, StepCancellationWorkflow.Scenario.LOCAL_EXECUTE);
             assertTrue(workflow.wasHandlerInterrupted());
             assertTrue(workflow.didContextReportCancellation());
-            assertEquals(1, workflow.blockingExecuteInvocations());
+            assertEquals(2, workflow.blockingExecuteInvocations());
             assertFalse(workflow.wasRecoveryRun());
             assertNull(environment.client().getAttribute(flowId, workflow.lateWrite));
         }
     }
 
     @Test
-    void testTimerCancelsAfterLocalTimeoutFallback() throws Exception {
+    void testTimerCancelsAfterLocalTimeoutFallbackWithoutWorkerProgress() throws Exception {
         final StepCancellationWorkflow workflow = new StepCancellationWorkflow(
                 StepCancellationWorkflow.Scenario.LOCAL_TIMEOUT_FALLBACK);
         try (DexDevTestEnvironment environment = DexDevTestEnvironment.start(
@@ -91,7 +91,7 @@ public final class StepCancellationTest {
                     environment,
                     flowId,
                     StepCancellationWorkflow.Scenario.LOCAL_TIMEOUT_FALLBACK);
-            assertEquals(1, workflow.blockingExecuteInvocations());
+            assertEquals(2, workflow.blockingExecuteInvocations());
             assertTrue(workflow.wasHandlerInterrupted());
             assertTrue(workflow.didContextReportCancellation());
             assertFalse(workflow.wasRecoveryRun());

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StepCancellationWorkflow.java
@@ -45,11 +45,12 @@ final class StepCancellationWorkflow implements Flow<Void> {
     }
 
     private static final Duration HANDLER_TIMEOUT = Duration.ofSeconds(15);
-    private static final Duration HEARTBEAT_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration HEARTBEAT_TIMEOUT = Duration.ofSeconds(10);
     private static final Duration WINNER_DELAY = Duration.ofSeconds(3);
     private static final long LOCAL_WINNER_DELAY_MILLIS = 1_000L;
     private static final long BLOCKING_HANDLER_MILLIS = 10_000L;
     private static final long LATE_HANDLER_MILLIS = 7_000L;
+    private static final long HEARTBEAT_INTERVAL_MILLIS = 250L;
 
     final Attribute<String> lateWrite = Attribute.define("cancellation-late-write", String.class);
     final Channel<Void> selectorWinnerRelease =
@@ -177,12 +178,28 @@ final class StepCancellationWorkflow implements Flow<Void> {
     private void blockUntilCanceled(final Context context) {
         blockingHandlerStarted.countDown();
         try {
-            Thread.sleep(BLOCKING_HANDLER_MILLIS);
+            final long deadline = System.currentTimeMillis() + BLOCKING_HANDLER_MILLIS;
+            while (System.currentTimeMillis() < deadline) {
+                Thread.sleep(HEARTBEAT_INTERVAL_MILLIS);
+                context.recordHeartbeat(null);
+            }
         } catch (InterruptedException interruption) {
             handlerInterrupted.set(true);
-            contextReportedCancellation.set(context.isCancellationRequested());
-            cancellationObserved.countDown();
+            observeCancellation(context);
+        } catch (RuntimeException failure) {
+            if (!context.isCancellationRequested()) {
+                throw failure;
+            }
+            observeCancellation(context);
         }
+    }
+
+    private void observeCancellation(final Context context) {
+        if (Thread.currentThread().isInterrupted()) {
+            handlerInterrupted.set(true);
+        }
+        contextReportedCancellation.set(context.isCancellationRequested());
+        cancellationObserved.countDown();
     }
 
     final class StepCancellationStartStep implements Step<Void> {
@@ -222,13 +239,26 @@ final class StepCancellationWorkflow implements Flow<Void> {
             blockingExecuteInvocations.incrementAndGet();
             blockingHandlerStarted.countDown();
             try {
-                Thread.sleep(scenario == Scenario.NO_HEARTBEAT
-                        ? LATE_HANDLER_MILLIS
-                        : BLOCKING_HANDLER_MILLIS);
+                if (scenario == Scenario.HEARTBEAT_EXECUTE
+                        || scenario == Scenario.LOCAL_EXECUTE) {
+                    final long deadline = System.currentTimeMillis() + BLOCKING_HANDLER_MILLIS;
+                    while (System.currentTimeMillis() < deadline) {
+                        Thread.sleep(HEARTBEAT_INTERVAL_MILLIS);
+                        context.recordHeartbeat(null);
+                    }
+                } else {
+                    Thread.sleep(scenario == Scenario.NO_HEARTBEAT
+                            ? LATE_HANDLER_MILLIS
+                            : BLOCKING_HANDLER_MILLIS);
+                }
             } catch (InterruptedException interruption) {
                 handlerInterrupted.set(true);
-                contextReportedCancellation.set(context.isCancellationRequested());
-                cancellationObserved.countDown();
+                observeCancellation(context);
+            } catch (RuntimeException failure) {
+                if (!context.isCancellationRequested()) {
+                    throw failure;
+                }
+                observeCancellation(context);
             }
             lateWrite.set(context, "late");
             lateHandlerReturned.countDown();

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StreamTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StreamTest.java
@@ -37,25 +37,35 @@ public final class StreamTest {
         final StreamTestWorkflow workflow = new StreamTestWorkflow();
         try (DexDevTestEnvironment environment = DexDevTestEnvironment.start(cacheDirectory, workflow)) {
             final String flowId = "stream-" + UUID.randomUUID();
-            final String runId = environment.client().startFlow(workflow, flowId, null);
+            environment.client().startFlow(workflow, flowId, null);
             environment.client().waitForFlow(flowId, Duration.ofSeconds(30));
 
             environment.client().writeStream(flowId, workflow.progress, "client-write", "client-progress");
-            environment.client().writeStream(flowId, workflow.progress, "client-write", "duplicate-ignored");
+            environment.client().writeStream(flowId, workflow.progress, "client-write", "duplicate-retained");
 
             final StreamMessage<String> step = environment.client()
                     .readStream(flowId, workflow.progress, "", Duration.ofSeconds(30));
-            assertEquals("step-progress", step.getValue());
+            assertEquals("step-progress-1", step.getValue());
             assertFalse(step.getResumeToken().isEmpty());
             assertTrue(step.getCreatedTime().isAfter(Instant.EPOCH));
-            assertTrue(step.getIdempotencyKey().startsWith(runId + "#"));
+            assertEquals("#StreamTestStep-1", step.getSource());
+
+            final StreamMessage<String> secondStep = environment.client()
+                    .readStream(flowId, workflow.progress, step.getResumeToken(), Duration.ofSeconds(30));
+            assertEquals("step-progress-2", secondStep.getValue());
+            assertEquals(step.getSource(), secondStep.getSource());
 
             final StreamMessage<String> client = environment.client()
-                    .readStream(flowId, workflow.progress, step.getResumeToken(), Duration.ofSeconds(30));
+                    .readStream(flowId, workflow.progress, secondStep.getResumeToken(), Duration.ofSeconds(30));
             assertEquals("client-progress", client.getValue());
-            assertFalse(client.getResumeToken().equals(step.getResumeToken()));
+            assertFalse(client.getResumeToken().equals(secondStep.getResumeToken()));
             assertTrue(client.getCreatedTime().isAfter(Instant.EPOCH));
-            assertEquals("client-write", client.getIdempotencyKey());
+            assertEquals("client-write", client.getSource());
+
+            final StreamMessage<String> duplicate = environment.client()
+                    .readStream(flowId, workflow.progress, client.getResumeToken(), Duration.ofSeconds(30));
+            assertEquals("duplicate-retained", duplicate.getValue());
+            assertEquals("client-write", duplicate.getSource());
         }
     }
 }

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StreamTestWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StreamTestWorkflow.java
@@ -42,7 +42,8 @@ final class StreamTestWorkflow implements Flow<Void> {
 
         @Override
         public StepDecision execute(final Context context, final Void input) {
-            progress.write(context, "step-progress");
+            progress.write(context, "step-progress-1");
+            progress.write(context, "step-progress-2");
             return StepDecision.gracefulComplete();
         }
     }


### PR DESCRIPTION
## Summary

- stream Java Step Worker WaitFor and Execute responses while keeping WorkerRpc unary
- add heartbeat checkpoint APIs and fire-and-forget Step Stream writes to Context
- rename Java Stream idempotency metadata to source and support repeated writes
- document server durability, retry, attempt, and heartbeat defaults
- add local and Dex integration coverage for protocol ordering, retry restoration, null heartbeat clearing, cancellation, and repeated Stream messages

## Rationale

This is stacked on #417 so Java handlers can use the new Step Worker response-streaming protocol without queues, generators, or an additional streaming thread.

## User impact

Java Step handlers keep synchronous method signatures. They can call `Context.recordHeartbeat(...)` and `Stream.write(...)` multiple times before returning the final result. `recordHeartbeat(null)` explicitly emits a heartbeat without details.

## Validation

- `make generated-code-check`
- `make copyright-check`
- `make docs-prose-check`
- `./gradlew test localIntegrationTest checkstyleMain javadoc --no-daemon`
- `./run-integration-tests.sh --coverage`
- `./run-integration-tests.sh`
- `./gradlew validatePublication -PreleaseVersion=0.2.3-test --no-daemon`

Stacked on #417.
