### PR TITLE
Fix event record label sizing

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2020,6 +2020,7 @@ pre {
 
 .semantic-record > summary > strong {
   margin-bottom: 0;
+  font-size: 10px;
 }
 
 .channel-record > summary > strong {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2001,6 +2001,7 @@ pre {
   align-items: center;
   list-style: none;
   cursor: pointer;
+  font-size: 10px;
 }
 
 .semantic-record > summary::-webkit-details-marker {
@@ -2020,7 +2021,7 @@ pre {
 
 .semantic-record > summary > strong {
   margin-bottom: 0;
-  font-size: 10px;
+  font-size: inherit;
 }
 
 .channel-record > summary > strong {


### PR DESCRIPTION
## Summary

- keep event-record labels at their compact semantic size
- apply the same size to AttributeMap and ChannelMap instance entries

## Rationale

Collapsible record labels moved inside `summary`, so they no longer inherited the compact label style. Defining the size on `summary` covers the label and its disclosure control at every nesting level.

## User impact

Attribute, Channel, AttributeMap, and ChannelMap labels no longer render larger than their enclosing section headings.

## Validation

- `npm run check`
- `npm run build`
