### PR TITLE
Separate timeout handlers from RPC legend

### DIFF
--- a/docs/content/references/flow-visualization.mdx
+++ b/docs/content/references/flow-visualization.mdx
@@ -31,7 +31,7 @@ Start Dex with a directory containing generated JSON files:
 dexcli dev --flow-rendering-dir ./build
 ```
 
-Open **Flow Rendering** in Dex Web. This page is independent from Flow search and run details. It renders the selected definition interactively. Its legend can show or hide control flow, WaitFor, RPC and timeout handlers, Attributes, Channels, Streams, SubFlows, and diagnostics. Streams are hidden by default. The other layers start visible.
+Open **Flow Rendering** in Dex Web. This page is independent from Flow search and run details. It renders the selected definition interactively. Its legend can show or hide control flow, WaitFor, RPCs, Attributes, Channels, Streams, SubFlows, and diagnostics. Flow timeout handlers are always shown as part of the Flow. Streams are hidden by default. The other layers start visible.
 
 Dex scans JSON files recursively and takes a snapshot when it starts. Restart Dex after changing the files. Invalid JSON, an unsupported schema version, or a path that is not a directory stops startup with an error.
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/references/flow-visualization.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/references/flow-visualization.mdx
@@ -31,7 +31,7 @@ dexcli visualize ./order_flow.py --out -
 dexcli dev --flow-rendering-dir ./build
 ```
 
-在 Dex Web 中打开 **Flow Rendering**。该页面独立于 Flow 搜索页和运行详情页，用于交互式渲染所选定义图。通过图例可以显示或隐藏控制流、WaitFor、RPC 和 timeout handler、Attribute、Channel、Stream、SubFlow 及诊断。Stream 默认隐藏，其他图层默认显示。
+在 Dex Web 中打开 **Flow Rendering**。该页面独立于 Flow 搜索页和运行详情页，用于交互式渲染所选定义图。通过图例可以显示或隐藏控制流、WaitFor、RPC、Attribute、Channel、Stream、SubFlow 及诊断。Flow timeout handler 始终作为 Flow 的一部分显示。Stream 默认隐藏，其他图层默认显示。
 
 Dex 会递归扫描 JSON 文件，并在启动时创建一次快照。文件改变后需要重启 Dex。无效 JSON、不支持的 schema 版本或非目录路径都会使启动失败并返回错误。
 

--- a/packages/flow-definition-renderer/README.md
+++ b/packages/flow-definition-renderer/README.md
@@ -20,4 +20,6 @@ import {
 
 The renderer fits the full definition into the viewport by default. Channel,
 Attribute, and Stream relations remain hidden until their resource or a related
-Step, WaitFor, Execute decision, RPC, or timeout handler is selected.
+Step, WaitFor, Execute decision, RPC, or timeout handler is selected. The RPC
+legend control affects only RPC nodes; Flow timeout handlers always remain
+visible as part of the Flow.

--- a/packages/flow-definition-renderer/src/FlowDefinitionGraph.tsx
+++ b/packages/flow-definition-renderer/src/FlowDefinitionGraph.tsx
@@ -38,7 +38,7 @@ import {
 const layerLabels: Array<[DefinitionLayer | 'diagnostics', string]> = [
   ['control', 'Control flow'],
   ['waits', 'WaitFor'],
-  ['handlers', 'RPC / timeout'],
+  ['rpcs', 'RPC'],
   ['channels', 'Channels'],
   ['attributes', 'Attributes'],
   ['streams', 'Streams'],
@@ -49,7 +49,7 @@ const layerLabels: Array<[DefinitionLayer | 'diagnostics', string]> = [
 const defaultVisibility: DefinitionVisibility & { diagnostics: boolean } = {
   control: true,
   waits: true,
-  handlers: true,
+  rpcs: true,
   attributes: true,
   channels: true,
   streams: false,

--- a/packages/flow-definition-renderer/src/definitionLayout.ts
+++ b/packages/flow-definition-renderer/src/definitionLayout.ts
@@ -18,7 +18,7 @@ import type {
 export type DefinitionLayer =
   | 'control'
   | 'waits'
-  | 'handlers'
+  | 'rpcs'
   | 'attributes'
   | 'channels'
   | 'streams'
@@ -85,7 +85,7 @@ export function buildDefinitionScene(
   const stepPositions = layoutStepTopology(graph, steps, stepLayouts, definitionsByID);
   const topologyBounds = boundsForSteps(steps, stepLayouts, stepPositions);
   const resourceNodes = layoutResources(graph, visibility);
-  const handlerNodes = layoutHandlers(graph, visibility);
+  const handlerNodes = layoutRPCsAndTimeoutHandlers(graph, visibility);
   const sideRailHeight = Math.max(
     flowHeaderHeight + 50,
     ...resourceNodes.map((node) => node.position.y + numericStyle(node, 'height')),
@@ -516,15 +516,14 @@ function layoutResources(
   return nodes;
 }
 
-function layoutHandlers(
+function layoutRPCsAndTimeoutHandlers(
   graph: FlowDefinitionGraph,
   visibility: DefinitionVisibility,
 ): Array<Node<DefinitionNodeData>> {
-  if (!visibility.handlers) return [];
   const nameByID = Object.fromEntries(graph.nodes.map((node) => [node.id, node.name]));
   let top = flowHeaderHeight + 36;
   return graph.nodes
-    .filter((node) => node.kind === 'rpc' || node.kind === 'timeout_handler')
+    .filter((node) => node.kind === 'timeout_handler' || (visibility.rpcs && node.kind === 'rpc'))
     .sort(byNameThenID)
     .map((handler) => {
       const decisions = graph.nodes.filter((node) => node.kind === 'decision' && node.parentId === handler.id);

--- a/packages/flow-definition-renderer/src/styles.css
+++ b/packages/flow-definition-renderer/src/styles.css
@@ -132,7 +132,7 @@
 }
 
 .definition-legend-swatch--waits { background: #d39732; }
-.definition-legend-swatch--handlers { background: #7c3aed; }
+.definition-legend-swatch--rpcs { background: #7c3aed; }
 .definition-legend-swatch--attributes,
 .definition-legend-swatch--channels { background: #2e8b57; }
 .definition-legend-swatch--streams { background: #16899a; }

--- a/web/README.md
+++ b/web/README.md
@@ -84,9 +84,10 @@ saved queries, configurable columns, Indexed Attributes, and timezone
 preferences.
 
 The Flow Rendering page displays source definition JSON loaded at startup. Its
-legend independently filters control flow, waits, handlers, resources, SubFlows,
-and diagnostics. Control flow, WaitFor, handlers, Channels, Attributes,
-SubFlows, and diagnostics start visible. Streams start hidden.
+legend independently filters control flow, WaitFor, RPCs, resources, SubFlows,
+and diagnostics. Control flow, WaitFor, RPCs, Channels, Attributes, SubFlows,
+and diagnostics start visible. Streams start hidden. Flow timeout handlers are
+always visible as part of the Flow rather than a legend layer.
 
 The Flow Definition renderer uses a compound layout separate from the runtime
 Execution graph. The lavender Flow frame contains blue Step frames. Each Step

--- a/web/app/rendering/definitionLayout.test.ts
+++ b/web/app/rendering/definitionLayout.test.ts
@@ -17,7 +17,7 @@ import {
 const visible: DefinitionVisibility = {
   control: true,
   waits: true,
-  handlers: true,
+  rpcs: true,
   attributes: true,
   channels: true,
   streams: false,
@@ -52,6 +52,13 @@ describe('Flow Definition Graph layout', () => {
     expect(overlaps(rpc, attributes)).toBe(false);
     expect(firstChannel.position.x - (rpc.position.x + Number(rpc.style?.width))).toBeGreaterThanOrEqual(40);
     expect(subflow.parentId).toBe(flow.id);
+  });
+
+  it('keeps timeout handlers visible when RPCs are hidden', () => {
+    const scene = buildDefinitionScene(graph, { ...visible, rpcs: false });
+
+    expect(scene.nodes.find((node) => node.id === 'rpc:approve')).toBeUndefined();
+    expect(requiredNode(scene, 'timeout_handler:ExampleFlow').type).toBe('definitionTimeout');
   });
 
   it('uses solid recovery and dashed resource and SubFlow relations', () => {


### PR DESCRIPTION
## Summary

- separate the RPC legend control from Flow timeout handlers
- keep timeout handlers visible as Flow-owned cards with their existing distinct style
- update renderer documentation and cover hidden-RPC visibility in the layout test

## Rationale

Timeout handlers are part of a Flow's lifecycle, not RPC endpoints. Hiding RPCs must not remove them from the definition graph.

## User impact

The Flow Rendering legend now shows an RPC control only. Timeout handlers remain visible regardless of the RPC setting.

## Validation

- `cd web && npm run check`
- `cd docs && npm run check`
- `make copyright-check`
