### PR TITLE
Encode AI agent emails as UTF-8

### DIFF
--- a/examples/python/dex_examples/products/ai-agent-email/ai_agent_flow.py
+++ b/examples/python/dex_examples/products/ai-agent-email/ai_agent_flow.py
@@ -21,6 +21,7 @@ import smtplib
 import time
 from dataclasses import dataclass
 from datetime import timedelta
+from email.message import EmailMessage
 
 from dex import (
     AsyncContext,
@@ -108,16 +109,31 @@ class Sending(Step[None]):
             return graceful_complete(STATUS_SKIPPED)
 
         sender, app_password = credentials
-        smtp_server = smtplib.SMTP_SSL("smtp.gmail.com", 465)
-        try:
-            smtp_server.ehlo()
-            smtp_server.login(sender, app_password)
-            smtp_server.sendmail(sender, recipient, f"Subject: {subject}\n\n{body}")
-        finally:
-            smtp_server.quit()
+        _send_email(sender, app_password, recipient, subject, body)
 
         self.flow.status.set(context, STATUS_SENT)
         return graceful_complete(STATUS_SENT)
+
+
+def _send_email(
+    sender: str,
+    app_password: str,
+    recipient: str,
+    subject: str,
+    body: str,
+) -> None:
+    smtp_server = smtplib.SMTP_SSL("smtp.gmail.com", 465)
+    try:
+        smtp_server.ehlo()
+        smtp_server.login(sender, app_password)
+        message = EmailMessage()
+        message["From"] = sender
+        message["To"] = recipient
+        message["Subject"] = subject
+        message.set_content(body)
+        smtp_server.send_message(message, from_addr=sender, to_addrs=[recipient])
+    finally:
+        smtp_server.quit()
 
 
 class Schedule(Step[None]):

--- a/examples/python/tests/unit/test_ai_agent_email.py
+++ b/examples/python/tests/unit/test_ai_agent_email.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests the OpenAI response boundary used by the email agent example."""
+"""Tests the OpenAI and SMTP boundaries used by the email agent example."""
 
 from __future__ import annotations
 
@@ -22,6 +22,7 @@ from typing import Any
 
 import pytest
 
+from dex_examples.products.ai_agent_email import ai_agent_flow
 from dex_examples.products.ai_agent_email import agent
 
 
@@ -75,5 +76,63 @@ async def test_request_email_fields_falls_back_when_output_cannot_be_parsed(
     assert reply.response.email_body == "Send an email"
 
 
+def test_send_email_supports_unicode_subject_and_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    smtp_server = _FakeSMTP()
+
+    def create_smtp_server(host: str, port: int) -> _FakeSMTP:
+        assert host == "smtp.gmail.com"
+        assert port == 465
+        return smtp_server
+
+    monkeypatch.setattr(ai_agent_flow.smtplib, "SMTP_SSL", create_smtp_server)
+
+    ai_agent_flow._send_email(
+        "sender@example.com",
+        "app-password",
+        "recipient@example.com",
+        "中文主题",
+        "这是一封中文正文。",
+    )
+
+    message = smtp_server.message
+    assert message is not None
+    assert message["Subject"] == "中文主题"
+    assert message.get_content().strip() == "这是一封中文正文。"
+    assert message.as_bytes()
+    assert smtp_server.from_addr == "sender@example.com"
+    assert smtp_server.to_addrs == ["recipient@example.com"]
+    assert smtp_server.has_quit is True
+
+
 async def _write_progress(progress: str) -> None:
     pass
+
+
+class _FakeSMTP:
+    def __init__(self) -> None:
+        self.message: Any | None = None
+        self.from_addr: str | None = None
+        self.to_addrs: list[str] | None = None
+        self.has_quit = False
+
+    def ehlo(self) -> None:
+        pass
+
+    def login(self, sender: str, app_password: str) -> None:
+        assert sender == "sender@example.com"
+        assert app_password == "app-password"
+
+    def send_message(
+        self,
+        message: Any,
+        from_addr: str,
+        to_addrs: list[str],
+    ) -> None:
+        self.message = message
+        self.from_addr = from_addr
+        self.to_addrs = to_addrs
+
+    def quit(self) -> None:
+        self.has_quit = True


### PR DESCRIPTION
## Summary

- Construct AI agent messages with Python's MIME-aware EmailMessage API.
- Send explicit envelope sender and recipient information through SMTP.
- Add regression coverage for non-ASCII subject and body content.

## Rationale

The previous bare message string made smtplib attempt ASCII encoding. Email generated in languages such as Chinese therefore failed in the Sending Step and retried.

## User impact

AI-generated email subjects and bodies can contain Unicode text and send through Gmail SMTP without an ASCII encoding failure.

## Validation

- `make -C examples/python unitTests`
- `make copyright-check`
- `examples/python/run-integ-tests.sh`
