### PR TITLE
Hide manual flush from managed buffered text streams

### DIFF
--- a/sdk-go/dex/buffered_text_stream.go
+++ b/sdk-go/dex/buffered_text_stream.go
@@ -65,8 +65,8 @@ type BufferedTextStreamOption interface {
 // text. The Context must belong to an active WaitFor or Execute invocation. The SDK automatically
 // flushes remaining text and stops the timer before sending that invocation's final result or error.
 //
-// The returned writer is safe for concurrent Write and Flush calls. Reuse it for the entire logical
-// feed; creating multiple writers gives each writer an independent buffer and timer.
+// The returned writer is safe for concurrent Write calls. Reuse it for the entire logical feed;
+// creating multiple writers gives each writer an independent buffer and timer.
 //
 // Returns an error for an inactive, RPC, or Flow-timeout Context, an unregistered Stream, or invalid
 // options.
@@ -131,7 +131,7 @@ func BufferedTextStreamMaxBytes(value int) BufferedTextStreamOption {
 //
 // Empty chunks are ignored. Write flushes immediately when the soft size threshold is reached. It
 // otherwise returns after buffering locally; it does not wait for the interval or Stream Store.
-// A timer or transport failure is returned by the next Write or Flush call.
+// A timer or transport failure is returned by the next Write or invocation finalization.
 func (writer *BufferedTextStream) Write(chunk string) error {
 	writer.mu.Lock()
 	defer writer.mu.Unlock()
@@ -149,20 +149,6 @@ func (writer *BufferedTextStream) Write(chunk string) error {
 	}
 	if writer.bufferedBytes < writer.maxBufferedBytes {
 		return nil
-	}
-	writer.stopTimerLocked()
-	return writer.flushLocked()
-}
-
-// Flush immediately appends the current non-empty batch.
-//
-// An empty flush is a no-op. A later Write starts a new timer. Flush returns local validation,
-// encoding, and gRPC transport failures but never waits for Stream Store acknowledgement.
-func (writer *BufferedTextStream) Flush() error {
-	writer.mu.Lock()
-	defer writer.mu.Unlock()
-	if err := writer.requireOpenLocked(); err != nil {
-		return err
 	}
 	writer.stopTimerLocked()
 	return writer.flushLocked()

--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -203,7 +203,7 @@ func compileBufferedTextStream(context dex.Context) error {
 	if err := progress.Write("thinking "); err != nil {
 		return err
 	}
-	return progress.Flush()
+	return nil
 }
 
 var _ = compileBufferedTextStream

--- a/sdk-go/integ/stream_test.go
+++ b/sdk-go/integ/stream_test.go
@@ -34,7 +34,11 @@ type streamTestStep struct {
 }
 
 func (streamTestStep) Execute(ctx dex.Context, _ struct{}) (*dex.StepDecision, error) {
-	progress, err := dex.NewBufferedTextStream(ctx, streamTestProgress)
+	progress, err := dex.NewBufferedTextStream(
+		ctx,
+		streamTestProgress,
+		dex.BufferedTextStreamMaxBytes(len("step-progress-1")),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -42,9 +46,6 @@ func (streamTestStep) Execute(ctx dex.Context, _ struct{}) (*dex.StepDecision, e
 		return nil, err
 	}
 	if err := progress.Write("1"); err != nil {
-		return nil, err
-	}
-	if err := progress.Flush(); err != nil {
 		return nil, err
 	}
 	if err := progress.Write("step-progress-"); err != nil {

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -123,11 +123,10 @@ BufferedTextStream progress = BufferedTextStream.create(context, thinking);
 progress.write(delta);
 ```
 
-It flushes after one second, at a soft 16 KiB UTF-8 threshold, on `flush()`, or
-before the final result or error. The configuration overload accepts a
-`Duration` and byte threshold. It preserves chunks exactly, and an empty buffer
-does not emit a message or heartbeat. Retry does not restore unsent text or
-deduplicate batches.
+It flushes after one second, at a soft 16 KiB UTF-8 threshold, or before the
+final result or error. The configuration overload accepts a `Duration` and byte
+threshold. It preserves chunks exactly, and an empty buffer does not emit a
+message or heartbeat. Retry does not restore unsent text or deduplicate batches.
 
 Flow timeout handlers and RPCs cannot send heartbeat or Stream progress.
 

--- a/sdk-java/src/main/java/io/superdurable/dex/BufferedTextStream.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/BufferedTextStream.java
@@ -128,20 +128,9 @@ public final class BufferedTextStream implements StepOutputFinalizer {
             startTimer();
         }
         if (bufferedBytes >= maxBufferedBytes) {
-            flush();
+            stopTimer();
+            flushBuffer();
         }
-    }
-
-    /**
-     * Emits the current nonempty batch immediately.
-     *
-     * @throws IllegalStateException if the invocation ended
-     * @throws RuntimeException if an earlier background or current output write failed
-     */
-    public synchronized void flush() {
-        requireOpen();
-        stopTimer();
-        flushBuffer();
     }
 
     /** Flushes the tail and closes this writer during invocation finalization. */

--- a/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
@@ -249,7 +249,6 @@ public class UserContractsTest {
                 Duration.ofMillis(500),
                 8 * 1024);
         progress.write("thinking ");
-        progress.flush();
     }
 
     public static class OrderFlow implements Flow<OrderInput> {

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/StreamTestWorkflow.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/StreamTestWorkflow.java
@@ -12,6 +12,8 @@
 
 package io.superdurable.dex.integ;
 
+import java.time.Duration;
+
 import io.superdurable.dex.BufferedTextStream;
 import io.superdurable.dex.Context;
 import io.superdurable.dex.Flow;
@@ -43,10 +45,13 @@ final class StreamTestWorkflow implements Flow<Void> {
 
         @Override
         public StepDecision execute(final Context context, final Void input) {
-            final BufferedTextStream writer = BufferedTextStream.create(context, progress);
+            final BufferedTextStream writer = BufferedTextStream.create(
+                    context,
+                    progress,
+                    Duration.ofSeconds(1),
+                    "step-progress-1".length());
             writer.write("step-progress-");
             writer.write("1");
-            writer.flush();
             writer.write("step-progress-");
             writer.write("2");
             return StepDecision.gracefulComplete();

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -163,10 +163,10 @@ async def execute(
     return dex.graceful_complete(input)
 ```
 
-The async buffered writer has synchronous `write` and `flush` methods, so
-`writer.write` can be passed directly as an LLM delta callback. It flushes after
-one second, at a soft 16 KiB UTF-8 threshold, or before the final result or
-error. It concatenates chunks exactly and ignores empty chunks.
+The async buffered writer has a synchronous `write` method, so `writer.write`
+can be passed directly as an LLM delta callback. It flushes after one second, at
+a soft 16 KiB UTF-8 threshold, or before the final result or error. It
+concatenates chunks exactly and ignores empty chunks.
 
 A synchronous generator uses the cooperative form because only yielded
 `StepOutput` values can reach gRPC:

--- a/sdk-python/dex/stream.py
+++ b/sdk-python/dex/stream.py
@@ -183,9 +183,9 @@ class StreamMessage(Generic[ValueT]):
 class AsyncBufferedTextStream:
     """Batch text chunks for an asynchronous Step invocation.
 
-    Create this writer with :meth:`Stream.buffered_text`. ``write`` and ``flush`` are synchronous
-    and return after local buffering or Worker-output enqueueing. AsyncWorker automatically stops
-    its timer and flushes remaining text before the invocation result or error.
+    Create this writer with :meth:`Stream.buffered_text`. ``write`` is synchronous and returns
+    after local buffering or Worker-output enqueueing. AsyncWorker automatically stops its timer
+    and flushes remaining text before the invocation result or error.
     """
 
     def __init__(
@@ -240,20 +240,8 @@ class AsyncBufferedTextStream:
         if was_empty:
             self._start_timer()
         if self._buffered_bytes >= self._max_buffered_bytes:
-            self.flush()
-
-    def flush(self) -> None:
-        """Immediately enqueue the current non-empty batch.
-
-        A later write starts a new timer. Stream Store failures remain unacknowledged.
-
-        Raises:
-            BaseException: A timer or Worker-output failure.
-            ValueError: If the invocation already finished.
-        """
-        self._require_open()
-        self._stop_timer()
-        self._flush_buffer()
+            self._stop_timer()
+            self._flush_buffer()
 
     def _finalize_step_output(self) -> None:
         if self._is_closed:

--- a/sdk-python/tests/integ/async_stream_flow.py
+++ b/sdk-python/tests/integ/async_stream_flow.py
@@ -33,10 +33,12 @@ class AsyncStreamTestStep(Step[None]):
         input: None,
     ) -> Wait:
         del input
-        progress = self.progress.buffered_text(context)
+        progress = self.progress.buffered_text(
+            context,
+            max_buffered_bytes=len("async-wait"),
+        )
         progress.write("async-")
         progress.write("wait")
-        progress.flush()
         await context.heartbeat("async-wait-checkpoint")
         return Wait.skip_immediately()
 
@@ -46,10 +48,12 @@ class AsyncStreamTestStep(Step[None]):
         input: None,
     ) -> StepDecision:
         del input
-        progress = self.progress.buffered_text(context)
+        progress = self.progress.buffered_text(
+            context,
+            max_buffered_bytes=len("async-step-first"),
+        )
         progress.write("async-step-")
         progress.write("first")
-        progress.flush()
         await context.heartbeat("async-checkpoint")
         progress.write("async-step-")
         progress.write("second")

--- a/sdk-python/tests/typecheck_contracts.py
+++ b/sdk-python/tests/typecheck_contracts.py
@@ -73,7 +73,6 @@ class AsyncTypedStep(Step[Input]):
     ) -> StepDecision:
         buffered = progress.buffered_text(context)
         buffered.write("thinking ")
-        buffered.flush()
         progress.write(context, input.value)
         await context.heartbeat(input.value)
         return graceful_complete()

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -205,9 +205,9 @@ progress.write(delta)?;
 ```
 
 `buffered_text_with_options` accepts a `BufferedTextStreamOptions` interval and soft UTF-8 byte
-threshold. Defaults are one second and 16 KiB. `flush` sends the current batch, while invocation
-finalization sends the tail before the final result or error. Empty buffers do not emit a message
-or heartbeat. Retry does not restore unsent text or deduplicate emitted batches.
+threshold. Defaults are one second and 16 KiB. Invocation finalization sends the tail before the
+final result or error. Empty buffers do not emit a message or heartbeat. Retry does not restore
+unsent text or deduplicate emitted batches.
 
 External writes remain unary. `Client::write_stream` requires a non-empty `source`, accepts `#`,
 and appends every call even when a source repeats. Read messages return that metadata in

--- a/sdk-rust/crates/dex-sdk/src/stream.rs
+++ b/sdk-rust/crates/dex-sdk/src/stream.rs
@@ -184,9 +184,9 @@ impl Default for BufferedTextStreamOptions {
 
 /// Batches text chunks during one Step invocation.
 ///
-/// [`Self::write`] and [`Self::flush`] block only on the Worker's bounded output queue. They do not
-/// wait for Dex Stream Store acknowledgement. The Worker automatically flushes the tail before
-/// returning the handler result or error.
+/// [`Self::write`] blocks only on the Worker's bounded output queue. It does not wait for Dex Stream
+/// Store acknowledgement. The Worker automatically flushes the tail before returning the handler
+/// result or error.
 #[derive(Clone)]
 pub struct BufferedTextStream {
     inner: Arc<BufferedTextStreamInner>,
@@ -218,18 +218,6 @@ impl BufferedTextStream {
             self.inner.flush_locked(&mut state)?;
         }
         Ok(())
-    }
-
-    /// Emits the current nonempty batch immediately.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`HandlerError`] after cancellation, invocation completion, or output failure.
-    pub fn flush(&self) -> HandlerResult<()> {
-        let mut state = self.inner.state.blocking_lock();
-        state.require_open()?;
-        self.inner.stop_timer(&mut state);
-        self.inner.flush_locked(&mut state)
     }
 }
 

--- a/sdk-rust/crates/dex-sdk/tests/compile_contracts.rs
+++ b/sdk-rust/crates/dex-sdk/tests/compile_contracts.rs
@@ -48,7 +48,6 @@ fn stream_definitions_and_client_calls_compile() {
             );
         if let Ok(buffered) = buffered {
             let _buffered_write: dex_sdk::HandlerResult<()> = buffered.write("thinking ");
-            let _buffered_flush: dex_sdk::HandlerResult<()> = buffered.flush();
         }
         client.write_stream("flow-1", stream, "client#source", "starting".to_owned())?;
         let message = client.read_stream("flow-1", stream, "")?;

--- a/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/stream_workflow.rs
@@ -52,10 +52,12 @@ impl Step for StreamTestStep {
 
     fn wait_for(&self, context: &mut Context, _input: ()) -> HandlerResult<Wait> {
         context.record_heartbeat()?;
-        let progress = PROGRESS.buffered_text(context)?;
+        let progress = PROGRESS.buffered_text_with_options(
+            context,
+            BufferedTextStreamOptions::new(Duration::from_secs(1), "wait-progress-1".len()),
+        )?;
         progress.write("wait-progress-")?;
         progress.write("1")?;
-        progress.flush()?;
         context.record_heartbeat_value("wait-checkpoint".to_string())?;
         progress.write("wait-progress-")?;
         progress.write("2")?;
@@ -66,11 +68,10 @@ impl Step for StreamTestStep {
         context.record_heartbeat()?;
         let progress = PROGRESS.buffered_text_with_options(
             context,
-            BufferedTextStreamOptions::new(Duration::from_millis(250), 16 * 1024),
+            BufferedTextStreamOptions::new(Duration::from_millis(250), "execute-progress-1".len()),
         )?;
         progress.write("execute-progress-")?;
         progress.write("1")?;
-        progress.flush()?;
         context.record_heartbeat_value("execute-checkpoint".to_string())?;
         progress.write("execute-progress-")?;
         progress.write("2")?;

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -216,10 +216,10 @@ const progress = thinking.bufferedText(context, { flushIntervalMs: 500 });
 await generateText(input, progress.write);
 ```
 
-The defaults are one second and a soft 16 KiB UTF-8 threshold. `flush()` sends
-the current nonempty batch, and invocation completion sends the tail before the
-final result or error. Chunks are concatenated exactly. Retry does not restore
-unsent text or deduplicate emitted batches.
+The defaults are one second and a soft 16 KiB UTF-8 threshold. Invocation
+completion sends the tail before the final result or error. Chunks are
+concatenated exactly. Retry does not restore unsent text or deduplicate emitted
+batches.
 
 External writes use `client.writeStream(flowId, stream, source, value)`. Source
 must be non-empty, may contain `#`, and may repeat; every write appends a new

--- a/sdk-typescript/src/stream.ts
+++ b/sdk-typescript/src/stream.ts
@@ -63,9 +63,9 @@ export class Stream<T> {
   /**
    * Creates an invocation-managed text writer for an asynchronous Step.
    *
-   * The writer concatenates chunks exactly and flushes on its timer, soft UTF-8 size threshold,
-   * an explicit {@link BufferedTextStream.flush}, or handler completion. The Worker flushes every
-   * remaining batch before the final result or error. Empty chunks are ignored.
+   * The writer concatenates chunks exactly and flushes on its timer, soft UTF-8 size threshold, or
+   * handler completion. The Worker flushes every remaining batch before the final result or error.
+   * Empty chunks are ignored.
    *
    * @param context - Current asynchronous Step Context.
    * @param options - Optional flush interval and soft byte threshold.
@@ -125,7 +125,6 @@ export class BufferedTextStream implements StepOutputFinalizer {
     private readonly maxBufferedBytes: number,
   ) {
     this.write = this.write.bind(this);
-    this.flush = this.flush.bind(this);
   }
 
   /**
@@ -148,18 +147,9 @@ export class BufferedTextStream implements StepOutputFinalizer {
       this.startTimer();
     }
     if (this.bufferedBytes >= this.maxBufferedBytes) {
-      this.flush();
+      this.stopTimer();
+      this.flushBuffer();
     }
-  }
-
-  /**
-   * Immediately emits the current non-empty batch and restarts timing with the next write.
-   * @throws {@link Error} if the invocation finished or an earlier flush failed.
-   */
-  public flush(): void {
-    this.requireOpen();
-    this.stopTimer();
-    this.flushBuffer();
   }
 
   /** Flushes the tail and closes this writer during invocation finalization. */

--- a/sdk-typescript/test/integ/stream_flow.ts
+++ b/sdk-typescript/test/integ/stream_flow.ts
@@ -40,10 +40,11 @@ class StreamTestStep implements Step<void> {
 
   public async waitFor(context: AsyncContext, _input: void): Promise<Wait> {
     await context.recordHeartbeat("wait-for", stringCodec);
-    const progress = this.progress.bufferedText(context);
+    const progress = this.progress.bufferedText(context, {
+      maxBufferedBytes: "wait-progress-1".length,
+    });
     progress.write("wait-progress-");
     progress.write("1");
-    progress.flush();
     progress.write("wait-progress-");
     progress.write("2");
     this.details.write(context, "wait-details");
@@ -52,10 +53,12 @@ class StreamTestStep implements Step<void> {
 
   public async execute(context: AsyncContext, _input: void): Promise<StepDecision> {
     await context.recordHeartbeat({ phase: "execute" });
-    const progress = this.progress.bufferedText(context, { flushIntervalMs: 500 });
+    const progress = this.progress.bufferedText(context, {
+      flushIntervalMs: 500,
+      maxBufferedBytes: "execute-progress-1".length,
+    });
     progress.write("execute-progress-");
     progress.write("1");
-    progress.flush();
     this.details.write(context, "execute-details");
     progress.write("execute-progress-");
     progress.write("2");


### PR DESCRIPTION
## Summary

- remove the public manual flush method from invocation-managed buffered text writers in Go, Java, Python async, TypeScript, and Rust
- keep Python sync generator flush public because the handler must yield its final StepOutput
- preserve timer, size-threshold, and invocation-finalization flushing
- update SDK contracts, integration fixtures, and SDK READMEs

## Rationale

Invocation-managed writers already stop their timer and emit the remaining tail before the final result or error. A public flush method makes routine application code look like it needs explicit cleanup. Applications should only call write; the SDK owns batch delivery and finalization.

Integration fixtures now use a small soft byte threshold for the first batch and invocation finalization for the tail, so multi-message ordering remains covered without exposing manual flushing.

## User impact

This is a breaking SDK API cleanup before launch. Go, Java, Python async, TypeScript, and Rust callers must remove explicit buffered-writer flush calls. Python sync generator callers continue to use `yield from writer.flush()`.

## Validation

- `make -C sdk-go docsCheck unitTests`
- `sdk-go/run-e2e-tests.sh`
- `sdk-java/gradlew compileTestJava checkstyleMain javadoc test --tests io.superdurable.dex.contracts.UserContractsTest --no-daemon`
- `sdk-java/run-integration-tests.sh`
- Python contract tests, mypy strict, pyright, public-doc checker, and pre-commit
- `sdk-python/run-integration-tests.sh` (76 passed)
- TypeScript docs check, typecheck, and unit tests
- `sdk-typescript/run-integration-tests.sh` (92 passed)
- Rust format, public docs, Clippy, workspace tests, and doctests
- `sdk-rust/run-integration-tests.sh` (78 passed)
- `make copyright-check docs-prose-check`
