### PR TITLE
Add buffered text streams to SDKs

### DIFF
--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -139,6 +139,24 @@ unavailability is visible through server logs and metrics rather than the
 handler return value. Heartbeats and Stream writes may run concurrently; their
 frames are serialized by the Worker.
 
+Use `NewBufferedTextStream` for token-sized text deltas. It preserves text
+exactly, flushes after one second or a soft 16 KiB UTF-8 threshold, and emits
+the tail before the handler result or error:
+
+```go
+progress, err := dex.NewBufferedTextStream(ctx, Thinking)
+if err != nil {
+	return nil, err
+}
+if err := progress.Write(delta); err != nil {
+	return nil, err
+}
+```
+
+`BufferedTextStreamFlushInterval` and `BufferedTextStreamMaxBytes` override the
+defaults. Empty buffers emit no message or heartbeat. Retry does not restore an
+unsent buffer or deduplicate batches already sent.
+
 Messages written by a Step have `#<stepExecutionID>` in
 `StreamMessage.Source`. Client writes accept any non-empty source, including
 values containing `#`. Reusing a source appends another message; source is

--- a/sdk-go/dex/buffered_text_stream.go
+++ b/sdk-go/dex/buffered_text_stream.go
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Super Durable, Inc.
+//
+// Licensed under the Super Durable Source License 1.0.
+// You may not use this file except in compliance with the License.
+// See the LICENSE file in the repository root.
+//
+// SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+package dex
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	defaultBufferedTextStreamFlushInterval = time.Second
+	defaultBufferedTextStreamMaxBytes      = 16 << 10
+)
+
+// BufferedTextStream batches text chunks before appending them to a Step Stream.
+//
+// Create one writer per logical text feed with NewBufferedTextStream. Write preserves every byte
+// and appends the current batch when its one-second default interval or 16 KiB default threshold is
+// reached. The invocation flushes and closes the writer before its final result or error is sent.
+// Stream Store failures remain unacknowledged, matching Stream.Write.
+//
+//	progress, err := dex.NewBufferedTextStream(ctx, Thinking)
+//	if err != nil {
+//		return nil, err
+//	}
+//	if err := progress.Write(delta); err != nil {
+//		return nil, err
+//	}
+type BufferedTextStream struct {
+	mu               sync.Mutex
+	invocation       *invocationContext
+	stream           Stream[string]
+	flushInterval    time.Duration
+	maxBufferedBytes int
+	buffer           string
+	bufferedBytes    int
+	timer            *time.Timer
+	timerGeneration  uint64
+	stopCancellation func() bool
+	isClosed         bool
+	terminalErr      error
+}
+
+type bufferedTextStreamConfig struct {
+	flushInterval    time.Duration
+	maxBufferedBytes int
+}
+
+// BufferedTextStreamOption configures a BufferedTextStream.
+type BufferedTextStreamOption interface {
+	applyBufferedTextStream(*bufferedTextStreamConfig)
+}
+
+// NewBufferedTextStream creates an invocation-managed writer for a registered string Stream.
+//
+// The default flush interval is one second and the default soft size threshold is 16 KiB of UTF-8
+// text. The Context must belong to an active WaitFor or Execute invocation. The SDK automatically
+// flushes remaining text and stops the timer before sending that invocation's final result or error.
+//
+// The returned writer is safe for concurrent Write and Flush calls. Reuse it for the entire logical
+// feed; creating multiple writers gives each writer an independent buffer and timer.
+//
+// Returns an error for an inactive, RPC, or Flow-timeout Context, an unregistered Stream, or invalid
+// options.
+func NewBufferedTextStream(
+	ctx Context,
+	stream Stream[string],
+	options ...BufferedTextStreamOption,
+) (*BufferedTextStream, error) {
+	config := bufferedTextStreamConfig{
+		flushInterval:    defaultBufferedTextStreamFlushInterval,
+		maxBufferedBytes: defaultBufferedTextStreamMaxBytes,
+	}
+	for _, option := range options {
+		if option == nil {
+			return nil, fmt.Errorf("dex: BufferedTextStream option is nil")
+		}
+		option.applyBufferedTextStream(&config)
+	}
+	if config.flushInterval <= 0 {
+		return nil, fmt.Errorf("dex: BufferedTextStream flush interval must be positive")
+	}
+	if config.maxBufferedBytes <= 0 {
+		return nil, fmt.Errorf("dex: BufferedTextStream maximum buffered bytes must be positive")
+	}
+	invocation, ok := ctx.(*invocationContext)
+	if !ok || invocation.outputEmitter == nil {
+		return nil, errInvalidInvocationContext
+	}
+	if _, err := invocation.flow.resolveStream(stream.definition); err != nil {
+		return nil, fmt.Errorf("dex: %w", err)
+	}
+	writer := &BufferedTextStream{
+		invocation:       invocation,
+		stream:           stream,
+		flushInterval:    config.flushInterval,
+		maxBufferedBytes: config.maxBufferedBytes,
+	}
+	writer.stopCancellation = context.AfterFunc(invocation, writer.cancel)
+	if err := invocation.registerOutputFinalizer(writer); err != nil {
+		return nil, err
+	}
+	return writer, nil
+}
+
+// BufferedTextStreamFlushInterval overrides the one-second batch interval.
+//
+// The duration must be positive. A non-empty buffer is appended when the interval elapses even if
+// the handler does not produce another chunk.
+func BufferedTextStreamFlushInterval(value time.Duration) BufferedTextStreamOption {
+	return bufferedTextStreamFlushIntervalOption{value: value}
+}
+
+// BufferedTextStreamMaxBytes overrides the 16 KiB soft UTF-8 size threshold.
+//
+// The value must be positive. A chunk is never split, so an emitted batch may exceed this threshold
+// by the size of its final chunk.
+func BufferedTextStreamMaxBytes(value int) BufferedTextStreamOption {
+	return bufferedTextStreamMaxBytesOption{value: value}
+}
+
+// Write appends one text chunk to the current batch.
+//
+// Empty chunks are ignored. Write flushes immediately when the soft size threshold is reached. It
+// otherwise returns after buffering locally; it does not wait for the interval or Stream Store.
+// A timer or transport failure is returned by the next Write or Flush call.
+func (writer *BufferedTextStream) Write(chunk string) error {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	if err := writer.requireOpenLocked(); err != nil {
+		return err
+	}
+	if chunk == "" {
+		return nil
+	}
+	wasEmpty := writer.buffer == ""
+	writer.buffer += chunk
+	writer.bufferedBytes += len(chunk)
+	if wasEmpty {
+		writer.startTimerLocked()
+	}
+	if writer.bufferedBytes < writer.maxBufferedBytes {
+		return nil
+	}
+	writer.stopTimerLocked()
+	return writer.flushLocked()
+}
+
+// Flush immediately appends the current non-empty batch.
+//
+// An empty flush is a no-op. A later Write starts a new timer. Flush returns local validation,
+// encoding, and gRPC transport failures but never waits for Stream Store acknowledgement.
+func (writer *BufferedTextStream) Flush() error {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	if err := writer.requireOpenLocked(); err != nil {
+		return err
+	}
+	writer.stopTimerLocked()
+	return writer.flushLocked()
+}
+
+func (writer *BufferedTextStream) finalize() error {
+	writer.stopCancellation()
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	if writer.isClosed {
+		return writer.terminalErr
+	}
+	writer.stopTimerLocked()
+	if writer.terminalErr == nil {
+		writer.terminalErr = writer.flushLocked()
+	}
+	writer.isClosed = true
+	return writer.terminalErr
+}
+
+func (writer *BufferedTextStream) cancel() {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	writer.stopTimerLocked()
+	writer.buffer = ""
+	writer.bufferedBytes = 0
+	writer.isClosed = true
+}
+
+func (writer *BufferedTextStream) startTimerLocked() {
+	writer.timerGeneration++
+	generation := writer.timerGeneration
+	writer.timer = time.AfterFunc(writer.flushInterval, func() {
+		writer.flushFromTimer(generation)
+	})
+}
+
+func (writer *BufferedTextStream) flushFromTimer(generation uint64) {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	if writer.isClosed || writer.terminalErr != nil || generation != writer.timerGeneration {
+		return
+	}
+	writer.timer = nil
+	if err := writer.flushLocked(); err != nil {
+		writer.terminalErr = err
+	}
+}
+
+func (writer *BufferedTextStream) stopTimerLocked() {
+	writer.timerGeneration++
+	if writer.timer != nil {
+		writer.timer.Stop()
+		writer.timer = nil
+	}
+}
+
+func (writer *BufferedTextStream) flushLocked() error {
+	if writer.buffer == "" {
+		return nil
+	}
+	value := writer.buffer
+	writer.buffer = ""
+	writer.bufferedBytes = 0
+	if err := writer.stream.Write(writer.invocation, value); err != nil {
+		writer.terminalErr = err
+		return err
+	}
+	return nil
+}
+
+func (writer *BufferedTextStream) requireOpenLocked() error {
+	if writer.terminalErr != nil {
+		return writer.terminalErr
+	}
+	if writer.isClosed {
+		return errInvalidInvocationContext
+	}
+	return nil
+}
+
+type bufferedTextStreamFlushIntervalOption struct {
+	value time.Duration
+}
+
+func (option bufferedTextStreamFlushIntervalOption) applyBufferedTextStream(
+	config *bufferedTextStreamConfig,
+) {
+	config.flushInterval = option.value
+}
+
+type bufferedTextStreamMaxBytesOption struct {
+	value int
+}
+
+func (option bufferedTextStreamMaxBytesOption) applyBufferedTextStream(
+	config *bufferedTextStreamConfig,
+) {
+	config.maxBufferedBytes = option.value
+}

--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -190,6 +190,24 @@ var _ dex.Flow = flow
 var _ dex.RPC[stepInput, command] = flow.Update
 var _ dex.RPC[dex.None, command] = flow.Describe
 
+func compileBufferedTextStream(context dex.Context) error {
+	progress, err := dex.NewBufferedTextStream(
+		context,
+		progressStream,
+		dex.BufferedTextStreamFlushInterval(500*time.Millisecond),
+		dex.BufferedTextStreamMaxBytes(8<<10),
+	)
+	if err != nil {
+		return err
+	}
+	if err := progress.Write("thinking "); err != nil {
+		return err
+	}
+	return progress.Flush()
+}
+
+var _ = compileBufferedTextStream
+
 func TestPublicContractsCompile(t *testing.T) {
 	_ = dex.MovementOf(noPayload, nil)
 	_ = noPayloadChannel.ForOne()

--- a/sdk-go/dex/invocation.go
+++ b/sdk-go/dex/invocation.go
@@ -12,6 +12,7 @@ package dex
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -60,6 +61,11 @@ type invocationContext struct {
 
 	conditionResults *dexpb.ConditionResults
 	channelSizes     map[string]int
+	outputFinalizers []invocationOutputFinalizer
+}
+
+type invocationOutputFinalizer interface {
+	finalize() error
 }
 
 func newInvocationContext(
@@ -795,11 +801,29 @@ func (invocation *invocationContext) requireActive(
 }
 
 func (invocation *invocationContext) finish() error {
+	var finalErr error
+	for _, finalizer := range invocation.outputFinalizers {
+		finalErr = errors.Join(finalErr, finalizer.finalize())
+	}
 	invocation.active = false
 	if invocation.outputEmitter == nil {
-		return nil
+		return finalErr
 	}
-	return invocation.outputEmitter.close()
+	return errors.Join(finalErr, invocation.outputEmitter.close())
+}
+
+func (invocation *invocationContext) registerOutputFinalizer(
+	finalizer invocationOutputFinalizer,
+) error {
+	if finalizer == nil {
+		panic("dex: invocation output finalizer is nil")
+	}
+	if err := invocation.requireActive(invocationWaitFor, invocationExecute); err != nil ||
+		invocation.outputEmitter == nil {
+		return errInvalidInvocationContext
+	}
+	invocation.outputFinalizers = append(invocation.outputFinalizers, finalizer)
+	return nil
 }
 
 func (invocation *invocationContext) mappedAttributeWrites() []*dexpb.AttributeWrite {

--- a/sdk-go/dex/worker_integration_test.go
+++ b/sdk-go/dex/worker_integration_test.go
@@ -605,6 +605,40 @@ func TestWorkerStepOutputEmitterSerializesAndRetainsSendFailure(t *testing.T) {
 	require.Len(t, failingStream.frames, 1)
 }
 
+func TestBufferedTextStreamFlushesOnTimerAndInvocationFinish(t *testing.T) {
+	progressStream := &bufferedTestProgressStream{}
+	registry, err := NewRegistry([]Flow{workerFlow})
+	require.NoError(t, err)
+	registeredFlow, found := registry.lookupFlow(GetFinalFlowType(workerFlow))
+	require.True(t, found)
+	invocation, err := newInvocationContext(
+		context.Background(),
+		invocationExecute,
+		registeredFlow,
+		progressStream,
+		workerStepContext(),
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	writer, err := NewBufferedTextStream(
+		invocation,
+		workerTestThinking,
+		BufferedTextStreamFlushInterval(5*time.Millisecond),
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Write("hello"))
+	require.Eventually(t, func() bool {
+		return len(progressStream.values()) == 1
+	}, time.Second, time.Millisecond)
+	require.NoError(t, writer.Write(" 世界"))
+	require.NoError(t, invocation.finish())
+	require.Equal(t, []string{"hello", " 世界"}, progressStream.values())
+	require.ErrorIs(t, writer.Write("late"), errInvalidInvocationContext)
+}
+
 func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 	client, closeService := newWorkerTestClient(t, nil)
 	defer closeService()
@@ -1407,6 +1441,28 @@ type workerTestProgressStream struct {
 	frames    []string
 	failure   error
 	failAfter int
+}
+
+type bufferedTestProgressStream struct {
+	mu      sync.Mutex
+	written []string
+}
+
+func (stream *bufferedTestProgressStream) sendHeartbeat(*dexpb.StepMethodHeartbeat) error {
+	return nil
+}
+
+func (stream *bufferedTestProgressStream) sendStreamWrite(write *dexpb.StepStreamWrite) error {
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	stream.written = append(stream.written, write.GetValue().GetStringValue())
+	return nil
+}
+
+func (stream *bufferedTestProgressStream) values() []string {
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	return append([]string(nil), stream.written...)
 }
 
 func (stream *workerTestProgressStream) sendHeartbeat(*dexpb.StepMethodHeartbeat) error {

--- a/sdk-go/dex/worker_service.go
+++ b/sdk-go/dex/worker_service.go
@@ -12,6 +12,7 @@ package dex
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -405,9 +406,7 @@ func callWaitForHandler(
 	input any,
 ) (wait *Wait, err error) {
 	defer func() {
-		if finishErr := invocation.finish(); err == nil {
-			err = finishErr
-		}
+		err = errors.Join(err, invocation.finish())
 	}()
 	return step.handler.waitFor(invocation, input)
 }
@@ -418,9 +417,7 @@ func callExecuteHandler(
 	input any,
 ) (decision *StepDecision, err error) {
 	defer func() {
-		if finishErr := invocation.finish(); err == nil {
-			err = finishErr
-		}
+		err = errors.Join(err, invocation.finish())
 	}()
 	return step.handler.execute(invocation, input)
 }
@@ -430,9 +427,7 @@ func callFlowTimeoutHandler(
 	invocation *invocationContext,
 ) (decision *StepDecision, err error) {
 	defer func() {
-		if finishErr := invocation.finish(); err == nil {
-			err = finishErr
-		}
+		err = errors.Join(err, invocation.finish())
 	}()
 	return handler.HandleTimeout(invocation)
 }
@@ -443,9 +438,7 @@ func callRPCHandler(
 	input any,
 ) (result rpcResult, err error) {
 	defer func() {
-		if finishErr := invocation.finish(); err == nil {
-			err = finishErr
-		}
+		err = errors.Join(err, invocation.finish())
 	}()
 	return rpc.invoke(invocation, input)
 }

--- a/sdk-go/integ/stream_test.go
+++ b/sdk-go/integ/stream_test.go
@@ -34,10 +34,23 @@ type streamTestStep struct {
 }
 
 func (streamTestStep) Execute(ctx dex.Context, _ struct{}) (*dex.StepDecision, error) {
-	if err := streamTestProgress.Write(ctx, "step-progress-1"); err != nil {
+	progress, err := dex.NewBufferedTextStream(ctx, streamTestProgress)
+	if err != nil {
 		return nil, err
 	}
-	if err := streamTestProgress.Write(ctx, "step-progress-2"); err != nil {
+	if err := progress.Write("step-progress-"); err != nil {
+		return nil, err
+	}
+	if err := progress.Write("1"); err != nil {
+		return nil, err
+	}
+	if err := progress.Flush(); err != nil {
+		return nil, err
+	}
+	if err := progress.Write("step-progress-"); err != nil {
+		return nil, err
+	}
+	if err := progress.Write("2"); err != nil {
 		return nil, err
 	}
 	return dex.GracefulComplete(struct{}{}), nil

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -115,6 +115,20 @@ One handler may write the same Stream any number of times. Dex assigns
 handler, although local validation, serialization, and Worker transport errors
 can still fail it.
 
+For text deltas, create one invocation-managed writer and pass its `write`
+method to the producer:
+
+```java
+BufferedTextStream progress = BufferedTextStream.create(context, thinking);
+progress.write(delta);
+```
+
+It flushes after one second, at a soft 16 KiB UTF-8 threshold, on `flush()`, or
+before the final result or error. The configuration overload accepts a
+`Duration` and byte threshold. It preserves chunks exactly, and an empty buffer
+does not emit a message or heartbeat. Retry does not restore unsent text or
+deduplicate batches.
+
 Flow timeout handlers and RPCs cannot send heartbeat or Stream progress.
 
 `Client.writeStream(flowId, stream, source, value)` appends on every call.

--- a/sdk-java/src/main/java/io/superdurable/dex/BufferedTextStream.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/BufferedTextStream.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Licensed under the Super Durable Source License 1.0.
+ * You may not use this file except in compliance with the License.
+ * See the LICENSE file in the repository root.
+ *
+ * SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+ */
+
+package io.superdurable.dex;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Batches text chunks into best-effort Stream messages during one Step invocation.
+ *
+ * <p>Create one writer with {@link #create(Context, Stream)} and call {@link #write(String)} from
+ * the handler or pass the method as a text-delta callback. The first nonempty chunk starts a
+ * one-shot timer. The Worker automatically stops the timer and flushes remaining text before the
+ * handler result or error is sent. Chunks are concatenated without separators and never split.
+ */
+public final class BufferedTextStream implements StepOutputFinalizer {
+    /** Default one-shot flush interval. */
+    public static final Duration DEFAULT_FLUSH_INTERVAL = Duration.ofSeconds(1);
+    /** Default soft UTF-8 batch threshold. */
+    public static final int DEFAULT_MAX_BUFFERED_BYTES = 16 * 1024;
+
+    private final InvocationContext context;
+    private final Stream<String> stream;
+    private final Duration flushInterval;
+    private final int maxBufferedBytes;
+    private final StringBuilder buffer = new StringBuilder();
+    private int bufferedBytes;
+    private long timerGeneration;
+    private ScheduledFuture<?> timer;
+    private boolean closed;
+    private RuntimeException terminalFailure;
+
+    private BufferedTextStream(
+            final InvocationContext context,
+            final Stream<String> stream,
+            final Duration flushInterval,
+            final int maxBufferedBytes) {
+        this.context = context;
+        this.stream = stream;
+        this.flushInterval = flushInterval;
+        this.maxBufferedBytes = maxBufferedBytes;
+    }
+
+    /**
+     * Creates a writer with a one-second interval and 16 KiB soft threshold.
+     *
+     * @param context current Step Context
+     * @param stream registered String Stream
+     * @return invocation-managed writer
+     * @throws IllegalArgumentException if an argument is null or the Stream is not String-valued
+     * @throws IllegalStateException if the Context is not an active Step invocation
+     */
+    public static BufferedTextStream create(
+            final Context context,
+            final Stream<String> stream) {
+        return create(context, stream, DEFAULT_FLUSH_INTERVAL, DEFAULT_MAX_BUFFERED_BYTES);
+    }
+
+    /**
+     * Creates a writer with explicit buffering settings.
+     *
+     * @param context current Step Context
+     * @param stream registered String Stream
+     * @param flushInterval positive one-shot flush interval
+     * @param maxBufferedBytes positive soft UTF-8 batch threshold
+     * @return invocation-managed writer
+     * @throws IllegalArgumentException if an argument or setting is invalid
+     * @throws IllegalStateException if the Context is not an active Step invocation
+     */
+    public static BufferedTextStream create(
+            final Context context,
+            final Stream<String> stream,
+            final Duration flushInterval,
+            final int maxBufferedBytes) {
+        if (!(context instanceof InvocationContext)) {
+            throw new IllegalArgumentException("Buffered Streams require a Dex Step Context");
+        }
+        if (stream == null || flushInterval == null) {
+            throw new IllegalArgumentException("Stream and flushInterval are required");
+        }
+        if (flushInterval.isZero() || flushInterval.isNegative()) {
+            throw new IllegalArgumentException("Buffered Stream flushInterval must be positive");
+        }
+        if (maxBufferedBytes <= 0) {
+            throw new IllegalArgumentException("Buffered Stream maxBufferedBytes must be positive");
+        }
+        final InvocationContext invocationContext = (InvocationContext) context;
+        invocationContext.prepareBufferedStream(stream);
+        final BufferedTextStream writer = new BufferedTextStream(
+                invocationContext,
+                stream,
+                flushInterval,
+                maxBufferedBytes);
+        invocationContext.registerStepOutputFinalizer(writer);
+        return writer;
+    }
+
+    /**
+     * Appends one chunk and flushes after crossing the soft size threshold.
+     *
+     * @param chunk text appended without modification; an empty value is ignored
+     * @throws IllegalArgumentException if chunk is null
+     * @throws IllegalStateException if the invocation ended
+     * @throws RuntimeException if an earlier background or current output write failed
+     */
+    public synchronized void write(final String chunk) {
+        requireOpen();
+        if (chunk == null) {
+            throw new IllegalArgumentException("Buffered Stream chunk is required");
+        }
+        if (chunk.isEmpty()) {
+            return;
+        }
+        final boolean wasEmpty = buffer.length() == 0;
+        buffer.append(chunk);
+        bufferedBytes += chunk.getBytes(StandardCharsets.UTF_8).length;
+        if (wasEmpty) {
+            startTimer();
+        }
+        if (bufferedBytes >= maxBufferedBytes) {
+            flush();
+        }
+    }
+
+    /**
+     * Emits the current nonempty batch immediately.
+     *
+     * @throws IllegalStateException if the invocation ended
+     * @throws RuntimeException if an earlier background or current output write failed
+     */
+    public synchronized void flush() {
+        requireOpen();
+        stopTimer();
+        flushBuffer();
+    }
+
+    /** Flushes the tail and closes this writer during invocation finalization. */
+    @Override
+    public synchronized void finalizeStepOutput() {
+        if (closed) {
+            if (terminalFailure != null) {
+                throw terminalFailure;
+            }
+            return;
+        }
+        stopTimer();
+        try {
+            if (terminalFailure != null) {
+                throw terminalFailure;
+            }
+            flushBuffer();
+        } finally {
+            closed = true;
+        }
+    }
+
+    /** Discards buffered text and stops the timer after invocation cancellation. */
+    @Override
+    public synchronized void cancelStepOutput() {
+        stopTimer();
+        buffer.setLength(0);
+        bufferedBytes = 0;
+        closed = true;
+    }
+
+    private void startTimer() {
+        final long generation = ++timerGeneration;
+        timer = context.getBufferedStreamScheduler().schedule(
+                () -> flushFromTimer(generation),
+                flushInterval.toNanos(),
+                TimeUnit.NANOSECONDS);
+    }
+
+    private synchronized void flushFromTimer(final long generation) {
+        if (closed || terminalFailure != null || generation != timerGeneration) {
+            return;
+        }
+        timer = null;
+        try {
+            flushBuffer();
+        } catch (RuntimeException failure) {
+            terminalFailure = failure;
+        }
+    }
+
+    private void stopTimer() {
+        timerGeneration++;
+        if (timer != null) {
+            timer.cancel(false);
+            timer = null;
+        }
+    }
+
+    private void flushBuffer() {
+        if (buffer.length() == 0) {
+            return;
+        }
+        final String value = buffer.toString();
+        buffer.setLength(0);
+        bufferedBytes = 0;
+        try {
+            stream.write(context, value);
+        } catch (RuntimeException failure) {
+            terminalFailure = failure;
+            throw failure;
+        }
+    }
+
+    private void requireOpen() {
+        if (terminalFailure != null) {
+            throw terminalFailure;
+        }
+        if (closed) {
+            throw new IllegalStateException("Buffered Stream invocation has finished");
+        }
+    }
+}

--- a/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 final class InvocationContext implements Context {
     enum Method {
@@ -56,12 +57,19 @@ final class InvocationContext implements Context {
     private final Map<String, Value> locals;
     private final ConditionResults conditionResults;
     private final Map<String, ChannelInfo> channelInfos;
+    private final ScheduledExecutorService bufferedStreamScheduler;
+    private final io.grpc.Context requestContext;
+    private final io.grpc.Context.CancellationListener cancellationListener;
     private final Map<String, AttributeWrite> attributeWrites =
             new LinkedHashMap<String, AttributeWrite>();
     private final Map<String, KV> localWrites = new LinkedHashMap<String, KV>();
     private final List<KV> events = new ArrayList<KV>();
     private final Set<String> eventNames = new HashSet<String>();
     private final List<ChannelMessage> publications = new ArrayList<ChannelMessage>();
+    private final List<StepOutputFinalizer> stepOutputFinalizers =
+            new ArrayList<StepOutputFinalizer>();
+    private boolean stepOutputsFinalized;
+
     InvocationContext(
             final Method method,
             final Registry.RegisteredFlow flow,
@@ -72,6 +80,30 @@ final class InvocationContext implements Context {
             final List<KV> locals,
             final ConditionResults conditionResults,
             final Map<String, ChannelInfo> channelInfos) {
+        this(
+                method,
+                flow,
+                metadata,
+                values,
+                stepOutputEmitter,
+                attributes,
+                locals,
+                conditionResults,
+                channelInfos,
+                null);
+    }
+
+    InvocationContext(
+            final Method method,
+            final Registry.RegisteredFlow flow,
+            final io.superdurable.gen.Context metadata,
+            final ValueMapper values,
+            final StepOutputEmitter stepOutputEmitter,
+            final List<KV> attributes,
+            final List<KV> locals,
+            final ConditionResults conditionResults,
+            final Map<String, ChannelInfo> channelInfos,
+            final ScheduledExecutorService bufferedStreamScheduler) {
         if (metadata == null) {
             throw new IllegalArgumentException("Worker request Context is required");
         }
@@ -80,6 +112,12 @@ final class InvocationContext implements Context {
         this.metadata = metadata;
         this.values = values;
         this.stepOutputEmitter = stepOutputEmitter;
+        this.bufferedStreamScheduler = bufferedStreamScheduler;
+        this.requestContext = io.grpc.Context.current();
+        this.cancellationListener = ignored -> cancelStepOutputs();
+        if (stepOutputEmitter != null) {
+            requestContext.addListener(cancellationListener, Runnable::run);
+        }
         this.attributes = mapValues("Attribute", attributes);
         this.locals = mapValues("step-execution local", locals);
         this.conditionResults = conditionResults;
@@ -195,6 +233,62 @@ final class InvocationContext implements Context {
                 .setStreamCapacityBytes(stream.getStreamCapacityBytes())
                 .setValue(values.encode(value))
                 .build());
+    }
+
+    synchronized void prepareBufferedStream(final Stream<String> stream) {
+        requireStepOutput("Buffered Streams");
+        requireRegistered(stream);
+        if (stream.getValueType() != String.class) {
+            throw new IllegalArgumentException("Buffered Streams require Stream<String>");
+        }
+        if (stepOutputsFinalized) {
+            throw new IllegalStateException("Buffered Stream invocation has finished");
+        }
+    }
+
+    synchronized void registerStepOutputFinalizer(final StepOutputFinalizer finalizer) {
+        if (stepOutputsFinalized) {
+            throw new IllegalStateException("Buffered Stream invocation has finished");
+        }
+        stepOutputFinalizers.add(finalizer);
+    }
+
+    synchronized Throwable finalizeStepOutputs(final Throwable failure) {
+        if (stepOutputsFinalized) {
+            return failure;
+        }
+        stepOutputsFinalized = true;
+        requestContext.removeListener(cancellationListener);
+        Throwable combined = failure;
+        for (StepOutputFinalizer finalizer : stepOutputFinalizers) {
+            try {
+                finalizer.finalizeStepOutput();
+            } catch (Throwable finalizationFailure) {
+                if (combined == null) {
+                    combined = finalizationFailure;
+                } else if (combined != finalizationFailure) {
+                    combined.addSuppressed(finalizationFailure);
+                }
+            }
+        }
+        return combined;
+    }
+
+    private synchronized void cancelStepOutputs() {
+        if (stepOutputsFinalized) {
+            return;
+        }
+        stepOutputsFinalized = true;
+        for (StepOutputFinalizer finalizer : stepOutputFinalizers) {
+            finalizer.cancelStepOutput();
+        }
+    }
+
+    ScheduledExecutorService getBufferedStreamScheduler() {
+        if (bufferedStreamScheduler == null) {
+            throw new IllegalStateException("Buffered Stream scheduler is unavailable");
+        }
+        return bufferedStreamScheduler;
     }
 
     private void requireStepOutput(final String operation) {

--- a/sdk-java/src/main/java/io/superdurable/dex/JavaWorkerService.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/JavaWorkerService.java
@@ -64,7 +64,7 @@ final class JavaWorkerService extends WorkerServiceGrpc.WorkerServiceImplBase {
     public void invokeWaitForMethod(
             final InvokeWaitForMethodRequest request,
             final StreamObserver<InvokeWaitForMethodOutput> observer) {
-        final WaitForOutputEmitter emitter = new WaitForOutputEmitter(observer);
+        final WaitForOutputEmitter emitter = new WaitForOutputEmitter(observer, Context.current());
         submit(observer, () -> emitter.emitResult(dispatcher.invokeWaitFor(request, emitter)));
     }
 
@@ -72,7 +72,7 @@ final class JavaWorkerService extends WorkerServiceGrpc.WorkerServiceImplBase {
     public void invokeExecuteMethod(
             final InvokeExecuteMethodRequest request,
             final StreamObserver<InvokeExecuteMethodOutput> observer) {
-        final ExecuteOutputEmitter emitter = new ExecuteOutputEmitter(observer);
+        final ExecuteOutputEmitter emitter = new ExecuteOutputEmitter(observer, Context.current());
         submit(observer, () -> emitter.emitResult(dispatcher.invokeExecute(request, emitter)));
     }
 
@@ -183,6 +183,18 @@ final class JavaWorkerService extends WorkerServiceGrpc.WorkerServiceImplBase {
         }
     }
 
+    private static <Response> void emit(
+            final StreamObserver<Response> observer,
+            final Response response,
+            final Context requestContext) {
+        final Context previous = requestContext.attach();
+        try {
+            emit(observer, response);
+        } finally {
+            requestContext.detach(previous);
+        }
+    }
+
     private static void requireActiveInvocation() {
         if (Context.current().isCancelled()) {
             Thread.currentThread().interrupt();
@@ -198,53 +210,63 @@ final class JavaWorkerService extends WorkerServiceGrpc.WorkerServiceImplBase {
 
     private static final class WaitForOutputEmitter implements StepOutputEmitter {
         private final StreamObserver<InvokeWaitForMethodOutput> observer;
+        private final Context requestContext;
 
-        private WaitForOutputEmitter(final StreamObserver<InvokeWaitForMethodOutput> observer) {
+        private WaitForOutputEmitter(
+                final StreamObserver<InvokeWaitForMethodOutput> observer,
+                final Context requestContext) {
             this.observer = observer;
+            this.requestContext = requestContext;
         }
 
         @Override
-        public void emitHeartbeat(final StepMethodHeartbeat heartbeat) {
+        public synchronized void emitHeartbeat(final StepMethodHeartbeat heartbeat) {
             emit(observer, InvokeWaitForMethodOutput.newBuilder()
                     .setHeartbeat(heartbeat)
-                    .build());
+                    .build(), requestContext);
         }
 
         @Override
-        public void emitStreamWrite(final StepStreamWrite streamWrite) {
+        public synchronized void emitStreamWrite(final StepStreamWrite streamWrite) {
             emit(observer, InvokeWaitForMethodOutput.newBuilder()
                     .setStreamWrite(streamWrite)
-                    .build());
+                    .build(), requestContext);
         }
 
-        private void emitResult(final InvokeWaitForMethodResponse result) {
-            emit(observer, InvokeWaitForMethodOutput.newBuilder().setResult(result).build());
+        private synchronized void emitResult(final InvokeWaitForMethodResponse result) {
+            emit(observer, InvokeWaitForMethodOutput.newBuilder().setResult(result).build(),
+                    requestContext);
         }
     }
 
     private static final class ExecuteOutputEmitter implements StepOutputEmitter {
         private final StreamObserver<InvokeExecuteMethodOutput> observer;
+        private final Context requestContext;
 
-        private ExecuteOutputEmitter(final StreamObserver<InvokeExecuteMethodOutput> observer) {
+        private ExecuteOutputEmitter(
+                final StreamObserver<InvokeExecuteMethodOutput> observer,
+                final Context requestContext) {
             this.observer = observer;
+            this.requestContext = requestContext;
         }
 
         @Override
-        public void emitHeartbeat(final StepMethodHeartbeat heartbeat) {
+        public synchronized void emitHeartbeat(final StepMethodHeartbeat heartbeat) {
             emit(observer, InvokeExecuteMethodOutput.newBuilder()
                     .setHeartbeat(heartbeat)
-                    .build());
+                    .build(), requestContext);
         }
 
         @Override
-        public void emitStreamWrite(final StepStreamWrite streamWrite) {
+        public synchronized void emitStreamWrite(final StepStreamWrite streamWrite) {
             emit(observer, InvokeExecuteMethodOutput.newBuilder()
                     .setStreamWrite(streamWrite)
-                    .build());
+                    .build(), requestContext);
         }
 
-        private void emitResult(final InvokeExecuteMethodResponse result) {
-            emit(observer, InvokeExecuteMethodOutput.newBuilder().setResult(result).build());
+        private synchronized void emitResult(final InvokeExecuteMethodResponse result) {
+            emit(observer, InvokeExecuteMethodOutput.newBuilder().setResult(result).build(),
+                    requestContext);
         }
     }
 

--- a/sdk-java/src/main/java/io/superdurable/dex/StepOutputFinalizer.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StepOutputFinalizer.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Licensed under the Super Durable Source License 1.0.
+ * You may not use this file except in compliance with the License.
+ * See the LICENSE file in the repository root.
+ *
+ * SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+ */
+
+package io.superdurable.dex;
+
+interface StepOutputFinalizer {
+    void finalizeStepOutput();
+
+    void cancelStepOutput();
+}

--- a/sdk-java/src/main/java/io/superdurable/dex/Worker.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Worker.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -57,6 +59,7 @@ public final class Worker implements AutoCloseable {
     private final WorkerOptions options;
     private final WorkerTarget workerTarget;
     private final ExecutorService handlers;
+    private final ScheduledExecutorService bufferedStreamScheduler;
     private final ManagedChannel flowChannel;
     private final FlowServiceGrpc.FlowServiceBlockingStub flowService;
     private final JavaWorkerService workerService;
@@ -95,6 +98,11 @@ public final class Worker implements AutoCloseable {
                 ? targetFromBindAddress(options.getBindAddress())
                 : options.getWorkerTarget();
         this.handlers = newHandlerExecutor();
+        this.bufferedStreamScheduler = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            final Thread thread = new Thread(runnable, "dex-java-buffered-stream");
+            thread.setDaemon(true);
+            return thread;
+        });
         this.flowChannel = ManagedChannelBuilder.forTarget(options.getServerAddress())
                 .usePlaintext()
                 .build();
@@ -103,7 +111,8 @@ public final class Worker implements AutoCloseable {
         final WorkerDispatcher dispatcher = new WorkerDispatcher(
                 registry,
                 values,
-                new ValueHydrator(flowService, blobCache));
+                new ValueHydrator(flowService, blobCache),
+                bufferedStreamScheduler);
         this.workerService = new JavaWorkerService(
                 dispatcher,
                 handlers,
@@ -239,6 +248,7 @@ public final class Worker implements AutoCloseable {
             handlers.shutdownNow();
             Thread.currentThread().interrupt();
         }
+        bufferedStreamScheduler.shutdownNow();
         flowChannel.shutdown();
         try {
             if (!flowChannel.awaitTermination(5, TimeUnit.SECONDS)) {

--- a/sdk-java/src/main/java/io/superdurable/dex/WorkerDispatcher.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/WorkerDispatcher.java
@@ -44,6 +44,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 final class WorkerDispatcher {
     private static final String TIMEOUT_HANDLER_STEP_TYPE = "sys:timeout_handler";
@@ -51,19 +52,29 @@ final class WorkerDispatcher {
     private final Registry registry;
     private final ValueMapper values;
     private final ValueHydrator hydrator;
+    private final ScheduledExecutorService bufferedStreamScheduler;
 
     WorkerDispatcher(
             final Registry registry,
             final ValueMapper values,
             final ValueHydrator hydrator) {
+        this(registry, values, hydrator, null);
+    }
+
+    WorkerDispatcher(
+            final Registry registry,
+            final ValueMapper values,
+            final ValueHydrator hydrator,
+            final ScheduledExecutorService bufferedStreamScheduler) {
         this.registry = registry;
         this.values = values;
         this.hydrator = hydrator;
+        this.bufferedStreamScheduler = bufferedStreamScheduler;
     }
 
     InvokeWaitForMethodResponse invokeWaitFor(
             final InvokeWaitForMethodRequest original,
-            final StepOutputEmitter stepOutputEmitter) {
+            final StepOutputEmitter stepOutputEmitter) throws Throwable {
         final InvokeWaitForMethodRequest request = hydrator.hydrate(original);
         final Registry.RegisteredFlow flow = registry.getFlow(request.getFlowType());
         final Registry.RegisteredStep step = flow.getStep(request.getStepType());
@@ -76,26 +87,34 @@ final class WorkerDispatcher {
                 request.getAttributesList(),
                 null,
                 null,
-                null);
+                null,
+                bufferedStreamScheduler);
         final Object input = values.decode(request.getStepInput(), step.getStep().getInputType());
-        final Wait wait = callWaitFor(step.getStep(), context, input);
-
-        final InvokeWaitForMethodResponse.Builder response =
-                InvokeWaitForMethodResponse.newBuilder()
-                        .addAllUpsertAttributes(context.getAttributeWrites())
-                        .addAllUpsertStepExeLocals(context.getLocalWrites())
-                        .addAllRecordEvents(context.getEvents())
-                        .addAllPublishToChannel(context.getPublications());
-        final WaitingCondition waiting = mapWait(flow, step, wait);
-        if (waiting != null) {
-            response.setWaitingCondition(waiting);
+        try {
+            final Wait wait = callWaitFor(step.getStep(), context, input);
+            final InvokeWaitForMethodResponse.Builder response =
+                    InvokeWaitForMethodResponse.newBuilder()
+                            .addAllUpsertAttributes(context.getAttributeWrites())
+                            .addAllUpsertStepExeLocals(context.getLocalWrites())
+                            .addAllRecordEvents(context.getEvents())
+                            .addAllPublishToChannel(context.getPublications());
+            final WaitingCondition waiting = mapWait(flow, step, wait);
+            if (waiting != null) {
+                response.setWaitingCondition(waiting);
+            }
+            final Throwable finalizationFailure = context.finalizeStepOutputs(null);
+            if (finalizationFailure != null) {
+                throw finalizationFailure;
+            }
+            return response.build();
+        } catch (Throwable failure) {
+            throw context.finalizeStepOutputs(failure);
         }
-        return response.build();
     }
 
     InvokeExecuteMethodResponse invokeExecute(
             final InvokeExecuteMethodRequest original,
-            final StepOutputEmitter stepOutputEmitter) {
+            final StepOutputEmitter stepOutputEmitter) throws Throwable {
         final InvokeExecuteMethodRequest request = hydrator.hydrate(original);
         final Registry.RegisteredFlow flow = registry.getFlow(request.getFlowType());
         if (TIMEOUT_HANDLER_STEP_TYPE.equals(request.getStepType())) {
@@ -111,16 +130,26 @@ final class WorkerDispatcher {
                 request.getAttributesList(),
                 request.getStepExeLocalsList(),
                 request.hasConditionResults() ? request.getConditionResults() : null,
-                null);
+                null,
+                bufferedStreamScheduler);
         final Object input = values.decode(request.getStepInput(), step.getStep().getInputType());
-        final StepDecision decision = callExecute(step.getStep(), context, input);
-        return InvokeExecuteMethodResponse.newBuilder()
-                .setStepDecision(mapDecision(flow, step, decision))
-                .addAllUpsertAttributes(context.getAttributeWrites())
-                .addAllRecordEvents(context.getEvents())
-                .addAllUpsertStepExeLocals(context.getLocalWrites())
-                .addAllPublishToChannel(context.getPublications())
-                .build();
+        try {
+            final StepDecision decision = callExecute(step.getStep(), context, input);
+            final InvokeExecuteMethodResponse response = InvokeExecuteMethodResponse.newBuilder()
+                    .setStepDecision(mapDecision(flow, step, decision))
+                    .addAllUpsertAttributes(context.getAttributeWrites())
+                    .addAllRecordEvents(context.getEvents())
+                    .addAllUpsertStepExeLocals(context.getLocalWrites())
+                    .addAllPublishToChannel(context.getPublications())
+                    .build();
+            final Throwable finalizationFailure = context.finalizeStepOutputs(null);
+            if (finalizationFailure != null) {
+                throw finalizationFailure;
+            }
+            return response;
+        } catch (Throwable failure) {
+            throw context.finalizeStepOutputs(failure);
+        }
     }
 
     private InvokeExecuteMethodResponse invokeTimeoutHandler(
@@ -142,7 +171,8 @@ final class WorkerDispatcher {
                 request.getAttributesList(),
                 request.getStepExeLocalsList(),
                 request.hasConditionResults() ? request.getConditionResults() : null,
-                null);
+                null,
+                bufferedStreamScheduler);
         final StepDecision decision = flow.getFlow().handleTimeout(context);
         return InvokeExecuteMethodResponse.newBuilder()
                 .setStepDecision(mapDecision(
@@ -169,7 +199,8 @@ final class WorkerDispatcher {
                 request.getAttributesList(),
                 null,
                 null,
-                request.getChannelInfosMap());
+                request.getChannelInfosMap(),
+                bufferedStreamScheduler);
         final Method method = rpc.getMethod();
         final Object[] arguments;
         if (method.getParameterTypes().length == 2) {

--- a/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
@@ -143,6 +143,26 @@ final class WorkerServiceIntegrationTest {
     }
 
     @Test
+    void bufferedTextStreamFlushesBeforeTheResult() throws Exception {
+        final BridgeFlow flow = new BridgeFlow();
+        final RunningWorker running = startWorker(flow, new TestBlobCache(), null);
+        try {
+            final Iterator<InvokeExecuteMethodOutput> outputs =
+                    running.client.invokeExecuteMethod(executeRequest(concrete("buffered")));
+            assertTrue(outputs.hasNext());
+            assertEquals("hello", outputs.next().getStreamWrite().getValue().getStringValue());
+            flow.start.bufferedHandlerRelease.countDown();
+            assertTrue(outputs.hasNext());
+            assertEquals(" 世界", outputs.next().getStreamWrite().getValue().getStringValue());
+            assertTrue(outputs.hasNext());
+            assertTrue(outputs.next().hasResult());
+            assertFalse(outputs.hasNext());
+        } finally {
+            running.close();
+        }
+    }
+
+    @Test
     void preservesProgressBeforeHandlerFailureWithoutSendingResult() throws Exception {
         final RunningWorker running = startWorker(new BridgeFlow(), new TestBlobCache(), null);
         try {
@@ -982,6 +1002,7 @@ final class WorkerServiceIntegrationTest {
                 new AtomicReference<Boolean>(Boolean.FALSE);
         private final CountDownLatch blockStarted = new CountDownLatch(1);
         private final CountDownLatch cancellationObserved = new CountDownLatch(1);
+        private final CountDownLatch bufferedHandlerRelease = new CountDownLatch(1);
         private final Channel<Void> commands;
         private final Stream<String> thinking;
         private final Stream<String> findings;
@@ -1050,6 +1071,23 @@ final class WorkerServiceIntegrationTest {
                 thinking.write(context, "second");
                 context.recordHeartbeat(null);
                 findings.write(context, "third");
+            }
+            if ("buffered".equals(input)) {
+                final BufferedTextStream progress = BufferedTextStream.create(
+                        context,
+                        thinking,
+                        Duration.ofMillis(5),
+                        1_024);
+                progress.write("hello");
+                try {
+                    if (!bufferedHandlerRelease.await(5, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("buffered handler was not released");
+                    }
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("buffered handler was interrupted", interrupted);
+                }
+                progress.write(" 世界");
             }
             if ("read-heartbeat".equals(input)) {
                 return StepDecision.gracefulComplete(context.hasLastHeartbeatValue()

--- a/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
@@ -19,6 +19,7 @@ import io.superdurable.dex.Attribute;
 import io.superdurable.dex.AttributeMap;
 import io.superdurable.dex.BlobCache;
 import io.superdurable.dex.BlobCacheConfig;
+import io.superdurable.dex.BufferedTextStream;
 import io.superdurable.dex.Channel;
 import io.superdurable.dex.Client;
 import io.superdurable.dex.ClientOptions;
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -237,6 +239,17 @@ public class UserContractsTest {
         if (output == null) {
             throw new AssertionError("compile-only contract");
         }
+    }
+
+    @SuppressWarnings("unused")
+    private static void compileBufferedTextStreamContract(final Context context) {
+        final BufferedTextStream progress = BufferedTextStream.create(
+                context,
+                PROGRESS,
+                Duration.ofMillis(500),
+                8 * 1024);
+        progress.write("thinking ");
+        progress.flush();
     }
 
     public static class OrderFlow implements Flow<OrderInput> {

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/README.md
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/README.md
@@ -21,7 +21,7 @@ persistence, reset, signals, timers, recovery, and failure behavior.
 | `SignalTest` | typed publish, channel combinations, timer skipping, and closed-flow errors |
 | `SkipWaitUntilTest` | execute-only and mixed wait styles |
 | `StepCancellationTest` | global/sibling selectors, local and fallback cancellation, heartbeats, and discarded late results |
-| `StreamTest` | Pending the server-streaming Worker API update |
+| `StreamTest` | repeated Step/client writes, source metadata, and buffered text finalization |
 | `StateOptionsOverrideTest` | per-movement StepOptions overrides |
 | `StateOptionsTest` | attribute visibility and parallel WaitFor/Execute locks |
 | `StateRecoveryTest` | execute-failure recovery with and without WaitFor |

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StreamTestWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StreamTestWorkflow.java
@@ -12,6 +12,7 @@
 
 package io.superdurable.dex.integ;
 
+import io.superdurable.dex.BufferedTextStream;
 import io.superdurable.dex.Context;
 import io.superdurable.dex.Flow;
 import io.superdurable.dex.PersistenceSchema;
@@ -42,8 +43,12 @@ final class StreamTestWorkflow implements Flow<Void> {
 
         @Override
         public StepDecision execute(final Context context, final Void input) {
-            progress.write(context, "step-progress-1");
-            progress.write(context, "step-progress-2");
+            final BufferedTextStream writer = BufferedTextStream.create(context, progress);
+            writer.write("step-progress-");
+            writer.write("1");
+            writer.flush();
+            writer.write("step-progress-");
+            writer.write("2");
             return StepDecision.gracefulComplete();
         }
     }

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -157,10 +157,29 @@ Worker output queue:
 async def execute(
     self, context: dex.AsyncContext, input: str
 ) -> dex.StepDecision:
-    progress.write(context, "started")
+    writer = progress.buffered(context)
+    writer.write("started")
     await context.heartbeat({"offset": 10})
     return dex.graceful_complete(input)
 ```
+
+The async buffered writer has synchronous `write` and `flush` methods, so
+`writer.write` can be passed directly as an LLM delta callback. It flushes after
+one second, at a soft 16 KiB UTF-8 threshold, or before the final result or
+error. It concatenates chunks exactly and ignores empty chunks.
+
+A synchronous generator uses the cooperative form because only yielded
+`StepOutput` values can reach gRPC:
+
+```python
+writer = progress.buffered(context)
+yield from writer.write(delta)
+yield from writer.flush()
+```
+
+Its interval is checked by the next write, and the handler must explicitly
+flush the tail. Retry does not restore either writer's unsent buffer or
+deduplicate sent batches.
 
 Call `heartbeat()` or `await context.heartbeat()` without a value to clear previous
 details. Passing Python `None` persists a present null Value. On a later regular

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -157,7 +157,7 @@ Worker output queue:
 async def execute(
     self, context: dex.AsyncContext, input: str
 ) -> dex.StepDecision:
-    writer = progress.buffered(context)
+    writer = progress.buffered_text(context)
     writer.write("started")
     await context.heartbeat({"offset": 10})
     return dex.graceful_complete(input)
@@ -172,7 +172,7 @@ A synchronous generator uses the cooperative form because only yielded
 `StepOutput` values can reach gRPC:
 
 ```python
-writer = progress.buffered(context)
+writer = progress.buffered_text(context)
 yield from writer.write(delta)
 yield from writer.flush()
 ```

--- a/sdk-python/dex/__init__.py
+++ b/sdk-python/dex/__init__.py
@@ -92,7 +92,12 @@ from dex.step import (
     heartbeat,
 )
 from dex.step_execution import StepExecutionId, TimerId
-from dex.stream import Stream, StreamMessage
+from dex.stream import (
+    AsyncBufferedTextStream,
+    BufferedTextStream,
+    Stream,
+    StreamMessage,
+)
 from dex.subflow import SubFlow
 from dex.timer import Timer
 from dex.wait import Wait
@@ -112,9 +117,11 @@ __all__ = [
     "AttributeMap",
     "AsyncContext",
     "AsyncClient",
+    "AsyncBufferedTextStream",
     "AsyncWorker",
     "BlobCache",
     "BlobCacheConfig",
+    "BufferedTextStream",
     "Channel",
     "ChannelMap",
     "Client",

--- a/sdk-python/dex/_async_worker_dispatcher.py
+++ b/sdk-python/dex/_async_worker_dispatcher.py
@@ -29,6 +29,7 @@ class _AsyncStepOutputEmitter:
     def __init__(self) -> None:
         self.queue: asyncio.Queue[StepOutput] = asyncio.Queue()
         self._is_closed = False
+        self._close_callbacks: list[Callable[[], None]] = []
 
     def emit_nowait(self, output: StepOutput) -> None:
         if self._is_closed:
@@ -44,7 +45,17 @@ class _AsyncStepOutputEmitter:
             raise asyncio.CancelledError
 
     def close(self) -> None:
+        if self._is_closed:
+            return
         self._is_closed = True
+        for callback in self._close_callbacks:
+            callback()
+
+    def add_close_callback(self, callback: Callable[[], None]) -> None:
+        if self._is_closed:
+            callback()
+            return
+        self._close_callbacks.append(callback)
 
 
 class AsyncWorkerDispatcher(WorkerDispatcher):
@@ -93,18 +104,21 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             output_emitter=emitter,
         )
         input = self._values.decode(request.step_input, step.input_codec)
-        wait = step.step.wait_for(context, input)
-        if isgenerator(wait):
-            wait.close()
-            raise InvalidStepResultError(
-                flow.name,
-                step.name,
-                "wait_for",
-                "synchronous generators require Worker",
-            )
-        if isawaitable(wait):
-            wait = await wait
+        response: pb.InvokeWaitForMethodResponse | None = None
+        failure: BaseException | None = None
+        cause: BaseException | None = None
         try:
+            wait = step.step.wait_for(context, input)
+            if isgenerator(wait):
+                wait.close()
+                raise InvalidStepResultError(
+                    flow.name,
+                    step.name,
+                    "wait_for",
+                    "synchronous generators require Worker",
+                )
+            if isawaitable(wait):
+                wait = await wait
             if not isinstance(wait, Wait):
                 raise TypeError("wait_for must return Wait")
             response = pb.InvokeWaitForMethodResponse(
@@ -116,11 +130,22 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             waiting = self._map_wait(flow, wait)
             if waiting is not None:
                 response.waiting_condition.CopyFrom(waiting)
-            return response
+        except InvalidStepResultError as error:
+            failure = error
         except (TypeError, ValueError) as error:
-            raise InvalidStepResultError(
+            failure = InvalidStepResultError(
                 flow.name, step.name, "wait_for", str(error)
-            ) from error
+            )
+            cause = error
+        except BaseException as error:
+            failure = error
+        combined = context._finalize_step_outputs(failure)
+        if combined is not None:
+            if cause is not None:
+                raise combined from cause
+            raise combined
+        assert response is not None
+        return response
 
     async def invoke_execute(  # type: ignore[override]
         self,
@@ -166,31 +191,46 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             output_emitter=emitter,
         )
         input = self._values.decode(request.step_input, step.input_codec)
-        decision: Any = step.step.execute(context, input)
-        if isgenerator(decision):
-            decision.close()
-            raise InvalidStepResultError(
-                flow.name,
-                step.name,
-                "execute",
-                "synchronous generators require Worker",
-            )
-        if isawaitable(decision):
-            decision = await decision
+        response: pb.InvokeExecuteMethodResponse | None = None
+        failure: BaseException | None = None
+        cause: BaseException | None = None
         try:
+            decision: Any = step.step.execute(context, input)
+            if isgenerator(decision):
+                decision.close()
+                raise InvalidStepResultError(
+                    flow.name,
+                    step.name,
+                    "execute",
+                    "synchronous generators require Worker",
+                )
+            if isawaitable(decision):
+                decision = await decision
             if not isinstance(decision, StepDecision):
                 raise TypeError("execute must return StepDecision")
-            return pb.InvokeExecuteMethodResponse(
+            response = pb.InvokeExecuteMethodResponse(
                 step_decision=self._map_decision(flow, decision),
                 upsert_attributes=list(context.attribute_writes.values()),
                 record_events=context.events,
                 upsert_step_exe_locals=list(context.local_writes.values()),
                 publish_to_channel=context.publications,
             )
+        except InvalidStepResultError as error:
+            failure = error
         except (TypeError, ValueError) as error:
-            raise InvalidStepResultError(
+            failure = InvalidStepResultError(
                 flow.name, step.name, "execute", str(error)
-            ) from error
+            )
+            cause = error
+        except BaseException as error:
+            failure = error
+        combined = context._finalize_step_outputs(failure)
+        if combined is not None:
+            if cause is not None:
+                raise combined from cause
+            raise combined
+        assert response is not None
+        return response
 
     async def _invoke_timeout_handler_async(
         self,

--- a/sdk-python/dex/_invocation_context.py
+++ b/sdk-python/dex/_invocation_context.py
@@ -46,6 +46,14 @@ class _StepOutputEmitter(Protocol):
 
     async def emit(self, output: StepOutput) -> None: ...
 
+    def add_close_callback(self, callback: Callable[[], None]) -> None: ...
+
+
+class _StepOutputFinalizer(Protocol):
+    def _finalize_step_output(self) -> None: ...
+
+    def _cancel_step_output(self) -> None: ...
+
 
 class InvocationContext:
     def __init__(
@@ -76,6 +84,8 @@ class InvocationContext:
         self.events: list[pb.KV] = []
         self.publications: list[pb.ChannelMessage] = []
         self._event_names: set[str] = set()
+        self._step_output_finalizers: list[_StepOutputFinalizer] = []
+        self._step_outputs_finalized = False
 
     @property
     def flow_id(self) -> str:
@@ -220,6 +230,44 @@ class InvocationContext:
             return output
         self._output_emitter.emit_nowait(output)
         return None
+
+    def _prepare_buffered_stream(self, definition: Stream[object]) -> bool:
+        if self._method not in (InvocationMethod.WAIT_FOR, InvocationMethod.EXECUTE):
+            raise ValueError("Buffered Streams require a Step Context")
+        self._require_registered(definition)
+        return self._output_emitter is not None
+
+    def _register_step_output_finalizer(
+        self,
+        finalizer: _StepOutputFinalizer,
+    ) -> None:
+        if self._step_outputs_finalized or self._output_emitter is None:
+            raise ValueError(
+                "Buffered Stream finalizers require an active async Step Context"
+            )
+        self._step_output_finalizers.append(finalizer)
+        self._output_emitter.add_close_callback(finalizer._cancel_step_output)
+
+    def _finalize_step_outputs(
+        self,
+        failure: BaseException | None = None,
+    ) -> BaseException | None:
+        if self._step_outputs_finalized:
+            return failure
+        self._step_outputs_finalized = True
+        failures: list[BaseException] = [] if failure is None else [failure]
+        for finalizer in self._step_output_finalizers:
+            try:
+                finalizer._finalize_step_output()
+            except BaseException as error:
+                failures.append(error)
+        if not failures:
+            return None
+        if len(failures) == 1:
+            return failures[0]
+        return BaseExceptionGroup(
+            "Step handler and buffered Stream finalization failed", failures
+        )
 
     def _get_attribute(
         self,

--- a/sdk-python/dex/context.py
+++ b/sdk-python/dex/context.py
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
     from dex.step import StepOutput
     from dex.stream import Stream
 
+    class _StepOutputFinalizer(Protocol):
+        def _finalize_step_output(self) -> None: ...
+
+        def _cancel_step_output(self) -> None: ...
+
+
 ValueT = TypeVar("ValueT")
 
 
@@ -226,6 +232,13 @@ class Context(Protocol):
         definition: Stream[ValueT],
         value: ValueT,
     ) -> StepOutput | None: ...
+
+    def _prepare_buffered_stream(self, definition: Stream[object]) -> bool: ...
+
+    def _register_step_output_finalizer(
+        self,
+        finalizer: _StepOutputFinalizer,
+    ) -> None: ...
 
 
 class AsyncContext(Context, Protocol):

--- a/sdk-python/dex/stream.py
+++ b/sdk-python/dex/stream.py
@@ -93,7 +93,7 @@ class Stream(Generic[ValueT]):
         return context._write_stream(self, value)
 
     @overload
-    def buffered(  # type: ignore[overload-overlap]
+    def buffered_text(  # type: ignore[overload-overlap]
         self: Stream[str],
         context: AsyncContext,
         *,
@@ -102,7 +102,7 @@ class Stream(Generic[ValueT]):
     ) -> AsyncBufferedTextStream: ...
 
     @overload
-    def buffered(
+    def buffered_text(
         self: Stream[str],
         context: Context,
         *,
@@ -110,7 +110,7 @@ class Stream(Generic[ValueT]):
         max_buffered_bytes: int = _DEFAULT_BUFFERED_TEXT_MAX_BYTES,
     ) -> BufferedTextStream: ...
 
-    def buffered(
+    def buffered_text(
         self: Stream[str],
         context: Context,
         *,
@@ -183,9 +183,9 @@ class StreamMessage(Generic[ValueT]):
 class AsyncBufferedTextStream:
     """Batch text chunks for an asynchronous Step invocation.
 
-    Create this writer with :meth:`Stream.buffered`. ``write`` and ``flush`` are synchronous and
-    return after local buffering or Worker-output enqueueing. AsyncWorker automatically stops its
-    timer and flushes remaining text before the invocation result or error.
+    Create this writer with :meth:`Stream.buffered_text`. ``write`` and ``flush`` are synchronous
+    and return after local buffering or Worker-output enqueueing. AsyncWorker automatically stops
+    its timer and flushes remaining text before the invocation result or error.
     """
 
     def __init__(
@@ -328,8 +328,8 @@ class AsyncBufferedTextStream:
 class BufferedTextStream:
     """Batch text chunks for a synchronous Step generator.
 
-    Create this writer with :meth:`Stream.buffered`. Yield every output returned by ``write`` and
-    ``flush``. The interval is cooperative: elapsed time is checked when another chunk arrives.
+    Create this writer with :meth:`Stream.buffered_text`. Yield every output returned by ``write``
+    and ``flush``. The interval is cooperative: elapsed time is checked when another chunk arrives.
     """
 
     def __init__(

--- a/sdk-python/dex/stream.py
+++ b/sdk-python/dex/stream.py
@@ -8,9 +8,11 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from dataclasses import dataclass
-from datetime import datetime
-from typing import TYPE_CHECKING, Generic, TypeVar, overload
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Generic, TypeVar, cast, overload
 
 from dex._utils import require_name
 from dex.step import StepOutput
@@ -19,6 +21,8 @@ if TYPE_CHECKING:
     from dex.context import AsyncContext, Context
 
 ValueT = TypeVar("ValueT")
+_DEFAULT_BUFFERED_TEXT_FLUSH_INTERVAL = timedelta(seconds=1)
+_DEFAULT_BUFFERED_TEXT_MAX_BYTES = 16 * 1024
 
 
 @dataclass(frozen=True)
@@ -88,6 +92,76 @@ class Stream(Generic[ValueT]):
         """
         return context._write_stream(self, value)
 
+    @overload
+    def buffered(  # type: ignore[overload-overlap]
+        self: Stream[str],
+        context: AsyncContext,
+        *,
+        flush_interval: timedelta = _DEFAULT_BUFFERED_TEXT_FLUSH_INTERVAL,
+        max_buffered_bytes: int = _DEFAULT_BUFFERED_TEXT_MAX_BYTES,
+    ) -> AsyncBufferedTextStream: ...
+
+    @overload
+    def buffered(
+        self: Stream[str],
+        context: Context,
+        *,
+        flush_interval: timedelta = _DEFAULT_BUFFERED_TEXT_FLUSH_INTERVAL,
+        max_buffered_bytes: int = _DEFAULT_BUFFERED_TEXT_MAX_BYTES,
+    ) -> BufferedTextStream: ...
+
+    def buffered(
+        self: Stream[str],
+        context: Context,
+        *,
+        flush_interval: timedelta = _DEFAULT_BUFFERED_TEXT_FLUSH_INTERVAL,
+        max_buffered_bytes: int = _DEFAULT_BUFFERED_TEXT_MAX_BYTES,
+    ) -> AsyncBufferedTextStream | BufferedTextStream:
+        """Create an invocation-managed writer that batches text chunks.
+
+        The first non-empty chunk starts a one-shot timer. Async Step writers append their current
+        batch after ``flush_interval`` even without another chunk. Synchronous generator writers
+        check the interval only when ``write`` is called and require an explicit final ``flush``.
+        Both forms flush early after crossing the soft UTF-8 byte threshold. Chunks are never split
+        or modified.
+
+        AsyncWorker finalizes the writer before sending the invocation result or error. Its
+        synchronous ``write`` method can be passed directly as a text-delta callback. Neither form
+        waits for Dex Stream Store acknowledgement.
+
+        Args:
+            context: Current asynchronous or synchronous Step Context.
+            flush_interval: Positive maximum async buffering interval. Defaults to one second.
+            max_buffered_bytes: Positive soft UTF-8 threshold. Defaults to 16 KiB.
+
+        Returns:
+            An async invocation-managed writer, or a cooperative synchronous writer.
+
+        Raises:
+            TypeError: If this Stream does not carry ``str`` values or an option has the wrong type.
+            ValueError: If an option is not positive, the Stream is unregistered, or the Context is
+                not a Step invocation.
+        """
+        if self.value_type is not str:
+            raise TypeError("Buffered Streams require Stream[str]")
+        _validate_buffered_text_options(flush_interval, max_buffered_bytes)
+        is_async = context._prepare_buffered_stream(cast(Stream[object], self))
+        if is_async:
+            writer = AsyncBufferedTextStream(
+                self,
+                context,
+                flush_interval,
+                max_buffered_bytes,
+            )
+            context._register_step_output_finalizer(writer)
+            return writer
+        return BufferedTextStream(
+            self,
+            context,
+            flush_interval,
+            max_buffered_bytes,
+        )
+
 
 @dataclass(frozen=True)
 class StreamMessage(Generic[ValueT]):
@@ -104,3 +178,243 @@ class StreamMessage(Generic[ValueT]):
     resume_token: str
     created_time: datetime
     source: str
+
+
+class AsyncBufferedTextStream:
+    """Batch text chunks for an asynchronous Step invocation.
+
+    Create this writer with :meth:`Stream.buffered`. ``write`` and ``flush`` are synchronous and
+    return after local buffering or Worker-output enqueueing. AsyncWorker automatically stops its
+    timer and flushes remaining text before the invocation result or error.
+    """
+
+    def __init__(
+        self,
+        stream: Stream[str],
+        context: Context,
+        flush_interval: timedelta,
+        max_buffered_bytes: int,
+    ) -> None:
+        """Initialize an invocation-managed writer from validated factory inputs.
+
+        Args:
+            stream: Registered string Stream receiving each batch.
+            context: Current asynchronous Step Context.
+            flush_interval: Positive one-shot timer interval.
+            max_buffered_bytes: Positive soft UTF-8 batch threshold.
+        """
+        self._stream = stream
+        self._context = context
+        self._flush_interval_seconds = flush_interval.total_seconds()
+        self._max_buffered_bytes = max_buffered_bytes
+        self._buffer: list[str] = []
+        self._buffered_bytes = 0
+        self._timer: asyncio.TimerHandle | None = None
+        self._timer_generation = 0
+        self._is_closed = False
+        self._terminal_error: BaseException | None = None
+        self._loop = asyncio.get_running_loop()
+
+    def write(self, chunk: str) -> None:
+        """Append one text chunk and flush after reaching the soft size threshold.
+
+        Empty chunks are ignored. The first non-empty chunk starts the configured one-shot timer.
+        This method does not wait for the timer or Stream Store acknowledgement.
+
+        Args:
+            chunk: Text to append without modification.
+
+        Raises:
+            TypeError: If ``chunk`` is not a string.
+            BaseException: The previously latched timer or Worker-output failure.
+            ValueError: If the invocation already finished.
+        """
+        self._require_open()
+        if not isinstance(chunk, str):
+            raise TypeError("Buffered Stream chunks must be strings")
+        if not chunk:
+            return
+        was_empty = not self._buffer
+        self._buffer.append(chunk)
+        self._buffered_bytes += len(chunk.encode("utf-8"))
+        if was_empty:
+            self._start_timer()
+        if self._buffered_bytes >= self._max_buffered_bytes:
+            self.flush()
+
+    def flush(self) -> None:
+        """Immediately enqueue the current non-empty batch.
+
+        A later write starts a new timer. Stream Store failures remain unacknowledged.
+
+        Raises:
+            BaseException: A timer or Worker-output failure.
+            ValueError: If the invocation already finished.
+        """
+        self._require_open()
+        self._stop_timer()
+        self._flush_buffer()
+
+    def _finalize_step_output(self) -> None:
+        if self._is_closed:
+            if self._terminal_error is not None:
+                raise self._terminal_error
+            return
+        self._stop_timer()
+        try:
+            if self._terminal_error is not None:
+                raise self._terminal_error
+            self._flush_buffer()
+        finally:
+            self._is_closed = True
+
+    def _cancel_step_output(self) -> None:
+        self._stop_timer()
+        self._buffer.clear()
+        self._buffered_bytes = 0
+        self._is_closed = True
+
+    def _start_timer(self) -> None:
+        self._timer_generation += 1
+        generation = self._timer_generation
+        self._timer = self._loop.call_later(
+            self._flush_interval_seconds,
+            self._flush_from_timer,
+            generation,
+        )
+
+    def _flush_from_timer(self, generation: int) -> None:
+        if (
+            self._is_closed
+            or self._terminal_error is not None
+            or generation != self._timer_generation
+        ):
+            return
+        self._timer = None
+        try:
+            self._flush_buffer()
+        except BaseException as error:
+            self._terminal_error = error
+
+    def _stop_timer(self) -> None:
+        self._timer_generation += 1
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+
+    def _flush_buffer(self) -> None:
+        if not self._buffer:
+            return
+        value = "".join(self._buffer)
+        self._buffer.clear()
+        self._buffered_bytes = 0
+        try:
+            output = self._stream.write(self._context, value)
+            if output is not None:
+                raise RuntimeError(
+                    "Async Buffered Stream produced a synchronous StepOutput"
+                )
+        except BaseException as error:
+            self._terminal_error = error
+            raise
+
+    def _require_open(self) -> None:
+        if self._terminal_error is not None:
+            raise self._terminal_error
+        if self._is_closed:
+            raise ValueError("Buffered Stream invocation has finished")
+
+
+class BufferedTextStream:
+    """Batch text chunks for a synchronous Step generator.
+
+    Create this writer with :meth:`Stream.buffered`. Yield every output returned by ``write`` and
+    ``flush``. The interval is cooperative: elapsed time is checked when another chunk arrives.
+    """
+
+    def __init__(
+        self,
+        stream: Stream[str],
+        context: Context,
+        flush_interval: timedelta,
+        max_buffered_bytes: int,
+    ) -> None:
+        """Initialize a cooperative writer from validated factory inputs.
+
+        Args:
+            stream: Registered string Stream receiving each batch.
+            context: Current synchronous Step Context.
+            flush_interval: Positive cooperative flush interval.
+            max_buffered_bytes: Positive soft UTF-8 batch threshold.
+        """
+        self._stream = stream
+        self._context = context
+        self._flush_interval_seconds = flush_interval.total_seconds()
+        self._max_buffered_bytes = max_buffered_bytes
+        self._buffer: list[str] = []
+        self._buffered_bytes = 0
+        self._started_at: float | None = None
+
+    def write(self, chunk: str) -> tuple[StepOutput, ...]:
+        """Append one chunk and return an output when a threshold is reached.
+
+        Args:
+            chunk: Text to append without modification.
+
+        Returns:
+            An empty tuple while buffering, or one StepOutput that the handler must yield.
+
+        Raises:
+            TypeError: If ``chunk`` is not a string.
+            ValueMappingError: If the combined text cannot be encoded.
+        """
+        if not isinstance(chunk, str):
+            raise TypeError("Buffered Stream chunks must be strings")
+        if not chunk:
+            return ()
+        if self._started_at is None:
+            self._started_at = time.monotonic()
+        self._buffer.append(chunk)
+        self._buffered_bytes += len(chunk.encode("utf-8"))
+        has_elapsed = (
+            time.monotonic() - self._started_at >= self._flush_interval_seconds
+        )
+        if self._buffered_bytes < self._max_buffered_bytes and not has_elapsed:
+            return ()
+        return self.flush()
+
+    def flush(self) -> tuple[StepOutput, ...]:
+        """Return the current batch as one StepOutput for the handler to yield.
+
+        Returns:
+            An empty tuple for an empty buffer, or one Stream StepOutput.
+
+        Raises:
+            ValueMappingError: If the combined text cannot be encoded.
+        """
+        if not self._buffer:
+            return ()
+        value = "".join(self._buffer)
+        self._buffer.clear()
+        self._buffered_bytes = 0
+        self._started_at = None
+        output = self._stream.write(self._context, value)
+        if output is None:
+            raise RuntimeError(
+                "Synchronous Buffered Stream did not produce a StepOutput"
+            )
+        return (output,)
+
+
+def _validate_buffered_text_options(
+    flush_interval: timedelta,
+    max_buffered_bytes: int,
+) -> None:
+    if not isinstance(flush_interval, timedelta):
+        raise TypeError("Buffered Stream flush_interval must be timedelta")
+    if flush_interval <= timedelta(0):
+        raise ValueError("Buffered Stream flush_interval must be positive")
+    if not isinstance(max_buffered_bytes, int) or isinstance(max_buffered_bytes, bool):
+        raise TypeError("Buffered Stream max_buffered_bytes must be an integer")
+    if max_buffered_bytes <= 0:
+        raise ValueError("Buffered Stream max_buffered_bytes must be positive")

--- a/sdk-python/tests/integ/README.md
+++ b/sdk-python/tests/integ/README.md
@@ -36,7 +36,8 @@ uv run --frozen pyright tests/integ
   local contracts cover Condition IDs and map introspection.
 - Sync generator and async coroutine suites cover ordered heartbeat and Stream
   frames, repeated Stream sources, heartbeat-value recovery, explicit clearing,
-  and persisted Python `None`.
+  persisted Python `None`, cooperative sync buffering, and async timer/final-result
+  flushing.
 
 ## Error coverage
 

--- a/sdk-python/tests/integ/async_stream_flow.py
+++ b/sdk-python/tests/integ/async_stream_flow.py
@@ -33,7 +33,10 @@ class AsyncStreamTestStep(Step[None]):
         input: None,
     ) -> Wait:
         del input
-        self.progress.write(context, "async-wait")
+        progress = self.progress.buffered(context)
+        progress.write("async-")
+        progress.write("wait")
+        progress.flush()
         await context.heartbeat("async-wait-checkpoint")
         return Wait.skip_immediately()
 
@@ -43,9 +46,13 @@ class AsyncStreamTestStep(Step[None]):
         input: None,
     ) -> StepDecision:
         del input
-        self.progress.write(context, "async-step-first")
+        progress = self.progress.buffered(context)
+        progress.write("async-step-")
+        progress.write("first")
+        progress.flush()
         await context.heartbeat("async-checkpoint")
-        self.progress.write(context, "async-step-second")
+        progress.write("async-step-")
+        progress.write("second")
         await context.heartbeat()
         return graceful_complete()
 

--- a/sdk-python/tests/integ/async_stream_flow.py
+++ b/sdk-python/tests/integ/async_stream_flow.py
@@ -33,7 +33,7 @@ class AsyncStreamTestStep(Step[None]):
         input: None,
     ) -> Wait:
         del input
-        progress = self.progress.buffered(context)
+        progress = self.progress.buffered_text(context)
         progress.write("async-")
         progress.write("wait")
         progress.flush()
@@ -46,7 +46,7 @@ class AsyncStreamTestStep(Step[None]):
         input: None,
     ) -> StepDecision:
         del input
-        progress = self.progress.buffered(context)
+        progress = self.progress.buffered_text(context)
         progress.write("async-step-")
         progress.write("first")
         progress.flush()

--- a/sdk-python/tests/test_contracts.py
+++ b/sdk-python/tests/test_contracts.py
@@ -763,6 +763,60 @@ def test_sync_step_generator_maps_ordered_progress_and_result() -> None:
     ] == ["first", "second"]
 
 
+def test_sync_buffered_text_stream_is_cooperative() -> None:
+    progress = Stream("sync-buffered-progress", str, 1_048_576)
+
+    class BufferedStep(Step[str]):
+        def execute(
+            self,
+            context: Context,
+            input: str,
+        ) -> Generator[StepOutput, None, StepDecision]:
+            writer = progress.buffered(context, max_buffered_bytes=5)
+            yield from writer.write(input)
+            yield from writer.write(" 世界")
+            yield from writer.flush()
+            return graceful_complete(input)
+
+    class BufferedFlow(Flow[str]):
+        start = BufferedStep()
+
+        def get_steps(self) -> StepList[str]:
+            return StepList.start_step(self.start)
+
+        def get_persistence_schema(self) -> PersistenceSchema:
+            return PersistenceSchema.of(progress)
+
+    class PassthroughHydrator:
+        @staticmethod
+        def execute_request(
+            request: pb.InvokeExecuteMethodRequest,
+        ) -> pb.InvokeExecuteMethodRequest:
+            return request
+
+    registry = Registry((BufferedFlow(),))
+    values = ValueMapper(registry.codec_registry)
+    dispatcher = WorkerDispatcher(registry, values, cast(Any, PassthroughHydrator()))
+    outputs = list(
+        dispatcher.invoke_execute(
+            pb.InvokeExecuteMethodRequest(
+                flow_type="BufferedFlow",
+                step_type="BufferedStep",
+                step_input=values.encode("hello", values.codec(str)),
+            )
+        )
+    )
+    assert [output.WhichOneof("output") for output in outputs] == [
+        "stream_write",
+        "stream_write",
+        "result",
+    ]
+    assert [
+        values.decode(output.stream_write.value, values.codec(str))
+        for output in outputs[:-1]
+    ] == ["hello", " 世界"]
+
+
 @pytest.mark.parametrize("invalid_output", [graceful_complete(), object()])
 def test_sync_step_generator_rejects_invalid_yields(invalid_output: object) -> None:
     class InvalidGeneratorStep(Step[None]):
@@ -1043,6 +1097,74 @@ async def _assert_async_step_outputs_preserve_call_order() -> None:
     ]
     assert not outputs[1].heartbeat.HasField("value")
     assert outputs[3].heartbeat.HasField("value")
+
+
+def test_async_buffered_text_stream_flushes_on_timer_and_completion() -> None:
+    asyncio.run(_assert_async_buffered_text_stream_flushes())
+
+
+async def _assert_async_buffered_text_stream_flushes() -> None:
+    progress = Stream("async-buffered-progress", str, 1_048_576)
+    release_handler = asyncio.Event()
+
+    class BufferedStep(Step[str]):
+        async def execute(  # type: ignore[override]
+            self,
+            context: AsyncContext,
+            input: str,
+        ) -> StepDecision:
+            writer = progress.buffered(
+                context,
+                flush_interval=timedelta(milliseconds=5),
+            )
+            writer.write(input)
+            await release_handler.wait()
+            writer.write(" ")
+            writer.write("世界")
+            return graceful_complete(input)
+
+    class BufferedFlow(Flow[str]):
+        start = BufferedStep()
+
+        def get_steps(self) -> StepList[str]:
+            return StepList.start_step(self.start)
+
+        def get_persistence_schema(self) -> PersistenceSchema:
+            return PersistenceSchema.of(progress)
+
+    class AsyncPassthroughHydrator:
+        @staticmethod
+        async def execute_request(
+            request: pb.InvokeExecuteMethodRequest,
+        ) -> pb.InvokeExecuteMethodRequest:
+            return request
+
+    registry = Registry((BufferedFlow(),), allow_async_handlers=True)
+    values = ValueMapper(registry.codec_registry)
+    dispatcher = AsyncWorkerDispatcher(
+        registry,
+        values,
+        cast(Any, AsyncPassthroughHydrator()),
+    )
+    invocation = dispatcher.invoke_execute(
+        pb.InvokeExecuteMethodRequest(
+            flow_type="BufferedFlow",
+            step_type="BufferedStep",
+            step_input=values.encode("hello", values.codec(str)),
+        )
+    )
+    first_output = await anext(invocation)
+    release_handler.set()
+    outputs = [first_output, *[output async for output in invocation]]
+    assert [output.WhichOneof("output") for output in outputs] == [
+        "stream_write",
+        "stream_write",
+        "result",
+    ]
+    assert [
+        values.decode(output.stream_write.value, values.codec(str))
+        for output in outputs[:-1]
+    ] == ["hello", " 世界"]
 
 
 def test_async_step_stream_cancellation_cancels_handler() -> None:

--- a/sdk-python/tests/test_contracts.py
+++ b/sdk-python/tests/test_contracts.py
@@ -772,7 +772,7 @@ def test_sync_buffered_text_stream_is_cooperative() -> None:
             context: Context,
             input: str,
         ) -> Generator[StepOutput, None, StepDecision]:
-            writer = progress.buffered(context, max_buffered_bytes=5)
+            writer = progress.buffered_text(context, max_buffered_bytes=5)
             yield from writer.write(input)
             yield from writer.write(" 世界")
             yield from writer.flush()
@@ -1113,7 +1113,7 @@ async def _assert_async_buffered_text_stream_flushes() -> None:
             context: AsyncContext,
             input: str,
         ) -> StepDecision:
-            writer = progress.buffered(
+            writer = progress.buffered_text(
                 context,
                 flush_interval=timedelta(milliseconds=5),
             )

--- a/sdk-python/tests/typecheck_contracts.py
+++ b/sdk-python/tests/typecheck_contracts.py
@@ -57,6 +57,9 @@ class StreamingStep(Step[Input]):
         context: Context,
         input: Input,
     ) -> Generator[StepOutput, None, StepDecision]:
+        buffered = progress.buffered(context)
+        yield from buffered.write("thinking ")
+        yield from buffered.flush()
         yield heartbeat({"input": input.value})
         yield progress.write(context, "working")
         return graceful_complete()
@@ -68,6 +71,9 @@ class AsyncTypedStep(Step[Input]):
         context: AsyncContext,
         input: Input,
     ) -> StepDecision:
+        buffered = progress.buffered(context)
+        buffered.write("thinking ")
+        buffered.flush()
         progress.write(context, input.value)
         await context.heartbeat(input.value)
         return graceful_complete()

--- a/sdk-python/tests/typecheck_contracts.py
+++ b/sdk-python/tests/typecheck_contracts.py
@@ -57,7 +57,7 @@ class StreamingStep(Step[Input]):
         context: Context,
         input: Input,
     ) -> Generator[StepOutput, None, StepDecision]:
-        buffered = progress.buffered(context)
+        buffered = progress.buffered_text(context)
         yield from buffered.write("thinking ")
         yield from buffered.flush()
         yield heartbeat({"input": input.value})
@@ -71,7 +71,7 @@ class AsyncTypedStep(Step[Input]):
         context: AsyncContext,
         input: Input,
     ) -> StepDecision:
-        buffered = progress.buffered(context)
+        buffered = progress.buffered_text(context)
         buffered.write("thinking ")
         buffered.flush()
         progress.write(context, input.value)

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -197,6 +197,18 @@ response stream and may append repeatedly to the same Stream. It does not wait f
 acknowledgment; storage rejection or failure is observable on Dex, not by the handler.
 Flow timeout handlers and RPCs cannot send heartbeat or Stream progress.
 
+Use an invocation-managed writer for text deltas:
+
+```rust
+let progress = THINKING.buffered(context)?;
+progress.write(delta)?;
+```
+
+`buffered_with_options` accepts a `BufferedTextStreamOptions` interval and soft UTF-8 byte
+threshold. Defaults are one second and 16 KiB. `flush` sends the current batch, while invocation
+finalization sends the tail before the final result or error. Empty buffers do not emit a message
+or heartbeat. Retry does not restore unsent text or deduplicate emitted batches.
+
 External writes remain unary. `Client::write_stream` requires a non-empty `source`, accepts `#`,
 and appends every call even when a source repeats. Read messages return that metadata in
 `StreamMessage::source`. Step writes use `#<stepExecutionID>`.

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -200,11 +200,11 @@ Flow timeout handlers and RPCs cannot send heartbeat or Stream progress.
 Use an invocation-managed writer for text deltas:
 
 ```rust
-let progress = THINKING.buffered(context)?;
+let progress = THINKING.buffered_text(context)?;
 progress.write(delta)?;
 ```
 
-`buffered_with_options` accepts a `BufferedTextStreamOptions` interval and soft UTF-8 byte
+`buffered_text_with_options` accepts a `BufferedTextStreamOptions` interval and soft UTF-8 byte
 threshold. Defaults are one second and 16 KiB. `flush` sends the current batch, while invocation
 finalization sends the tail before the final result or error. Empty buffers do not emit a message
 or heartbeat. Retry does not restore unsent text or deduplicate emitted batches.

--- a/sdk-rust/crates/dex-sdk/src/context.rs
+++ b/sdk-rust/crates/dex-sdk/src/context.rs
@@ -62,6 +62,13 @@ pub struct Context {
     event_names: HashSet<String>,
     publications: Vec<ChannelMessage>,
     cancellation: InvocationCancellation,
+    runtime: Option<tokio::runtime::Handle>,
+    step_output_finalizers: Vec<Arc<dyn StepOutputFinalizer>>,
+    step_outputs_finalized: bool,
+}
+
+pub(crate) trait StepOutputFinalizer: Send + Sync {
+    fn finalize_step_output(&self) -> HandlerResult<()>;
 }
 
 impl Context {
@@ -85,6 +92,9 @@ impl Context {
             event_names: HashSet::new(),
             publications: Vec::new(),
             cancellation,
+            runtime: tokio::runtime::Handle::try_current().ok(),
+            step_output_finalizers: Vec::new(),
+            step_outputs_finalized: false,
         })
     }
 
@@ -553,6 +563,83 @@ impl Context {
         })
     }
 
+    pub(crate) fn prepare_buffered_text_stream(
+        &self,
+        stream: &Stream<String>,
+    ) -> HandlerResult<(
+        StepOutputEmitter,
+        InvocationCancellation,
+        tokio::runtime::Handle,
+    )> {
+        let output_emitter = self.step_output_emitter()?.clone();
+        let definition = self
+            .flow
+            .persistence
+            .get(stream.name())
+            .filter(|definition| {
+                definition.kind == PersistenceKind::Stream
+                    && definition.stream_identity == Some(stream.identity())
+            })
+            .ok_or_else(|| {
+                HandlerError::new(
+                    "dex_sdk::HandlerError",
+                    format!("Stream does not belong to Flow: {}", stream.name()),
+                )
+            })?;
+        if definition.stream_capacity_bytes != Some(stream.stream_capacity_bytes()) {
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                format!(
+                    "Stream capacity does not match its registered definition: {}",
+                    stream.name()
+                ),
+            ));
+        }
+        let runtime = self.runtime.clone().ok_or_else(|| {
+            HandlerError::new(
+                "dex_sdk::HandlerError",
+                "Buffered Stream runtime is unavailable",
+            )
+        })?;
+        Ok((output_emitter, self.cancellation.clone(), runtime))
+    }
+
+    pub(crate) fn register_step_output_finalizer(
+        &mut self,
+        finalizer: Arc<dyn StepOutputFinalizer>,
+    ) -> HandlerResult<()> {
+        if self.step_outputs_finalized {
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "Buffered Stream invocation has finished",
+            ));
+        }
+        self.step_output_finalizers.push(finalizer);
+        Ok(())
+    }
+
+    pub(crate) fn finalize_step_outputs<T>(
+        &mut self,
+        result: HandlerResult<T>,
+    ) -> HandlerResult<T> {
+        if self.step_outputs_finalized {
+            return result;
+        }
+        self.step_outputs_finalized = true;
+        let mut result = result;
+        for finalizer in &self.step_output_finalizers {
+            if let Err(finalization_failure) = finalizer.finalize_step_output() {
+                match &mut result {
+                    Ok(_) => result = Err(finalization_failure),
+                    Err(handler_failure) => {
+                        handler_failure.attach_finalizer_error(&finalization_failure);
+                    }
+                }
+            }
+        }
+        result
+    }
+
     pub(crate) fn cancellation(&self) -> InvocationCancellation {
         self.cancellation.clone()
     }
@@ -752,6 +839,7 @@ struct InvocationCancellationInner {
     cancelled: AtomicBool,
     mutex: Mutex<()>,
     condition: Condvar,
+    notification: tokio::sync::Notify,
 }
 
 impl InvocationCancellation {
@@ -761,6 +849,7 @@ impl InvocationCancellation {
                 cancelled: AtomicBool::new(false),
                 mutex: Mutex::new(()),
                 condition: Condvar::new(),
+                notification: tokio::sync::Notify::new(),
             }),
         }
     }
@@ -780,6 +869,15 @@ impl InvocationCancellation {
         let _guard = self.inner.mutex.lock().expect("cancellation lock");
         self.inner.cancelled.store(true, Ordering::Release);
         self.inner.condition.notify_all();
+        self.inner.notification.notify_waiters();
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        let notified = self.inner.notification.notified();
+        if self.is_cancelled() {
+            return;
+        }
+        notified.await;
     }
 }
 

--- a/sdk-rust/crates/dex-sdk/src/handler_error.rs
+++ b/sdk-rust/crates/dex-sdk/src/handler_error.rs
@@ -188,6 +188,12 @@ impl HandlerError {
         &self.error_type
     }
 
+    pub(crate) fn attach_finalizer_error(&mut self, failure: &Self) {
+        self.message
+            .push_str("; buffered Stream finalization failed: ");
+        self.message.push_str(&failure.message);
+    }
+
     pub(crate) fn stack_trace(&self) -> &Backtrace {
         &self.stack
     }

--- a/sdk-rust/crates/dex-sdk/src/lib.rs
+++ b/sdk-rust/crates/dex-sdk/src/lib.rs
@@ -68,7 +68,7 @@ pub use step::{Step, StepDecision, StepList, StepMovement};
 pub use step_execution::StepExecutionId;
 pub use step_options::{StepDurability, StepOptions, WaitForFailurePolicy};
 pub use stop_flow_options::StopFlowOptions;
-pub use stream::{Stream, StreamMessage};
+pub use stream::{BufferedTextStream, BufferedTextStreamOptions, Stream, StreamMessage};
 pub use sub_flow::{SubFlow, SubFlowOptions, SubFlowReusePolicy};
 pub use time_travel_options::{TimeTravelOptions, TimeTravelStepMethod};
 pub use timer::{Timer, TimerId};

--- a/sdk-rust/crates/dex-sdk/src/stream.rs
+++ b/sdk-rust/crates/dex-sdk/src/stream.rs
@@ -7,10 +7,19 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 use std::marker::PhantomData;
-use std::sync::Arc;
-use std::time::SystemTime;
+use std::sync::{Arc, Weak};
+use std::time::{Duration, SystemTime};
 
-use crate::{Context, HandlerResult, Value};
+use dex_protocol::dex::StepStreamWrite;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+use crate::context::{InvocationCancellation, StepOutputFinalizer};
+use crate::worker_output::StepOutputEmitter;
+use crate::{Context, HandlerError, HandlerResult, Value, value_mapper};
+
+const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
+const DEFAULT_MAX_BUFFERED_BYTES: usize = 16 * 1024;
 
 #[derive(Debug)]
 struct StreamDefinition {
@@ -76,6 +85,304 @@ impl<T> Stream<T> {
 
     pub(crate) fn identity(&self) -> usize {
         Arc::as_ptr(&self.definition) as usize
+    }
+}
+
+impl Stream<String> {
+    /// Creates an invocation-managed writer with a one-second interval and 16 KiB threshold.
+    ///
+    /// The Worker flushes remaining text before the handler result or error. The writer preserves
+    /// chunks exactly, ignores empty chunks, and never splits a chunk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] unless this registered String Stream is used by an active Step.
+    pub fn buffered(&self, context: &mut Context) -> HandlerResult<BufferedTextStream> {
+        self.buffered_with_options(context, BufferedTextStreamOptions::default())
+    }
+
+    /// Creates an invocation-managed writer with explicit buffering settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] for invalid settings, an unregistered Stream, cancellation, or a
+    /// Context that does not belong to a Step.
+    pub fn buffered_with_options(
+        &self,
+        context: &mut Context,
+        options: BufferedTextStreamOptions,
+    ) -> HandlerResult<BufferedTextStream> {
+        options.validate()?;
+        let (output_emitter, cancellation, runtime) = context.prepare_buffered_text_stream(self)?;
+        let inner = Arc::new(BufferedTextStreamInner {
+            stream: self.clone(),
+            output_emitter,
+            cancellation: cancellation.clone(),
+            runtime: runtime.clone(),
+            options,
+            state: Mutex::new(BufferedTextStreamState::default()),
+        });
+        context.register_step_output_finalizer(inner.clone())?;
+        BufferedTextStreamInner::watch_cancellation(&inner);
+        Ok(BufferedTextStream { inner })
+    }
+}
+
+/// Configures an invocation-managed buffered text Stream writer.
+#[derive(Clone, Copy, Debug)]
+pub struct BufferedTextStreamOptions {
+    flush_interval: Duration,
+    max_buffered_bytes: usize,
+}
+
+impl BufferedTextStreamOptions {
+    /// Creates settings with a positive interval and soft UTF-8 byte threshold.
+    ///
+    /// Validation occurs when the writer is created.
+    pub fn new(flush_interval: Duration, max_buffered_bytes: usize) -> Self {
+        Self {
+            flush_interval,
+            max_buffered_bytes,
+        }
+    }
+
+    /// Returns the one-shot flush interval.
+    pub fn flush_interval(&self) -> Duration {
+        self.flush_interval
+    }
+
+    /// Returns the soft UTF-8 batch threshold.
+    pub fn max_buffered_bytes(&self) -> usize {
+        self.max_buffered_bytes
+    }
+
+    fn validate(&self) -> HandlerResult<()> {
+        if self.flush_interval.is_zero() {
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "Buffered Stream flush interval must be positive",
+            ));
+        }
+        if self.max_buffered_bytes == 0 {
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "Buffered Stream max buffered bytes must be positive",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Default for BufferedTextStreamOptions {
+    fn default() -> Self {
+        Self {
+            flush_interval: DEFAULT_FLUSH_INTERVAL,
+            max_buffered_bytes: DEFAULT_MAX_BUFFERED_BYTES,
+        }
+    }
+}
+
+/// Batches text chunks during one Step invocation.
+///
+/// [`Self::write`] and [`Self::flush`] block only on the Worker's bounded output queue. They do not
+/// wait for Dex Stream Store acknowledgement. The Worker automatically flushes the tail before
+/// returning the handler result or error.
+#[derive(Clone)]
+pub struct BufferedTextStream {
+    inner: Arc<BufferedTextStreamInner>,
+}
+
+impl BufferedTextStream {
+    /// Appends one chunk and flushes after crossing the soft UTF-8 size threshold.
+    ///
+    /// Empty chunks are ignored. The first nonempty chunk starts a one-shot timer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] after cancellation, invocation completion, or output failure.
+    pub fn write(&self, chunk: impl AsRef<str>) -> HandlerResult<()> {
+        let chunk = chunk.as_ref();
+        let mut state = self.inner.state.blocking_lock();
+        state.require_open()?;
+        if chunk.is_empty() {
+            return Ok(());
+        }
+        let was_empty = state.buffer.is_empty();
+        state.buffer.push_str(chunk);
+        state.buffered_bytes += chunk.len();
+        if was_empty {
+            self.inner.start_timer(&mut state);
+        }
+        if state.buffered_bytes >= self.inner.options.max_buffered_bytes {
+            self.inner.stop_timer(&mut state);
+            self.inner.flush_locked(&mut state)?;
+        }
+        Ok(())
+    }
+
+    /// Emits the current nonempty batch immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HandlerError`] after cancellation, invocation completion, or output failure.
+    pub fn flush(&self) -> HandlerResult<()> {
+        let mut state = self.inner.state.blocking_lock();
+        state.require_open()?;
+        self.inner.stop_timer(&mut state);
+        self.inner.flush_locked(&mut state)
+    }
+}
+
+struct BufferedTextStreamInner {
+    stream: Stream<String>,
+    output_emitter: StepOutputEmitter,
+    cancellation: InvocationCancellation,
+    runtime: tokio::runtime::Handle,
+    options: BufferedTextStreamOptions,
+    state: Mutex<BufferedTextStreamState>,
+}
+
+#[derive(Default)]
+struct BufferedTextStreamState {
+    buffer: String,
+    buffered_bytes: usize,
+    timer_generation: u64,
+    timer: Option<JoinHandle<()>>,
+    closed: bool,
+    terminal_failure: Option<String>,
+}
+
+impl BufferedTextStreamState {
+    fn require_open(&self) -> HandlerResult<()> {
+        if let Some(failure) = &self.terminal_failure {
+            return Err(HandlerError::new("dex_sdk::HandlerError", failure));
+        }
+        if self.closed {
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "Buffered Stream invocation has finished",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl BufferedTextStreamInner {
+    fn start_timer(self: &Arc<Self>, state: &mut BufferedTextStreamState) {
+        state.timer_generation += 1;
+        let generation = state.timer_generation;
+        let weak = Arc::downgrade(self);
+        let interval = self.options.flush_interval;
+        state.timer = Some(self.runtime.spawn(async move {
+            tokio::time::sleep(interval).await;
+            if let Some(inner) = weak.upgrade() {
+                inner.flush_from_timer(generation).await;
+            }
+        }));
+    }
+
+    fn stop_timer(&self, state: &mut BufferedTextStreamState) -> Option<JoinHandle<()>> {
+        state.timer_generation += 1;
+        let timer = state.timer.take();
+        if let Some(timer) = &timer {
+            timer.abort();
+        }
+        timer
+    }
+
+    fn flush_locked(&self, state: &mut BufferedTextStreamState) -> HandlerResult<()> {
+        if state.buffer.is_empty() {
+            return Ok(());
+        }
+        let value = std::mem::take(&mut state.buffer);
+        state.buffered_bytes = 0;
+        let write = self.stream_write(value)?;
+        if let Err(failure) = self.output_emitter.send_stream_write(write) {
+            state.terminal_failure = Some(failure.to_string());
+            return Err(failure);
+        }
+        Ok(())
+    }
+
+    async fn flush_from_timer(&self, generation: u64) {
+        let mut state = self.state.lock().await;
+        if state.closed
+            || state.terminal_failure.is_some()
+            || generation != state.timer_generation
+            || self.cancellation.is_cancelled()
+        {
+            return;
+        }
+        state.timer = None;
+        if state.buffer.is_empty() {
+            return;
+        }
+        let value = std::mem::take(&mut state.buffer);
+        state.buffered_bytes = 0;
+        let write = match self.stream_write(value) {
+            Ok(write) => write,
+            Err(failure) => {
+                state.terminal_failure = Some(failure.to_string());
+                return;
+            }
+        };
+        if let Err(failure) = self.output_emitter.send_stream_write_async(write).await {
+            state.terminal_failure = Some(failure.to_string());
+        }
+    }
+
+    fn stream_write(&self, value: String) -> HandlerResult<StepStreamWrite> {
+        Ok(StepStreamWrite {
+            stream_name: self.stream.name().to_string(),
+            stream_capacity_bytes: self.stream.stream_capacity_bytes(),
+            value: Some(value_mapper::encode_handler(&value)?),
+        })
+    }
+
+    fn watch_cancellation(this: &Arc<Self>) {
+        let weak: Weak<Self> = Arc::downgrade(this);
+        let cancellation = this.cancellation.clone();
+        this.runtime.spawn(async move {
+            cancellation.cancelled().await;
+            if let Some(inner) = weak.upgrade() {
+                inner.cancel().await;
+            }
+        });
+    }
+
+    async fn cancel(&self) {
+        let mut state = self.state.lock().await;
+        state.closed = true;
+        self.stop_timer(&mut state);
+        state.buffer.clear();
+        state.buffered_bytes = 0;
+    }
+}
+
+impl StepOutputFinalizer for BufferedTextStreamInner {
+    fn finalize_step_output(&self) -> HandlerResult<()> {
+        let timer = {
+            let mut state = self.state.blocking_lock();
+            if state.closed {
+                return Ok(());
+            }
+            state.closed = true;
+            self.stop_timer(&mut state)
+        };
+        if let Some(timer) = timer
+            && let Err(failure) = self.runtime.block_on(timer)
+            && !failure.is_cancelled()
+        {
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                format!("Buffered Stream timer failed: {failure}"),
+            ));
+        }
+        let mut state = self.state.blocking_lock();
+        if let Some(failure) = &state.terminal_failure {
+            return Err(HandlerError::new("dex_sdk::HandlerError", failure));
+        }
+        self.flush_locked(&mut state)
     }
 }
 

--- a/sdk-rust/crates/dex-sdk/src/stream.rs
+++ b/sdk-rust/crates/dex-sdk/src/stream.rs
@@ -97,8 +97,8 @@ impl Stream<String> {
     /// # Errors
     ///
     /// Returns [`HandlerError`] unless this registered String Stream is used by an active Step.
-    pub fn buffered(&self, context: &mut Context) -> HandlerResult<BufferedTextStream> {
-        self.buffered_with_options(context, BufferedTextStreamOptions::default())
+    pub fn buffered_text(&self, context: &mut Context) -> HandlerResult<BufferedTextStream> {
+        self.buffered_text_with_options(context, BufferedTextStreamOptions::default())
     }
 
     /// Creates an invocation-managed writer with explicit buffering settings.
@@ -107,7 +107,7 @@ impl Stream<String> {
     ///
     /// Returns [`HandlerError`] for invalid settings, an unregistered Stream, cancellation, or a
     /// Context that does not belong to a Step.
-    pub fn buffered_with_options(
+    pub fn buffered_text_with_options(
         &self,
         context: &mut Context,
         options: BufferedTextStreamOptions,

--- a/sdk-rust/crates/dex-sdk/src/worker_dispatcher.rs
+++ b/sdk-rust/crates/dex-sdk/src/worker_dispatcher.rs
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 use std::collections::{HashMap, HashSet};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -116,10 +117,13 @@ impl WorkerDispatcher {
         let cancellation = context.cancellation();
         let registry = self.registry.clone();
         run_handler(cancellation, move || {
-            let wait = flow.handler.wait_for(step.name, &mut context, &input)?;
-            let waiting_condition = map_wait(&registry, &flow, wait).map_err(|error| {
-                HandlerError::invalid_step_result(flow.name, Some(step.name), "wait_for", error)
-            })?;
+            let handler_result = catch_handler_panic(|| {
+                let wait = flow.handler.wait_for(step.name, &mut context, &input)?;
+                map_wait(&registry, &flow, wait).map_err(|error| {
+                    HandlerError::invalid_step_result(flow.name, Some(step.name), "wait_for", error)
+                })
+            });
+            let waiting_condition = context.finalize_step_outputs(handler_result)?;
             let (attributes, locals, events, publications) = context.take_outputs();
             Ok(InvokeWaitForMethodResponse {
                 local_activity_metadata: None,
@@ -200,10 +204,13 @@ impl WorkerDispatcher {
             .ok_or_else(|| HandlerError::new("dex_sdk::HandlerError", "Step input is required"))?;
         let cancellation = context.cancellation();
         run_handler(cancellation, move || {
-            let decision = flow.handler.execute(step.name, &mut context, &input)?;
-            let decision = map_decision(&flow, decision).map_err(|error| {
-                HandlerError::invalid_step_result(flow.name, Some(step.name), "execute", error)
-            })?;
+            let handler_result = catch_handler_panic(|| {
+                let decision = flow.handler.execute(step.name, &mut context, &input)?;
+                map_decision(&flow, decision).map_err(|error| {
+                    HandlerError::invalid_step_result(flow.name, Some(step.name), "execute", error)
+                })
+            });
+            let decision = context.finalize_step_outputs(handler_result)?;
             let (attributes, locals, events, publications) = context.take_outputs();
             Ok(InvokeExecuteMethodResponse {
                 local_activity_metadata: None,
@@ -466,6 +473,22 @@ async fn send_handler_result<Output>(
     if sender.send(result).await.is_err() {
         cancellation.cancel();
     }
+}
+
+fn catch_handler_panic<Output>(
+    handler: impl FnOnce() -> HandlerResult<Output>,
+) -> HandlerResult<Output> {
+    catch_unwind(AssertUnwindSafe(handler)).unwrap_or_else(|payload| {
+        let message = payload
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| payload.downcast_ref::<&str>().copied())
+            .unwrap_or("unknown panic");
+        Err(HandlerError::new(
+            "dex_sdk::HandlerError",
+            format!("user handler task failed: task panicked with message {message}"),
+        ))
+    })
 }
 
 async fn run_handler<Output, Handler>(

--- a/sdk-rust/crates/dex-sdk/src/worker_output.rs
+++ b/sdk-rust/crates/dex-sdk/src/worker_output.rs
@@ -80,6 +80,26 @@ impl StepOutputEmitter {
         }
     }
 
+    pub(crate) async fn send_stream_write_async(
+        &self,
+        write: StepStreamWrite,
+    ) -> HandlerResult<()> {
+        match self {
+            Self::WaitFor(sender) => sender
+                .send(Ok(InvokeWaitForMethodOutput {
+                    output: Some(invoke_wait_for_method_output::Output::StreamWrite(write)),
+                }))
+                .await
+                .map_err(output_closed),
+            Self::Execute(sender) => sender
+                .send(Ok(InvokeExecuteMethodOutput {
+                    output: Some(invoke_execute_method_output::Output::StreamWrite(write)),
+                }))
+                .await
+                .map_err(output_closed),
+        }
+    }
+
     pub(crate) fn wait_for_sender(&self) -> mpsc::Sender<HandlerResult<InvokeWaitForMethodOutput>> {
         match self {
             Self::WaitFor(sender) => sender.clone(),

--- a/sdk-rust/crates/dex-sdk/tests/compile_contracts.rs
+++ b/sdk-rust/crates/dex-sdk/tests/compile_contracts.rs
@@ -39,7 +39,7 @@ fn stream_definitions_and_client_calls_compile() {
         let _stream_write: dex_sdk::HandlerResult<()> =
             stream.write(context, "checking".to_owned());
         let buffered: dex_sdk::HandlerResult<dex_sdk::BufferedTextStream> = stream
-            .buffered_with_options(
+            .buffered_text_with_options(
                 context,
                 dex_sdk::BufferedTextStreamOptions::new(
                     std::time::Duration::from_millis(500),

--- a/sdk-rust/crates/dex-sdk/tests/compile_contracts.rs
+++ b/sdk-rust/crates/dex-sdk/tests/compile_contracts.rs
@@ -38,6 +38,18 @@ fn stream_definitions_and_client_calls_compile() {
             context.last_heartbeat_value::<Option<String>>();
         let _stream_write: dex_sdk::HandlerResult<()> =
             stream.write(context, "checking".to_owned());
+        let buffered: dex_sdk::HandlerResult<dex_sdk::BufferedTextStream> = stream
+            .buffered_with_options(
+                context,
+                dex_sdk::BufferedTextStreamOptions::new(
+                    std::time::Duration::from_millis(500),
+                    8 * 1024,
+                ),
+            );
+        if let Ok(buffered) = buffered {
+            let _buffered_write: dex_sdk::HandlerResult<()> = buffered.write("thinking ");
+            let _buffered_flush: dex_sdk::HandlerResult<()> = buffered.flush();
+        }
         client.write_stream("flow-1", stream, "client#source", "starting".to_owned())?;
         let message = client.read_stream("flow-1", stream, "")?;
         let _source: &str = &message.source;

--- a/sdk-rust/crates/dex-sdk/tests/integ/README.md
+++ b/sdk-rust/crates/dex-sdk/tests/integ/README.md
@@ -63,5 +63,6 @@ introspection. Persistence integration covers singleton Attribute equality waits
 Heartbeat recovery verifies typed checkpoints, explicit clearing, JSON null versus an absent Value,
 Stream implicit-heartbeat preservation, and the absence of local-activity details after regular
 fallback. Stream integration interleaves WaitFor and Execute heartbeat frames with repeated Step
-writes, then verifies repeated client sources containing `#` all append. Cancellation coverage uses
-active heartbeat output so blocked synchronous handlers observe response-stream closure promptly.
+writes, exercises default and custom buffered text writers, then verifies repeated client sources
+containing `#` all append. Cancellation coverage uses active heartbeat output so blocked
+synchronous handlers observe response-stream closure promptly.

--- a/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
@@ -52,7 +52,7 @@ impl Step for StreamTestStep {
 
     fn wait_for(&self, context: &mut Context, _input: ()) -> HandlerResult<Wait> {
         context.record_heartbeat()?;
-        let progress = PROGRESS.buffered(context)?;
+        let progress = PROGRESS.buffered_text(context)?;
         progress.write("wait-progress-")?;
         progress.write("1")?;
         progress.flush()?;
@@ -64,7 +64,7 @@ impl Step for StreamTestStep {
 
     fn execute(&self, context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
         context.record_heartbeat()?;
-        let progress = PROGRESS.buffered_with_options(
+        let progress = PROGRESS.buffered_text_with_options(
             context,
             BufferedTextStreamOptions::new(Duration::from_millis(250), 16 * 1024),
         )?;

--- a/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
@@ -9,9 +9,11 @@
 // See LICENSE and LEGACY_NOTICES.md.
 
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use dex_sdk::{
-    Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision, StepList, Stream, Wait,
+    BufferedTextStreamOptions, Context, Flow, HandlerResult, PersistenceSchema, Step, StepDecision,
+    StepList, Stream, Wait,
 };
 
 pub(crate) static PROGRESS: LazyLock<Stream<String>> =
@@ -50,17 +52,28 @@ impl Step for StreamTestStep {
 
     fn wait_for(&self, context: &mut Context, _input: ()) -> HandlerResult<Wait> {
         context.record_heartbeat()?;
-        PROGRESS.write(context, "wait-progress-1".to_string())?;
+        let progress = PROGRESS.buffered(context)?;
+        progress.write("wait-progress-")?;
+        progress.write("1")?;
+        progress.flush()?;
         context.record_heartbeat_value("wait-checkpoint".to_string())?;
-        PROGRESS.write(context, "wait-progress-2".to_string())?;
+        progress.write("wait-progress-")?;
+        progress.write("2")?;
         Ok(Wait::skip_immediately())
     }
 
     fn execute(&self, context: &mut Context, _input: ()) -> HandlerResult<StepDecision> {
         context.record_heartbeat()?;
-        PROGRESS.write(context, "execute-progress-1".to_string())?;
+        let progress = PROGRESS.buffered_with_options(
+            context,
+            BufferedTextStreamOptions::new(Duration::from_millis(250), 16 * 1024),
+        )?;
+        progress.write("execute-progress-")?;
+        progress.write("1")?;
+        progress.flush()?;
         context.record_heartbeat_value("execute-checkpoint".to_string())?;
-        PROGRESS.write(context, "execute-progress-2".to_string())?;
+        progress.write("execute-progress-")?;
+        progress.write("2")?;
         Ok(StepDecision::graceful_complete(()))
     }
 }

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -208,6 +208,19 @@ different Streams. Dex attempts each append in call order, but Stream Store
 failures are not returned to the handler. RPC and Flow timeout Contexts reject
 Step Stream writes.
 
+For text deltas, create one writer and pass its bound `write` method directly
+to the producer:
+
+```typescript
+const progress = thinking.buffered(context, { flushIntervalMs: 500 });
+await generateText(input, progress.write);
+```
+
+The defaults are one second and a soft 16 KiB UTF-8 threshold. `flush()` sends
+the current nonempty batch, and invocation completion sends the tail before the
+final result or error. Chunks are concatenated exactly. Retry does not restore
+unsent text or deduplicate emitted batches.
+
 External writes use `client.writeStream(flowId, stream, source, value)`. Source
 must be non-empty, may contain `#`, and may repeat; every write appends a new
 message. `Client.readStream` returns it as `StreamMessage.source`. Step writes

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -212,7 +212,7 @@ For text deltas, create one writer and pass its bound `write` method directly
 to the producer:
 
 ```typescript
-const progress = thinking.buffered(context, { flushIntervalMs: 500 });
+const progress = thinking.bufferedText(context, { flushIntervalMs: 500 });
 await generateText(input, progress.write);
 ```
 

--- a/sdk-typescript/src/invocation-context.ts
+++ b/sdk-typescript/src/invocation-context.ts
@@ -37,6 +37,11 @@ export interface StepOutputEmitter {
   writeStream(write: StepStreamWrite): void;
 }
 
+export interface StepOutputFinalizer {
+  finalizeStepOutput(): void;
+  cancelStepOutput(): void;
+}
+
 export class InvocationContext implements AsyncContext {
   public readonly flowId: string;
   public readonly runId: string;
@@ -56,6 +61,8 @@ export class InvocationContext implements AsyncContext {
   private readonly eventNames = new Set<string>();
   private readonly publications: ChannelMessage[] = [];
   private readonly lastHeartbeatValue: Value | undefined;
+  private readonly stepOutputFinalizers: StepOutputFinalizer[] = [];
+  private stepOutputsFinalized = false;
 
   public constructor(
     private readonly method: InvocationMethod,
@@ -83,6 +90,7 @@ export class InvocationContext implements AsyncContext {
     this.attributes = mapValues("Attribute", attributes);
     this.locals = mapValues("step-execution local", locals);
     this.channelInfos = new Map(Object.entries(channelInfos));
+    cancellationSignal.addEventListener("abort", () => this.cancelStepOutputs(), { once: true });
   }
 
   public hasLastHeartbeatValue(): boolean {
@@ -115,6 +123,52 @@ export class InvocationContext implements AsyncContext {
       streamCapacityBytes: BigInt(stream.streamCapacityBytes),
       value: encodeValue(stream.codec, value),
     });
+  }
+
+  public prepareBufferedStream(stream: Stream<unknown>): void {
+    if (this.stepOutput === undefined || (this.method !== "waitFor" && this.method !== "execute")) {
+      throw new TypeError("Buffered Streams require an async Step Context");
+    }
+    requireFlowStream(this.flow, stream);
+  }
+
+  public registerStepOutputFinalizer(finalizer: StepOutputFinalizer): void {
+    if (this.stepOutputsFinalized || this.stepOutput === undefined) {
+      throw new TypeError("Buffered Stream invocation has finished");
+    }
+    this.stepOutputFinalizers.push(finalizer);
+  }
+
+  public finalizeStepOutputs(failure?: unknown): unknown | undefined {
+    if (this.stepOutputsFinalized) {
+      return failure;
+    }
+    this.stepOutputsFinalized = true;
+    const failures: unknown[] = failure === undefined ? [] : [failure];
+    for (const finalizer of this.stepOutputFinalizers) {
+      try {
+        finalizer.finalizeStepOutput();
+      } catch (finalizerFailure) {
+        failures.push(finalizerFailure);
+      }
+    }
+    if (failures.length === 0) {
+      return undefined;
+    }
+    if (failures.length === 1) {
+      return failures[0];
+    }
+    return new AggregateError(failures, "Step handler and buffered Stream finalization failed");
+  }
+
+  private cancelStepOutputs(): void {
+    if (this.stepOutputsFinalized) {
+      return;
+    }
+    this.stepOutputsFinalized = true;
+    for (const finalizer of this.stepOutputFinalizers) {
+      finalizer.cancelStepOutput();
+    }
   }
 
   public hasTimerFired(index?: number): boolean {

--- a/sdk-typescript/src/stream.ts
+++ b/sdk-typescript/src/stream.ts
@@ -8,7 +8,22 @@
 
 import type { Codec } from "./codec.js";
 import type { Context } from "./context.js";
+import {
+  InvocationContext,
+  type StepOutputFinalizer,
+} from "./invocation-context.js";
 import { requireName } from "./validation.js";
+
+const DEFAULT_BUFFERED_TEXT_FLUSH_INTERVAL_MS = 1_000;
+const DEFAULT_BUFFERED_TEXT_MAX_BYTES = 16 * 1_024;
+
+/** Configures a buffered text Stream writer. */
+export interface BufferedTextStreamOptions {
+  /** One-shot flush interval in milliseconds. Defaults to 1,000. */
+  readonly flushIntervalMs?: number;
+  /** Soft UTF-8 batch threshold in bytes. Defaults to 16 KiB. */
+  readonly maxBufferedBytes?: number;
+}
 
 /**
  * Defines a typed, best-effort resumable message stream owned by one Flow type.
@@ -44,6 +59,182 @@ export class Stream<T> {
   public write(context: Context, value: T): void {
     context.writeStream(this, value);
   }
+
+  /**
+   * Creates an invocation-managed text writer for an asynchronous Step.
+   *
+   * The writer concatenates chunks exactly and flushes on its timer, soft UTF-8 size threshold,
+   * an explicit {@link BufferedTextStream.flush}, or handler completion. The Worker flushes every
+   * remaining batch before the final result or error. Empty chunks are ignored.
+   *
+   * @param context - Current asynchronous Step Context.
+   * @param options - Optional flush interval and soft byte threshold.
+   * @param this - String Stream that receives each emitted batch.
+   * @returns A writer whose bound {@link BufferedTextStream.write} method can be used as a callback.
+   * @throws {@link TypeError} if this is not a string Stream or the Context is not an active Step.
+   * @throws {@link RangeError} if an option is not a positive finite number.
+   */
+  public buffered(
+    this: Stream<string>,
+    context: Context,
+    options: BufferedTextStreamOptions = {},
+  ): BufferedTextStream {
+    if (this.codec.wireKind !== "string") {
+      throw new TypeError("Buffered Streams require Stream<string>");
+    }
+    if (!(context instanceof InvocationContext)) {
+      throw new TypeError("Buffered Streams require a Dex Step Context");
+    }
+    const flushIntervalMs = options.flushIntervalMs ?? DEFAULT_BUFFERED_TEXT_FLUSH_INTERVAL_MS;
+    const maxBufferedBytes = options.maxBufferedBytes ?? DEFAULT_BUFFERED_TEXT_MAX_BYTES;
+    requirePositiveNumber("flushIntervalMs", flushIntervalMs);
+    requirePositiveSafeInteger("maxBufferedBytes", maxBufferedBytes);
+    context.prepareBufferedStream(this);
+    const writer = new BufferedTextStream(
+      this,
+      context,
+      flushIntervalMs,
+      maxBufferedBytes,
+    );
+    context.registerStepOutputFinalizer(writer);
+    return writer;
+  }
+}
+
+/** Batches text chunks during one asynchronous Step invocation. */
+export class BufferedTextStream implements StepOutputFinalizer {
+  private readonly encoder = new TextEncoder();
+  private readonly chunks: string[] = [];
+  private bufferedBytes = 0;
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private timerGeneration = 0;
+  private isClosed = false;
+  private terminalFailure: unknown | undefined;
+
+  /**
+   * Creates a writer from validated invocation-owned components.
+   * @param stream - Registered string Stream receiving emitted batches.
+   * @param context - Current asynchronous Step Context.
+   * @param flushIntervalMs - Positive one-shot interval in milliseconds.
+   * @param maxBufferedBytes - Positive soft UTF-8 threshold.
+   */
+  public constructor(
+    private readonly stream: Stream<string>,
+    private readonly context: Context,
+    private readonly flushIntervalMs: number,
+    private readonly maxBufferedBytes: number,
+  ) {
+    this.write = this.write.bind(this);
+    this.flush = this.flush.bind(this);
+  }
+
+  /**
+   * Appends one chunk without modification and flushes after crossing the soft size threshold.
+   * @param value - Text to append; an empty string is ignored.
+   * @throws {@link Error} if the invocation finished or an earlier background flush failed.
+   */
+  public write(value: string): void {
+    this.requireOpen();
+    if (typeof value !== "string") {
+      throw new TypeError("Buffered Stream chunks must be strings");
+    }
+    if (value.length === 0) {
+      return;
+    }
+    const wasEmpty = this.chunks.length === 0;
+    this.chunks.push(value);
+    this.bufferedBytes += this.encoder.encode(value).byteLength;
+    if (wasEmpty) {
+      this.startTimer();
+    }
+    if (this.bufferedBytes >= this.maxBufferedBytes) {
+      this.flush();
+    }
+  }
+
+  /**
+   * Immediately emits the current non-empty batch and restarts timing with the next write.
+   * @throws {@link Error} if the invocation finished or an earlier flush failed.
+   */
+  public flush(): void {
+    this.requireOpen();
+    this.stopTimer();
+    this.flushBuffer();
+  }
+
+  /** Flushes the tail and closes this writer during invocation finalization. */
+  public finalizeStepOutput(): void {
+    if (this.isClosed) {
+      if (this.terminalFailure !== undefined) {
+        throw this.terminalFailure;
+      }
+      return;
+    }
+    this.stopTimer();
+    try {
+      if (this.terminalFailure !== undefined) {
+        throw this.terminalFailure;
+      }
+      this.flushBuffer();
+    } finally {
+      this.isClosed = true;
+    }
+  }
+
+  /** Discards buffered text and stops the timer after invocation cancellation. */
+  public cancelStepOutput(): void {
+    this.stopTimer();
+    this.chunks.length = 0;
+    this.bufferedBytes = 0;
+    this.isClosed = true;
+  }
+
+  private startTimer(): void {
+    const generation = ++this.timerGeneration;
+    this.timer = setTimeout(() => {
+      if (this.isClosed || generation !== this.timerGeneration) {
+        return;
+      }
+      this.timer = undefined;
+      try {
+        this.flushBuffer();
+      } catch (failure) {
+        this.terminalFailure = failure;
+      }
+    }, this.flushIntervalMs);
+  }
+
+  private stopTimer(): void {
+    this.timerGeneration += 1;
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private flushBuffer(): void {
+    if (this.chunks.length === 0) {
+      return;
+    }
+    const value = this.chunks.join("");
+    this.chunks.length = 0;
+    this.bufferedBytes = 0;
+    try {
+      this.stream.write(this.context, value);
+    } catch (failure) {
+      this.terminalFailure = failure;
+      throw failure;
+    }
+  }
+
+  private requireOpen(): void {
+    if (this.terminalFailure !== undefined) {
+      throw this.terminalFailure;
+    }
+    if (this.isClosed) {
+      throw new Error("Buffered Stream invocation has finished");
+    }
+  }
 }
 
 /**
@@ -59,4 +250,16 @@ export interface StreamMessage<T> {
   readonly createdTime: Date;
   /** Client-supplied source or Step-generated `#stepExecutionID` source. */
   readonly source: string;
+}
+
+function requirePositiveNumber(name: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RangeError(`Buffered Stream ${name} must be positive`);
+  }
+}
+
+function requirePositiveSafeInteger(name: string, value: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new RangeError(`Buffered Stream ${name} must be a positive safe integer`);
+  }
 }

--- a/sdk-typescript/src/stream.ts
+++ b/sdk-typescript/src/stream.ts
@@ -74,7 +74,7 @@ export class Stream<T> {
    * @throws {@link TypeError} if this is not a string Stream or the Context is not an active Step.
    * @throws {@link RangeError} if an option is not a positive finite number.
    */
-  public buffered(
+  public bufferedText(
     this: Stream<string>,
     context: Context,
     options: BufferedTextStreamOptions = {},

--- a/sdk-typescript/src/worker-dispatcher.ts
+++ b/sdk-typescript/src/worker-dispatcher.ts
@@ -109,17 +109,27 @@ export class WorkerDispatcher {
     if (step.step.waitFor === undefined) {
       throw new TypeError(`Step ${step.name} does not implement waitFor`);
     }
-    const wait = await step.step.waitFor(context, input);
     try {
-      return InvokeWaitForMethodResponse.create({
-        upsertAttributes: [...context.getAttributeWrites()],
-        waitingCondition: mapWait(this.registry, flow, wait),
-        upsertStepExeLocals: [...context.getLocalWrites()],
-        recordEvents: [...context.getEvents()],
-        publishToChannel: [...context.getPublications()],
-      });
+      const wait = await step.step.waitFor(context, input);
+      let response: InvokeWaitForMethodResponse;
+      try {
+        response = InvokeWaitForMethodResponse.create({
+          upsertAttributes: [...context.getAttributeWrites()],
+          waitingCondition: mapWait(this.registry, flow, wait),
+          upsertStepExeLocals: [...context.getLocalWrites()],
+          recordEvents: [...context.getEvents()],
+          publishToChannel: [...context.getPublications()],
+        });
+      } catch (failure) {
+        throw invalidStepResult(flow.name, step.name, "waitFor", failure);
+      }
+      const finalizationFailure = context.finalizeStepOutputs();
+      if (finalizationFailure !== undefined) {
+        throw finalizationFailure;
+      }
+      return response;
     } catch (failure) {
-      throw invalidStepResult(flow.name, step.name, "waitFor", failure);
+      throw context.finalizeStepOutputs(failure);
     }
   }
 
@@ -150,17 +160,27 @@ export class WorkerDispatcher {
       codecOrJson(step.step.inputCodec),
       requireValue(request.stepInput, "Step input"),
     );
-    const decision = await step.step.execute(context, input);
     try {
-      return InvokeExecuteMethodResponse.create({
-        stepDecision: mapDecision(flow, decision),
-        upsertAttributes: [...context.getAttributeWrites()],
-        recordEvents: [...context.getEvents()],
-        upsertStepExeLocals: [...context.getLocalWrites()],
-        publishToChannel: [...context.getPublications()],
-      });
+      const decision = await step.step.execute(context, input);
+      let response: InvokeExecuteMethodResponse;
+      try {
+        response = InvokeExecuteMethodResponse.create({
+          stepDecision: mapDecision(flow, decision),
+          upsertAttributes: [...context.getAttributeWrites()],
+          recordEvents: [...context.getEvents()],
+          upsertStepExeLocals: [...context.getLocalWrites()],
+          publishToChannel: [...context.getPublications()],
+        });
+      } catch (failure) {
+        throw invalidStepResult(flow.name, step.name, "execute", failure);
+      }
+      const finalizationFailure = context.finalizeStepOutputs();
+      if (finalizationFailure !== undefined) {
+        throw finalizationFailure;
+      }
+      return response;
     } catch (failure) {
-      throw invalidStepResult(flow.name, step.name, "execute", failure);
+      throw context.finalizeStepOutputs(failure);
     }
   }
 

--- a/sdk-typescript/test/contracts.test.ts
+++ b/sdk-typescript/test/contracts.test.ts
@@ -571,6 +571,79 @@ test("Step Stream writes emit every message on the active invocation", async () 
   assert.throws(() => void rpc.recordHeartbeat("value"), /require an async Step Context/);
 });
 
+test("buffered text Stream flushes on timer and before the final result", async () => {
+  const thinking = new Stream("thinking", stringCodec, 1_048_576);
+  let handlerFinished = false;
+  let releaseHandler: (() => void) | undefined;
+  class BufferedStep implements Step<string> {
+    public readonly inputCodec = stringCodec;
+
+    public getStepType(): string {
+      return "BufferedStep";
+    }
+
+    public async execute(context: Context, input: string): Promise<StepDecision> {
+      const progress = thinking.buffered(context, {
+        flushIntervalMs: 5,
+        maxBufferedBytes: 1_024,
+      });
+      progress.write(input);
+      await new Promise<void>((resolve) => {
+        releaseHandler = resolve;
+      });
+      progress.write(" ");
+      progress.write("世界");
+      handlerFinished = true;
+      return gracefulComplete(input);
+    }
+  }
+  class BufferedFlow implements Flow<string> {
+    public readonly start = new BufferedStep();
+
+    public getFlowType(): string {
+      return "BufferedFlow";
+    }
+
+    public getSteps(): StepList<string> {
+      return StepList.startStep(this.start);
+    }
+
+    public getPersistenceSchema() {
+      return { streams: [thinking] };
+    }
+  }
+  const observed: Array<{ value: string; handlerFinished: boolean }> = [];
+  const output = {
+    recordHeartbeat: async () => {},
+    writeStream(write: StepStreamWrite) {
+      observed.push({
+        value: write.value?.kind?.$case === "stringValue" ? write.value.kind.value : "",
+        handlerFinished,
+      });
+      releaseHandler?.();
+    },
+  };
+  const flow = new BufferedFlow();
+  const dispatcher = new WorkerDispatcher(
+    new Registry([flow]),
+    { hydrateAll: async (values: readonly unknown[]) => values } as unknown as ValueHydrator,
+  );
+  await dispatcher.invokeExecute(
+    InvokeExecuteMethodRequest.create({
+      context: ProtoContext.create({ stepExecutionId: "step-1" }),
+      flowType: flow.getFlowType(),
+      stepType: flow.start.getStepType(),
+      stepInput: encodeValue(stringCodec, "hello"),
+    }),
+    new AbortController().signal,
+    output,
+  );
+  assert.deepEqual(observed, [
+    { value: "hello", handlerFinished: false },
+    { value: " 世界", handlerFinished: true },
+  ]);
+});
+
 test("Async Step Context preserves heartbeat Value presence and codecs", async () => {
   const observed: Array<{ hasValue: boolean; value: unknown }> = [];
   class HeartbeatStep implements Step<string> {

--- a/sdk-typescript/test/contracts.test.ts
+++ b/sdk-typescript/test/contracts.test.ts
@@ -583,7 +583,7 @@ test("buffered text Stream flushes on timer and before the final result", async 
     }
 
     public async execute(context: Context, input: string): Promise<StepDecision> {
-      const progress = thinking.buffered(context, {
+      const progress = thinking.bufferedText(context, {
         flushIntervalMs: 5,
         maxBufferedBytes: 1_024,
       });

--- a/sdk-typescript/test/integ/README.md
+++ b/sdk-typescript/test/integ/README.md
@@ -36,7 +36,8 @@ Full integration verification:
 - Persistence integration covers singleton Attribute equality waits; local
   contracts cover Condition IDs and buffered map introspection.
 - Step streaming covers repeated and cross-Stream writes, duplicate source
-  metadata, heartbeat detail recovery and clearing, and local-activity fallback.
+  metadata, heartbeat detail recovery and clearing, local-activity fallback, and
+  buffered text timer/final-result ordering.
 
 ## Error coverage
 

--- a/sdk-typescript/test/integ/stream_flow.ts
+++ b/sdk-typescript/test/integ/stream_flow.ts
@@ -40,17 +40,25 @@ class StreamTestStep implements Step<void> {
 
   public async waitFor(context: AsyncContext, _input: void): Promise<Wait> {
     await context.recordHeartbeat("wait-for", stringCodec);
-    this.progress.write(context, "wait-progress-1");
-    this.progress.write(context, "wait-progress-2");
+    const progress = this.progress.buffered(context);
+    progress.write("wait-progress-");
+    progress.write("1");
+    progress.flush();
+    progress.write("wait-progress-");
+    progress.write("2");
     this.details.write(context, "wait-details");
     return Wait.skipImmediately();
   }
 
   public async execute(context: AsyncContext, _input: void): Promise<StepDecision> {
     await context.recordHeartbeat({ phase: "execute" });
-    this.progress.write(context, "execute-progress-1");
+    const progress = this.progress.buffered(context, { flushIntervalMs: 500 });
+    progress.write("execute-progress-");
+    progress.write("1");
+    progress.flush();
     this.details.write(context, "execute-details");
-    this.progress.write(context, "execute-progress-2");
+    progress.write("execute-progress-");
+    progress.write("2");
     return gracefulComplete();
   }
 }

--- a/sdk-typescript/test/integ/stream_flow.ts
+++ b/sdk-typescript/test/integ/stream_flow.ts
@@ -40,7 +40,7 @@ class StreamTestStep implements Step<void> {
 
   public async waitFor(context: AsyncContext, _input: void): Promise<Wait> {
     await context.recordHeartbeat("wait-for", stringCodec);
-    const progress = this.progress.buffered(context);
+    const progress = this.progress.bufferedText(context);
     progress.write("wait-progress-");
     progress.write("1");
     progress.flush();
@@ -52,7 +52,7 @@ class StreamTestStep implements Step<void> {
 
   public async execute(context: AsyncContext, _input: void): Promise<StepDecision> {
     await context.recordHeartbeat({ phase: "execute" });
-    const progress = this.progress.buffered(context, { flushIntervalMs: 500 });
+    const progress = this.progress.bufferedText(context, { flushIntervalMs: 500 });
     progress.write("execute-progress-");
     progress.write("1");
     progress.flush();


### PR DESCRIPTION
## Summary

- add invocation-managed buffered text Stream writers to Go, Java, Python async, TypeScript, and Rust
- keep Python sync generator buffering cooperative with explicit yielded flushes
- finalize buffered tails before Step results or errors and preserve handler plus finalizer failures
- add contract and dexcli-dev integration coverage across all five SDKs

## Rationale

LLM APIs often produce very small text deltas. Writing every delta as a separate Stream message increases storage pressure and creates noisy progress feeds. These opt-in SDK helpers concatenate text exactly and flush on a one-second timer, a 16 KiB soft UTF-8 threshold, an explicit flush, or invocation completion.

The server and protocol are unchanged. Every emitted batch remains an ordinary best-effort Step Stream message and implicit heartbeat.

## User impact

Applications create one buffered writer per text feed and call `write(chunk)`. Go, Java, Python async, TypeScript, and Rust automatically flush the tail before the invocation result or error. Python sync generators continue to yield outputs from `write` and an explicit final `flush`.

## Validation

- Go public-doc, unit, worker integration, race, and full dexcli-dev E2E coverage
- Java checkstyle, Javadoc, contracts, local integration, and dexcli-dev integration coverage
- Python contracts, mypy strict, pyright, pre-commit, public-doc, and 76 dexcli-dev integration tests
- Rust format, docs, Clippy, workspace tests, compile contracts, and 88 integration tests
- TypeScript public-doc, typecheck, contracts, and 92 dexcli-dev integration tests
- root copyright check
