### PR TITLE
Improve persistence value disclosure

### DIFF
--- a/web/app/components/JsonView.tsx
+++ b/web/app/components/JsonView.tsx
@@ -24,6 +24,7 @@ export function JsonView({
   collapseNonce = 0,
   parentFlowId = '',
   stepExecutionId = '',
+  persistenceKind,
 }: {
   value: unknown;
   label?: string;
@@ -33,6 +34,7 @@ export function JsonView({
   collapseNonce?: number;
   parentFlowId?: string;
   stepExecutionId?: string;
+  persistenceKind?: 'attributes' | 'channels';
 }) {
   const storageKey = persistKey ?? label;
   const [open, setOpen] = useState(() => openByKey.get(storageKey) ?? initiallyOpen);
@@ -104,6 +106,7 @@ export function JsonView({
                 value={value}
                 parentFlowId={parentFlowId}
                 stepExecutionId={stepExecutionId}
+                persistenceKind={persistenceKind}
               />
             : (
               <pre className="json-view-raw">

--- a/web/app/components/StructuredValue.tsx
+++ b/web/app/components/StructuredValue.tsx
@@ -179,14 +179,105 @@ function WaitingConditionStructured({
   );
 }
 
+function mapEntry(key: string): { name: string; instance: string } | null {
+  const separator = key.indexOf('/');
+  if (separator <= 0 || separator === key.length - 1) return null;
+  const name = key.slice(0, separator);
+  const encodedInstance = key.slice(separator + 1);
+  try {
+    return { name, instance: decodeURIComponent(encodedInstance) };
+  } catch {
+    return { name, instance: encodedInstance };
+  }
+}
+
+type PersistenceGroup =
+  | { kind: 'value'; entry: Data; index: number }
+  | { kind: 'map'; name: string; entries: Array<{ entry: Data; instance: string; index: number }> };
+
+function persistenceGroups(entries: Data[]): PersistenceGroup[] {
+  const groups: PersistenceGroup[] = [];
+  const mapsByName = new Map<string, Extract<PersistenceGroup, { kind: 'map' }>>();
+  for (const [index, entry] of entries.entries()) {
+    const key = typeof entry.key === 'string' ? entry.key : displayValue(entry.key);
+    const mapped = mapEntry(key);
+    if (!mapped) {
+      groups.push({ kind: 'value', entry, index });
+      continue;
+    }
+    let group = mapsByName.get(mapped.name);
+    if (!group) {
+      group = { kind: 'map', name: mapped.name, entries: [] };
+      mapsByName.set(mapped.name, group);
+      groups.push(group);
+    }
+    group.entries.push({ entry, instance: mapped.instance, index });
+  }
+  return groups;
+}
+
 function KeyValueListStructured({ value }: { value: unknown }) {
+  const groups = persistenceGroups(asDataArray(value));
   return (
     <div className="structured-value semantic-records">
-      {asDataArray(value).map((entry, index) => (
-        <div className="semantic-record" key={`${String(entry.key)}-${index}`}>
-          <strong>{displayValue(entry.key)}</strong>
-          <div className="semantic-value">
-            <ValueChip value={entry.value} />
+      {groups.map((group) => group.kind === 'value' ? (
+        <div className="semantic-record" key={`${String(group.entry.key)}-${group.index}`}>
+          <strong>{displayValue(group.entry.key)}</strong>
+          <div className="semantic-value"><ValueChip value={group.entry.value} /></div>
+        </div>
+      ) : (
+        <div className="semantic-record semantic-map-record" key={group.name}>
+          <strong>{group.name}</strong>
+          <div className="semantic-map-list">
+            {group.entries.map(({ entry, instance, index }) => (
+              <details className="semantic-record semantic-map-entry" key={`${instance}-${index}`}>
+                <summary><strong>{instance}</strong></summary>
+                <div className="semantic-record-content">
+                  <div className="semantic-value"><ValueChip value={entry.value} /></div>
+                </div>
+              </details>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ChannelValues({ value }: { value: unknown }) {
+  const values = asDataArray(asData(value).values);
+  if (values.length === 0) return <ValueChip value={value} />;
+  return (
+    <div className="semantic-records semantic-channel-values">
+      {values.map((message, index) => (
+        <div className="semantic-record" key={index}>
+          <strong>Message {index + 1}</strong>
+          <div className="semantic-value"><ValueChip value={message} /></div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PendingChannelsStructured({ value }: { value: Data }) {
+  const groups = persistenceGroups(Object.entries(value).map(([key, entry]) => ({ key, value: entry })));
+  return (
+    <div className="structured-value semantic-records">
+      {groups.map((group) => group.kind === 'value' ? (
+        <div className="semantic-record channel-record" key={`${String(group.entry.key)}-${group.index}`}>
+          <strong>{displayValue(group.entry.key)}</strong>
+          <ChannelValues value={group.entry.value} />
+        </div>
+      ) : (
+        <div className="semantic-record channel-record semantic-map-record" key={group.name}>
+          <strong>{group.name}</strong>
+          <div className="semantic-map-list">
+            {group.entries.map(({ entry, instance, index }) => (
+              <details className="semantic-record semantic-map-entry" key={`${instance}-${index}`}>
+                <summary><strong>{instance}</strong></summary>
+                <div className="semantic-record-content"><ChannelValues value={entry.value} /></div>
+              </details>
+            ))}
           </div>
         </div>
       ))}
@@ -262,22 +353,25 @@ export function StructuredValue({
   value,
   parentFlowId = '',
   stepExecutionId = '',
+  persistenceKind,
 }: {
   value: unknown;
   parentFlowId?: string;
   stepExecutionId?: string;
+  persistenceKind?: 'attributes' | 'channels';
 }) {
   if (value === undefined || value === null) {
     return <p className="muted">No value</p>;
   }
   if (Array.isArray(value)) {
     if (value.length === 0) return <p className="muted">Empty list</p>;
-    if (isKeyValueList(value)) return <KeyValueListStructured value={value} />;
+    if (persistenceKind === 'attributes' && isKeyValueList(value)) return <KeyValueListStructured value={value} />;
     if (isTimerList(value)) return <TimerListStructured value={value} />;
     return <ArrayStructured value={value} />;
   }
   if (typeof value === 'object') {
     if (Object.keys(value).length === 0) return <p className="muted">Empty object</p>;
+    if (persistenceKind === 'channels') return <PendingChannelsStructured value={asData(value)} />;
     if (isWaitingCondition(value)) {
       return <WaitingConditionStructured
         value={value}

--- a/web/app/flows/details/EventDetails.test.tsx
+++ b/web/app/flows/details/EventDetails.test.tsx
@@ -498,6 +498,44 @@ describe('RPC event details', () => {
     expect(markup).not.toContain('RPC call');
     expect(markup).not.toContain('RPC name');
   });
+
+  it('keeps Attribute and Channel values collapsed, with two levels for maps', () => {
+    const attributesEvent: FlowHistoryEvent = {
+      eventId: 10,
+      eventTime: '2026-08-05T23:44:31Z',
+      type: 'RpcExecutionCompleted',
+      payload: {
+        isSetAttributeApi: true,
+        upsertAttributes: [
+          { key: 'status', value: { stringValue: 'ready' } },
+          { key: 'orders/first%20order', value: { stringValue: 'pending' } },
+        ],
+      },
+    };
+    const channelEvent: FlowHistoryEvent = {
+      eventId: 11,
+      eventTime: '2026-08-05T23:44:32Z',
+      type: 'ChannelExternalPublish',
+      payload: {
+        messages: [
+          { channelName: 'notifications', value: { stringValue: 'sent' } },
+          { channelName: 'updates/first%20order', value: { stringValue: 'queued' } },
+        ],
+      },
+    };
+
+    const attributeMarkup = renderDetails(attributesEvent);
+    const channelMarkup = renderDetails(channelEvent);
+
+    expect(attributeMarkup).toContain('<details class="semantic-record">');
+    expect(attributeMarkup).toContain('<details class="semantic-record semantic-map-record">');
+    expect(attributeMarkup).toContain('first order');
+    expect(attributeMarkup).not.toContain('<details class="semantic-record" open="">');
+    expect(channelMarkup).toContain('<details class="semantic-record channel-record">');
+    expect(channelMarkup).toContain('<details class="semantic-record channel-record semantic-map-record">');
+    expect(channelMarkup).toContain('first order');
+    expect(channelMarkup).not.toContain('<details class="semantic-record channel-record" open="">');
+  });
 });
 
 describe('pending step method details', () => {

--- a/web/app/flows/details/EventDetails.tsx
+++ b/web/app/flows/details/EventDetails.tsx
@@ -83,10 +83,6 @@ function asDataArray(value: unknown): Data[] {
   return Array.isArray(value) ? value.map(asData) : [];
 }
 
-function asArray(value: unknown): unknown[] {
-  return Array.isArray(value) ? value : [];
-}
-
 function hasData(value: Data): boolean {
   return Object.keys(value).length > 0;
 }
@@ -187,16 +183,89 @@ function ValueBlock({
   );
 }
 
+function mapEntry(key: string): { name: string; instance: string } | null {
+  const separator = key.indexOf('/');
+  if (separator <= 0 || separator === key.length - 1) return null;
+  const name = key.slice(0, separator);
+  const encodedInstance = key.slice(separator + 1);
+  try {
+    return { name, instance: decodeURIComponent(encodedInstance) };
+  } catch {
+    return { name, instance: encodedInstance };
+  }
+}
+
+type PersistenceGroup =
+  | { kind: 'value'; entry: Data; index: number }
+  | { kind: 'map'; name: string; entries: Array<{ entry: Data; instance: string; index: number }> };
+
+function persistenceGroups(entries: Data[], keyForEntry: (entry: Data) => string): PersistenceGroup[] {
+  const groups: PersistenceGroup[] = [];
+  const mapsByName = new Map<string, Extract<PersistenceGroup, { kind: 'map' }>>();
+  for (const [index, entry] of entries.entries()) {
+    const key = keyForEntry(entry);
+    const mapped = mapEntry(key);
+    if (!mapped) {
+      groups.push({ kind: 'value', entry, index });
+      continue;
+    }
+    let group = mapsByName.get(mapped.name);
+    if (!group) {
+      group = { kind: 'map', name: mapped.name, entries: [] };
+      mapsByName.set(mapped.name, group);
+      groups.push(group);
+    }
+    group.entries.push({ entry, instance: mapped.instance, index });
+  }
+  return groups;
+}
+
+function CollapsedValueRecord({
+  label,
+  value,
+  valueLabel,
+  channel = false,
+}: {
+  label: string;
+  value: unknown;
+  valueLabel: string;
+  channel?: boolean;
+}) {
+  return (
+    <details className={`semantic-record${channel ? ' channel-record' : ''}`}>
+      <summary><strong>{channel && <ChannelIcon />}{label}</strong></summary>
+      <div className="semantic-record-content"><ValueBlock label={valueLabel} value={value} /></div>
+    </details>
+  );
+}
+
 function KeyValues({ values, emptyLabel }: { values: unknown; emptyLabel?: string }) {
   const entries = asDataArray(values);
   if (entries.length === 0) return emptyLabel ? <p className="muted">{emptyLabel}</p> : null;
+  const groups = persistenceGroups(entries, (entry) => displayValue(entry.key));
   return (
     <div className="semantic-records">
-      {entries.map((entry, index) => (
-        <div className="semantic-record" key={`${String(entry.key)}-${index}`}>
-          <strong>{displayValue(entry.key)}</strong>
-          <ValueBlock label="Value" value={entry.value} />
-        </div>
+      {groups.map((group) => group.kind === 'value' ? (
+        <CollapsedValueRecord
+          key={`${String(group.entry.key)}-${group.index}`}
+          label={displayValue(group.entry.key)}
+          value={group.entry.value}
+          valueLabel="Value"
+        />
+      ) : (
+        <details className="semantic-record semantic-map-record" key={group.name}>
+          <summary><strong>{group.name}</strong></summary>
+          <div className="semantic-record-content semantic-map-list">
+            {group.entries.map(({ entry, instance, index }) => (
+              <CollapsedValueRecord
+                key={`${instance}-${index}`}
+                label={instance}
+                value={entry.value}
+                valueLabel="Value"
+              />
+            ))}
+          </div>
+        </details>
       ))}
     </div>
   );
@@ -205,13 +274,32 @@ function KeyValues({ values, emptyLabel }: { values: unknown; emptyLabel?: strin
 function ChannelMessages({ values }: { values: unknown }) {
   const messages = asDataArray(values);
   if (messages.length === 0) return null;
+  const groups = persistenceGroups(messages, (message) => displayValue(message.channelName));
   return (
     <div className="semantic-records">
-      {messages.map((message, index) => (
-        <div className="semantic-record channel-record" key={`${String(message.channelName)}-${index}`}>
-          <strong><ChannelIcon />{displayValue(message.channelName)}</strong>
-          <ValueBlock label="Message" value={message.value} />
-        </div>
+      {groups.map((group) => group.kind === 'value' ? (
+        <CollapsedValueRecord
+          channel
+          key={`${String(group.entry.channelName)}-${group.index}`}
+          label={displayValue(group.entry.channelName)}
+          value={group.entry.value}
+          valueLabel="Message"
+        />
+      ) : (
+        <details className="semantic-record channel-record semantic-map-record" key={group.name}>
+          <summary><strong><ChannelIcon />{group.name}</strong></summary>
+          <div className="semantic-record-content semantic-map-list">
+            {group.entries.map(({ entry, instance, index }) => (
+              <CollapsedValueRecord
+                channel
+                key={`${instance}-${index}`}
+                label={instance}
+                value={entry.value}
+                valueLabel="Message"
+              />
+            ))}
+          </div>
+        </details>
       ))}
     </div>
   );
@@ -977,16 +1065,9 @@ function ContinuedStartDetails({
       )}
       {Object.keys(pendingChannels).length > 0 && (
         <DetailSection title="Pending channels">
-          <div className="semantic-records">
-            {Object.entries(pendingChannels).map(([name, entry]) => (
-              <div className="semantic-record channel-record" key={name}>
-                <strong><ChannelIcon />{name}</strong>
-                {asArray(asData(entry).values).map((value, index) => (
-                  <ValueBlock label={`Message ${index + 1}`} value={value} key={index} />
-                ))}
-              </div>
-            ))}
-          </div>
+          <ChannelMessages values={Object.entries(pendingChannels).flatMap(([channelName, entry]) => (
+            asDataArray(asData(entry).values).map((value) => ({ channelName, value }))
+          ))} />
         </DetailSection>
       )}
       {Array.isArray(continued.attributes) && continued.attributes.length > 0 && (

--- a/web/app/flows/details/FlowOverview.test.tsx
+++ b/web/app/flows/details/FlowOverview.test.tsx
@@ -8,6 +8,7 @@
 
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
+import { StructuredValue } from '@/app/components/StructuredValue';
 import type { FlowState, FlowSummary } from '@/lib/types';
 import { FlowOverview } from './FlowOverview';
 
@@ -71,5 +72,59 @@ describe('live Flow state failures', () => {
     expect(markup).toContain('<details class="active-step-card" open="">');
     expect(markup).toContain('Collapse all');
     expect(markup).toContain('<details class="failure-stack" open="">');
+  });
+
+  it('expands Attributes while keeping AttributeMap instance values collapsed', () => {
+    const summary: FlowSummary = {
+      flowId: 'flow-1',
+      runId: 'run-1',
+      firstRunId: 'run-1',
+      requestId: 'request-1',
+      flowType: 'PaymentFlow',
+      flowStatus: 'Running',
+      flowStatusCode: 1,
+      startTime: '2026-08-10T00:00:00Z',
+      closeTime: null,
+    };
+    const state: FlowState = {
+      flowConfig: {},
+      attributes: [
+        { key: 'status', value: 'ready' },
+        { key: 'orders/first%20order', value: 'pending' },
+        { key: 'orders/second', value: 'complete' },
+      ],
+      activeStepExecutions: [],
+      queuedSteps: [],
+      pendingChannelMessages: {},
+      completedSteps: [],
+    };
+
+    const markup = renderToStaticMarkup(
+      <FlowOverview summary={summary} events={[]} state={state} selectedEvent={null} />,
+    );
+
+    expect(markup).toContain('status');
+    expect(markup).toContain('ready');
+    expect(markup).toContain('orders');
+    expect(markup).toContain('first order');
+    expect(markup).toContain('second');
+    expect(markup).toContain('<details class="semantic-record semantic-map-entry">');
+  });
+
+  it('shows ChannelMap instances before their queued messages', () => {
+    const markup = renderToStaticMarkup(
+      <StructuredValue
+        persistenceKind="channels"
+        value={{
+          'updates/first%20order': { values: ['queued'] },
+          'updates/second': { values: ['complete'] },
+        }}
+      />,
+    );
+
+    expect(markup).toContain('updates');
+    expect(markup).toContain('first order');
+    expect(markup).toContain('second');
+    expect(markup).toContain('<details class="semantic-record semantic-map-entry">');
   });
 });

--- a/web/app/flows/details/FlowOverview.tsx
+++ b/web/app/flows/details/FlowOverview.tsx
@@ -191,7 +191,9 @@ export function FlowOverview({
                 <JsonView
                   value={state.attributes}
                   label="Attributes"
+                  initiallyOpen
                   persistKey="overview:attributes"
+                  persistenceKind="attributes"
                   forceOpen={attributesExpand.expanded || undefined}
                   collapseNonce={attributesExpand.collapseNonce}
                 />
@@ -217,6 +219,7 @@ export function FlowOverview({
                   value={state.pendingChannelMessages}
                   label="Pending channel messages"
                   persistKey="overview:pending-channels"
+                  persistenceKind="channels"
                   forceOpen={channelsExpand.expanded || undefined}
                   collapseNonce={channelsExpand.collapseNonce}
                 />

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1279,6 +1279,55 @@ pre {
   overflow-wrap: anywhere;
 }
 
+.semantic-record > summary {
+  display: flex;
+  align-items: center;
+  list-style: none;
+  cursor: pointer;
+}
+
+.semantic-record > summary::-webkit-details-marker {
+  display: none;
+}
+
+.semantic-record > summary::before {
+  content: '▸';
+  margin-right: 5px;
+  color: var(--muted);
+  transition: transform 120ms ease;
+}
+
+.semantic-record[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.semantic-record > summary > strong {
+  margin-bottom: 0;
+}
+
+.channel-record > summary > strong {
+  color: #765620;
+}
+
+.semantic-record-content {
+  margin-top: 8px;
+}
+
+.semantic-map-list {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.semantic-map-entry {
+  padding: 7px;
+  background: #fbfcfc;
+}
+
+.semantic-channel-values {
+  margin-top: 8px;
+}
+
 .channel-record > strong {
   color: #765620;
 }


### PR DESCRIPTION
## Summary

- Collapse Attribute and Channel values in selected event details until clicked.
- Group AttributeMap and ChannelMap entries under their logical definitions, with a second disclosure for each instance value.
- Open Overview Attributes by default while retaining collapsed map-instance values.

## Rationale and user impact

Large persisted values no longer dominate selected event details. Map-backed values are easier to scan because their instances are grouped under one AttributeMap or ChannelMap name.

## Validation

- `cd web && npm run check`
- `cd web && npm run build`
