### PR TITLE
Reserve persistence definition separator

### DIFF
--- a/sdk-go/dex/attribute.go
+++ b/sdk-go/dex/attribute.go
@@ -31,6 +31,7 @@ type Attribute[T any] struct {
 }
 
 // DefineAttribute creates a typed Attribute with a stable name and definition options.
+// "/" is reserved as the AttributeMap separator and is prohibited in Attribute names.
 // The definition does not perform I/O; register it through PersistenceSchema before use.
 func DefineAttribute[T any](key string, options ...AttributeOption) Attribute[T] {
 	config := applyAttributeOptions(options)
@@ -123,6 +124,7 @@ type AttributeMap[T any] struct {
 }
 
 // DefineAttributeMap creates a typed Attribute map with a stable name and definition options.
+// "/" is reserved as the AttributeMap separator and is prohibited in AttributeMap names.
 // The definition performs no I/O; register it through PersistenceSchema before use.
 func DefineAttributeMap[T any](name string, options ...AttributeOption) AttributeMap[T] {
 	config := applyAttributeOptions(options)

--- a/sdk-go/dex/channel.go
+++ b/sdk-go/dex/channel.go
@@ -24,6 +24,7 @@ type Channel[T any] struct {
 }
 
 // DefineChannel creates a typed Channel with a stable name without performing I/O.
+// "/" is reserved as the ChannelMap separator and is prohibited in Channel names.
 func DefineChannel[T any](name string) Channel[T] {
 	return Channel[T]{name: name}
 }
@@ -127,6 +128,7 @@ type ChannelMap[T any] struct {
 }
 
 // DefineChannelMap creates a typed Channel map with a stable name.
+// "/" is reserved as the ChannelMap separator and is prohibited in ChannelMap names.
 func DefineChannelMap[T any](name string) ChannelMap[T] {
 	return ChannelMap[T]{name: name}
 }

--- a/sdk-go/dex/registration.go
+++ b/sdk-go/dex/registration.go
@@ -207,8 +207,8 @@ func (flow *registeredFlow) registerAttribute(
 	indexTypes map[string]IndexType,
 ) error {
 	name := definition.attributeName()
-	if name == "" {
-		return fmt.Errorf("attribute name must not be empty")
+	if err := validatePersistenceDefinitionName(name, "attribute"); err != nil {
+		return err
 	}
 	if _, found := flow.attributes[name]; found {
 		return fmt.Errorf("duplicate attribute %q", name)
@@ -248,8 +248,8 @@ func (flow *registeredFlow) registerChannel(
 	definition ChannelDef,
 ) error {
 	name := definition.channelName()
-	if name == "" {
-		return fmt.Errorf("channel name must not be empty")
+	if err := validatePersistenceDefinitionName(name, "channel"); err != nil {
+		return err
 	}
 	if _, found := flow.channels[name]; found {
 		return fmt.Errorf("duplicate channel %q", name)
@@ -258,6 +258,16 @@ func (flow *registeredFlow) registerChannel(
 		def:   definition,
 		name:  name,
 		isMap: definition.channelIsMap(),
+	}
+	return nil
+}
+
+func validatePersistenceDefinitionName(name string, kind string) error {
+	if name == "" {
+		return fmt.Errorf("%s name must not be empty", kind)
+	}
+	if strings.Contains(name, "/") {
+		return fmt.Errorf("%s name must not contain /", kind)
 	}
 	return nil
 }

--- a/sdk-go/dex/registration_test.go
+++ b/sdk-go/dex/registration_test.go
@@ -530,6 +530,26 @@ func TestRegistryValidatesPersistenceSchema(t *testing.T) {
 			error: "attribute name must not be empty",
 		},
 		{
+			name: "slash attribute",
+			flows: []Flow{&registrationFlow{
+				flowType: "flow",
+				schema: PersistenceSchema{
+					Attributes: []AttributeDef{DefineAttribute[string]("orders/by-id")},
+				},
+			}},
+			error: "attribute name must not contain /",
+		},
+		{
+			name: "slash attribute map",
+			flows: []Flow{&registrationFlow{
+				flowType: "flow",
+				schema: PersistenceSchema{
+					Attributes: []AttributeDef{DefineAttributeMap[string]("orders/by-id")},
+				},
+			}},
+			error: "attribute name must not contain /",
+		},
+		{
 			name: "duplicate attribute",
 			flows: []Flow{&registrationFlow{
 				flowType: "flow",
@@ -578,6 +598,26 @@ func TestRegistryValidatesPersistenceSchema(t *testing.T) {
 				},
 			}},
 			error: "channel name must not be empty",
+		},
+		{
+			name: "slash channel",
+			flows: []Flow{&registrationFlow{
+				flowType: "flow",
+				schema: PersistenceSchema{
+					Channels: []ChannelDef{DefineChannel[string]("orders/by-id")},
+				},
+			}},
+			error: "channel name must not contain /",
+		},
+		{
+			name: "slash channel map",
+			flows: []Flow{&registrationFlow{
+				flowType: "flow",
+				schema: PersistenceSchema{
+					Channels: []ChannelDef{DefineChannelMap[string]("orders/by-id")},
+				},
+			}},
+			error: "channel name must not contain /",
 		},
 		{
 			name: "duplicate channel",

--- a/sdk-java/src/main/java/io/superdurable/dex/Attribute.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Attribute.java
@@ -53,7 +53,7 @@ public final class Attribute<T> extends PersistenceDefinition {
             final Class<T> valueType,
             final AttributeIndex index,
             final boolean syncToAttributeStore) {
-        this.name = requireName(name);
+        this.name = requirePersistenceDefinitionName(name);
         this.valueType = Objects.requireNonNull(valueType, "valueType");
         this.index = index;
         this.syncToAttributeStore = syncToAttributeStore;
@@ -62,11 +62,11 @@ public final class Attribute<T> extends PersistenceDefinition {
     /**
      * Defines an Attribute without a search index.
      *
-     * @param name the stable Attribute name; must not be blank
+     * @param name the stable Attribute name; must not be blank or contain {@code /}
      * @param valueType the concrete Java class used to serialize and deserialize values
      * @param <T> the Java value type
      * @return the typed Attribute definition
-     * @throws IllegalArgumentException if {@code name} is {@code null} or blank
+     * @throws IllegalArgumentException if {@code name} is {@code null}, blank, or contains {@code /}
      * @throws NullPointerException if {@code valueType} is {@code null}
      */
     public static <T> Attribute<T> define(final String name, final Class<T> valueType) {
@@ -76,12 +76,12 @@ public final class Attribute<T> extends PersistenceDefinition {
     /**
      * Defines an Attribute with a search index.
      *
-     * @param name the stable Attribute name; must not be blank
+     * @param name the stable Attribute name; must not be blank or contain {@code /}
      * @param valueType the concrete Java class used to serialize and deserialize values
      * @param index the search-index definition, or {@code null} for no index
      * @param <T> the Java value type
      * @return the typed Attribute definition
-     * @throws IllegalArgumentException if {@code name} is {@code null} or blank
+     * @throws IllegalArgumentException if {@code name} is {@code null}, blank, or contains {@code /}
      * @throws NullPointerException if {@code valueType} is {@code null}
      */
     public static <T> Attribute<T> define(
@@ -155,5 +155,13 @@ public final class Attribute<T> extends PersistenceDefinition {
             throw new IllegalArgumentException("name is required");
         }
         return name;
+    }
+
+    static String requirePersistenceDefinitionName(final String name) {
+        final String value = requireName(name);
+        if (value.contains("/")) {
+            throw new IllegalArgumentException("persistence definition names must not contain '/'");
+        }
+        return value;
     }
 }

--- a/sdk-java/src/main/java/io/superdurable/dex/AttributeMap.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/AttributeMap.java
@@ -42,7 +42,7 @@ public final class AttributeMap<T> extends PersistenceDefinition {
             final Class<T> valueType,
             final AttributeIndex index,
             final boolean syncToAttributeStore) {
-        this.name = Attribute.requireName(name);
+        this.name = Attribute.requirePersistenceDefinitionName(name);
         this.valueType = Objects.requireNonNull(valueType, "valueType");
         this.index = index;
         this.syncToAttributeStore = syncToAttributeStore;
@@ -51,11 +51,11 @@ public final class AttributeMap<T> extends PersistenceDefinition {
     /**
      * Defines an Attribute map without a search index.
      *
-     * @param name the stable Attribute-map name; must not be blank
+     * @param name the stable Attribute-map name; must not be blank or contain {@code /}
      * @param valueType the concrete Java class used for every instance value
      * @param <T> the Java value type
      * @return the typed Attribute-map definition
-     * @throws IllegalArgumentException if {@code name} is {@code null} or blank
+     * @throws IllegalArgumentException if {@code name} is {@code null}, blank, or contains {@code /}
      * @throws NullPointerException if {@code valueType} is {@code null}
      */
     public static <T> AttributeMap<T> define(final String name, final Class<T> valueType) {
@@ -65,12 +65,12 @@ public final class AttributeMap<T> extends PersistenceDefinition {
     /**
      * Defines an Attribute map with a search index.
      *
-     * @param name the stable Attribute-map name; must not be blank
+     * @param name the stable Attribute-map name; must not be blank or contain {@code /}
      * @param valueType the concrete Java class used for every instance value
      * @param index the search-index definition, or {@code null} for no index
      * @param <T> the Java value type
      * @return the typed Attribute-map definition
-     * @throws IllegalArgumentException if {@code name} is {@code null} or blank
+     * @throws IllegalArgumentException if {@code name} is {@code null}, blank, or contains {@code /}
      * @throws NullPointerException if {@code valueType} is {@code null}
      */
     public static <T> AttributeMap<T> define(

--- a/sdk-java/src/main/java/io/superdurable/dex/Channel.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Channel.java
@@ -40,18 +40,18 @@ public final class Channel<T> extends PersistenceDefinition {
     private final Class<T> valueType;
 
     private Channel(final String name, final Class<T> valueType) {
-        this.name = Attribute.requireName(name);
+        this.name = Attribute.requirePersistenceDefinitionName(name);
         this.valueType = Objects.requireNonNull(valueType, "valueType");
     }
 
     /**
      * Defines a typed Channel.
      *
-     * @param name the stable Channel name; must not be blank
+     * @param name the stable Channel name; must not be blank or contain {@code /}
      * @param valueType the concrete Java class used to serialize messages
      * @param <T> the Java message type
      * @return the typed Channel definition
-     * @throws IllegalArgumentException if {@code name} is {@code null} or blank
+     * @throws IllegalArgumentException if {@code name} is {@code null}, blank, or contains {@code /}
      * @throws NullPointerException if {@code valueType} is {@code null}
      */
     public static <T> Channel<T> define(final String name, final Class<T> valueType) {

--- a/sdk-java/src/main/java/io/superdurable/dex/ChannelMap.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/ChannelMap.java
@@ -34,18 +34,18 @@ public final class ChannelMap<T> extends PersistenceDefinition {
     private final Class<T> valueType;
 
     private ChannelMap(final String name, final Class<T> valueType) {
-        this.name = Attribute.requireName(name);
+        this.name = Attribute.requirePersistenceDefinitionName(name);
         this.valueType = Objects.requireNonNull(valueType, "valueType");
     }
 
     /**
      * Defines a typed Channel map.
      *
-     * @param name the stable Channel-map name; must not be blank
+     * @param name the stable Channel-map name; must not be blank or contain {@code /}
      * @param valueType the concrete Java class used to serialize messages
      * @param <T> the Java message type
      * @return the typed Channel-map definition
-     * @throws IllegalArgumentException if {@code name} is {@code null} or blank
+     * @throws IllegalArgumentException if {@code name} is {@code null}, blank, or contains {@code /}
      * @throws NullPointerException if {@code valueType} is {@code null}
      */
     public static <T> ChannelMap<T> define(final String name, final Class<T> valueType) {

--- a/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
@@ -21,6 +21,7 @@ import io.superdurable.dex.BlobCache;
 import io.superdurable.dex.BlobCacheConfig;
 import io.superdurable.dex.BufferedTextStream;
 import io.superdurable.dex.Channel;
+import io.superdurable.dex.ChannelMap;
 import io.superdurable.dex.Client;
 import io.superdurable.dex.ClientOptions;
 import io.superdurable.dex.Context;
@@ -78,6 +79,23 @@ public class UserContractsTest {
                 () -> PersistenceSchema.of(
                         Collections.singletonList(COMMANDS),
                         Collections.emptyList()));
+    }
+
+    @Test
+    public void persistenceDefinitionNamesReserveSlash() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> Attribute.define("orders/by-id", String.class));
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> AttributeMap.define("orders/by-id", String.class));
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> Channel.define("orders/by-id", String.class));
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> ChannelMap.define("orders/by-id", String.class));
+
     }
 
     @Test

--- a/sdk-python/dex/_utils.py
+++ b/sdk-python/dex/_utils.py
@@ -13,6 +13,13 @@ def require_name(name: str) -> str:
     return name
 
 
+def require_persistence_definition_name(name: str) -> str:
+    require_name(name)
+    if "/" in name:
+        raise ValueError("persistence definition names must not contain '/'")
+    return name
+
+
 def validate_condition_id(condition_id: str | None) -> None:
     if condition_id is not None and not condition_id:
         raise ValueError("condition ID must not be empty")

--- a/sdk-python/dex/attribute.py
+++ b/sdk-python/dex/attribute.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Generic, TypeVar, cast
 
-from dex._utils import require_name
+from dex._utils import require_name, require_persistence_definition_name
 from dex.context import Context
 from dex.dexpb import dex_pb2 as pb
 
@@ -71,7 +71,7 @@ class Attribute(Generic[ValueT]):
     projects SQL NULL, and failures do not roll back the Flow Attribute.
 
     Attributes:
-        name: The non-empty logical Attribute name, unique within its Flow.
+        name: The non-empty logical Attribute name without ``/``, unique within its Flow.
         value_type: The Python type used to encode and decode values.
         index: Optional search-index configuration; ``None`` disables indexing.
         sync_to_attribute_store: Whether writes are projected to the selected
@@ -90,7 +90,7 @@ class Attribute(Generic[ValueT]):
     sync_to_attribute_store: bool = False
 
     def __post_init__(self) -> None:
-        require_name(self.name)
+        require_persistence_definition_name(self.name)
 
     def get(self, context: Context) -> ValueT:
         """Return the current value from a Step or RPC Context.
@@ -150,7 +150,7 @@ class AttributeMap(Generic[ValueT]):
     do not roll back Flow Attributes.
 
     Attributes:
-        name: The non-empty logical Attribute name, unique within its Flow.
+        name: The non-empty logical Attribute name without ``/``, unique within its Flow.
         value_type: The Python type used for every map instance.
         index: Optional shared search-index configuration.
         sync_to_attribute_store: Whether every instance is projected to the selected
@@ -169,7 +169,7 @@ class AttributeMap(Generic[ValueT]):
     sync_to_attribute_store: bool = False
 
     def __post_init__(self) -> None:
-        require_name(self.name)
+        require_persistence_definition_name(self.name)
 
     def get(self, context: Context, instance: str) -> ValueT:
         """Return one map instance from a Step or RPC Context.

--- a/sdk-python/dex/channel.py
+++ b/sdk-python/dex/channel.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Generic, Sequence, TypeVar, cast
 
-from dex._utils import require_name
+from dex._utils import require_persistence_definition_name
 from dex.condition import ChannelCondition, Condition
 from dex.context import Context
 
@@ -29,7 +29,7 @@ class Channel(Generic[ValueT]):
     selected values through ``results``.
 
     Attributes:
-        name: The non-empty Channel name, unique within its Flow.
+        name: The non-empty Channel name without ``/``, unique within its Flow.
         value_type: The Python type of every published value.
 
     Examples:
@@ -42,7 +42,7 @@ class Channel(Generic[ValueT]):
     value_type: type[ValueT]
 
     def __post_init__(self) -> None:
-        require_name(self.name)
+        require_persistence_definition_name(self.name)
 
     def publish(self, context: Context, value: ValueT) -> None:
         """Stage one value to append with the current handler decision.
@@ -173,7 +173,7 @@ class ChannelMap(Generic[ValueT]):
     Add the ChannelMap definition to the Flow's ``PersistenceSchema``.
 
     Attributes:
-        name: The non-empty Channel name, unique within its Flow.
+        name: The non-empty Channel name without ``/``, unique within its Flow.
         value_type: The Python type of every published value.
 
     Examples:
@@ -186,7 +186,7 @@ class ChannelMap(Generic[ValueT]):
     value_type: type[ValueT]
 
     def __post_init__(self) -> None:
-        require_name(self.name)
+        require_persistence_definition_name(self.name)
 
     def publish(self, context: Context, instance: str, value: ValueT) -> None:
         """Stage a value to append to one ChannelMap instance.

--- a/sdk-python/tests/test_contracts.py
+++ b/sdk-python/tests/test_contracts.py
@@ -84,6 +84,20 @@ STATUS = Attribute("status", str)
 COMMANDS = Channel("commands", OrderInput)
 
 
+@pytest.mark.parametrize(
+    "definition",
+    (
+        lambda: Attribute("orders/by-id", str),
+        lambda: AttributeMap("orders/by-id", str),
+        lambda: Channel("orders/by-id", str),
+        lambda: ChannelMap("orders/by-id", str),
+    ),
+)
+def test_persistence_definition_names_reserve_slash(definition: Any) -> None:
+    with pytest.raises(ValueError, match="must not contain"):
+        definition()
+
+
 class ApproveOrder(Step[OrderInput]):
     def get_step_type(self) -> str:
         return "ApproveOrder"

--- a/sdk-rust/crates/dex-sdk/src/attribute.rs
+++ b/sdk-rust/crates/dex-sdk/src/attribute.rs
@@ -34,7 +34,7 @@ pub struct Attribute<T> {
 }
 
 impl<T> Attribute<T> {
-    /// Defines an unindexed Attribute with stable `name`.
+    /// Defines an unindexed Attribute with stable slash-free `name`.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -160,7 +160,7 @@ pub struct AttributeMap<T> {
 }
 
 impl<T> AttributeMap<T> {
-    /// Defines an unindexed Attribute map with stable `name`.
+    /// Defines an unindexed Attribute map with stable slash-free `name`.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),

--- a/sdk-rust/crates/dex-sdk/src/channel.rs
+++ b/sdk-rust/crates/dex-sdk/src/channel.rs
@@ -30,7 +30,7 @@ pub struct Channel<T> {
 }
 
 impl<T> Channel<T> {
-    /// Defines a Channel with stable `name`.
+    /// Defines a Channel with stable slash-free `name`.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -124,7 +124,7 @@ pub struct ChannelMap<T> {
 }
 
 impl<T> ChannelMap<T> {
-    /// Defines a Channel map with stable `name`.
+    /// Defines a Channel map with stable slash-free `name`.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),

--- a/sdk-rust/crates/dex-sdk/src/registry.rs
+++ b/sdk-rust/crates/dex-sdk/src/registry.rs
@@ -312,6 +312,19 @@ fn assemble_persistence(
                 "Flow {flow_name} has an empty persistence definition name"
             )));
         }
+        if matches!(
+            definition.kind,
+            PersistenceKind::Attribute
+                | PersistenceKind::AttributeMap
+                | PersistenceKind::Channel
+                | PersistenceKind::ChannelMap
+        ) && definition.name.contains('/')
+        {
+            return Err(definition_error(format!(
+                "Flow {flow_name} persistence definition {} must not contain /",
+                definition.name
+            )));
+        }
         if persistence
             .insert(definition.name.clone(), definition.clone())
             .is_some()
@@ -427,5 +440,38 @@ fn hex_value(byte: u8) -> Result<u8, String> {
             "invalid percent-encoding digit {}",
             char::from(byte)
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PersistenceDefinition, PersistenceKind, assemble_persistence, physical_name};
+
+    #[test]
+    fn persistence_definition_names_reserve_slash() {
+        for kind in [
+            PersistenceKind::Attribute,
+            PersistenceKind::AttributeMap,
+            PersistenceKind::Channel,
+            PersistenceKind::ChannelMap,
+        ] {
+            let result = assemble_persistence(
+                "TestFlow",
+                &[PersistenceDefinition {
+                    name: "orders/by-id".to_string(),
+                    kind,
+                    index: None,
+                    sync_to_attribute_store: false,
+                    stream_identity: None,
+                    stream_capacity_bytes: None,
+                }],
+            );
+            assert!(result.is_err());
+        }
+
+        assert_eq!(
+            physical_name("messages", "orders/by-id"),
+            "messages/orders%2Fby-id"
+        );
     }
 }

--- a/sdk-typescript/src/persistence.ts
+++ b/sdk-typescript/src/persistence.ts
@@ -11,7 +11,7 @@ import { markAttributeStoreSynced } from "./attribute-store-sync.js";
 import type { Codec } from "./codec.js";
 import type { Context } from "./context.js";
 import type { Stream } from "./stream.js";
-import { requireName } from "./validation.js";
+import { requirePersistenceDefinitionName, requireName } from "./validation.js";
 
 /** Selects how Dex indexes an Attribute for Flow search. */
 export const IndexType = Object.freeze({
@@ -65,7 +65,7 @@ export interface AttributeLock {
 export class Attribute<T> {
   /**
    * Creates an Attribute definition for a PersistenceSchema.
-   * @param name - Non-empty logical name unique within the Flow.
+   * @param name - Non-empty logical name without `/`, unique within the Flow.
    * @param codec - Value codec used by handlers and Client calls.
    * @param index - Optional visibility search index.
    */
@@ -74,7 +74,7 @@ export class Attribute<T> {
     public readonly codec: Codec<T>,
     public readonly index?: AttributeIndex,
   ) {
-    requireName(name);
+    requirePersistenceDefinitionName(name);
   }
 
   /**
@@ -130,7 +130,7 @@ export class Attribute<T> {
 export class AttributeMap<T> {
   /**
    * Creates an AttributeMap definition for a PersistenceSchema.
-   * @param name - Non-empty logical name unique within the Flow.
+   * @param name - Non-empty logical name without `/`, unique within the Flow.
    * @param codec - Value codec shared by every instance.
    * @param index - Optional shared visibility search index.
    */
@@ -139,7 +139,7 @@ export class AttributeMap<T> {
     public readonly codec: Codec<T>,
     public readonly index?: AttributeIndex,
   ) {
-    requireName(name);
+    requirePersistenceDefinitionName(name);
   }
 
   /**

--- a/sdk-typescript/src/validation.ts
+++ b/sdk-typescript/src/validation.ts
@@ -13,6 +13,14 @@ export function requireName(name: string): string {
   return name;
 }
 
+export function requirePersistenceDefinitionName(name: string): string {
+  requireName(name);
+  if (name.includes("/")) {
+    throw new TypeError("persistence definition names must not contain '/'");
+  }
+  return name;
+}
+
 export function requireConditionId(conditionId: string | undefined): void {
   if (conditionId !== undefined && conditionId.length === 0) {
     throw new TypeError("condition ID must not be empty");

--- a/sdk-typescript/src/wait.ts
+++ b/sdk-typescript/src/wait.ts
@@ -13,6 +13,7 @@ import type { SubFlowOptions } from "./subflow.js";
 import {
   requireConditionId,
   requireName,
+  requirePersistenceDefinitionName,
   validateChannelBounds,
 } from "./validation.js";
 
@@ -86,14 +87,14 @@ export const Timer = Object.freeze({
 export class Channel<T> {
   /**
    * Creates a Channel definition.
-   * @param name - Non-empty name unique within the Flow.
+   * @param name - Non-empty name without `/`, unique within the Flow.
    * @param codec - Element codec.
    */
   public constructor(
     public readonly name: string,
     public readonly codec: Codec<T>,
   ) {
-    requireName(name);
+    requirePersistenceDefinitionName(name);
   }
 
   /**
@@ -189,14 +190,14 @@ export class Channel<T> {
 export class ChannelMap<T> {
   /**
    * Creates a ChannelMap definition.
-   * @param name - Non-empty name unique within the Flow.
+   * @param name - Non-empty name without `/`, unique within the Flow.
    * @param codec - Element codec shared by every instance.
    */
   public constructor(
     public readonly name: string,
     public readonly codec: Codec<T>,
   ) {
-    requireName(name);
+    requirePersistenceDefinitionName(name);
   }
 
   /**

--- a/sdk-typescript/test/contracts.test.ts
+++ b/sdk-typescript/test/contracts.test.ts
@@ -788,6 +788,16 @@ test("map introspection tracks buffered changes", () => {
   assert.equal(channels.getMapSize(context), 2);
 });
 
+test("persistence definitions reserve slash while map instances keep it", () => {
+  assert.throws(() => new Attribute("orders/by-id", stringCodec), TypeError);
+  assert.throws(() => new AttributeMap("orders/by-id", stringCodec), TypeError);
+  assert.throws(() => new Channel("orders/by-id", stringCodec), TypeError);
+  assert.throws(() => new ChannelMap("orders/by-id", stringCodec), TypeError);
+
+  const messages = new ChannelMap("messages", stringCodec);
+  assert.equal(messages.forOne("orders/by-id").instance, "orders/by-id");
+});
+
 test("blob cache contract opens the native DXBC cache", () => {
   const directory = mkdtempSync(join(tmpdir(), "dex-typescript-blob-cache-"));
   const cache = openBlobCache({ directory, maxBytes: 1024, frequencyCounters: 0 });


### PR DESCRIPTION
## Summary

- Reject `/` in Attribute, AttributeMap, Channel, and ChannelMap definition names across Go, Java, Python, Rust, and TypeScript.
- Preserve `/` in map instance names by keeping their percent-encoding behavior unchanged.
- Document the reserved separator and add cross-SDK contract coverage.

## Rationale

Map instances use `definitionName/escapedInstance` physical keys. Reserving the separator prevents singleton definitions from colliding with map instances.

## User impact

New definitions containing `/` now fail local validation or Flow registration. Existing map instance keys containing `/` continue to work.

## Validation

- `make -C sdk-go unitTests`
- `make -C sdk-go docsCheck`
- `./gradlew test --tests io.superdurable.dex.contracts.UserContractsTest`
- `./gradlew checkstyleMain`
- `uv run pytest tests/test_contracts.py`
- `uv run ruff check dex/_utils.py dex/attribute.py dex/channel.py tests/test_contracts.py`
- `cargo test --locked -p dex-sdk registry::tests`
- `cargo fmt --all --check && cargo clippy --locked -p dex-sdk --all-targets -- -D warnings`
- `npm test`
- `npm run docs:check`
- `make copyright-check`
