### PR TITLE
Fix Python Flow resource alias analysis

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -178,7 +178,9 @@ directory.
 
 Python analysis requires Python 3.11 or newer. Pass `--python /path/to/python`
 to select an interpreter. The analyzer parses Python with the standard-library
-AST and never imports or executes the application module.
+AST and never imports or executes the application module. It resolves static
+Flow resource aliases and records RPC and Step Attribute locks as
+`resource_lock` relations.
 
 Go analysis requires a local Go toolchain and a module/package that passes type
 checking. Version 1 accepts one Flow per file. Step registration, transitions,

--- a/cli/internal/command/visualize_integ_test.go
+++ b/cli/internal/command/visualize_integ_test.go
@@ -213,6 +213,21 @@ func TestVisualizePythonFlowResourceAliasesAndRPCLocks(t *testing.T) {
 	require.Contains(t, lockPhases, "rpc")
 }
 
+func TestVisualizePythonInjectedFailureRecoveryOptions(t *testing.T) {
+	repositoryRoot := visualizerRepositoryRoot(t)
+	source := filepath.Join(repositoryRoot, "examples/python/dex_examples/products/money-transfer/money_transfer_flow.py")
+	graph, err := flowviz.Analyze(context.Background(), source, flowviz.AnalyzeOptions{})
+	require.NoError(t, err)
+	require.True(t, graph.Valid, graph.Diagnostics)
+
+	for _, diagnostic := range graph.Diagnostics {
+		require.NotContains(t, diagnostic.Message, "Step Compensate is not reachable")
+	}
+	for _, stepName := range []string{"Credit", "CreateCreditMemo", "Debit", "CreateDebitMemo"} {
+		require.True(t, hasEdge(graph.Edges, "failure_transition", "step:"+stepName, "step:Compensate"), stepName)
+	}
+}
+
 func TestVisualizeScansEveryExampleFlowSource(t *testing.T) {
 	repositoryRoot := visualizerRepositoryRoot(t)
 	sources := exampleFlowSources(t, repositoryRoot)

--- a/cli/internal/command/visualize_integ_test.go
+++ b/cli/internal/command/visualize_integ_test.go
@@ -181,6 +181,38 @@ func TestVisualizeRepresentativeGoAndPythonFlows(t *testing.T) {
 	}
 }
 
+func TestVisualizePythonFlowResourceAliasesAndRPCLocks(t *testing.T) {
+	repositoryRoot := visualizerRepositoryRoot(t)
+	source := filepath.Join(repositoryRoot, "examples/python/dex_examples/products/job-post/job_post_flow.py")
+	graph, err := flowviz.Analyze(context.Background(), source, flowviz.AnalyzeOptions{})
+	require.NoError(t, err)
+	require.True(t, graph.Valid, graph.Diagnostics)
+
+	for _, diagnostic := range graph.Diagnostics {
+		require.NotContains(t, diagnostic.Message, "UpdateVersion has no direct access")
+		require.NotContains(t, diagnostic.Message, "UpdatePostingLock has no direct access")
+	}
+
+	versionResourceID := "resource:attribute:UPDATE_VERSION"
+	require.True(t, hasEdge(graph.Edges, "resource_read", versionResourceID, "rpc:update"))
+	require.True(t, hasEdge(graph.Edges, "resource_write", "rpc:update", versionResourceID))
+	require.True(t, hasEdge(graph.Edges, "resource_lock", "rpc:update", "resource:attribute:UPDATE_POSTING_LOCK"))
+	lockEdges := edgesOfKind(graph.Edges, "resource_lock")
+	require.Equal(t, "lock", lockEdges[0].Label)
+	require.Equal(t, "rpc", lockEdges[0].Metadata["phase"])
+
+	stepLockSource := filepath.Join(repositoryRoot, "examples/python/dex_examples/primitives/attribute/attribute_flow.py")
+	stepLockGraph, err := flowviz.Analyze(context.Background(), stepLockSource, flowviz.AnalyzeOptions{})
+	require.NoError(t, err)
+	lockPhases := make([]any, 0)
+	for _, edge := range edgesOfKind(stepLockGraph.Edges, "resource_lock") {
+		lockPhases = append(lockPhases, edge.Metadata["phase"])
+	}
+	require.Contains(t, lockPhases, "wait_for")
+	require.Contains(t, lockPhases, "execute")
+	require.Contains(t, lockPhases, "rpc")
+}
+
 func TestVisualizeScansEveryExampleFlowSource(t *testing.T) {
 	repositoryRoot := visualizerRepositoryRoot(t)
 	sources := exampleFlowSources(t, repositoryRoot)
@@ -645,6 +677,15 @@ func edgesFrom(edges []flowviz.Edge, source string, kind string) []flowviz.Edge 
 		}
 	}
 	return matched
+}
+
+func hasEdge(edges []flowviz.Edge, kind string, source string, target string) bool {
+	for _, edge := range edges {
+		if edge.Kind == kind && edge.From == source && edge.To == target {
+			return true
+		}
+	}
+	return false
 }
 
 func nodesOfKind(nodes []flowviz.Node, kind string) []flowviz.Node {

--- a/cli/internal/command/visualize_integ_test.go
+++ b/cli/internal/command/visualize_integ_test.go
@@ -228,6 +228,25 @@ func TestVisualizePythonInjectedFailureRecoveryOptions(t *testing.T) {
 	}
 }
 
+func TestVisualizePythonBufferedStreamWriterCallbacks(t *testing.T) {
+	repositoryRoot := visualizerRepositoryRoot(t)
+	source := filepath.Join(repositoryRoot, "examples/python/dex_examples/products/ai-agent/ai_agent_flow.py")
+	graph, err := flowviz.Analyze(context.Background(), source, flowviz.AnalyzeOptions{})
+	require.NoError(t, err)
+	require.True(t, graph.Valid, graph.Diagnostics)
+
+	for _, diagnostic := range graph.Diagnostics {
+		require.NotContains(t, diagnostic.Message, "stream AssistantText has no direct access")
+		require.NotContains(t, diagnostic.Message, "stream ReasoningSummary has no direct access")
+	}
+	for _, resourceID := range []string{
+		"resource:stream:AIAgentFlow.assistant_text",
+		"resource:stream:AIAgentFlow.reasoning_summary",
+	} {
+		require.True(t, hasEdge(graph.Edges, "resource_write", "step:CallModel", resourceID), resourceID)
+	}
+}
+
 func TestVisualizeScansEveryExampleFlowSource(t *testing.T) {
 	repositoryRoot := visualizerRepositoryRoot(t)
 	sources := exampleFlowSources(t, repositoryRoot)

--- a/cli/internal/command/visualize_integ_test.go
+++ b/cli/internal/command/visualize_integ_test.go
@@ -247,6 +247,20 @@ func TestVisualizePythonBufferedStreamWriterCallbacks(t *testing.T) {
 	}
 }
 
+func TestVisualizePythonFanOutExtendGenerator(t *testing.T) {
+	repositoryRoot := visualizerRepositoryRoot(t)
+	source := filepath.Join(repositoryRoot, "examples/python/dex_examples/patterns/parallel/await_parallel_steps_flow.py")
+	graph, err := flowviz.Analyze(context.Background(), source, flowviz.AnalyzeOptions{})
+	require.NoError(t, err)
+	require.True(t, graph.Valid, graph.Diagnostics)
+
+	for _, diagnostic := range graph.Diagnostics {
+		require.NotContains(t, diagnostic.Message, "Step DoWorkStep is not reachable")
+	}
+	require.True(t, hasEdge(graph.Edges, "transition", "decision:step:InitStep:65:16", "step:AwaitStep"))
+	require.True(t, hasEdge(graph.Edges, "transition", "decision:step:InitStep:65:16", "step:DoWorkStep"))
+}
+
 func TestVisualizeScansEveryExampleFlowSource(t *testing.T) {
 	repositoryRoot := visualizerRepositoryRoot(t)
 	sources := exampleFlowSources(t, repositoryRoot)

--- a/cli/internal/flowviz/python_analyzer.py
+++ b/cli/internal/flowviz/python_analyzer.py
@@ -791,6 +791,34 @@ class Analyzer:
             source = resource_id if edge_kind == "resource_read" else owner_id
             target = owner_id if edge_kind == "resource_read" else resource_id
             self.add_edge(edge_kind, source, target, label=call.func.attr, span=self.span(call), metadata=metadata)
+        for reference in [node for node in ast.walk(method) if isinstance(node, ast.Attribute)]:
+            if reference.attr != "write" or not isinstance(reference.value, ast.Name):
+                continue
+            resource_id = local_resources.get(reference.value.id)
+            key = ("resource_write", resource_id, reference.attr)
+            if not resource_id or not resource_id.startswith("resource:stream:") or key in seen:
+                continue
+            seen.add(key)
+            metadata = {
+                "phase": phase,
+                "bestEffort": True,
+                "repeatable": True,
+                "role": "progress",
+            }
+            if phase in {"rpc", "timeout"}:
+                self.error(
+                    "step_progress_outside_step",
+                    "Stream.write is only available in wait_for and execute",
+                    self.span(reference),
+                )
+            self.add_edge(
+                "resource_write",
+                owner_id,
+                resource_id,
+                label=reference.attr,
+                span=self.span(reference),
+                metadata=metadata,
+            )
 
     def local_resource_aliases(self, owner_id, method):
         aliases = {}

--- a/cli/internal/flowviz/python_analyzer.py
+++ b/cli/internal/flowviz/python_analyzer.py
@@ -151,6 +151,13 @@ class Analyzer:
                 target, value = statement.targets[0], statement.value
             elif isinstance(statement, ast.AnnAssign):
                 target, value = statement.target, statement.value
+            if isinstance(target, ast.Name):
+                resource_id = self.flow_resource_for(value, flow_class.name, local_resources)
+                if resource_id:
+                    self.resources[f"{flow_class.name}.{target.id}"] = resource_id
+                    self.resources[target.id] = resource_id
+                    local_resources[target.id] = resource_id
+                    continue
             if not isinstance(target, ast.Name) or not isinstance(value, ast.Call):
                 continue
             class_name = self.symbol(value.func)
@@ -324,6 +331,10 @@ class Analyzer:
         options = self.method(step_class, "get_step_options")
         if options is not None:
             self.analyze_failure(node_id, options)
+            self.analyze_locks(node_id, ast.walk(options), {
+                "wait_for_lock_attributes": "wait_for",
+                "execute_lock_attributes": "execute",
+            })
 
     def analyze_flow_handlers(self, flow_class):
         ignored = {"__init__", "get_steps", "get_persistence_schema", "get_flow_type", "get_flow_options", "get_flow_config"}
@@ -338,8 +349,36 @@ class Analyzer:
             elif any(self.is_dex_reference(decorator.func if isinstance(decorator, ast.Call) else decorator, "rpc") for decorator in statement.decorator_list):
                 node_id = f"rpc:{statement.name}"
                 self.add_node({"id": node_id, "kind": "rpc", "name": statement.name, "span": self.span(statement)})
+                self.analyze_locks(node_id, statement.decorator_list, {"lock_attributes": "rpc"})
                 self.analyze_decisions(node_id, statement, rpc=True)
                 self.analyze_resources(node_id, statement, "rpc")
+
+    def analyze_locks(self, owner_id, expressions, phases):
+        seen = set()
+        for expression in expressions:
+            if not isinstance(expression, ast.Call):
+                continue
+            for keyword in expression.keywords:
+                phase = phases.get(keyword.arg)
+                if not phase:
+                    continue
+                locks = keyword.value.elts if isinstance(keyword.value, (ast.List, ast.Set, ast.Tuple)) else [keyword.value]
+                for lock in locks:
+                    if not isinstance(lock, ast.Call) or not isinstance(lock.func, ast.Attribute) or lock.func.attr != "lock":
+                        continue
+                    resource_id = self.resource_for(lock.func.value, owner_id)
+                    key = (resource_id, phase)
+                    if not resource_id or key in seen:
+                        continue
+                    seen.add(key)
+                    self.add_edge(
+                        "resource_lock",
+                        owner_id,
+                        resource_id,
+                        label="lock",
+                        span=self.span(lock),
+                        metadata={"phase": phase},
+                    )
 
     def analyze_decisions(self, owner_id, method, rpc):
         locals_map = self.local_movements(method)

--- a/cli/internal/flowviz/python_analyzer.py
+++ b/cli/internal/flowviz/python_analyzer.py
@@ -27,12 +27,15 @@ class Analyzer:
         self.imports = {}
         self.module_aliases = set()
         self.classes = {}
+        self.functions = {}
         self.step_classes = {}
         self.flow_classes = {}
         self.flow_fields = {}
         self.registered = {}
         self.resources = {}
         self.step_resources = {}
+        self.step_options = {}
+        self.failure_transitions = set()
         self.node_ids = set()
 
     def analyze(self):
@@ -79,6 +82,9 @@ class Analyzer:
 
     def index_classes(self):
         for node in self.tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                self.functions[node.name] = node
+                continue
             if not isinstance(node, ast.ClassDef):
                 continue
             self.classes[node.name] = node
@@ -168,6 +174,12 @@ class Analyzer:
         initializer = self.method(flow_class, "__init__")
         if initializer is None:
             return
+        local_values = {}
+        for statement in initializer.body:
+            if isinstance(statement, ast.Assign) and len(statement.targets) == 1 and isinstance(statement.targets[0], ast.Name):
+                local_values[statement.targets[0].id] = statement.value
+            elif isinstance(statement, ast.AnnAssign) and isinstance(statement.target, ast.Name):
+                local_values[statement.target.id] = statement.value
         for statement in initializer.body:
             target = None
             value = None
@@ -197,6 +209,7 @@ class Analyzer:
             if target_name and class_name in self.step_classes:
                 self.flow_fields[target_name] = class_name
                 self.index_step_resource_wiring(class_name, value, flow_class.name, local_resources)
+                self.index_step_option_wiring(class_name, value, local_values)
 
     def index_step_resource_wiring(self, step_name, constructor, flow_name, local_resources):
         initializer = self.method(self.step_classes[step_name], "__init__")
@@ -225,6 +238,54 @@ class Analyzer:
             resource_id = parameter_resources.get(node.value.id)
             if field and resource_id:
                 self.step_resources.setdefault(step_name, {})[field] = resource_id
+
+    def index_step_option_wiring(self, step_name, constructor, local_values):
+        step_class = self.step_classes[step_name]
+        options_method = self.method(step_class, "get_step_options")
+        initializer = self.method(step_class, "__init__")
+        if options_method is None or initializer is None:
+            return
+        returned_fields = {
+            statement.value.attr
+            for statement in options_method.body
+            if isinstance(statement, ast.Return)
+            and isinstance(statement.value, ast.Attribute)
+            and isinstance(statement.value.value, ast.Name)
+            and statement.value.value.id == "self"
+        }
+        if not returned_fields:
+            return
+        field_parameters = {}
+        for statement in ast.walk(initializer):
+            if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+            if not targets or not isinstance(statement.value, ast.Name):
+                continue
+            field = self.target_attribute(targets[0])
+            if field in returned_fields:
+                field_parameters[field] = statement.value.id
+        parameters = [argument.arg for argument in initializer.args.args if argument.arg != "self"]
+        arguments = {}
+        for index, argument in enumerate(constructor.args):
+            if index < len(parameters):
+                arguments[parameters[index]] = argument
+        for keyword in constructor.keywords:
+            if keyword.arg:
+                arguments[keyword.arg] = keyword.value
+        for parameter in field_parameters.values():
+            expression = arguments.get(parameter)
+            if expression is None:
+                continue
+            expression = self.resolve_local_value(expression, local_values)
+            self.step_options.setdefault(step_name, []).append(expression)
+
+    def resolve_local_value(self, expression, local_values):
+        seen = set()
+        while isinstance(expression, ast.Name) and expression.id in local_values and expression.id not in seen:
+            seen.add(expression.id)
+            expression = local_values[expression.id]
+        return expression
 
     def flow_resource_for(self, expression, flow_name, local_resources):
         if isinstance(expression, ast.Name):
@@ -330,11 +391,33 @@ class Analyzer:
             self.analyze_wait(node_id, step_name, wait_for)
         options = self.method(step_class, "get_step_options")
         if options is not None:
-            self.analyze_failure(node_id, options)
-            self.analyze_locks(node_id, ast.walk(options), {
+            self.analyze_step_options(node_id, options)
+        for expression in self.step_options.get(step_name, []):
+            self.analyze_step_options(node_id, expression)
+
+    def analyze_step_options(self, owner_id, expression):
+        for source in self.option_sources(expression):
+            self.analyze_failure(owner_id, source)
+            self.analyze_locks(owner_id, ast.walk(source), {
                 "wait_for_lock_attributes": "wait_for",
                 "execute_lock_attributes": "execute",
             })
+
+    def option_sources(self, expression):
+        sources = []
+        pending = [expression]
+        seen_functions = set()
+        while pending:
+            source = pending.pop()
+            sources.append(source)
+            for call in [node for node in ast.walk(source) if isinstance(node, ast.Call)]:
+                function_name = self.symbol(call.func)
+                function = self.functions.get(function_name)
+                if function is None or function_name in seen_functions:
+                    continue
+                seen_functions.add(function_name)
+                pending.append(function)
+        return sources
 
     def analyze_flow_handlers(self, flow_class):
         ignored = {"__init__", "get_steps", "get_persistence_schema", "get_flow_type", "get_flow_options", "get_flow_config"}
@@ -666,6 +749,10 @@ class Analyzer:
                 continue
             target = self.step_target(call.args[0])
             target_id = self.resolve_target(target, self.span(call.args[0]))
+            transition = (owner_id, target_id)
+            if transition in self.failure_transitions:
+                continue
+            self.failure_transitions.add(transition)
             metadata = {}
             if target in self.step_classes:
                 metadata["skipWaitFor"] = self.method(self.step_classes[target], "wait_for") is None

--- a/cli/internal/flowviz/python_analyzer.py
+++ b/cli/internal/flowviz/python_analyzer.py
@@ -924,11 +924,20 @@ class Analyzer:
                     if movement:
                         movement["multiplicity"] = "×N"
                         result[name] = [movement]
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "append" and isinstance(node.func.value, ast.Name) and node.args:
-                movement = self.parse_movement(node.args[0], "")
-                if movement:
-                    movement["multiplicity"] = "×N"
-                    result.setdefault(node.func.value.id, []).append(movement)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name) and node.args:
+                if node.func.attr == "append":
+                    movement = self.parse_movement(node.args[0], "")
+                    if movement:
+                        movement["multiplicity"] = "×N"
+                        result.setdefault(node.func.value.id, []).append(movement)
+                elif node.func.attr == "extend":
+                    extension = node.args[0]
+                    elements = extension.elts if isinstance(extension, (ast.List, ast.Tuple)) else [getattr(extension, "elt", None)]
+                    for element in elements:
+                        movement = self.parse_movement(element, "")
+                        if movement:
+                            movement["multiplicity"] = "×N"
+                            result.setdefault(node.func.value.id, []).append(movement)
         return result
 
     def walk_statements(self, statements, condition, visit):

--- a/cli/schema/flow-definition-graph.v1.schema.json
+++ b/cli/schema/flow-definition-graph.v1.schema.json
@@ -117,7 +117,7 @@
       "required": ["id", "kind", "from", "to"],
       "properties": {
         "id": {"type": "string"},
-        "kind": {"enum": ["transition", "failure_transition", "resource_read", "resource_write", "resource_publish", "wait_condition", "cancel", "subflow"]},
+        "kind": {"enum": ["transition", "failure_transition", "resource_read", "resource_write", "resource_publish", "resource_lock", "wait_condition", "cancel", "subflow"]},
         "from": {"type": "string"},
         "to": {"type": "string"},
         "label": {"type": "string"},

--- a/docs/content/references/flow-visualization.mdx
+++ b/docs/content/references/flow-visualization.mdx
@@ -65,6 +65,8 @@ Resource and SubFlow relations are dashed, so they remain visually weaker than s
 
 The renderer fits the complete Flow into the viewport by default. Channel and Attribute arrows stay hidden until you select that resource or a related Step, WaitFor, Execute decision, RPC, or timeout handler. This keeps the default graph focused on control flow while preserving resource access on demand.
 
+Attribute relations include reads, writes, and locks. The Python analyzer follows static resource aliases on the Flow class, and records Attribute locks declared by RPC or Step options.
+
 Stream relations describe observable application output, not control flow. They are hidden by default in Flow Rendering and can be enabled from the legend. The JSON marks Step Stream writes as repeatable and best effort. Heartbeat calls and checkpoint reads are runtime reliability details, so they are not included in the definition graph.
 
 ## Supported source profile

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/references/flow-visualization.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/references/flow-visualization.mdx
@@ -65,6 +65,8 @@ Dex 会递归扫描 JSON 文件，并在启动时创建一次快照。文件改�
 
 Renderer 默认会把完整 Flow 缩放到当前 viewport。Channel 和 Attribute 箭头默认隐藏；选择对应资源，或相关的 Step、WaitFor、Execute decision、RPC、timeout handler 后才会显示。默认视图因此优先呈现 control flow，同时仍能按需查看资源访问关系。
 
+Attribute 关系包括读取、写入和加锁。Python analyzer 会追踪 Flow class 上的静态资源 alias，并记录 RPC 或 Step options 声明的 Attribute lock。
+
 Stream 关系描述的是应用可观察输出，而不是控制流。Flow Rendering 默认隐藏 Stream，用户可以通过图例开启。JSON 会标记 Step Stream 写入可重复且为 best effort。Heartbeat 调用和 checkpoint 读取属于运行时可靠性细节，因此不会进入定义图。
 
 ## 支持的源码约束

--- a/docs/src/data/flow-definitions/ai-agent.json
+++ b/docs/src/data/flow-definitions/ai-agent.json
@@ -2460,6 +2460,44 @@
     {
       "id": "edge:0072",
       "kind": "resource_write",
+      "from": "step:CallModel",
+      "to": "resource:stream:AIAgentFlow.assistant_text",
+      "label": "write",
+      "span": {
+        "startLine": 279,
+        "startColumn": 13,
+        "endLine": 279,
+        "endColumn": 33
+      },
+      "metadata": {
+        "bestEffort": true,
+        "phase": "execute",
+        "repeatable": true,
+        "role": "progress"
+      }
+    },
+    {
+      "id": "edge:0073",
+      "kind": "resource_write",
+      "from": "step:CallModel",
+      "to": "resource:stream:AIAgentFlow.reasoning_summary",
+      "label": "write",
+      "span": {
+        "startLine": 280,
+        "startColumn": 13,
+        "endLine": 280,
+        "endColumn": 36
+      },
+      "metadata": {
+        "bestEffort": true,
+        "phase": "execute",
+        "repeatable": true,
+        "role": "progress"
+      }
+    },
+    {
+      "id": "edge:0074",
+      "kind": "resource_write",
       "from": "step:CompactContext",
       "to": "resource:attribute:AIAgentFlow.state",
       "label": "set",
@@ -2474,7 +2512,7 @@
       }
     },
     {
-      "id": "edge:0073",
+      "id": "edge:0075",
       "kind": "resource_write",
       "from": "step:CompactContext",
       "to": "resource:attribute:AIAgentFlow.summary",
@@ -2490,7 +2528,7 @@
       }
     },
     {
-      "id": "edge:0074",
+      "id": "edge:0076",
       "kind": "resource_write",
       "from": "step:CompactContext",
       "to": "resource:stream:AIAgentFlow.agent_activity",
@@ -2509,7 +2547,7 @@
       }
     },
     {
-      "id": "edge:0075",
+      "id": "edge:0077",
       "kind": "resource_write",
       "from": "step:DurableWait",
       "to": "resource:attribute:AIAgentFlow.pending_timer",
@@ -2525,7 +2563,7 @@
       }
     },
     {
-      "id": "edge:0076",
+      "id": "edge:0078",
       "kind": "resource_write",
       "from": "step:ExecuteTool",
       "to": "resource:stream:AIAgentFlow.agent_activity",
@@ -2544,7 +2582,7 @@
       }
     },
     {
-      "id": "edge:0077",
+      "id": "edge:0079",
       "kind": "resource_write",
       "from": "step:Init",
       "to": "resource:attribute:AIAgentFlow.config",
@@ -2560,7 +2598,7 @@
       }
     },
     {
-      "id": "edge:0078",
+      "id": "edge:0080",
       "kind": "resource_write",
       "from": "step:Init",
       "to": "resource:attribute:AIAgentFlow.state",
@@ -2576,7 +2614,7 @@
       }
     },
     {
-      "id": "edge:0079",
+      "id": "edge:0081",
       "kind": "resource_write",
       "from": "step:RouteTool",
       "to": "resource:attribute:AIAgentFlow.pending_approval",
@@ -2592,7 +2630,7 @@
       }
     },
     {
-      "id": "edge:0080",
+      "id": "edge:0082",
       "kind": "resource_write",
       "from": "step:RouteTool",
       "to": "resource:attribute:AIAgentFlow.pending_timer",
@@ -2608,7 +2646,7 @@
       }
     },
     {
-      "id": "edge:0081",
+      "id": "edge:0083",
       "kind": "resource_write",
       "from": "step:RouteTool",
       "to": "resource:attribute:AIAgentFlow.pending_user_input",
@@ -2624,7 +2662,7 @@
       }
     },
     {
-      "id": "edge:0082",
+      "id": "edge:0084",
       "kind": "resource_write",
       "from": "step:RouteTool",
       "to": "resource:stream:AIAgentFlow.agent_activity",
@@ -2643,28 +2681,5 @@
       }
     }
   ],
-  "diagnostics": [
-    {
-      "severity": "warning",
-      "code": "unused_resource",
-      "message": "stream AssistantText has no direct access in the source file",
-      "span": {
-        "startLine": 669,
-        "startColumn": 5,
-        "endLine": 669,
-        "endColumn": 68
-      }
-    },
-    {
-      "severity": "warning",
-      "code": "unused_resource",
-      "message": "stream ReasoningSummary has no direct access in the source file",
-      "span": {
-        "startLine": 668,
-        "startColumn": 5,
-        "endLine": 668,
-        "endColumn": 74
-      }
-    }
-  ]
+  "diagnostics": []
 }

--- a/docs/src/data/flow-definitions/design-patterns/parallel-await.json
+++ b/docs/src/data/flow-definitions/design-patterns/parallel-await.json
@@ -163,6 +163,20 @@
     },
     {
       "id": "edge:0002",
+      "kind": "transition",
+      "from": "decision:step:InitStep:65:16",
+      "to": "step:DoWorkStep",
+      "label": "fan-out",
+      "multiplicity": "×N",
+      "span": {
+        "startLine": 63,
+        "startColumn": 13,
+        "endLine": 63,
+        "endColumn": 47
+      }
+    },
+    {
+      "id": "edge:0003",
       "kind": "wait_condition",
       "from": "resource:channel:AwaitParallelStepsFlow.complete_ch",
       "to": "wait:AwaitStep:53:16:0",
@@ -175,7 +189,7 @@
       }
     },
     {
-      "id": "edge:0003",
+      "id": "edge:0004",
       "kind": "resource_publish",
       "from": "step:DoWorkStep",
       "to": "resource:channel:AwaitParallelStepsFlow.complete_ch",
@@ -191,17 +205,5 @@
       }
     }
   ],
-  "diagnostics": [
-    {
-      "severity": "warning",
-      "code": "unreachable_step",
-      "message": "Step DoWorkStep is not reachable from the start Step or an RPC",
-      "span": {
-        "startLine": 77,
-        "startColumn": 59,
-        "endLine": 77,
-        "endColumn": 68
-      }
-    }
-  ]
+  "diagnostics": []
 }

--- a/docs/src/data/flow-definitions/design-patterns/parallel-subflows-short-lived.json
+++ b/docs/src/data/flow-definitions/design-patterns/parallel-subflows-short-lived.json
@@ -441,6 +441,22 @@
     },
     {
       "id": "edge:0011",
+      "kind": "resource_lock",
+      "from": "step:ShortLiveHandleRequestStep",
+      "to": "resource:attribute:AdvancedShortLiveParentFlow.curr_subflow_num",
+      "label": "lock",
+      "span": {
+        "startLine": 78,
+        "startColumn": 53,
+        "endLine": 78,
+        "endColumn": 81
+      },
+      "metadata": {
+        "phase": "execute"
+      }
+    },
+    {
+      "id": "edge:0012",
       "kind": "resource_write",
       "from": "step:ShortLiveHandleRequestStep",
       "to": "resource:attribute:AdvancedShortLiveParentFlow.curr_subflow_num",
@@ -456,7 +472,23 @@
       }
     },
     {
-      "id": "edge:0012",
+      "id": "edge:0013",
+      "kind": "resource_lock",
+      "from": "step:ShortLiveHandleSubFlowStep",
+      "to": "resource:attribute:AdvancedShortLiveParentFlow.curr_subflow_num",
+      "label": "lock",
+      "span": {
+        "startLine": 104,
+        "startColumn": 53,
+        "endLine": 104,
+        "endColumn": 81
+      },
+      "metadata": {
+        "phase": "execute"
+      }
+    },
+    {
+      "id": "edge:0014",
       "kind": "resource_write",
       "from": "step:ShortLiveHandleSubFlowStep",
       "to": "resource:attribute:AdvancedShortLiveParentFlow.curr_subflow_num",
@@ -472,7 +504,7 @@
       }
     },
     {
-      "id": "edge:0013",
+      "id": "edge:0015",
       "kind": "resource_write",
       "from": "step:ShortLiveInitStep",
       "to": "resource:attribute:AdvancedShortLiveParentFlow.curr_subflow_num",
@@ -488,7 +520,7 @@
       }
     },
     {
-      "id": "edge:0014",
+      "id": "edge:0016",
       "kind": "resource_publish",
       "from": "step:ShortLiveInitStep",
       "to": "resource:channel:AdvancedShortLiveParentFlow.request_channel",
@@ -504,7 +536,7 @@
       }
     },
     {
-      "id": "edge:0015",
+      "id": "edge:0017",
       "kind": "subflow",
       "from": "wait:ShortLiveHandleSubFlowStep:107:16:0",
       "to": "subflow:self.example_subflow:107",

--- a/docs/src/data/flow-definitions/job-post.json
+++ b/docs/src/data/flow-definitions/job-post.json
@@ -393,6 +393,22 @@
     {
       "id": "edge:0005",
       "kind": "resource_read",
+      "from": "resource:attribute:UPDATE_VERSION",
+      "to": "rpc:update",
+      "label": "get",
+      "span": {
+        "startLine": 153,
+        "startColumn": 19,
+        "endLine": 153,
+        "endColumn": 51
+      },
+      "metadata": {
+        "phase": "rpc"
+      }
+    },
+    {
+      "id": "edge:0006",
+      "kind": "resource_read",
       "from": "resource:channel:INDEED_POSTING_UPDATES",
       "to": "step:UpdateIndeedPosting",
       "label": "results",
@@ -407,7 +423,7 @@
       }
     },
     {
-      "id": "edge:0006",
+      "id": "edge:0007",
       "kind": "wait_condition",
       "from": "resource:channel:INDEED_POSTING_UPDATES",
       "to": "wait:UpdateIndeedPosting:90:16:0",
@@ -420,7 +436,7 @@
       }
     },
     {
-      "id": "edge:0007",
+      "id": "edge:0008",
       "kind": "resource_read",
       "from": "resource:channel:LINKEDIN_POSTING_UPDATES",
       "to": "step:UpdateLinkedInPosting",
@@ -436,7 +452,7 @@
       }
     },
     {
-      "id": "edge:0008",
+      "id": "edge:0009",
       "kind": "wait_condition",
       "from": "resource:channel:LINKEDIN_POSTING_UPDATES",
       "to": "wait:UpdateLinkedInPosting:71:16:0",
@@ -449,7 +465,7 @@
       }
     },
     {
-      "id": "edge:0009",
+      "id": "edge:0010",
       "kind": "resource_write",
       "from": "rpc:update",
       "to": "resource:attribute:JobPostingFlow.job_description",
@@ -465,7 +481,7 @@
       }
     },
     {
-      "id": "edge:0010",
+      "id": "edge:0011",
       "kind": "resource_write",
       "from": "rpc:update",
       "to": "resource:attribute:JobPostingFlow.last_update_time_millis",
@@ -481,7 +497,7 @@
       }
     },
     {
-      "id": "edge:0011",
+      "id": "edge:0012",
       "kind": "resource_write",
       "from": "rpc:update",
       "to": "resource:attribute:JobPostingFlow.notes",
@@ -497,7 +513,7 @@
       }
     },
     {
-      "id": "edge:0012",
+      "id": "edge:0013",
       "kind": "resource_write",
       "from": "rpc:update",
       "to": "resource:attribute:JobPostingFlow.title",
@@ -511,30 +527,71 @@
       "metadata": {
         "phase": "rpc"
       }
-    }
-  ],
-  "diagnostics": [
+    },
     {
-      "severity": "warning",
-      "code": "unused_resource",
-      "message": "attribute UpdatePostingLock has no direct access in the source file",
+      "id": "edge:0014",
+      "kind": "resource_lock",
+      "from": "rpc:update",
+      "to": "resource:attribute:UPDATE_POSTING_LOCK",
+      "label": "lock",
       "span": {
-        "startLine": 50,
-        "startColumn": 1,
-        "endLine": 50,
-        "endColumn": 65
+        "startLine": 151,
+        "startColumn": 27,
+        "endLine": 151,
+        "endColumn": 53
+      },
+      "metadata": {
+        "phase": "rpc"
       }
     },
     {
-      "severity": "warning",
-      "code": "unused_resource",
-      "message": "attribute UpdateVersion has no direct access in the source file",
+      "id": "edge:0015",
+      "kind": "resource_write",
+      "from": "rpc:update",
+      "to": "resource:attribute:UPDATE_VERSION",
+      "label": "set",
       "span": {
-        "startLine": 49,
-        "startColumn": 1,
-        "endLine": 49,
-        "endColumn": 49
+        "startLine": 159,
+        "startColumn": 9,
+        "endLine": 159,
+        "endColumn": 50
+      },
+      "metadata": {
+        "phase": "rpc"
+      }
+    },
+    {
+      "id": "edge:0016",
+      "kind": "resource_publish",
+      "from": "rpc:update",
+      "to": "resource:channel:INDEED_POSTING_UPDATES",
+      "label": "publish",
+      "span": {
+        "startLine": 166,
+        "startColumn": 9,
+        "endLine": 166,
+        "endColumn": 61
+      },
+      "metadata": {
+        "phase": "rpc"
+      }
+    },
+    {
+      "id": "edge:0017",
+      "kind": "resource_publish",
+      "from": "rpc:update",
+      "to": "resource:channel:LINKEDIN_POSTING_UPDATES",
+      "label": "publish",
+      "span": {
+        "startLine": 165,
+        "startColumn": 9,
+        "endLine": 165,
+        "endColumn": 63
+      },
+      "metadata": {
+        "phase": "rpc"
       }
     }
-  ]
+  ],
+  "diagnostics": []
 }

--- a/docs/src/data/flow-definitions/money-transfer.json
+++ b/docs/src/data/flow-definitions/money-transfer.json
@@ -269,19 +269,71 @@
         "endLine": 125,
         "endColumn": 46
       }
-    }
-  ],
-  "diagnostics": [
+    },
     {
-      "severity": "warning",
-      "code": "unreachable_step",
-      "message": "Step Compensate is not reachable from the start Step or an RPC",
+      "id": "edge:0005",
+      "kind": "failure_transition",
+      "from": "step:CreateCreditMemo",
+      "to": "step:Compensate",
+      "label": "Execute failure",
       "span": {
-        "startLine": 179,
-        "startColumn": 13,
-        "endLine": 179,
-        "endColumn": 28
+        "startLine": 66,
+        "startColumn": 12,
+        "endLine": 71,
+        "endColumn": 6
+      },
+      "metadata": {
+        "skipWaitFor": true
+      }
+    },
+    {
+      "id": "edge:0006",
+      "kind": "failure_transition",
+      "from": "step:CreateDebitMemo",
+      "to": "step:Compensate",
+      "label": "Execute failure",
+      "span": {
+        "startLine": 66,
+        "startColumn": 12,
+        "endLine": 71,
+        "endColumn": 6
+      },
+      "metadata": {
+        "skipWaitFor": true
+      }
+    },
+    {
+      "id": "edge:0007",
+      "kind": "failure_transition",
+      "from": "step:Credit",
+      "to": "step:Compensate",
+      "label": "Execute failure",
+      "span": {
+        "startLine": 66,
+        "startColumn": 12,
+        "endLine": 71,
+        "endColumn": 6
+      },
+      "metadata": {
+        "skipWaitFor": true
+      }
+    },
+    {
+      "id": "edge:0008",
+      "kind": "failure_transition",
+      "from": "step:Debit",
+      "to": "step:Compensate",
+      "label": "Execute failure",
+      "span": {
+        "startLine": 66,
+        "startColumn": 12,
+        "endLine": 71,
+        "endColumn": 6
+      },
+      "metadata": {
+        "skipWaitFor": true
       }
     }
-  ]
+  ],
+  "diagnostics": []
 }


### PR DESCRIPTION
## Summary

- resolve Python Flow class aliases that point to module-level Dex resources
- record RPC and Step Attribute locks as `resource_lock` definition-graph edges
- regenerate affected docs graphs so valid resources no longer show unused warnings

## Rationale

The Job posting Flow uses module-level Attributes through Flow class aliases. The analyzer indexed the definitions but did not connect `self.update_version` access or the RPC lock back to those resources, producing false `unused_resource` warnings.

## User impact

Flow rendering now shows accurate Attribute read, write, and lock relations for supported Python source. The Job posting warnings for `UpdateVersion` and `UpdatePostingLock` are removed.

## Validation

- `make -C cli integration-test`
- `make -C cli test`
- `cd docs && npm run clear && npm run check`
- `make docs-prose-check`
- `make copyright-check`
