### PR TITLE
Update examples and docs for Step streaming

### DIFF
--- a/docs/content/design-patterns/draining-channel-for-external-publishing.mdx
+++ b/docs/content/design-patterns/draining-channel-for-external-publishing.mdx
@@ -37,7 +37,7 @@ class ProcessMessage(Step[str]):
         return Wait.skip_immediately()
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: str
+        self, context: AsyncContext, input: str
     ) -> StepDecision:
         if input is not None:
             print(f"DrainingExternalChannelFlow process message: {input}")

--- a/docs/content/design-patterns/parallel-subflows/back-pressure.mdx
+++ b/docs/content/design-patterns/parallel-subflows/back-pressure.mdx
@@ -35,7 +35,7 @@ class SubmitStep(Step[SubmitRequestInput]):
         self.parent_flow = parent_flow
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: SubmitRequestInput
+        self, context: AsyncContext, input: SubmitRequestInput
     ) -> StepDecision:
         if not input.parent_ids:
             raise ValueError("at least one parent Flow ID is required")

--- a/docs/content/design-patterns/parallel-subflows/wait-for-half.mdx
+++ b/docs/content/design-patterns/parallel-subflows/wait-for-half.mdx
@@ -44,7 +44,7 @@ class SubFlowStep(Step[str]):
     def wait_for(self, context: Context, request: str) -> Wait:
         return Wait.any_of(SubFlow.run(self.example_subflow, request), self.all_done_ch.for_one())
 
-    async def execute(self, context: Context, request: str) -> StepDecision:
+    async def execute(self, context: AsyncContext, request: str) -> StepDecision:
         if SubFlow.get_condition_results(context).status is not FlowStatus.RUNNING:
             self.subflow_completed_ch.publish(context, True)
             return graceful_complete()

--- a/docs/content/design-patterns/parallel/await.mdx
+++ b/docs/content/design-patterns/parallel/await.mdx
@@ -30,7 +30,7 @@ class DoWorkStep(Step[int]):
         self.complete_ch = complete_ch
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: int
+        self, context: AsyncContext, input: int
     ) -> StepDecision:
         await asyncio.sleep(random.uniform(0.05, 0.5))
         self.complete_ch.publish(context, None)

--- a/docs/content/design-patterns/parallel/dynamic.mdx
+++ b/docs/content/design-patterns/parallel/dynamic.mdx
@@ -27,7 +27,7 @@ The starting Step builds the movement list at runtime. The worker's random delay
 ```python
 class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
-        self, context: Context, input: int
+        self, context: AsyncContext, input: int
     ) -> StepDecision:
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input)

--- a/docs/content/design-patterns/parallel/first-win.mdx
+++ b/docs/content/design-patterns/parallel/first-win.mdx
@@ -27,7 +27,7 @@ The cancellation selector targets sibling executions of the same Step type, not 
 ```python
 class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
-        self, context: Context, input: int
+        self, context: AsyncContext, input: int
     ) -> StepDecision:
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input).with_canceling_sibling_steps(DoWorkStep)

--- a/docs/content/design-patterns/responsive-update/stream.mdx
+++ b/docs/content/design-patterns/responsive-update/stream.mdx
@@ -8,7 +8,7 @@ Use a Stream when the caller should receive a sequence of updates rather than on
 
 The **StreamFlow** sample exposes a progress Stream. Its read endpoint long-polls for up to 20 seconds, returns one message, and gives the client the token to keep. A client can issue the next read immediately after handling that message.
 
-Streams are durable ordered messages, not a final Flow result. Use **WaitForStepCompletion** or **WaitForAttributeEqual** when the caller needs one specific durable condition before it can proceed.
+Streams are best-effort ordered messages, not a final Flow result. Use **WaitForStepCompletion** or **WaitForAttributeEqual** when the caller needs one specific durable condition before it can proceed.
 
 ## Core implementation
 
@@ -34,10 +34,10 @@ func (controller *controller) read(request *gin.Context) {
 		return
 	}
 	request.JSON(http.StatusOK, gin.H{
-		"value":          value,
-		"resumeToken":    message.ResumeToken,
-		"createdTime":    message.CreatedTime.Format(time.RFC3339Nano),
-		"idempotencyKey": message.IdempotencyKey,
+		"value":       value,
+		"resumeToken": message.ResumeToken,
+		"createdTime": message.CreatedTime.Format(time.RFC3339Nano),
+		"source":      message.Source,
 	})
 }
 ```
@@ -58,7 +58,7 @@ async def read() -> Response:
         value=message.value,
         resume_token=message.resume_token,
         created_time=message.created_time.isoformat(),
-        idempotency_key=message.idempotency_key,
+        source=message.source,
     )
 ```
 
@@ -79,7 +79,7 @@ public ResponseEntity<Map<String, String>> read(
     response.put("value", message.getValue());
     response.put("resumeToken", message.getResumeToken());
     response.put("createdTime", message.getCreatedTime().toString());
-    response.put("idempotencyKey", message.getIdempotencyKey());
+    response.put("source", message.getSource());
     return ResponseEntity.ok(response);
 }
 ```
@@ -119,7 +119,7 @@ async fn read(
                 value: message.value,
                 resume_token: message.resume_token,
                 created_time: format!("{:?}", message.created_time),
-                idempotency_key: message.idempotency_key,
+                source: message.source,
             })
     }) {
         Ok(response) => ok_json(response),

--- a/docs/content/primitives/flow/flow-options.mdx
+++ b/docs/content/primitives/flow/flow-options.mdx
@@ -313,7 +313,7 @@ At start, Dex applies the supplied fields over the Dex Server defaults. Omitted 
 | **ActiveStepSearchMode** | Index every active Step, only Steps that ran **WaitFor**, or no active Steps. The default indexes Steps with **WaitFor**.       |
 | **ContinueAsNewThreshold** | Continue as new after this many tracked events. Zero turns it off.                                                              |
 | **ContinueAsNewPageSizeBytes** | Limit each page of state carried into continue-as-new. Zero uses 1 MiB.|
-| **StepDurability** | Default durability for Step writes. A Step override wins. Recovery uses synchronous durability unless you override it in StepOptions. |
+| **StepDurability** | Default durability for methods without a Step override. Dex resolves a method override first, then this value, then **SYNC**. Failure policies do not change the order. |
 | **WorkerTarget** | WorkerService endpoint for Step and RPC invocation                                                                              |
 | **AttributeStoreNames** | Dex Server Attribute Stores for Attributes that opt in to attribute sync                                                        |
 

--- a/docs/content/primitives/flow/flow-options.mdx
+++ b/docs/content/primitives/flow/flow-options.mdx
@@ -313,7 +313,7 @@ At start, Dex applies the supplied fields over the Dex Server defaults. Omitted 
 | **ActiveStepSearchMode** | Index every active Step, only Steps that ran **WaitFor**, or no active Steps. The default indexes Steps with **WaitFor**.       |
 | **ContinueAsNewThreshold** | Continue as new after this many tracked events. Zero turns it off.                                                              |
 | **ContinueAsNewPageSizeBytes** | Limit each page of state carried into continue-as-new. Zero uses 1 MiB.|
-| **StepDurability** | Default durability for methods without a Step override. Dex resolves a method override first, then this value, then **SYNC**. Failure policies do not change the order. |
+| **StepDurability** | Default durability for methods without a Step override. Dex resolves a method override first, then this value, then **SYNC**. |
 | **WorkerTarget** | WorkerService endpoint for Step and RPC invocation                                                                              |
 | **AttributeStoreNames** | Dex Server Attribute Stores for Attributes that opt in to attribute sync                                                        |
 

--- a/docs/content/primitives/step/basic.mdx
+++ b/docs/content/primitives/step/basic.mdx
@@ -38,6 +38,8 @@ If a Step does not implement **WaitFor**, **Execute** runs immediately.
 
 Each **WaitFor** or **Execute** invocation is a separate commit boundary. Dex Server stages the Attribute writes and Channel publications from that method, then commits them with its **Wait** or **StepDecision** only after the method returns successfully. If the method fails, none of those durable changes are committed. **WaitFor** and **Execute** do not share a commit. External API calls are outside this atomic boundary.
 
+The Worker returns each invocation as a response stream. Before its final **Wait** or **StepDecision**, a handler can send [heartbeat checkpoints](/primitives/step/step-options#heartbeat) and any number of best-effort [Stream messages](/primitives/stream). The response stream must end with exactly one final result. These progress frames are not part of the method's commit, and a Stream Store failure does not fail the Step.
+
 <StepWaitExecuteDiagram />
 
 <SdkTabs

--- a/docs/content/primitives/step/basic.mdx
+++ b/docs/content/primitives/step/basic.mdx
@@ -38,7 +38,7 @@ If a Step does not implement **WaitFor**, **Execute** runs immediately.
 
 Each **WaitFor** or **Execute** invocation is a separate commit boundary. Dex Server stages the Attribute writes and Channel publications from that method, then commits them with its **Wait** or **StepDecision** only after the method returns successfully. If the method fails, none of those durable changes are committed. **WaitFor** and **Execute** do not share a commit. External API calls are outside this atomic boundary.
 
-The Worker returns each invocation as a response stream. Before its final **Wait** or **StepDecision**, a handler can send [heartbeat checkpoints](/primitives/step/step-options#heartbeat) and any number of best-effort [Stream messages](/primitives/stream). The response stream must end with exactly one final result. These progress frames are not part of the method's commit, and a Stream Store failure does not fail the Step.
+Before its final **Wait** or **StepDecision**, a handler can send [heartbeat checkpoints](/primitives/step/step-options#heartbeat) and any number of best-effort [Stream messages](/primitives/stream). The response stream must end with exactly one final result. These progress frames are not part of the method's commit, and a Stream Store failure does not fail the Step.
 
 <StepWaitExecuteDiagram />
 

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -82,11 +82,11 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 
 **ASYNC** durability does this asynchronously. Every few seconds, Dex Server flushes accumulated Step completions and persists them. It provides much higher throughput because it removes a lot of overhead from the backend database and server.
 
-**SYNC** is the default. Dex resolves durability in this order: a method override in **StepOptions**, the Flow's **FlowConfig**, then **SYNC**. A failure policy does not change that order.
+**SYNC** is the default. Dex resolves durability in this order: a method override in **StepOptions**, the Flow's **FlowConfig**, then **SYNC**.
 
-**SYNC** runs only as a regular activity. Its default method attempt timeout is two hours, and its default heartbeat timeout is one minute.
+**SYNC** runs only as a regular Temporal activity. Its default method attempt timeout is two hours, and its default heartbeat timeout is one minute.
 
-**ASYNC** first runs locally for at most seven seconds and three attempts. A smaller user retry duration or attempt limit still applies. The local phase ignores the method timeout and heartbeat settings. If it falls back to a regular activity, Dex applies the remaining retry budget and the same two-hour method attempt and one-minute heartbeat defaults.
+**ASYNC** first runs as a Temporal local activity for at most seven seconds and three attempts, then falls back to a regular activity if it still fails. A smaller user retry duration or attempt limit still applies. The local activity phase ignores the method timeout and heartbeat settings. If it falls back to a regular activity, Dex applies the remaining retry budget and the same two-hour method attempt and one-minute heartbeat defaults.
 
 The default total retry duration is four hours for both durability modes. An explicit retry duration may be shorter or longer.
 
@@ -164,9 +164,11 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 ## Heartbeat {#heartbeat}
 
-Dex Server does not send automatic heartbeats for Step handlers. During a regular activity attempt, the Worker must send a heartbeat or a [Stream message](/primitives/stream) before the **HeartbeatTimeout** expires. A Stream message is an implicit heartbeat because it shows that the handler is making progress.
+During a regular activity attempt, the Worker must send a heartbeat or a [Stream message](/primitives/stream) before the **HeartbeatTimeout** expires. In other words, sending a Stream message is an implicit heartbeat.
 
-An omitted or zero **HeartbeatTimeout** uses the one-minute default. Dex Server controls the smallest explicit value; the default minimum is 10 seconds. For example, an **Execute** method timeout of 60 seconds and a **HeartbeatTimeout** of 10 seconds lets Dex retry the Step in about 10 seconds instead of waiting for the full 60 seconds.
+**HeartbeatTimeout** defaults to one minute. The default allowed minimum is 10 seconds.
+
+For example, an **Execute** method timeout of 60 seconds and a **HeartbeatTimeout** of 10 seconds lets Dex retry the Step in about 10 seconds instead of waiting for the full 60 seconds.
 
 A heartbeat can persist a checkpoint value. The next regular attempt receives the latest value and can resume from it. An explicit heartbeat without a value clears the previous checkpoint. An implicit heartbeat from a Stream message preserves the latest explicit state, including an explicitly cleared state.
 
@@ -322,7 +324,7 @@ fn execute(&self, context: &mut Context, batches: Self::Input) -> HandlerResult<
 </SdkSnippet>
 </SdkTabs>
 
-Cancellation reaches a regular handler on its next heartbeat or Stream output. A heartbeat does not make an external API call atomic. Use idempotency or compensation when the API needs it.
+A heartbeat helps deliver cancellation. A Step invocation is canceled only when it completes, fails, or records a heartbeat.
 
 ## Attribute locks
 

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -82,11 +82,13 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 
 **ASYNC** durability does this asynchronously. Every few seconds, Dex Server flushes accumulated Step completions and persists them. It provides much higher throughput because it removes a lot of overhead from the backend database and server.
 
-A Step should usually be idempotent, so **ASYNC** durability is generally safe to use. It is the default for most Steps.
+**SYNC** is the default. Dex resolves durability in this order: a method override in **StepOptions**, the Flow's **FlowConfig**, then **SYNC**. A failure policy does not change that order.
 
-Steps with a recovery failure policy default to **SYNC** durability. The business may assume that once a Flow enters the following Execute method or recovery Step, it does not go back to the previous method.
+**SYNC** runs only as a regular activity. Its default method attempt timeout is two hours, and its default heartbeat timeout is one minute.
 
-Set the default durability with **FlowConfig**. This default does not apply to a method with a recovery failure policy. To override the durability for that method, set it in the Step's **StepOptions**.
+**ASYNC** first runs locally for at most seven seconds and three attempts. A smaller user retry duration or attempt limit still applies. The local phase ignores the method timeout and heartbeat settings. If it falls back to a regular activity, Dex applies the remaining retry budget and the same two-hour method attempt and one-minute heartbeat defaults.
+
+The default total retry duration is four hours for both durability modes. An explicit retry duration may be shorter or longer.
 
 <SdkTabs
   examples={{
@@ -162,12 +164,13 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 ## Heartbeat {#heartbeat}
 
-**Heartbeat** lets a Step with a long method timeout fail and schedule the next attempt earlier, or being canceled earlier.
+Dex Server does not send automatic heartbeats for Step handlers. During a regular activity attempt, the Worker must send a heartbeat or a [Stream message](/primitives/stream) before the **HeartbeatTimeout** expires. A Stream message is an implicit heartbeat because it shows that the handler is making progress.
 
-Set a **HeartbeatTimeout** to use it.
+An omitted or zero **HeartbeatTimeout** uses the one-minute default. Dex Server controls the smallest explicit value; the default minimum is 10 seconds. For example, an **Execute** method timeout of 60 seconds and a **HeartbeatTimeout** of 10 seconds lets Dex retry the Step in about 10 seconds instead of waiting for the full 60 seconds.
 
+A heartbeat can persist a checkpoint value. The next regular attempt receives the latest value and can resume from it. An explicit heartbeat without a value clears the previous checkpoint. An implicit heartbeat from a Stream message preserves the latest explicit state, including an explicitly cleared state.
 
-For example, an **Execute** method timeout of 60 seconds and a **HeartbeatTimeout** of 10 seconds lets Dex retry the Step in about 10 seconds instead of waiting for the full 60 seconds. Similarly, a Step that is being canceled does not have to wait for the full timeout, fail, or complete first.
+The local phase of **ASYNC** durability ignores heartbeat output and does not pass a checkpoint to the fallback regular activity. Stream messages are still emitted during the local phase.
 
 <SdkTabs
   examples={{
@@ -183,19 +186,26 @@ For example, an **Execute** method timeout of 60 seconds and a **HeartbeatTimeou
 func (heartbeatStep) GetStepOptions() *dex.StepOptions {
 	return &dex.StepOptions{
 		ExecuteMethodTimeout: 60 * time.Second,
-		HeartbeatTimeout:       10 * time.Second,
-		ExecuteRetry:           &dex.RetryPolicy{MaximumAttempts: 3},
+		HeartbeatTimeout:     10 * time.Second,
+		ExecuteRetry:         &dex.RetryPolicy{MaximumAttempts: 3},
 	}
 }
 
 func (step heartbeatStep) Execute(ctx dex.Context, batches int) (*dex.StepDecision, error) {
-	for batch := 0; batch < batches; batch++ {
+	completedBatches := 0
+	if _, err := ctx.GetLastHeartbeatValue(&completedBatches); err != nil {
+		return nil, err
+	}
+	for batch := completedBatches; batch < batches; batch++ {
 		select {
 		case <-ctx.Done():
 			return dex.DeadEnd(), nil
 		default:
 		}
 		time.Sleep(2 * time.Second)
+		if err := ctx.RecordHeartbeat(batch + 1); err != nil {
+			return nil, err
+		}
 	}
 	return dex.GracefulComplete("processed"), nil
 }
@@ -207,7 +217,10 @@ func (step heartbeatStep) Execute(ctx dex.Context, batches int) (*dex.StepDecisi
 ```java
 @Override
 public StepDecision execute(final Context context, final Integer batches) {
-    for (int batch = 0; batch < batches; batch++) {
+    final int completedBatches = context.hasLastHeartbeatValue()
+            ? context.getLastHeartbeatValue(Integer.class)
+            : 0;
+    for (int batch = completedBatches; batch < batches; batch++) {
         if (context.isCancellationRequested()) {
             return StepDecision.deadEnd();
         }
@@ -217,6 +230,7 @@ public StepDecision execute(final Context context, final Integer batches) {
             Thread.currentThread().interrupt();
             return StepDecision.deadEnd();
         }
+        context.recordHeartbeat(batch + 1);
     }
     return StepDecision.gracefulComplete("processed");
 }
@@ -242,11 +256,15 @@ def get_step_options(self) -> StepOptions:
         execute_retry=RetryPolicy(maximum_attempts=3),
     )
 
-async def execute(self, context: Context, batches: int) -> StepDecision:
-    for _batch in range(batches):
+async def execute(
+    self, context: AsyncContext, batches: int
+) -> StepDecision:
+    completed_batches = context.get_last_heartbeat_value(int) or 0
+    for batch in range(completed_batches, batches):
         if context.is_cancellation_requested():
             return dead_end()
         await asyncio.sleep(2)
+        await context.heartbeat(batch + 1)
     return graceful_complete("processed")
 ```
 
@@ -264,12 +282,14 @@ public getStepOptions(): StepOptions {
   };
 }
 
-public async execute(context: Context, batches: number): Promise<StepDecision> {
-  for (let batch = 0; batch < batches; batch++) {
+public async execute(context: AsyncContext, batches: number): Promise<StepDecision> {
+  const completedBatches = context.getLastHeartbeatValue(doubleCodec) ?? 0;
+  for (let batch = completedBatches; batch < batches; batch++) {
     if (context.cancellationSignal.aborted) {
       return deadEnd();
     }
     await new Promise((resolve) => setTimeout(resolve, 2_000));
+    await context.recordHeartbeat(batch + 1, doubleCodec);
   }
   return gracefulComplete("processed");
 }
@@ -287,11 +307,13 @@ fn options(&self) -> StepOptions<Self::Input> {
 }
 
 fn execute(&self, context: &mut Context, batches: Self::Input) -> HandlerResult<StepDecision> {
-    for _batch in 0..batches {
+    let completed_batches = context.last_heartbeat_value::<i32>()?.unwrap_or_default();
+    for batch in completed_batches..batches {
         if context.is_cancelled() {
             return Ok(StepDecision::dead_end());
         }
         thread::sleep(Duration::from_secs(2));
+        context.record_heartbeat_value(batch + 1)?;
     }
     Ok(StepDecision::graceful_complete(String::from("processed")))
 }
@@ -300,7 +322,7 @@ fn execute(&self, context: &mut Context, batches: Self::Input) -> HandlerResult<
 </SdkSnippet>
 </SdkTabs>
 
-Heartbeat makes cancellation reach a regular handler earlier. It does not make an external API call atomic. Use idempotency or compensation when the API needs it.
+Cancellation reaches a regular handler on its next heartbeat or Stream output. A heartbeat does not make an external API call atomic. Use idempotency or compensation when the API needs it.
 
 ## Attribute locks
 

--- a/docs/content/primitives/stream.mdx
+++ b/docs/content/primitives/stream.mdx
@@ -19,7 +19,7 @@ A Stream provides best-effort durability only, using an in-memory store such as 
 
 A Stream has a stable name, a message type, and **streamCapacityBytes**. streamCapacityBytes is an approximate capacity shared by all Flow executions with the same Flow type and Stream name. It is not a per-Flow-ID limit.
 
-This example writes a progress message before its Step returns. The write becomes visible as soon as Dex accepts it; the Client does not wait for the Step to complete.
+This example writes two progress messages before its Step returns. Each write enters the Worker output stream immediately; the handler does not wait for a Stream Store acknowledgement.
 
 <SdkTabs examples={{
 python: 'examples/python/dex_examples/primitives/stream/stream_flow.py',
@@ -35,8 +35,9 @@ class RenderPreview(Step[str]):
     def __init__(self, progress: Stream[str]) -> None:
         self.progress = progress
 
-    async def execute(self, context: Context, input: str) -> StepDecision:
-        await self.progress.write(context, f"Rendering preview for {input}")
+    async def execute(self, context: AsyncContext, input: str) -> StepDecision:
+        self.progress.write(context, f"Rendering preview for {input}")
+        self.progress.write(context, f"Preview ready for {input}")
         return graceful_complete(f"Rendered {input}")
 
 
@@ -79,6 +80,9 @@ func (renderPreview) Execute(ctx dex.Context, input string) (*dex.StepDecision, 
 	if err := Progress.Write(ctx, "Rendering preview for "+input); err != nil {
 		return nil, err
 	}
+	if err := Progress.Write(ctx, "Preview ready for "+input); err != nil {
+		return nil, err
+	}
 	return dex.GracefulComplete("Rendered " + input), nil
 }
 ```
@@ -111,6 +115,7 @@ public final class StreamFlow implements Flow<String> {
         @Override
         public StepDecision execute(final Context context, final String input) {
             progress.write(context, "Rendering preview for " + input);
+            progress.write(context, "Preview ready for " + input);
             return StepDecision.gracefulComplete("Rendered " + input);
         }
     }
@@ -131,7 +136,8 @@ class RenderPreview implements Step<string> {
   }
 
   public async execute(context: Context, input: string): Promise<StepDecision> {
-    await progress.write(context, `Rendering preview for ${input}`);
+    progress.write(context, `Rendering preview for ${input}`);
+    progress.write(context, `Preview ready for ${input}`);
     return gracefulComplete(`Rendered ${input}`);
   }
 }
@@ -189,6 +195,7 @@ impl Step for RenderPreview {
         input: Self::Input,
     ) -> HandlerResult<StepDecision> {
         PROGRESS.write(context, format!("Rendering preview for {input}"))?;
+        PROGRESS.write(context, format!("Preview ready for {input}"))?;
         Ok(StepDecision::graceful_complete(format!(
             "Rendered {input}"
         )))
@@ -205,17 +212,19 @@ impl Step for RenderPreview {
 
 A direct Step write has these semantics:
 
-- Dex sends it immediately during **Execute**. It is not buffered until the Step completes.
+- Dex sends it immediately during **WaitFor** or **Execute**. It is not buffered until the Step completes.
 - A later Step failure does not roll the message back.
-- One Step execution can write once to each Stream. Dex derives the idempotency key from the run ID and Step execution ID, so a retry does not append the same message again.
+- One method invocation can write any number of messages to the same or different Streams. Each write is an implicit heartbeat and preserves the last explicit heartbeat value.
+- The SDK only confirms local encoding and delivery to the Worker output stream. A disabled, unavailable, full, or rejecting Stream Store drops the message without failing the Step.
+- Every Step message has source **#StepExecutionID**. Attempts and messages from the same Step execution share that source. Source is informational, not unique, and does not deduplicate retries.
 
-A Client can write even when the Flow instance does not exist or is no longer active. Supply a non-empty idempotency key for every logical message. RPC handlers cannot write through the Step Context, but they can send Stream messages through an injected Client dependency.
+A Client can write even when the Flow instance does not exist or is no longer active. Supply a non-empty source for each write. A source may be repeated and may contain **#**; every call appends another message. RPC handlers cannot write through their Context, but they can send Stream messages through an injected Client dependency.
 
-While an idempotency key remains retained, repeating it is a successful first-write-wins no-op. Once trimming removes the message and its idempotency record, the same key may append again.
+Python coroutine Steps call **Stream.write** without **await**. Python synchronous Steps must yield the returned **StepOutput** from a generator. Other SDKs send the frame through their Step Context and return after local enqueueing.
 
 ### Resumable reads
 
-**ReadStream** returns one message with its value, resume token, creation time, and producer idempotency key.
+**ReadStream** returns one message with its value, resume token, creation time, and source.
 
 - An empty token starts at the current retained head.
 - A token older than the retained head also starts at that head.
@@ -228,7 +237,7 @@ Resume is best effort. A slow reader can miss messages trimmed before its next r
 
 **streamCapacityBytes** is an approximate capacity shared by all Flow executions with the same Flow type and Stream name. It is not a per-Flow-ID limit.
 
-The Dex server calculates the estimated size from each message's serialized value, identity bytes, and configured per-message overhead.
+The Dex server calculates the estimated size from each message's serialized value, Flow ID, source, and configured per-message overhead.
 
 When usage reaches the trim trigger threshold, one background trimmer removes the oldest messages across all instances until usage reaches the trim target threshold. In rare cases, if trimming is too slow and usage reaches the capacity limit (**streamCapacityBytes**), the write request is rejected.
 

--- a/docs/content/use-cases/ai-agent-email.mdx
+++ b/docs/content/use-cases/ai-agent-email.mdx
@@ -19,7 +19,9 @@ Losing a progress chunk does not change the email draft or send decision. That m
 
 ## Streaming from the Agent Step
 
-A direct Step Stream write supports one message per Stream and Step execution. An LLM produces many chunks during one Step execution, so this example injects an AsyncClient and writes each chunk with a stable sequence key. Retries reuse the same run ID, Step execution ID, and sequence numbers, making retained chunks first-write-wins.
+The Agent Step writes every LLM progress chunk directly to its Stream. In an async handler, **Stream.write** queues each message locally and returns without waiting for a Stream Store acknowledgement. A Stream Store failure does not fail the Step.
+
+Step messages use **#StepExecutionID** as their source. The source describes where a message came from; it is not an idempotency key. All writes append, so a retry can produce duplicate progress chunks. That is acceptable because the feed is presentational and the final draft remains in durable Attributes.
 
 The OpenAI call requests a user-visible reasoning summary. It does not expose private chain-of-thought. When OpenAI is not configured, the local fallback emits progress messages through the same Stream path.
 
@@ -27,25 +29,10 @@ The OpenAI call requests a user-visible reasoning summary. It does not expose pr
 <SdkSnippet lang="python">
 
 ```python
-        progress_index = 0
-
         async def write_progress(chunk: str) -> None:
-            nonlocal progress_index
             if not chunk:
                 return
-            idempotency_key = (
-                f"{context.run_id}/{context.step_execution_id}/{progress_index}"
-            )
-            progress_index += 1
-            try:
-                await self.client_provider().write_stream(
-                    context.flow_id,
-                    self.flow.thinking,
-                    idempotency_key,
-                    chunk,
-                )
-            except DexServiceError as error:
-                print(f"thinking update dropped: {error}")
+            self.flow.thinking.write(context, chunk)
 
         reply = await request_email_fields(
             user_request,

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/draining-channel-for-external-publishing.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/draining-channel-for-external-publishing.mdx
@@ -38,7 +38,7 @@ class ProcessMessage(Step[str]):
         return Wait.skip_immediately()
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: str
+        self, context: AsyncContext, input: str
     ) -> StepDecision:
         if input is not None:
             print(f"DrainingExternalChannelFlow process message: {input}")

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/back-pressure.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/back-pressure.mdx
@@ -35,7 +35,7 @@ class SubmitStep(Step[SubmitRequestInput]):
         self.parent_flow = parent_flow
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: SubmitRequestInput
+        self, context: AsyncContext, input: SubmitRequestInput
     ) -> StepDecision:
         if not input.parent_ids:
             raise ValueError("at least one parent Flow ID is required")

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/wait-for-half.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel-subflows/wait-for-half.mdx
@@ -44,7 +44,7 @@ class SubFlowStep(Step[str]):
     def wait_for(self, context: Context, request: str) -> Wait:
         return Wait.any_of(SubFlow.run(self.example_subflow, request), self.all_done_ch.for_one())
 
-    async def execute(self, context: Context, request: str) -> StepDecision:
+    async def execute(self, context: AsyncContext, request: str) -> StepDecision:
         if SubFlow.get_condition_results(context).status is not FlowStatus.RUNNING:
             self.subflow_completed_ch.publish(context, True)
             return graceful_complete()

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/await.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/await.mdx
@@ -29,7 +29,7 @@ class DoWorkStep(Step[int]):
         self.complete_ch = complete_ch
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: int
+        self, context: AsyncContext, input: int
     ) -> StepDecision:
         await asyncio.sleep(random.uniform(0.05, 0.5))
         self.complete_ch.publish(context, None)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/dynamic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/dynamic.mdx
@@ -26,7 +26,7 @@ sidebar_label: Dynamic Parallel Steps
 ```python
 class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
-        self, context: Context, input: int
+        self, context: AsyncContext, input: int
     ) -> StepDecision:
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/first-win.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/parallel/first-win.mdx
@@ -26,7 +26,7 @@ sidebar_label: First-Win Parallel Steps
 ```python
 class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
-        self, context: Context, input: int
+        self, context: AsyncContext, input: int
     ) -> StepDecision:
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input).with_canceling_sibling_steps(DoWorkStep)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/responsive-update/stream.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/responsive-update/stream.mdx
@@ -8,7 +8,7 @@ title: 等待并流式接收更新
 
 **StreamFlow** 示例公开一个 progress Stream。它的 read endpoint 最多长轮询 20 秒，返回一条消息，并提供客户端应保存的 token。客户端处理这条消息后可以立刻发起下一次读取。
 
-Stream 是 durable、有序消息，而不是最终 Flow 结果。当调用方必须在继续前等待一个特定 durable 条件时，使用 **WaitForStepCompletion** 或 **WaitForAttributeEqual**。
+Stream 是 best-effort、有序消息，而不是最终 Flow 结果。当调用方必须在继续前等待一个特定 durable 条件时，使用 **WaitForStepCompletion** 或 **WaitForAttributeEqual**。
 
 ## 核心实现
 
@@ -34,10 +34,10 @@ func (controller *controller) read(request *gin.Context) {
 		return
 	}
 	request.JSON(http.StatusOK, gin.H{
-		"value":          value,
-		"resumeToken":    message.ResumeToken,
-		"createdTime":    message.CreatedTime.Format(time.RFC3339Nano),
-		"idempotencyKey": message.IdempotencyKey,
+		"value":       value,
+		"resumeToken": message.ResumeToken,
+		"createdTime": message.CreatedTime.Format(time.RFC3339Nano),
+		"source":      message.Source,
 	})
 }
 ```
@@ -58,7 +58,7 @@ async def read() -> Response:
         value=message.value,
         resume_token=message.resume_token,
         created_time=message.created_time.isoformat(),
-        idempotency_key=message.idempotency_key,
+        source=message.source,
     )
 ```
 
@@ -79,7 +79,7 @@ public ResponseEntity<Map<String, String>> read(
     response.put("value", message.getValue());
     response.put("resumeToken", message.getResumeToken());
     response.put("createdTime", message.getCreatedTime().toString());
-    response.put("idempotencyKey", message.getIdempotencyKey());
+    response.put("source", message.getSource());
     return ResponseEntity.ok(response);
 }
 ```
@@ -119,7 +119,7 @@ async fn read(
                 value: message.value,
                 resume_token: message.resume_token,
                 created_time: format!("{:?}", message.created_time),
-                idempotency_key: message.idempotency_key,
+                source: message.source,
             })
     }) {
         Ok(response) => ok_json(response),

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/flow-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/flow-options.mdx
@@ -313,7 +313,7 @@ Dex Server 要求 **RequestID** 非空。省略时，SDK 会在发送请求前�
 | **ActiveStepSearchMode** | 索引所有 active Step、只索引运行过 **WaitFor** 的 Step，或不索引 active Step。默认只索引带 **WaitFor** 的 Step。 |
 | **ContinueAsNewThreshold** | 追踪到这个事件数后 continue as new。零会关闭它。 |
 | **ContinueAsNewPageSizeBytes** | 限制 continue-as-new 带入的每一页 state。零使用 1 MiB。 |
-| **StepDurability** | 没有 Step override 的 method 使用的默认 durability。Dex 依次使用 method override、这里的值，最后使用 **SYNC**。Failure policy 不会改变这个顺序。 |
+| **StepDurability** | 没有 Step override 的 method 使用的默认 durability。Dex 依次使用 method override、这里的值，最后使用 **SYNC**。 |
 | **WorkerTarget** | 用于 Step 和 RPC invocation 的 WorkerService endpoint。 |
 | **AttributeStoreNames** | Dex Server Attribute Store 名称，供 opt-in attribute sync 的 Attribute 使用。 |
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/flow-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/flow-options.mdx
@@ -313,7 +313,7 @@ Dex Server 要求 **RequestID** 非空。省略时，SDK 会在发送请求前�
 | **ActiveStepSearchMode** | 索引所有 active Step、只索引运行过 **WaitFor** 的 Step，或不索引 active Step。默认只索引带 **WaitFor** 的 Step。 |
 | **ContinueAsNewThreshold** | 追踪到这个事件数后 continue as new。零会关闭它。 |
 | **ContinueAsNewPageSizeBytes** | 限制 continue-as-new 带入的每一页 state。零使用 1 MiB。 |
-| **StepDurability** | Step 写入的默认 durability。Step override 优先。除非在 **StepOptions** 中覆盖，recovery 使用 synchronous durability。 |
+| **StepDurability** | 没有 Step override 的 method 使用的默认 durability。Dex 依次使用 method override、这里的值，最后使用 **SYNC**。Failure policy 不会改变这个顺序。 |
 | **WorkerTarget** | 用于 Step 和 RPC invocation 的 WorkerService endpoint。 |
 | **AttributeStoreNames** | Dex Server Attribute Store 名称，供 opt-in attribute sync 的 Attribute 使用。 |
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
@@ -104,6 +104,8 @@ Step implementation 通常只有一个或两个小方法：**WaitFor** -> **Exec
 
 每次 **WaitFor** 或 **Execute** 调用都有独立的 commit 边界。Dex Server 会暂存该 method 内的 Attribute 写入和 Channel publish，并只在 method 成功返回时，将它们与相应的 **Wait** 或 **StepDecision** 一起 commit。如果 method 失败，这些 durable 变更都不会被 commit。**WaitFor** 和 **Execute** 不共享一次 commit，外部 API 调用也不在这个原子边界内。
 
+Worker 会通过 response stream 返回每次调用。在最终 **Wait** 或 **StepDecision** 之前，handler 可以发送 [heartbeat checkpoint](/primitives/step/step-options#heartbeat) 和任意多条 best-effort [Stream message](/primitives/stream)。Response stream 必须以且仅以一个最终 result 结束。这些 progress frame 不属于 method commit，Stream Store 写入失败也不会让 Step 失败。
+
 <StepWaitExecuteDiagram />
 
 <SdkTabs

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/basic.mdx
@@ -104,7 +104,7 @@ Step implementation 通常只有一个或两个小方法：**WaitFor** -> **Exec
 
 每次 **WaitFor** 或 **Execute** 调用都有独立的 commit 边界。Dex Server 会暂存该 method 内的 Attribute 写入和 Channel publish，并只在 method 成功返回时，将它们与相应的 **Wait** 或 **StepDecision** 一起 commit。如果 method 失败，这些 durable 变更都不会被 commit。**WaitFor** 和 **Execute** 不共享一次 commit，外部 API 调用也不在这个原子边界内。
 
-Worker 会通过 response stream 返回每次调用。在最终 **Wait** 或 **StepDecision** 之前，handler 可以发送 [heartbeat checkpoint](/primitives/step/step-options#heartbeat) 和任意多条 best-effort [Stream message](/primitives/stream)。Response stream 必须以且仅以一个最终 result 结束。这些 progress frame 不属于 method commit，Stream Store 写入失败也不会让 Step 失败。
+在最终 **Wait** 或 **StepDecision** 之前，handler 可以发送 [heartbeat checkpoint](/primitives/step/step-options#heartbeat) 和任意多条 best-effort [Stream message](/primitives/stream)。Response stream 必须以且仅以一个最终 result 结束。这些 progress frame 不属于 method commit，Stream Store 写入失败也不会让 Step 失败。
 
 <StepWaitExecuteDiagram />
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -82,11 +82,13 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 
 **ASYNC** durability 会异步完成这件事。每隔几秒，Dex Server 会 flush 累积的 Step completion 并持久化。它减少了 backend database 和 server 的大量开销，因此吞吐量高得多。
 
-Step 通常应当是 idempotent，所以一般可以安全使用 **ASYNC** durability。它是大多数 Step 的默认值。
+**SYNC** 是默认值。Dex 按这个顺序确定 durability：**StepOptions** 中的 method override、Flow 的 **FlowConfig**，最后是 **SYNC**。Failure policy 不会改变这个顺序。
 
-使用 recovery failure policy 的 Step 默认使用 **SYNC** durability。业务可能假设 Flow 进入后续的 Execute 方法或 recovery Step 后，不会再回到前一个方法。
+**SYNC** 只使用 regular activity。默认 method attempt timeout 是两小时，默认 heartbeat timeout 是一分钟。
 
-用 **FlowConfig** 设置默认 durability。这个默认值不适用于使用 recovery failure policy 的方法。如需 override 这些方法的 durability，在该 Step 的 **StepOptions** 中设置。
+**ASYNC** 先在 local activity 中执行，最多七秒和三次 attempt。用户设置的更短 retry duration 或更少 attempt 仍然生效。Local 阶段忽略 method timeout 和 heartbeat 设置。Fallback 到 regular activity 后，Dex 使用剩余 retry budget，并采用同样的两小时 method attempt 和一分钟 heartbeat 默认值。
+
+两种 durability mode 的默认 retry total duration 都是四小时。显式设置的 retry duration 可以更短或更长。
 
 <SdkTabs
   examples={{
@@ -162,11 +164,13 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 ## Heartbeat {#heartbeat}
 
-**Heartbeat** 让拥有较长 method timeout 的 Step 更早失败并安排下一次 attempt，或更早被 cancel。
+Dex Server 不会为 Step handler 自动发送 heartbeat。在 regular activity attempt 中，Worker 必须在 **HeartbeatTimeout** 到期前发送 heartbeat 或 [Stream message](/primitives/stream)。Stream message 是 implicit heartbeat，因为它表明 handler 仍在推进。
 
-设置 **HeartbeatTimeout** 即可使用它。
+省略 **HeartbeatTimeout** 或设为零时，使用一分钟默认值。最小显式值由 Dex Server 控制，默认最小值是 10 秒。例如，**Execute** method timeout 为 60 秒、**HeartbeatTimeout** 为 10 秒时，Dex 大约 10 秒后就能 retry 这个 Step，而不必等满 60 秒。
 
-例如，**Execute** method timeout 为 60 秒，**HeartbeatTimeout** 为 10 秒时，Dex 大约 10 秒后就能 retry 这个 Step，而不必等完整的 60 秒。类似地，正在被 cancel 的 Step 不必等到完整 timeout、失败或完成后才被 cancel。
+Heartbeat 可以持久化 checkpoint value。下一次 regular attempt 会收到最新值，并从那里继续。显式发送不带 value 的 heartbeat 会清除之前的 checkpoint。Stream message 产生的 implicit heartbeat 会保留最新的显式状态，包括已经显式清空的状态。
+
+**ASYNC** durability 的 local 阶段忽略 heartbeat output，也不会把 checkpoint 传给 fallback regular activity。Local 阶段仍会发送 Stream message。
 
 <SdkTabs
   examples={{
@@ -182,19 +186,26 @@ fn options(&self) -> StepOptions<Self::Input> {
 func (heartbeatStep) GetStepOptions() *dex.StepOptions {
 	return &dex.StepOptions{
 		ExecuteMethodTimeout: 60 * time.Second,
-		HeartbeatTimeout:       10 * time.Second,
-		ExecuteRetry:           &dex.RetryPolicy{MaximumAttempts: 3},
+		HeartbeatTimeout:     10 * time.Second,
+		ExecuteRetry:         &dex.RetryPolicy{MaximumAttempts: 3},
 	}
 }
 
 func (step heartbeatStep) Execute(ctx dex.Context, batches int) (*dex.StepDecision, error) {
-	for batch := 0; batch < batches; batch++ {
+	completedBatches := 0
+	if _, err := ctx.GetLastHeartbeatValue(&completedBatches); err != nil {
+		return nil, err
+	}
+	for batch := completedBatches; batch < batches; batch++ {
 		select {
 		case <-ctx.Done():
 			return dex.DeadEnd(), nil
 		default:
 		}
 		time.Sleep(2 * time.Second)
+		if err := ctx.RecordHeartbeat(batch + 1); err != nil {
+			return nil, err
+		}
 	}
 	return dex.GracefulComplete("processed"), nil
 }
@@ -206,7 +217,10 @@ func (step heartbeatStep) Execute(ctx dex.Context, batches int) (*dex.StepDecisi
 ```java
 @Override
 public StepDecision execute(final Context context, final Integer batches) {
-    for (int batch = 0; batch < batches; batch++) {
+    final int completedBatches = context.hasLastHeartbeatValue()
+            ? context.getLastHeartbeatValue(Integer.class)
+            : 0;
+    for (int batch = completedBatches; batch < batches; batch++) {
         if (context.isCancellationRequested()) {
             return StepDecision.deadEnd();
         }
@@ -216,6 +230,7 @@ public StepDecision execute(final Context context, final Integer batches) {
             Thread.currentThread().interrupt();
             return StepDecision.deadEnd();
         }
+        context.recordHeartbeat(batch + 1);
     }
     return StepDecision.gracefulComplete("processed");
 }
@@ -241,11 +256,15 @@ def get_step_options(self) -> StepOptions:
         execute_retry=RetryPolicy(maximum_attempts=3),
     )
 
-async def execute(self, context: Context, batches: int) -> StepDecision:
-    for _batch in range(batches):
+async def execute(
+    self, context: AsyncContext, batches: int
+) -> StepDecision:
+    completed_batches = context.get_last_heartbeat_value(int) or 0
+    for batch in range(completed_batches, batches):
         if context.is_cancellation_requested():
             return dead_end()
         await asyncio.sleep(2)
+        await context.heartbeat(batch + 1)
     return graceful_complete("processed")
 ```
 
@@ -263,12 +282,14 @@ public getStepOptions(): StepOptions {
   };
 }
 
-public async execute(context: Context, batches: number): Promise<StepDecision> {
-  for (let batch = 0; batch < batches; batch++) {
+public async execute(context: AsyncContext, batches: number): Promise<StepDecision> {
+  const completedBatches = context.getLastHeartbeatValue(doubleCodec) ?? 0;
+  for (let batch = completedBatches; batch < batches; batch++) {
     if (context.cancellationSignal.aborted) {
       return deadEnd();
     }
     await new Promise((resolve) => setTimeout(resolve, 2_000));
+    await context.recordHeartbeat(batch + 1, doubleCodec);
   }
   return gracefulComplete("processed");
 }
@@ -286,11 +307,13 @@ fn options(&self) -> StepOptions<Self::Input> {
 }
 
 fn execute(&self, context: &mut Context, batches: Self::Input) -> HandlerResult<StepDecision> {
-    for _batch in 0..batches {
+    let completed_batches = context.last_heartbeat_value::<i32>()?.unwrap_or_default();
+    for batch in completed_batches..batches {
         if context.is_cancelled() {
             return Ok(StepDecision::dead_end());
         }
         thread::sleep(Duration::from_secs(2));
+        context.record_heartbeat_value(batch + 1)?;
     }
     Ok(StepDecision::graceful_complete(String::from("processed")))
 }
@@ -299,7 +322,7 @@ fn execute(&self, context: &mut Context, batches: Self::Input) -> HandlerResult<
 </SdkSnippet>
 </SdkTabs>
 
-Heartbeat 能让取消更早到达普通 handler。它不会让外部 API 调用原子化。API 需要时，使用幂等或补偿。
+取消会在 regular handler 下一次发送 heartbeat 或 Stream output 时到达。Heartbeat 不会让外部 API 调用原子化。API 需要时，使用幂等或补偿。
 
 ## Attribute locks
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -82,11 +82,11 @@ Ok(StepDecision::graceful_complete(String::from("ready")))
 
 **ASYNC** durability 会异步完成这件事。每隔几秒，Dex Server 会 flush 累积的 Step completion 并持久化。它减少了 backend database 和 server 的大量开销，因此吞吐量高得多。
 
-**SYNC** 是默认值。Dex 按这个顺序确定 durability：**StepOptions** 中的 method override、Flow 的 **FlowConfig**，最后是 **SYNC**。Failure policy 不会改变这个顺序。
+**SYNC** 是默认值。Dex 按这个顺序确定 durability：**StepOptions** 中的 method override、Flow 的 **FlowConfig**，最后是 **SYNC**。
 
-**SYNC** 只使用 regular activity。默认 method attempt timeout 是两小时，默认 heartbeat timeout 是一分钟。
+**SYNC** 只使用 regular Temporal activity。默认 method attempt timeout 是两小时，默认 heartbeat timeout 是一分钟。
 
-**ASYNC** 先在 local activity 中执行，最多七秒和三次 attempt。用户设置的更短 retry duration 或更少 attempt 仍然生效。Local 阶段忽略 method timeout 和 heartbeat 设置。Fallback 到 regular activity 后，Dex 使用剩余 retry budget，并采用同样的两小时 method attempt 和一分钟 heartbeat 默认值。
+**ASYNC** 先作为 Temporal local activity 执行，最多七秒和三次 attempt；如果仍然失败，再 fallback 到 regular activity。用户设置的更短 retry duration 或更少 attempt 仍然生效。Local activity 阶段忽略 method timeout 和 heartbeat 设置。Fallback 到 regular activity 后，Dex 使用剩余 retry budget，并采用同样的两小时 method attempt 和一分钟 heartbeat 默认值。
 
 两种 durability mode 的默认 retry total duration 都是四小时。显式设置的 retry duration 可以更短或更长。
 
@@ -164,9 +164,11 @@ fn options(&self) -> StepOptions<Self::Input> {
 
 ## Heartbeat {#heartbeat}
 
-Dex Server 不会为 Step handler 自动发送 heartbeat。在 regular activity attempt 中，Worker 必须在 **HeartbeatTimeout** 到期前发送 heartbeat 或 [Stream message](/primitives/stream)。Stream message 是 implicit heartbeat，因为它表明 handler 仍在推进。
+在 regular activity attempt 中，Worker 必须在 **HeartbeatTimeout** 到期前发送 heartbeat 或 [Stream message](/primitives/stream)。换句话说，发送 Stream message 就是 implicit heartbeat。
 
-省略 **HeartbeatTimeout** 或设为零时，使用一分钟默认值。最小显式值由 Dex Server 控制，默认最小值是 10 秒。例如，**Execute** method timeout 为 60 秒、**HeartbeatTimeout** 为 10 秒时，Dex 大约 10 秒后就能 retry 这个 Step，而不必等满 60 秒。
+**HeartbeatTimeout** 默认是一分钟。默认允许的最小值是 10 秒。
+
+例如，**Execute** method timeout 为 60 秒、**HeartbeatTimeout** 为 10 秒时，Dex 大约 10 秒后就能 retry 这个 Step，而不必等满 60 秒。
 
 Heartbeat 可以持久化 checkpoint value。下一次 regular attempt 会收到最新值，并从那里继续。显式发送不带 value 的 heartbeat 会清除之前的 checkpoint。Stream message 产生的 implicit heartbeat 会保留最新的显式状态，包括已经显式清空的状态。
 
@@ -322,7 +324,7 @@ fn execute(&self, context: &mut Context, batches: Self::Input) -> HandlerResult<
 </SdkSnippet>
 </SdkTabs>
 
-取消会在 regular handler 下一次发送 heartbeat 或 Stream output 时到达。Heartbeat 不会让外部 API 调用原子化。API 需要时，使用幂等或补偿。
+Heartbeat 有助于传递 cancellation。Step invocation 只会在完成、失败或记录 heartbeat 时被 cancel。
 
 ## Attribute locks
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/stream.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/stream.mdx
@@ -20,7 +20,7 @@ Stream 只提供 best-effort durability，底层使用 Redis 等内存存储。�
 
 Stream 包含稳定名称、消息类型和 **streamCapacityBytes**。streamCapacityBytes 是相同 Flow type 和 Stream name 下所有 Flow execution 共享的近似容量，不是每个 Flow ID 独立的 limit。
 
-下面的 Step 在返回之前写入一条 progress message。Dex 接受写入后，Client 立刻就能读取；不需要等待 Step 完成。
+下面的 Step 在返回前写入两条 progress message。每次写入都会立即进入 Worker output stream；handler 不会等待 Stream Store acknowledgement。
 
 <SdkTabs examples={{
 python: 'examples/python/dex_examples/primitives/stream/stream_flow.py',
@@ -36,8 +36,9 @@ class RenderPreview(Step[str]):
     def __init__(self, progress: Stream[str]) -> None:
         self.progress = progress
 
-    async def execute(self, context: Context, input: str) -> StepDecision:
-        await self.progress.write(context, f"Rendering preview for {input}")
+    async def execute(self, context: AsyncContext, input: str) -> StepDecision:
+        self.progress.write(context, f"Rendering preview for {input}")
+        self.progress.write(context, f"Preview ready for {input}")
         return graceful_complete(f"Rendered {input}")
 
 
@@ -62,6 +63,9 @@ func (renderPreview) Execute(ctx dex.Context, input string) (*dex.StepDecision, 
 	if err := Progress.Write(ctx, "Rendering preview for "+input); err != nil {
 		return nil, err
 	}
+	if err := Progress.Write(ctx, "Preview ready for "+input); err != nil {
+		return nil, err
+	}
 	return dex.GracefulComplete("Rendered " + input), nil
 }
 ```
@@ -83,6 +87,7 @@ public final class StreamFlow implements Flow<String> {
         @Override
         public StepDecision execute(final Context context, final String input) {
             progress.write(context, "Rendering preview for " + input);
+            progress.write(context, "Preview ready for " + input);
             return StepDecision.gracefulComplete("Rendered " + input);
         }
     }
@@ -97,7 +102,8 @@ export const progress = new Stream("Progress", stringCodec, 10 * 1024 * 1024);
 
 class RenderPreview implements Step<string> {
   public async execute(context: Context, input: string): Promise<StepDecision> {
-    await progress.write(context, `Rendering preview for ${input}`);
+    progress.write(context, `Rendering preview for ${input}`);
+    progress.write(context, `Preview ready for ${input}`);
     return gracefulComplete(`Rendered ${input}`);
   }
 }
@@ -133,6 +139,7 @@ impl Step for RenderPreview {
         input: Self::Input,
     ) -> HandlerResult<StepDecision> {
         PROGRESS.write(context, format!("Rendering preview for {input}"))?;
+        PROGRESS.write(context, format!("Preview ready for {input}"))?;
         Ok(StepDecision::graceful_complete(format!(
             "Rendered {input}"
         )))
@@ -149,17 +156,19 @@ impl Step for RenderPreview {
 
 Step 直接写入 Stream 时：
 
-- Dex 在 **Execute** 期间立即发送，不会缓存到 Step 完成。
+- Dex 在 **WaitFor** 或 **Execute** 期间立即发送，不会缓存到 Step 完成。
 - Step 随后失败不会回滚已经写入的消息。
-- 每个 Step execution 对每个 Stream 最多直接写一次。Dex 使用 run ID 和 Step execution ID 生成 idempotency key，因此 retry 不会重复追加。
+- 一次 method invocation 可以向同一个或不同 Stream 写入任意数量的消息。每次写入都是 implicit heartbeat，并保留最近一次 explicit heartbeat value。
+- SDK 只确认本地编码并把消息交给 Worker output stream。Stream Store 被禁用、不可用、已满或拒绝写入时，消息会被丢弃，但 Step 不会失败。
+- 每条 Step message 的 source 都是 **#StepExecutionID**。同一个 Step execution 的不同 attempt 与 message 共用 source。Source 只表示来源，不要求唯一，也不会 deduplicate retry。
 
-即使 Flow instance 不存在或已经结束，Client 仍可以写入。每条逻辑消息都要提供非空 idempotency key。RPC handler 不能通过 Step Context 写入，但可以通过注入的 Client dependency 发送 Stream 消息。
+即使 Flow instance 不存在或已经结束，Client 仍可以写入。每次写入都要提供非空 source。Source 可以重复，也可以包含 **#**；每次调用都会追加一条消息。RPC handler 不能通过自己的 Context 写入，但可以通过注入的 Client dependency 发送 Stream message。
 
-只要 idempotency key 仍被保留，重复使用相同 key 就会成为成功的 first-write-wins no-op。消息及其幂等记录被 trim 后，同一个 key 可以再次写入。
+Python coroutine Step 调用 **Stream.write** 时不使用 **await**。Python synchronous Step 必须从 generator yield 返回的 **StepOutput**。其他 SDK 通过 Step Context 发送 frame，并在本地 enqueue 后返回。
 
 ### 可续读
 
-**ReadStream** 每次返回一条消息，包括 value、resume token、created time 与 producer idempotency key。
+**ReadStream** 每次返回一条消息，包括 value、resume token、created time 与 source。
 
 - 空 token 从当前保留的头部开始。
 - token 比当前头部更旧时，也从当前头部开始。
@@ -172,7 +181,7 @@ Step 直接写入 Stream 时：
 
 **streamCapacityBytes** 是相同 Flow type 和 Stream name 下所有 Flow execution 共享的近似容量，不是每个 Flow ID 独立的 limit。
 
-Dex server 根据每条消息的 serialized value、identity bytes 和可配置的 per-message overhead 计算估算大小。
+Dex server 根据每条消息的 serialized value、Flow ID、source 和可配置的 per-message overhead 计算估算大小。
 
 当 usage 达到 trim trigger threshold 时，全局只有一个 background trimmer 会删除所有 instance 中最旧的消息，直到 usage 降至 trim target threshold。极少数情况下，如果 trimming 太慢，usage 达到 capacity limit（**streamCapacityBytes**），write request 会被拒绝。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/use-cases/ai-agent-email.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/use-cases/ai-agent-email.mdx
@@ -20,7 +20,9 @@ sidebar_label: AI agent email
 
 ## 从 Agent Step streaming
 
-Step 直接写 Stream 时，每个 Stream 和 Step execution 只能写一条消息。一次 LLM call 会在同一个 Step execution 中生成许多 chunk，因此本 example 注入 AsyncClient，并用稳定的 sequence key 写入每个 chunk。Retry 会复用相同的 run ID、Step execution ID 与 sequence number，使仍被保留的 chunk 保持 first-write-wins。
+Agent Step 会把每个 LLM progress chunk 直接写入 Stream。在 async handler 中，**Stream.write** 会把每条消息放入本地队列，然后直接返回，不会等待 Stream Store acknowledgement。Stream Store 写入失败不会让 Step 失败。
+
+Step message 使用 **#StepExecutionID** 作为 source。Source 只说明消息来自哪里，不是 idempotency key。每次写入都会 append，因此 retry 可能产生重复 progress chunk。这对展示用 feed 没有影响，最终 draft 仍保存在 durable Attribute 中。
 
 OpenAI call 请求的是可以展示给用户的 reasoning summary，而不是 private chain-of-thought。没有配置 OpenAI 时，local fallback 也会通过同一条 Stream path 发送 progress message。
 
@@ -28,25 +30,10 @@ OpenAI call 请求的是可以展示给用户的 reasoning summary，而不是 p
 <SdkSnippet lang="python">
 
 ```python
-        progress_index = 0
-
         async def write_progress(chunk: str) -> None:
-            nonlocal progress_index
             if not chunk:
                 return
-            idempotency_key = (
-                f"{context.run_id}/{context.step_execution_id}/{progress_index}"
-            )
-            progress_index += 1
-            try:
-                await self.client_provider().write_stream(
-                    context.flow_id,
-                    self.flow.thinking,
-                    idempotency_key,
-                    chunk,
-                )
-            except DexServiceError as error:
-                print(f"thinking update dropped: {error}")
+            self.flow.thinking.write(context, chunk)
 
         reply = await request_email_fields(
             user_request,

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -1,6 +1,6 @@
 # Dex Go examples
 
-These examples target `github.com/superdurable/dex/sdk-go v0.2.4`.
+These examples target `github.com/superdurable/dex/sdk-go v0.2.6`.
 
 `dex.None` marks a nil-only Step, RPC, or Channel payload. Calls pass `nil`.
 

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/stretchr/testify v1.11.1
 	github.com/superdurable/dex/blob-cache-go v0.1.0
-	github.com/superdurable/dex/sdk-go v0.2.5
+	github.com/superdurable/dex/sdk-go v0.2.6
 )
 
 require (

--- a/examples/go/go.sum
+++ b/examples/go/go.sum
@@ -90,12 +90,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/superdurable/dex/blob-cache-go v0.1.0 h1:+c3H5YBWG3DlICOHbgT9IUM5vTlfLYGP5Vd5sWr7WTY=
 github.com/superdurable/dex/blob-cache-go v0.1.0/go.mod h1:Atepb7+sztvDCztVKmlvEKCSKFCkHKtDhoFYjaFmtEw=
-github.com/superdurable/dex/sdk-go v0.2.3 h1:ZgtvPOyFok1zdtiAkNWuta8PT6NAxqJ902xWgRxg1IM=
-github.com/superdurable/dex/sdk-go v0.2.3/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
-github.com/superdurable/dex/sdk-go v0.2.4 h1:M5GWxCRAK4hNAxL6svGjzSSZH2VXYpv0/xkL75A//QA=
-github.com/superdurable/dex/sdk-go v0.2.4/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
-github.com/superdurable/dex/sdk-go v0.2.5 h1:d6SFTgm9Jt/w2Lkj7zKwMki/N0RV7ih8KeqRQXErrKs=
-github.com/superdurable/dex/sdk-go v0.2.5/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
+github.com/superdurable/dex/sdk-go v0.2.6 h1:aDjZbLXj2QzAaImt3C1rGjF7WJAPxGMtui3AiI150fk=
+github.com/superdurable/dex/sdk-go v0.2.6/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=

--- a/examples/go/integ/engagement_test.go
+++ b/examples/go/integ/engagement_test.go
@@ -21,6 +21,7 @@
 package integ
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -70,6 +71,17 @@ func TestEngagementStartChannelRPCAndSearch(t *testing.T) {
 		engagement.OptOutReminder,
 		nil,
 	))
+	require.Eventually(t, func() bool {
+		err = integClient.InvokeRPC(
+			ctx,
+			flowID,
+			registry.Engagement.Describe,
+			nil,
+			&description,
+			dex.InvokeOptions{},
+		)
+		return err == nil && strings.Contains(description.Notes, "user opted out of reminders")
+	}, 20*time.Second, 200*time.Millisecond, "reminder opt-out failed: %v", err)
 
 	var status engagement.Status
 	require.NoError(t, integClient.InvokeRPC(
@@ -81,6 +93,12 @@ func TestEngagementStartChannelRPCAndSearch(t *testing.T) {
 		dex.InvokeOptions{},
 	))
 	require.Equal(t, engagement.StatusDeclined, status)
+	require.NoError(t, integClient.WaitForAttributeEqual(
+		ctx,
+		flowID,
+		engagement.EngagementStatus,
+		engagement.StatusDeclined,
+	))
 	require.NoError(t, integClient.InvokeRPC(
 		ctx,
 		flowID,

--- a/examples/go/integ/stream_test.go
+++ b/examples/go/integ/stream_test.go
@@ -21,6 +21,7 @@
 package integ
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -52,6 +53,19 @@ func TestStreamResumesAfterStepAndClientWrites(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Rendering preview for invoice", stepValue)
 	require.NotEmpty(t, stepMessage.ResumeToken)
+	require.True(t, strings.HasPrefix(stepMessage.Source, "#"))
+
+	var secondStepValue string
+	secondStepMessage, err := integClient.ReadStream(
+		ctx,
+		flowID,
+		streamprimitive.Progress,
+		stepMessage.ResumeToken,
+		&secondStepValue,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "Preview ready for invoice", secondStepValue)
+	require.Equal(t, stepMessage.Source, secondStepMessage.Source)
 
 	err = integClient.WriteStream(
 		ctx,
@@ -67,10 +81,10 @@ func TestStreamResumesAfterStepAndClientWrites(t *testing.T) {
 		ctx,
 		flowID,
 		streamprimitive.Progress,
-		stepMessage.ResumeToken,
+		secondStepMessage.ResumeToken,
 		&clientValue,
 	)
 	require.NoError(t, err)
 	require.Equal(t, "Preview displayed", clientValue)
-	require.Equal(t, "browser/complete", clientMessage.IdempotencyKey)
+	require.Equal(t, "browser/complete", clientMessage.Source)
 }

--- a/examples/go/primitives/heartbeat/workflow.go
+++ b/examples/go/primitives/heartbeat/workflow.go
@@ -50,19 +50,26 @@ type heartbeatStep struct {
 func (heartbeatStep) GetStepOptions() *dex.StepOptions {
 	return &dex.StepOptions{
 		ExecuteMethodTimeout: 60 * time.Second,
-		HeartbeatTimeout:       10 * time.Second,
-		ExecuteRetry:           &dex.RetryPolicy{MaximumAttempts: 3},
+		HeartbeatTimeout:     10 * time.Second,
+		ExecuteRetry:         &dex.RetryPolicy{MaximumAttempts: 3},
 	}
 }
 
 func (step heartbeatStep) Execute(ctx dex.Context, batches int) (*dex.StepDecision, error) {
-	for batch := 0; batch < batches; batch++ {
+	completedBatches := 0
+	if _, err := ctx.GetLastHeartbeatValue(&completedBatches); err != nil {
+		return nil, err
+	}
+	for batch := completedBatches; batch < batches; batch++ {
 		select {
 		case <-ctx.Done():
 			return dex.DeadEnd(), nil
 		default:
 		}
 		time.Sleep(2 * time.Second)
+		if err := ctx.RecordHeartbeat(batch + 1); err != nil {
+			return nil, err
+		}
 	}
 	return dex.GracefulComplete("processed"), nil
 }

--- a/examples/go/primitives/stream/controller.go
+++ b/examples/go/primitives/stream/controller.go
@@ -66,7 +66,7 @@ func (controller *controller) write(request *gin.Context) {
 	if !found {
 		return
 	}
-	idempotencyKey, found := httputil.RequiredQuery(request, "idempotencyKey")
+	source, found := httputil.RequiredQuery(request, "source")
 	if !found {
 		return
 	}
@@ -78,7 +78,7 @@ func (controller *controller) write(request *gin.Context) {
 		request.Request.Context(),
 		flowID,
 		Progress,
-		idempotencyKey,
+		source,
 		message,
 	)
 	httputil.RespondString(request, "done", err)
@@ -102,10 +102,10 @@ func (controller *controller) read(request *gin.Context) {
 		return
 	}
 	request.JSON(http.StatusOK, gin.H{
-		"value":          value,
-		"resumeToken":    message.ResumeToken,
-		"createdTime":    message.CreatedTime.Format(time.RFC3339Nano),
-		"idempotencyKey": message.IdempotencyKey,
+		"value":       value,
+		"resumeToken": message.ResumeToken,
+		"createdTime": message.CreatedTime.Format(time.RFC3339Nano),
+		"source":      message.Source,
 	})
 }
 

--- a/examples/go/primitives/stream/workflow.go
+++ b/examples/go/primitives/stream/workflow.go
@@ -48,6 +48,9 @@ func (renderPreview) Execute(ctx dex.Context, input string) (*dex.StepDecision, 
 	if err := Progress.Write(ctx, "Rendering preview for "+input); err != nil {
 		return nil, err
 	}
+	if err := Progress.Write(ctx, "Preview ready for "+input); err != nil {
+		return nil, err
+	}
 	return dex.GracefulComplete("Rendered " + input), nil
 }
 

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -1,6 +1,6 @@
 # Dex Java examples
 
-These examples target `io.superdurable:dex-sdk:0.2.4` (`io.superdurable.dex`).
+These examples target `io.superdurable:dex-sdk:0.2.6` (`io.superdurable.dex`).
 
 The sample process hosts one gRPC Worker on `127.0.0.1:8803` and an HTTP
 controller on port `8080`. One Registry and disk BlobCache are shared by its

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "io.superdurable:dex-sdk:0.2.5"
+    implementation "io.superdurable:dex-sdk:0.2.6"
 
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"

--- a/examples/java/run-integration-tests.sh
+++ b/examples/java/run-integration-tests.sh
@@ -115,7 +115,7 @@ fi
 cd "$script_dir"
 export DEXCLI_PATH="$binary_dir/dexcli"
 DEX_FLOW_SERVICE_ADDRESS="$dex_address" \
-  ./gradlew test --tests 'io.superdurable.dex.integ.*' --tests 'io.superdurable.dex.integ.smoke.*' --info --no-daemon "${test_args[@]}"
+  ./gradlew test --tests 'io.superdurable.dex.integ.*' --tests 'io.superdurable.dex.integ.smoke.*' --info --no-daemon ${test_args[@]+"${test_args[@]}"}
 
 if $keep_running; then
   echo ""

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/stepheartbeat/StepHeartbeatFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/stepheartbeat/StepHeartbeatFlow.java
@@ -50,7 +50,10 @@ public final class StepHeartbeatFlow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer batches) {
-            for (int batch = 0; batch < batches; batch++) {
+            final int completedBatches = context.hasLastHeartbeatValue()
+                    ? context.getLastHeartbeatValue(Integer.class)
+                    : 0;
+            for (int batch = completedBatches; batch < batches; batch++) {
                 if (context.isCancellationRequested()) {
                     return StepDecision.deadEnd();
                 }
@@ -60,6 +63,7 @@ public final class StepHeartbeatFlow implements Flow<Integer> {
                     Thread.currentThread().interrupt();
                     return StepDecision.deadEnd();
                 }
+                context.recordHeartbeat(batch + 1);
             }
             return StepDecision.gracefulComplete("processed");
         }

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/stream/StreamController.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/stream/StreamController.java
@@ -55,9 +55,9 @@ public final class StreamController {
     @GetMapping("/write")
     public ResponseEntity<String> write(
             @RequestParam final String workflowId,
-            @RequestParam final String idempotencyKey,
+            @RequestParam final String source,
             @RequestParam final String message) {
-        client.writeStream(workflowId, flow.progress, idempotencyKey, message);
+        client.writeStream(workflowId, flow.progress, source, message);
         return ResponseEntity.ok("done");
     }
 
@@ -74,7 +74,7 @@ public final class StreamController {
         response.put("value", message.getValue());
         response.put("resumeToken", message.getResumeToken());
         response.put("createdTime", message.getCreatedTime().toString());
-        response.put("idempotencyKey", message.getIdempotencyKey());
+        response.put("source", message.getSource());
         return ResponseEntity.ok(response);
     }
 }

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/stream/StreamFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/stream/StreamFlow.java
@@ -50,6 +50,7 @@ public final class StreamFlow implements Flow<String> {
         @Override
         public StepDecision execute(final Context context, final String input) {
             progress.write(context, "Rendering preview for " + input);
+            progress.write(context, "Preview ready for " + input);
             return StepDecision.gracefulComplete("Rendered " + input);
         }
     }

--- a/examples/java/src/test/java/io/superdurable/dex/integ/EngagementIntegTest.java
+++ b/examples/java/src/test/java/io/superdurable/dex/integ/EngagementIntegTest.java
@@ -60,11 +60,21 @@ public class EngagementIntegTest {
         assertEquals(Status.INITIATED, description.currentStatus);
 
         environment.client().publish(flowId, flow.optOutReminder, (Void) null);
+        environment.awaitCondition(
+                () -> environment.client().invokeRPC(stub::describe),
+                current -> current.notes.contains("user opted out of reminders"),
+                Duration.ofSeconds(20),
+                "engagement reminder did not stop");
 
         final Status declined = environment.client().invokeRPC(
                 stub::decline,
                 "declined in integration test");
         assertEquals(Status.DECLINED, declined);
+        environment.awaitAttribute(
+                flowId,
+                flow.engagementStatus,
+                Status.DECLINED,
+                Duration.ofSeconds(20));
 
         final Status accepted = environment.client().invokeRPC(
                 stub::accept,

--- a/examples/java/src/test/java/io/superdurable/dex/integ/StreamIntegTest.java
+++ b/examples/java/src/test/java/io/superdurable/dex/integ/StreamIntegTest.java
@@ -44,6 +44,15 @@ public class StreamIntegTest {
                 Duration.ofSeconds(20));
         assertEquals("Rendering preview for invoice", stepMessage.getValue());
         assertFalse(stepMessage.getResumeToken().isEmpty());
+        assertEquals('#', stepMessage.getSource().charAt(0));
+
+        final StreamMessage<String> secondStepMessage = environment.client().readStream(
+                flowId,
+                environment.streamFlow().progress,
+                stepMessage.getResumeToken(),
+                Duration.ofSeconds(20));
+        assertEquals("Preview ready for invoice", secondStepMessage.getValue());
+        assertEquals(stepMessage.getSource(), secondStepMessage.getSource());
 
         environment.client().writeStream(
                 flowId,
@@ -53,9 +62,9 @@ public class StreamIntegTest {
         final StreamMessage<String> clientMessage = environment.client().readStream(
                 flowId,
                 environment.streamFlow().progress,
-                stepMessage.getResumeToken(),
+                secondStepMessage.getResumeToken(),
                 Duration.ofSeconds(20));
         assertEquals("Preview displayed", clientMessage.getValue());
-        assertEquals("browser/complete", clientMessage.getIdempotencyKey());
+        assertEquals("browser/complete", clientMessage.getSource());
     }
 }

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,6 +1,6 @@
 # Dex Python examples
 
-These examples target [`dex-python-sdk==0.2.3`](https://pypi.org/project/dex-python-sdk/0.2.3/)
+These examples target [`dex-python-sdk==0.2.6`](https://pypi.org/project/dex-python-sdk/0.2.6/)
 (`import dex`). Requires Python 3.11+.
 
 The primary sample process hosts one asyncio `AsyncWorker` on `127.0.0.1:8803` and a

--- a/examples/python/dex_examples/app.py
+++ b/examples/python/dex_examples/app.py
@@ -182,7 +182,7 @@ class ExampleApp:
 
         self.controller = ControllerFlow(client_provider, lambda: self.processing)
         self.processing = ProcessingFlow(client_provider, lambda: self.controller)
-        self.email_agent = EmailAgentFlow(client_provider)
+        self.email_agent = EmailAgentFlow()
 
         flows: list[Flow[Any]] = [
             self.money_transfer,

--- a/examples/python/dex_examples/patterns/drain-channels/external_publishing/draining_channel_flow.py
+++ b/examples/python/dex_examples/patterns/drain-channels/external_publishing/draining_channel_flow.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 
 from dex import (
+    AsyncContext,
     Channel,
     Context,
     Flow,
@@ -44,7 +45,7 @@ class ProcessMessage(Step[str]):
         return Wait.skip_immediately()
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: str
+        self, context: AsyncContext, input: str
     ) -> StepDecision:
         if input is not None:
             print(f"DrainingExternalChannelFlow process message: {input}")

--- a/examples/python/dex_examples/patterns/parallel-subflows/flows.py
+++ b/examples/python/dex_examples/patterns/parallel-subflows/flows.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from typing import Callable
 
 from dex import (
+    AsyncContext,
     AsyncClient,
     Attribute,
     Channel,
@@ -61,7 +62,7 @@ class SubmitRequestInput:
 
 
 class DoWorkStep(Step[str]):
-    async def execute(self, context: Context, request: str) -> StepDecision:
+    async def execute(self, context: AsyncContext, request: str) -> StepDecision:
         await asyncio.sleep((50 + len(request) % 10 * 50) / 1000)
         return graceful_complete(request)
 
@@ -124,7 +125,7 @@ class SubFlowStep(Step[str]):
         )
 
     async def execute(  # type: ignore[override]
-        self, context: Context, request: str
+        self, context: AsyncContext, request: str
     ) -> StepDecision:
         result = SubFlow.get_condition_results(context)
         if result.status is not FlowStatus.RUNNING:
@@ -379,7 +380,7 @@ class SubmitStep(Step[SubmitRequestInput]):
         self.parent_flow = parent_flow
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: SubmitRequestInput
+        self, context: AsyncContext, input: SubmitRequestInput
     ) -> StepDecision:
         if not input.parent_ids:
             raise ValueError("at least one parent Flow ID is required")

--- a/examples/python/dex_examples/patterns/parallel/await_parallel_steps_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/await_parallel_steps_flow.py
@@ -17,6 +17,7 @@ import random
 from typing import Any
 
 from dex import (
+    AsyncContext,
     Channel,
     Context,
     Flow,
@@ -37,7 +38,7 @@ class DoWorkStep(Step[int]):
         self.complete_ch = complete_ch
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: int
+        self, context: AsyncContext, input: int
     ) -> StepDecision:
         await asyncio.sleep(random.uniform(0.05, 0.5))
         self.complete_ch.publish(context, None)

--- a/examples/python/dex_examples/patterns/parallel/dynamic_parallel_steps_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/dynamic_parallel_steps_flow.py
@@ -16,6 +16,7 @@ import asyncio
 import random
 
 from dex import (
+    AsyncContext,
     Context,
     Flow,
     PersistenceSchema,
@@ -30,7 +31,7 @@ from dex import (
 
 class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
-        self, context: Context, input: int
+        self, context: AsyncContext, input: int
     ) -> StepDecision:
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input)

--- a/examples/python/dex_examples/patterns/parallel/first_win_parallel_steps_flow.py
+++ b/examples/python/dex_examples/patterns/parallel/first_win_parallel_steps_flow.py
@@ -16,6 +16,7 @@ import asyncio
 import random
 
 from dex import (
+    AsyncContext,
     Context,
     Flow,
     PersistenceSchema,
@@ -30,7 +31,7 @@ from dex import (
 
 class DoWorkStep(Step[int]):
     async def execute(  # type: ignore[override]
-        self, context: Context, input: int
+        self, context: AsyncContext, input: int
     ) -> StepDecision:
         await asyncio.sleep(random.uniform(0.05, 0.5))
         return graceful_complete(input).with_canceling_sibling_steps(DoWorkStep)

--- a/examples/python/dex_examples/patterns/resource-control/controller_flow.py
+++ b/examples/python/dex_examples/patterns/resource-control/controller_flow.py
@@ -24,6 +24,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Callable
 
 from dex import (
+    AsyncContext,
     AsyncClient,
     Attribute,
     Channel,
@@ -95,7 +96,7 @@ class LoopForNextRequest(Step[None]):
         return Wait.any_of(*conditions)
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: None
+        self, context: AsyncContext, input: None
     ) -> StepDecision:
         waiting = list(self.current_wait_child_wfs.get(context) or [])
 
@@ -121,7 +122,9 @@ class LoopForNextRequest(Step[None]):
             )
         return go_to(LoopForNextRequest, None)
 
-    async def start_child_flow(self, context: Context, request: Request) -> str | None:
+    async def start_child_flow(
+        self, context: AsyncContext, request: Request
+    ) -> str | None:
         """Returns the child Flow ID to wait for, or None when another run owns it."""
         processing_flow = self.processing_flow_provider()
         child_flow_id = f"processing-{request.id}"

--- a/examples/python/dex_examples/patterns/resource-control/processing_flow.py
+++ b/examples/python/dex_examples/patterns/resource-control/processing_flow.py
@@ -20,6 +20,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Callable
 
 from dex import (
+    AsyncContext,
     AsyncClient,
     Attribute,
     Context,
@@ -62,7 +63,7 @@ class Complete(Step[None]):
         self.parent_flow_id = parent_flow_id
 
     async def execute(  # type: ignore[override]
-        self, context: Context, input: None
+        self, context: AsyncContext, input: None
     ) -> StepDecision:
         parent_flow_id = self.parent_flow_id.get(context)
         if parent_flow_id:

--- a/examples/python/dex_examples/primitives/flow/__init__.py
+++ b/examples/python/dex_examples/primitives/flow/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/python/dex_examples/primitives/heartbeat/heartbeat_flow.py
+++ b/examples/python/dex_examples/primitives/heartbeat/heartbeat_flow.py
@@ -18,7 +18,7 @@ import asyncio
 from datetime import timedelta
 
 from dex import (
-    Context,
+    AsyncContext,
     Flow,
     RetryPolicy,
     Step,
@@ -38,11 +38,15 @@ class HeartbeatStep(Step[int]):
             execute_retry=RetryPolicy(maximum_attempts=3),
         )
 
-    async def execute(self, context: Context, batches: int) -> StepDecision:  # type: ignore[override]
-        for _batch in range(batches):
+    async def execute(
+        self, context: AsyncContext, batches: int
+    ) -> StepDecision:
+        completed_batches = context.get_last_heartbeat_value(int) or 0
+        for batch in range(completed_batches, batches):
             if context.is_cancellation_requested():
                 return dead_end()
             await asyncio.sleep(2)
+            await context.heartbeat(batch + 1)
         return graceful_complete("processed")
 
 

--- a/examples/python/dex_examples/primitives/stream/controller.py
+++ b/examples/python/dex_examples/primitives/stream/controller.py
@@ -42,7 +42,7 @@ def create_stream_blueprint(app_state: ExampleApp) -> Blueprint:
         await app_state.client.write_stream(
             required_query("workflowId"),
             app_state.stream.progress,
-            required_query("idempotencyKey"),
+            required_query("source"),
             required_query("message"),
         )
         return "done"
@@ -59,7 +59,7 @@ def create_stream_blueprint(app_state: ExampleApp) -> Blueprint:
             value=message.value,
             resume_token=message.resume_token,
             created_time=message.created_time.isoformat(),
-            idempotency_key=message.idempotency_key,
+            source=message.source,
         )
 
     return blueprint

--- a/examples/python/dex_examples/primitives/stream/stream_flow.py
+++ b/examples/python/dex_examples/primitives/stream/stream_flow.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from dex import Context, Flow, PersistenceSchema, Step, StepDecision, StepList, Stream
+from dex import AsyncContext, Flow, PersistenceSchema, Step, StepDecision, StepList, Stream
 from dex import graceful_complete
 
 
@@ -24,8 +24,9 @@ class RenderPreview(Step[str]):
     def __init__(self, progress: Stream[str]) -> None:
         self.progress = progress
 
-    async def execute(self, context: Context, input: str) -> StepDecision:
-        await self.progress.write(context, f"Rendering preview for {input}")
+    async def execute(self, context: AsyncContext, input: str) -> StepDecision:
+        self.progress.write(context, f"Rendering preview for {input}")
+        self.progress.write(context, f"Preview ready for {input}")
         return graceful_complete(f"Rendered {input}")
 
 

--- a/examples/python/dex_examples/products/ai-agent-email/ai_agent_flow.py
+++ b/examples/python/dex_examples/products/ai-agent-email/ai_agent_flow.py
@@ -19,16 +19,14 @@ from __future__ import annotations
 import os
 import smtplib
 import time
-from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 
 from dex import (
+    AsyncContext,
     Attribute,
-    AsyncClient,
     Channel,
     Context,
-    DexServiceError,
     Flow,
     PersistenceSchema,
     RetryPolicy,
@@ -61,8 +59,8 @@ STATUS_SKIPPED = "skipped"
 STATUS_CANCELED = "canceled"
 
 AGENT_OPTIONS = StepOptions(execute_method_timeout=timedelta(seconds=90))
-# Sending retries forever by default; stop after a minute so a bad app password
-# surfaces instead of looping.
+# The default retry budget is four hours; stop after a minute so a bad app
+# password surfaces sooner.
 SENDING_OPTIONS = StepOptions(
     execute_retry=RetryPolicy(total_duration=timedelta(seconds=60))
 )
@@ -149,11 +147,9 @@ class Agent(Step[None]):
         self,
         flow: EmailAgentFlow,
         schedule: Schedule,
-        client_provider: Callable[[], AsyncClient],
     ) -> None:
         self.flow = flow
         self.schedule = schedule
-        self.client_provider = client_provider
 
     def get_step_options(self) -> StepOptions:
         return AGENT_OPTIONS
@@ -164,7 +160,7 @@ class Agent(Step[None]):
 
     async def execute(  # type: ignore[override]
         self,
-        context: Context,
+        context: AsyncContext,
         input: None,
     ) -> StepDecision:
         requests = user_input.results(context)
@@ -173,25 +169,10 @@ class Agent(Step[None]):
         user_request = requests[0]
         self.flow.current_request.set(context, user_request)
 
-        progress_index = 0
-
         async def write_progress(chunk: str) -> None:
-            nonlocal progress_index
             if not chunk:
                 return
-            idempotency_key = (
-                f"{context.run_id}/{context.step_execution_id}/{progress_index}"
-            )
-            progress_index += 1
-            try:
-                await self.client_provider().write_stream(
-                    context.flow_id,
-                    self.flow.thinking,
-                    idempotency_key,
-                    chunk,
-                )
-            except DexServiceError as error:
-                print(f"thinking update dropped: {error}")
+            self.flow.thinking.write(context, chunk)
 
         reply = await request_email_fields(
             user_request,
@@ -260,10 +241,10 @@ class EmailAgentFlow(Flow[None]):
     scheduled_time_seconds = Attribute(DA_SCHEDULED_TIME_SECONDS, int)
     thinking = Stream("Thinking", str, 10 * 1024 * 1024)
 
-    def __init__(self, client_provider: Callable[[], AsyncClient]) -> None:
+    def __init__(self) -> None:
         self.sending = Sending(self)
         self.schedule = Schedule(self, self.sending)
-        self.agent = Agent(self, self.schedule, client_provider)
+        self.agent = Agent(self, self.schedule)
         self.init = Init(self)
 
     def get_steps(self) -> StepList[None]:

--- a/examples/python/dex_examples/products/ai-agent-email/http_routes.py
+++ b/examples/python/dex_examples/products/ai-agent-email/http_routes.py
@@ -78,7 +78,7 @@ def create_ai_agent_blueprint(app_state: ExampleApp) -> Blueprint:
             value=message.value,
             resume_token=message.resume_token,
             created_time=message.created_time.isoformat(),
-            idempotency_key=message.idempotency_key,
+            source=message.source,
         )
 
     @blueprint.get("/save_draft")

--- a/examples/python/pyproject.toml
+++ b/examples/python/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "dex-python-sdk==0.2.5",
+    "dex-python-sdk==0.2.6",
     "flask>=3.0,<4",
     "openai>=1.66.2,<2",
     "openai-agents>=0.0.4,<0.0.5",

--- a/examples/python/sync-python/README.md
+++ b/examples/python/sync-python/README.md
@@ -3,7 +3,7 @@
 Showcase of the **sync** Dex Python SDK surface (`Client` / `Worker`) next to
 the primary async examples under `examples/python/`.
 
-Targets [`dex-python-sdk==0.2.3`](https://pypi.org/project/dex-python-sdk/0.2.3/).
+Targets [`dex-python-sdk==0.2.6`](https://pypi.org/project/dex-python-sdk/0.2.6/).
 Requires Python 3.11+.
 
 The samples use concrete SDK errors for missing, inactive, and duplicate Flows

--- a/examples/python/sync-python/sync_tests/integ/test_sync_examples.py
+++ b/examples/python/sync-python/sync_tests/integ/test_sync_examples.py
@@ -23,6 +23,7 @@ from dex_examples.products.engagement.status import Status
 from dex_examples.products.money_transfer.transfer_request import TransferRequest
 from dex_examples.products.subscription.customer import Customer
 from dex_examples.products.subscription.subscription import Subscription
+from dex_examples.products.subscription.subscription_flow import SubscriptionFlow
 from sync_examples.app import SyncExampleApp
 from sync_examples.config import DEFAULT_TIMEOUT, start_options
 from sync_examples.wait import (
@@ -102,10 +103,12 @@ def test_subscription_describe_and_cancel(
         ),
     )
     client.start_flow(app.subscription, flow_id, customer, start_options())
-    subscription = wait_until(
-        "Initialize to store the customer",
-        lambda: client.invoke_rpc(app.subscription.describe, flow_id),
+    wait_for_attribute(
+        client,
+        flow_id,
+        SubscriptionFlow.customer_details,
     )
+    subscription = client.invoke_rpc(app.subscription.describe, flow_id)
     assert subscription.billing_period_charge == 100
     client.publish(flow_id, app.subscription.cancel_subscription, None)
     assert (

--- a/examples/python/tests/integ/test_engagement.py
+++ b/examples/python/tests/integ/test_engagement.py
@@ -22,7 +22,7 @@ from dex_examples.config import start_options
 from dex_examples.products.engagement.engagement_flow import EngagementFlow
 from dex_examples.products.engagement.engagement_input import EngagementInput
 from dex_examples.products.engagement.status import Status
-from tests.integ.conftest import WAIT_TIMEOUT, wait_for_attribute
+from tests.integ.conftest import WAIT_TIMEOUT, wait_for_attribute, wait_until
 
 from dex import AsyncClient
 
@@ -73,6 +73,14 @@ async def test_engagement_decline_then_accept(
     assert await client.invoke_rpc(app.engagement.decline, flow_id, "not now") is (
         Status.DECLINED
     )
+
+    async def engagement_is_declined() -> bool:
+        return (
+            await client.get_attribute(flow_id, EngagementFlow.engagement_status)
+            is Status.DECLINED
+        )
+
+    await wait_until("the engagement to become declined", engagement_is_declined)
     assert await client.invoke_rpc(
         app.engagement.accept, flow_id, "changed my mind"
     ) is (Status.ACCEPTED)
@@ -101,6 +109,11 @@ async def test_engagement_opt_out_of_reminders(
     await client.publish(flow_id, app.engagement.opt_out_reminder, None)
 
     # Opting out ends the reminder loop but leaves the engagement open.
+    async def reminder_is_stopped() -> bool:
+        description = await client.invoke_rpc(app.engagement.describe, flow_id)
+        return "user opted out of reminders" in description.notes
+
+    await wait_until("the reminder loop to stop", reminder_is_stopped)
     await client.invoke_rpc(app.engagement.accept, flow_id, "")
     assert (await client.wait_for_flow(flow_id, WAIT_TIMEOUT)).single_output(
         str

--- a/examples/python/tests/integ/test_patterns.py
+++ b/examples/python/tests/integ/test_patterns.py
@@ -25,7 +25,10 @@ from dex_examples.patterns.entity_store.user_profile import (
     UserProfileMetadata,
 )
 from dex_examples.patterns.entity_store.user_profile_flow import STORE_NAME
-from dex_examples.patterns.parallel_subflows.flows import ParentInput
+from dex_examples.patterns.parallel_subflows.flows import (
+    AdvancedLongLiveParentFlow,
+    ParentInput,
+)
 from dex_examples.patterns.recovery.failure_recovery_workflow_input import (
     FailureRecoveryWorkflowInput,
 )
@@ -40,6 +43,7 @@ from dex_examples.patterns.wait_for_step_completion.job_seeker_data import (
 from tests.integ.conftest import (
     LONG_WAIT_TIMEOUT,
     WAIT_TIMEOUT,
+    attribute_or_none,
     flow_status_or_none,
     wait_until,
 )
@@ -235,6 +239,17 @@ async def test_long_lived_parallel_subflows_stop(
         ParentInput(["one", "two"], 2),
         start_options(),
     )
+
+    async def initialized() -> bool:
+        return (
+            await attribute_or_none(
+                client,
+                flow_id,
+                AdvancedLongLiveParentFlow.stopped,
+            )
+        ) is not None
+
+    await wait_until("the long-lived parent to initialize", initialized)
     await client.invoke_rpc(app.long_live_subflows.stop, flow_id, None)
     result = await client.wait_for_flow(flow_id, LONG_WAIT_TIMEOUT)
     assert result.status == FlowStatus.COMPLETED

--- a/examples/python/tests/integ/test_python_only.py
+++ b/examples/python/tests/integ/test_python_only.py
@@ -56,6 +56,16 @@ async def test_stream_resumes_after_step_and_client_writes(
         timeout=WAIT_TIMEOUT,
     )
     assert step_message.value == "Rendering preview for invoice"
+    assert step_message.source.startswith("#")
+
+    second_step_message = await client.read_stream(
+        flow_id,
+        app.stream.progress,
+        step_message.resume_token,
+        WAIT_TIMEOUT,
+    )
+    assert second_step_message.value == "Preview ready for invoice"
+    assert second_step_message.source == step_message.source
 
     await client.write_stream(
         flow_id,
@@ -66,11 +76,11 @@ async def test_stream_resumes_after_step_and_client_writes(
     client_message = await client.read_stream(
         flow_id,
         app.stream.progress,
-        step_message.resume_token,
+        second_step_message.resume_token,
         WAIT_TIMEOUT,
     )
     assert client_message.value == "Preview displayed"
-    assert client_message.idempotency_key == "browser/complete"
+    assert client_message.source == "browser/complete"
 
 
 async def test_resourcecontrol_enqueue(

--- a/examples/python/tests/integ/test_subscription.py
+++ b/examples/python/tests/integ/test_subscription.py
@@ -21,7 +21,8 @@ from dex_examples.app import ExampleApp
 from dex_examples.config import start_options
 from dex_examples.products.subscription.customer import Customer
 from dex_examples.products.subscription.subscription import Subscription
-from tests.integ.conftest import WAIT_TIMEOUT, wait_until
+from dex_examples.products.subscription.subscription_flow import SubscriptionFlow
+from tests.integ.conftest import WAIT_TIMEOUT, wait_for_attribute, wait_until
 
 from dex import AsyncClient
 
@@ -72,10 +73,12 @@ async def test_subscription_describe_returns_the_stored_plan(
         start_options(),
     )
 
-    subscription = await wait_until(
-        "Initialize to store the customer",
-        lambda: client.invoke_rpc(app.subscription.describe, flow_id),
+    await wait_for_attribute(
+        client,
+        flow_id,
+        SubscriptionFlow.customer_details,
     )
+    subscription = await client.invoke_rpc(app.subscription.describe, flow_id)
     assert subscription.trial_period_seconds == LONG_TRIAL_SECONDS
     assert subscription.billing_period_charge == 100
 
@@ -98,9 +101,10 @@ async def test_subscription_update_charge_amount(
         start_options(),
     )
 
-    await wait_until(
-        "Initialize to store the customer",
-        lambda: client.invoke_rpc(app.subscription.describe, flow_id),
+    await wait_for_attribute(
+        client,
+        flow_id,
+        SubscriptionFlow.customer_details,
     )
     await client.publish(flow_id, app.subscription.update_charge_amount, 250)
 

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -293,7 +293,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dex-python-sdk", specifier = "==0.2.5" },
+    { name = "dex-python-sdk", specifier = "==0.2.6" },
     { name = "flask", specifier = ">=3.0,<4" },
     { name = "openai", specifier = ">=1.66.2,<2" },
     { name = "openai-agents", specifier = ">=0.0.4,<0.0.5" },
@@ -312,20 +312,20 @@ dev = [
 
 [[package]]
 name = "dex-python-sdk"
-version = "0.2.5"
+version = "0.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "grpcio-status" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/3d/ae1261cdd66bb04506da545209f1b9e9e829fbf5a81bc29f0a5ec11cdbad/dex_python_sdk-0.2.5.tar.gz", hash = "sha256:5a6d14eae993fc6c5b5d7128b87c44c15de0ac4cb41a3bc4107fcc2f764dfb74", size = 153219, upload-time = "2026-08-29T04:46:49.682Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/c7/237c07dd8a452edb03ca744ee40a8259100e6c462d623226f9bbe7c68ecf/dex_python_sdk-0.2.6.tar.gz", hash = "sha256:947db7330d2f5d5b492b407291166b3f231397e62c1fec5f61efc5f01306c071", size = 158083, upload-time = "2026-09-01T01:55:03.597Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/db/e761e792ff44af9684adc30a6a44947bc6eeebd0255cdbe0297ccdc95764/dex_python_sdk-0.2.5-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e594d16658a71fbad151b3ed9fd780547a4b73f2e90388ec132652579b3e6136", size = 635840, upload-time = "2026-08-29T04:46:44.126Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/44/0c853db549b73c7ca44c862b312cdac1671e215dcbf029850c03705876ff/dex_python_sdk-0.2.5-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:a49c354bf8ad5d7d4d17dc053b86dc5b371971adc7b4d9897e1f6ac3dc5b2126", size = 614306, upload-time = "2026-08-29T04:46:45.215Z" },
-    { url = "https://files.pythonhosted.org/packages/44/38/323ceea333e43a51bb652eb8541d6a04c8e1f3a1477297431453ac003eae/dex_python_sdk-0.2.5-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:246749f6fdda73f2aa3d4ea93c09aaad63eacc932304d6e51afc8c606c5c7825", size = 677251, upload-time = "2026-08-29T04:46:46.241Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/db/662c6a61fa1f11804219c4744e54a587c0e2f44bf069657e4ad0b14da812/dex_python_sdk-0.2.5-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3792a04339a01b06b1932d8239a8c71768cddb3feb5a51db82dbd044ea47a5a0", size = 679570, upload-time = "2026-08-29T04:46:47.528Z" },
-    { url = "https://files.pythonhosted.org/packages/95/59/d3737df143e92dc956537d0475bfd246897f7aa5b087c10cff78eeb8afb4/dex_python_sdk-0.2.5-cp311-abi3-win_amd64.whl", hash = "sha256:997ada01542053a38945275d554f4a766e331c13b1ad908696c991970c33dd9c", size = 523492, upload-time = "2026-08-29T04:46:48.593Z" },
+    { url = "https://files.pythonhosted.org/packages/62/26/a915a5648a6f8b83a55a96ec2fcbac7cbdd2e07013d4aa3e5c2ae12990a3/dex_python_sdk-0.2.6-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c97e4e6af7faa704e4895e9421805364794f0f57105ac98b1025140e207ce5a7", size = 639916, upload-time = "2026-09-01T01:54:56.98Z" },
+    { url = "https://files.pythonhosted.org/packages/71/41/64ae533bd2710d596b0c197ff9859ca3066e30f7d17fcd51e3d04bf0a3bd/dex_python_sdk-0.2.6-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:a392ad6c835e573de087ab7e97674d282ec1844aa7ce781c2b4f351cf268a51d", size = 618387, upload-time = "2026-09-01T01:54:58.376Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0f/1356baafebcc79300afd9a1980413cef1acce47224f109ca59ccd74f87c6/dex_python_sdk-0.2.6-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7c2d2ac6cd3a2546b7c559ff6e755c0393408c12356abd5d7184a20324c951a", size = 681334, upload-time = "2026-09-01T01:54:59.574Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cc/19ce1dd96bfb55f95263607e3cde9194ca44a1c7d40ae397e24192de996c/dex_python_sdk-0.2.6-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a277a05359a7919e0f5481bb7048c80069f9799f73683758ca3ed8a28904bd03", size = 683646, upload-time = "2026-09-01T01:55:00.963Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a7/46c0ebfc6ccc5ad3d0d41a5662d77688a52bcd5aaced069fd52ef069ceb1/dex_python_sdk-0.2.6-cp311-abi3-win_amd64.whl", hash = "sha256:89a98928f74b5e1b85780b9dab677b800c9c70e801ac759ca078a652fec95723", size = 527623, upload-time = "2026-09-01T01:55:02.524Z" },
 ]
 
 [[package]]

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "dex-blob-cache"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc2eefbf9d360e836ebb651b485e3612b06bd0498a084503c74a0f9d42ee35b"
+checksum = "05a603e7cc3d83fa537ec90cfb18d8ba57588a0859cc03f21e6eadb59cef2081"
 dependencies = [
  "crc32c",
  "sha2",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "dex-protocol"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ee3bd9c2009e4b22677929cea43a6113daa971d482502342098aaf97fdc523"
+checksum = "bed1724ae96e3577a3ee4e9d96f1e8f76bd8cc229a70731317d155d8a52916dc"
 dependencies = [
  "prost",
  "prost-types",
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "dex-sdk"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa239d6d35c1d031e4df9c0db13a83b3c16a47ad3fdc98979de71a2a8f54d37"
+checksum = "1b4820967663d52b78e2f67ba3475b11215d6940baeae0e7853360f186162515"
 dependencies = [
  "dex-blob-cache",
  "dex-protocol",

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 rust-version = "1.97"
 
 [dependencies]
-dex-sdk = "=0.2.4"
+dex-sdk = "=0.2.5"
 fastrand = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -1,7 +1,7 @@
 # Rust examples
 
 This application mirrors the examples shared by the Java, Python, and TypeScript
-applications. It intentionally depends on the published `dex-sdk = "=0.2.3"`
+applications. It intentionally depends on the published `dex-sdk = "=0.2.5"`
 crate without a repository path override.
 
 ## Layout

--- a/examples/rust/src/primitives/heartbeat/flow.rs
+++ b/examples/rust/src/primitives/heartbeat/flow.rs
@@ -46,11 +46,13 @@ impl Step for HeartbeatStep {
     }
 
     fn execute(&self, context: &mut Context, batches: Self::Input) -> HandlerResult<StepDecision> {
-        for _batch in 0..batches {
+        let completed_batches = context.last_heartbeat_value::<i32>()?.unwrap_or_default();
+        for batch in completed_batches..batches {
             if context.is_cancelled() {
                 return Ok(StepDecision::dead_end());
             }
             thread::sleep(Duration::from_secs(2));
+            context.record_heartbeat_value(batch + 1)?;
         }
         Ok(StepDecision::graceful_complete(String::from("processed")))
     }

--- a/examples/rust/src/primitives/stream/controller.rs
+++ b/examples/rust/src/primitives/stream/controller.rs
@@ -39,8 +39,8 @@ struct StartQuery {
 struct WriteQuery {
     #[serde(default, rename = "workflowId")]
     workflow_id: String,
-    #[serde(default, rename = "idempotencyKey")]
-    idempotency_key: String,
+    #[serde(default)]
+    source: String,
     #[serde(default)]
     message: String,
 }
@@ -60,8 +60,7 @@ struct ReadResponse {
     resume_token: String,
     #[serde(rename = "createdTime")]
     created_time: String,
-    #[serde(rename = "idempotencyKey")]
-    idempotency_key: String,
+    source: String,
 }
 
 pub fn mount(client: SharedClient) -> Router {
@@ -93,12 +92,7 @@ async fn write(
     Query(query): Query<WriteQuery>,
 ) -> impl IntoResponse {
     match run_blocking(move || {
-        client.write_stream(
-            &query.workflow_id,
-            &PROGRESS,
-            &query.idempotency_key,
-            query.message,
-        )
+        client.write_stream(&query.workflow_id, &PROGRESS, &query.source, query.message)
     }) {
         Ok(()) => ok_text("done"),
         Err(error) => map_sdk_error(error).into_response(),
@@ -121,7 +115,7 @@ async fn read(
                 value: message.value,
                 resume_token: message.resume_token,
                 created_time: format!("{:?}", message.created_time),
-                idempotency_key: message.idempotency_key,
+                source: message.source,
             })
     }) {
         Ok(response) => ok_json(response),

--- a/examples/rust/src/primitives/stream/flow.rs
+++ b/examples/rust/src/primitives/stream/flow.rs
@@ -46,6 +46,7 @@ impl Step for RenderPreview {
 
     fn execute(&self, context: &mut Context, input: Self::Input) -> HandlerResult<StepDecision> {
         PROGRESS.write(context, format!("Rendering preview for {input}"))?;
+        PROGRESS.write(context, format!("Preview ready for {input}"))?;
         Ok(StepDecision::graceful_complete(format!("Rendered {input}")))
     }
 }

--- a/examples/rust/tests/dex_integration.rs
+++ b/examples/rust/tests/dex_integration.rs
@@ -338,6 +338,19 @@ fn stream_resumes_after_step_and_client_writes() {
         .expect("read Rust Step Stream message");
     assert_eq!(step_message.value, "Rendering preview for invoice");
     assert!(!step_message.resume_token.is_empty());
+    assert!(step_message.source.starts_with('#'));
+
+    let second_step_message = environment
+        .client
+        .read_stream_with_timeout(
+            &flow_id,
+            &PROGRESS,
+            &step_message.resume_token,
+            Duration::from_secs(20),
+        )
+        .expect("read second Rust Step Stream message");
+    assert_eq!(second_step_message.value, "Preview ready for invoice");
+    assert_eq!(second_step_message.source, step_message.source);
 
     environment
         .client
@@ -353,12 +366,12 @@ fn stream_resumes_after_step_and_client_writes() {
         .read_stream_with_timeout(
             &flow_id,
             &PROGRESS,
-            &step_message.resume_token,
+            &second_step_message.resume_token,
             Duration::from_secs(20),
         )
         .expect("resume Rust Stream");
     assert_eq!(client_message.value, "Preview displayed");
-    assert_eq!(client_message.idempotency_key, "browser/complete");
+    assert_eq!(client_message.source, "browser/complete");
 }
 
 #[test]

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,6 +1,6 @@
 # Dex TypeScript examples
 
-These examples target [`@superdurable/dex@0.2.3`](https://www.npmjs.com/package/@superdurable/dex).
+These examples target [`@superdurable/dex@0.2.5`](https://www.npmjs.com/package/@superdurable/dex).
 
 The sample process hosts one gRPC Worker (default `127.0.0.1:8803`) and an HTTP
 controller on port `8080`. Step `execute` / `waitFor` / RPC handlers may

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@superdurable/dex-examples-typescript",
       "version": "0.0.0",
       "dependencies": {
-        "@superdurable/dex": "0.2.4",
+        "@superdurable/dex": "0.2.5",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -125,9 +125,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@superdurable/dex": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.2.4.tgz",
-      "integrity": "sha512-QHmMvX8xnGrTl7q2J+HxAPXZj9GVuFwpA9Lu3fl3blWRgAhbXGeuIlaPqnAW/pDOKjBklIo+JrSpHbVIY8L0aQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.2.5.tgz",
+      "integrity": "sha512-HVwXFrSWQ+lf7eVHFWWL/3G7Zx4BCx9XgnUHR4X4FZzUzEf5Pumxe5qDBY6L8zeF/fDm4YgaMxmN85ZHaKmBLA==",
       "license": "LicenseRef-Super-Durable-1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.13.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -16,7 +16,7 @@
     "smoke": "npm run build && node --test --experimental-test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/e2e/flow-smoke.test.js'"
   },
   "dependencies": {
-    "@superdurable/dex": "0.2.4",
+    "@superdurable/dex": "0.2.5",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/examples/typescript/src/primitives/heartbeat/heartbeat-flow.ts
+++ b/examples/typescript/src/primitives/heartbeat/heartbeat-flow.ts
@@ -19,7 +19,7 @@ import {
   deadEnd,
   doubleCodec,
   gracefulComplete,
-  type Context,
+  type AsyncContext,
   type Flow,
   type PersistenceSchema,
   type Step,
@@ -44,12 +44,14 @@ class HeartbeatStep implements Step<number> {
     };
   }
 
-  public async execute(context: Context, batches: number): Promise<StepDecision> {
-    for (let batch = 0; batch < batches; batch++) {
+  public async execute(context: AsyncContext, batches: number): Promise<StepDecision> {
+    const completedBatches = context.getLastHeartbeatValue(doubleCodec) ?? 0;
+    for (let batch = completedBatches; batch < batches; batch++) {
       if (context.cancellationSignal.aborted) {
         return deadEnd();
       }
       await new Promise((resolve) => setTimeout(resolve, 2_000));
+      await context.recordHeartbeat(batch + 1, doubleCodec);
     }
     return gracefulComplete("processed");
   }

--- a/examples/typescript/src/primitives/stream/controller.ts
+++ b/examples/typescript/src/primitives/stream/controller.ts
@@ -35,7 +35,7 @@ export function createStreamRouter(client: Client): Router {
     await client.writeStream(
       String(request.query.workflowId ?? ""),
       progress,
-      String(request.query.idempotencyKey ?? ""),
+      String(request.query.source ?? ""),
       String(request.query.message ?? ""),
     );
     response.send("done");

--- a/examples/typescript/src/primitives/stream/stream-flow.ts
+++ b/examples/typescript/src/primitives/stream/stream-flow.ts
@@ -36,7 +36,8 @@ class RenderPreview implements Step<string> {
   }
 
   public async execute(context: Context, input: string): Promise<StepDecision> {
-    await progress.write(context, `Rendering preview for ${input}`);
+    progress.write(context, `Rendering preview for ${input}`);
+    progress.write(context, `Preview ready for ${input}`);
     return gracefulComplete(`Rendered ${input}`);
   }
 }

--- a/examples/typescript/test/integ/engagement.test.ts
+++ b/examples/typescript/test/integ/engagement.test.ts
@@ -62,12 +62,25 @@ test("engagementStartChannelRpcAndStatus", async () => {
   assert.equal((description as { currentStatus: string }).currentStatus, "Initiated");
 
   await environment.client.publish(flowId, optOutReminder, undefined);
+  await awaitCondition(
+    () => environment.client.invokeRPC(flow.describe, flowId),
+    (current) => current.notes.includes("user opted out of reminders"),
+    20_000,
+    "engagement reminder did not stop",
+  );
   const declined = await environment.client.invokeRPC(
     flow.decline,
     flowId,
     "declined in integration test",
   );
   assert.equal(declined, "Declined");
+
+  await awaitCondition(
+    () => environment.client.getAttribute(flowId, flow.engagementStatus),
+    (status) => status === "Declined",
+    20_000,
+    "engagement status not Declined",
+  );
 
   const accepted = await environment.client.invokeRPC(
     flow.accept,

--- a/examples/typescript/test/integ/stream.test.ts
+++ b/examples/typescript/test/integ/stream.test.ts
@@ -44,6 +44,16 @@ test("streamResumesAfterStepAndClientWrites", async () => {
   const stepMessage = await environment.client.readStream(flowId, progress, "", 20_000);
   assert.equal(stepMessage.value, "Rendering preview for invoice");
   assert.ok(stepMessage.resumeToken.length > 0);
+  assert.ok(stepMessage.source.startsWith("#"));
+
+  const secondStepMessage = await environment.client.readStream(
+    flowId,
+    progress,
+    stepMessage.resumeToken,
+    20_000,
+  );
+  assert.equal(secondStepMessage.value, "Preview ready for invoice");
+  assert.equal(secondStepMessage.source, stepMessage.source);
 
   await environment.client.writeStream(
     flowId,
@@ -54,9 +64,9 @@ test("streamResumesAfterStepAndClientWrites", async () => {
   const clientMessage = await environment.client.readStream(
     flowId,
     progress,
-    stepMessage.resumeToken,
+    secondStepMessage.resumeToken,
     20_000,
   );
   assert.equal(clientMessage.value, "Preview displayed");
-  assert.equal(clientMessage.idempotencyKey, "browser/complete");
+  assert.equal(clientMessage.source, "browser/complete");
 });

--- a/skills/dex-developer/SKILL.md
+++ b/skills/dex-developer/SKILL.md
@@ -44,6 +44,8 @@ Keep external side effects in **Execute**. Use **WaitFor** to declare durable Co
 
 Treat each **WaitFor**, **Execute**, and RPC invocation as its own commit boundary. Dex Server stages all Attribute writes and Channel publications from one method, then commits them together only after that method succeeds. If the method fails, none become visible. **WaitFor** and **Execute** do not share a commit. This atomicity does not include external API calls, which still need idempotency or compensation.
 
+Heartbeat and Stream progress frames precede the final Step result and are outside that commit. Stream persistence is best-effort and unacknowledged.
+
 When a status Attribute means “waiting for X,” write it in the target Step's **WaitFor** beside the wait for X. Do not write it in the previous Step's **Execute**: the transition may fail before the target wait becomes active. A reminder self-loop may idempotently write the same status when it re-enters **WaitFor**.
 
 Read [modeling.md](references/modeling.md) for design rules and [primitives.md](references/primitives.md) when choosing or combining primitives.
@@ -87,5 +89,6 @@ Before handing off application code:
 - the relevant integration scenario passes
 - every used durable primitive is registered
 - retry, timeout, duplicate request, and terminal behavior are intentional
+- heartbeat cadence, checkpoint recovery, and best-effort progress behavior are intentional
 - Worker and Client share compatible registry and payload/blob configuration
 - user-facing instructions mention only Dex components and commands

--- a/skills/dex-developer/references/languages.md
+++ b/skills/dex-developer/references/languages.md
@@ -24,6 +24,8 @@ Match the language and exact SDK version already used by the project. For new pr
 
 Preserve whether the application uses the synchronous or asynchronous SDK style. Do not mix them in one execution path. Use typed models and the project's configured codec behavior.
 
+A synchronous Step with progress is a generator: yield each heartbeat or Stream **StepOutput**, then return the final **Wait** or **StepDecision**. An asynchronous Step is a coroutine with **AsyncContext**: await **heartbeat**, call **Stream.write** without await, then return the final result. Do not use an async generator.
+
 ### Go
 
 Use typed definitions and return every SDK error. Follow the repository's constructor and interface conventions. Prefer project Makefile targets for full suites.

--- a/skills/dex-developer/references/primitives.md
+++ b/skills/dex-developer/references/primitives.md
@@ -18,6 +18,8 @@ Step durability resolves in this order: a method override, FlowConfig, then **SY
 
 A long-running regular attempt must emit an explicit heartbeat or Stream message before its heartbeat timeout. A heartbeat value is a retry checkpoint. An explicit valueless heartbeat clears the checkpoint; a Stream message preserves its current state. The local phase of **ASYNC** durability ignores heartbeats but still emits Stream messages.
 
+For an LLM call that may remain healthy without output for more than one minute, tell the application developer to raise **HeartbeatTimeout** above its one-minute default. Size it to the longest acceptable silent interval, and use the method timeout to cap the whole attempt. Do not add periodic heartbeats solely to mask provider silence; they prove only that application code is running, not that the upstream request is progressing.
+
 Docs: https://docs.superdurable.io/primitives/step
 
 ## Attribute

--- a/skills/dex-developer/references/primitives.md
+++ b/skills/dex-developer/references/primitives.md
@@ -14,6 +14,10 @@ Use a Step for retried background work and explicit state transitions. **WaitFor
 
 Use multiple next Steps for parallel work. Use cancellation deliberately when a first-winner branch makes siblings unnecessary.
 
+Step durability resolves in this order: a method override, FlowConfig, then **SYNC**. Failure policies do not change that order. The default retry total duration is four hours. Regular attempts default to a two-hour method timeout and one-minute heartbeat timeout.
+
+Dex does not heartbeat a Step automatically. A long-running regular attempt must emit an explicit heartbeat or Stream message before its heartbeat timeout. A heartbeat value is a retry checkpoint. An explicit valueless heartbeat clears the checkpoint; a Stream message preserves its current state. The local phase of **ASYNC** durability ignores heartbeats but still emits Stream messages.
+
 Docs: https://docs.superdurable.io/primitives/step
 
 ## Attribute
@@ -47,6 +51,10 @@ Docs: https://docs.superdurable.io/primitives/rpc
 ## Stream
 
 Use a Stream for low-latency, best-effort, resumable updates such as progress displayed in a UI. Do not use a Stream when delivery must be durable; use a Channel or Attribute instead.
+
+A Step may append any number of messages to the same or different Streams before its final result. A Step Stream write is fire-and-forget: local encoding or registration can fail immediately, but Dex Server does not acknowledge Stream Store persistence and a Store failure does not fail the Step.
+
+Step messages use **#StepExecutionID** as source metadata. The source is not an idempotency key: attempts and messages may share it, and every write appends. Client Stream writes require a nonempty source, which may repeat or contain **#**.
 
 Docs: https://docs.superdurable.io/primitives/stream
 

--- a/skills/dex-developer/references/primitives.md
+++ b/skills/dex-developer/references/primitives.md
@@ -14,9 +14,9 @@ Use a Step for retried background work and explicit state transitions. **WaitFor
 
 Use multiple next Steps for parallel work. Use cancellation deliberately when a first-winner branch makes siblings unnecessary.
 
-Step durability resolves in this order: a method override, FlowConfig, then **SYNC**. Failure policies do not change that order. The default retry total duration is four hours. Regular attempts default to a two-hour method timeout and one-minute heartbeat timeout.
+Step durability resolves in this order: a method override, FlowConfig, then **SYNC**. The default retry total duration is four hours. Regular attempts default to a two-hour method timeout and one-minute heartbeat timeout.
 
-Dex does not heartbeat a Step automatically. A long-running regular attempt must emit an explicit heartbeat or Stream message before its heartbeat timeout. A heartbeat value is a retry checkpoint. An explicit valueless heartbeat clears the checkpoint; a Stream message preserves its current state. The local phase of **ASYNC** durability ignores heartbeats but still emits Stream messages.
+A long-running regular attempt must emit an explicit heartbeat or Stream message before its heartbeat timeout. A heartbeat value is a retry checkpoint. An explicit valueless heartbeat clears the checkpoint; a Stream message preserves its current state. The local phase of **ASYNC** durability ignores heartbeats but still emits Stream messages.
 
 Docs: https://docs.superdurable.io/primitives/step
 


### PR DESCRIPTION
## Summary

- upgrade all runnable examples to the published Step streaming SDK releases
- demonstrate multiple Step Stream messages, source metadata, heartbeat checkpoints, and the Python async Context API
- document the new SYNC defaults, retry/timeout behavior, explicit and implicit heartbeat semantics, and best-effort Stream writes in English and Simplified Chinese
- teach the Dex developer skill the sync-generator and async-coroutine Step progress models
- harden integration setup waits exposed by the new SYNC default

## Rationale and user impact

The server and SDK Step streaming changes are now published, but the runnable examples, product documentation, and developer skill still described the previous one-write/idempotency and automatic-heartbeat behavior. This PR makes those surfaces consistent with the shipped API. Applications can copy runnable examples for multi-message progress and heartbeat checkpoint recovery, and readers see the same semantics in both documentation locales.

## Validation

- `make generated-code-check`
- `make copyright-check`
- `make docs-prose-check`
- `npm --prefix docs run check`
- Python: `make unitTests`; `./run-integ-tests.sh`; sync and async integration suites
- Go: `GOWORK=off make unitTests`; `GOWORK=off make bins`; `make e2eTests`
- Java: product tests on Java 17, 21, 25, and 26; `./run-integration-tests.sh`
- TypeScript: `npm run typecheck`; `npm test`; `./run-integration-tests.sh`
- Rust: `make fmt-check clippy test`; `./run-integration-tests.sh`
- Dex developer skill validation with `quick_validate.py`

## UI/UX

N/A: no in-repo web UI changes.
