### PR TITLE
Add Channel message management to clients

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,5 +1,10 @@
 # Dex CLI
 
+Use `dexcli flow channel-messages FLOW_ID --channel NAME` to list pending FIFO
+messages with their server-assigned IDs and decoded values. Delete one with
+`dexcli flow delete-channel-message FLOW_ID --channel NAME --message-id ID --yes`.
+Raw `dexcli api call InvokeRPC` accepts the `isTransactional` field.
+
 `dexcli` starts a complete local Dex development environment with one command.
 It also gives humans and AI agents a JSON-first interface to every public Dex
 FlowService API without requiring a browser.

--- a/cli/internal/command/api.go
+++ b/cli/internal/command/api.go
@@ -239,7 +239,7 @@ func fullMethodName(service protoreflect.ServiceDescriptor, method protoreflect.
 func isMutatingMethod(name protoreflect.Name) bool {
 	switch name {
 	case "StartFlow", "PublishToChannel", "WriteStream", "StopFlow", "SetAttributes", "SyncAttributeIndexes",
-		"ResetFlow", "InvokeRPC", "SkipTimer", "UpdateFlowConfig", "TriggerContinueAsNew":
+		"ResetFlow", "InvokeRPC", "SkipTimer", "UpdateFlowConfig", "TriggerContinueAsNew", "DeleteChannelMessage":
 		return true
 	default:
 		return false

--- a/cli/internal/command/flow.go
+++ b/cli/internal/command/flow.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/superdurable/dex/gen/dexpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -50,6 +51,10 @@ func (c *flowCommand) Execute(ctx context.Context, args []string, options option
 		return c.state(ctx, args[1:], options)
 	case "history":
 		return c.history(ctx, args[1:], options)
+	case "channel-messages":
+		return c.channelMessages(ctx, args[1:], options)
+	case "delete-channel-message":
+		return c.deleteChannelMessage(ctx, args[1:], options)
 	case "inspect":
 		return executeInspect(c, ctx, args[1:], options)
 	case "watch":
@@ -72,6 +77,77 @@ func (c *flowCommand) Execute(ctx context.Context, args []string, options option
 	default:
 		return newUsageError("flow", fmt.Errorf("unknown command %q", args[0]))
 	}
+}
+
+func (c *flowCommand) channelMessages(ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow channel-messages", c.stderr)
+	runID := flags.String("run-id", "", "Flow run ID")
+	channelName := flags.String("channel", "", "physical Channel name")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow channel-messages FLOW_ID --channel NAME [flags]"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow channel-messages")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*channelName) == "" {
+		return newUsageError("flow channel-messages", fmt.Errorf("channel is required"))
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		response, callErr := client.service.GetChannelMessages(callCtx, &dexpb.GetChannelMessagesRequest{
+			FlowId: flowID, RunId: *runID, ChannelName: *channelName,
+		})
+		if callErr != nil {
+			return newOperationError("flow channel-messages", callErr)
+		}
+		mapped, warnings, mapErr := naturalMessage(callCtx, client.service, response, options.noHydrate)
+		if mapErr != nil {
+			return newOperationError("flow channel-messages", mapErr)
+		}
+		mapped["flowId"] = flowID
+		mapped["runId"] = *runID
+		mapped["channelName"] = *channelName
+		if len(warnings) > 0 {
+			mapped["warnings"] = warnings
+		}
+		return writeOutput(c.stdout, options.output, mapped)
+	})
+}
+
+func (c *flowCommand) deleteChannelMessage(ctx context.Context, args []string, options options) error {
+	flags := newFlagSet("dexcli flow delete-channel-message", c.stderr)
+	runID := flags.String("run-id", "", "Flow run ID")
+	channelName := flags.String("channel", "", "physical Channel name")
+	messageID := flags.String("message-id", "", "server-assigned message ID")
+	yes := flags.Bool("yes", false, "confirm the operation")
+	addCommonFlags(flags, &options)
+	if done, err := parseFlowFlags(flags, args, c.stdout, "dexcli flow delete-channel-message FLOW_ID --channel NAME --message-id ID --yes"); done || err != nil {
+		return err
+	}
+	flowID, err := oneFlowID(flags, "flow delete-channel-message")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*channelName) == "" || strings.TrimSpace(*messageID) == "" {
+		return newUsageError("flow delete-channel-message", fmt.Errorf("channel and message-id are required"))
+	}
+	if !*yes {
+		return newConfirmationError("flow delete-channel-message")
+	}
+	return withFlowService(ctx, options, func(callCtx context.Context, client *flowService) error {
+		_, callErr := client.service.DeleteChannelMessage(callCtx, &dexpb.DeleteChannelMessageRequest{
+			FlowId: flowID, RunId: *runID, ChannelName: *channelName,
+			MessageId: *messageID, RequestId: uuid.NewString(),
+		})
+		if callErr != nil {
+			return newOperationError("flow delete-channel-message", callErr)
+		}
+		return writeOutput(c.stdout, options.output, map[string]any{
+			"flowId": flowID, "runId": *runID, "channelName": *channelName,
+			"messageId": *messageID, "deleted": true,
+		})
+	})
 }
 
 func (c *flowCommand) search(ctx context.Context, args []string, options options) error {
@@ -306,7 +382,7 @@ func protoTimestamp(timestamp *timestamppb.Timestamp) any {
 func (c *flowCommand) printUsage() {
 	fmt.Fprintln(c.stdout, "Usage: dexcli flow <command>")
 	fmt.Fprintln(c.stdout)
-	fmt.Fprintln(c.stdout, "Commands: start, wait, search, summary, state, history, inspect, watch, stop, skip-timer, wait-step, update-config, trigger-continue-as-new, time-travel")
+	fmt.Fprintln(c.stdout, "Commands: start, wait, search, summary, state, history, channel-messages, delete-channel-message, inspect, watch, stop, skip-timer, wait-step, update-config, trigger-continue-as-new, time-travel")
 }
 
 func parseInt32(value string, name string) (int32, error) {

--- a/cli/internal/command/output.go
+++ b/cli/internal/command/output.go
@@ -67,7 +67,7 @@ func tableRows(value any) ([]map[string]any, []string) {
 		}
 		return rows, tableHeaders(rows)
 	case map[string]any:
-		for _, key := range []string{"flows", "events", "methods"} {
+		for _, key := range []string{"flows", "events", "methods", "messages"} {
 			if entries, ok := current[key].([]any); ok {
 				return tableRows(entries)
 			}

--- a/docs/design/plan/channel-message-queue.md
+++ b/docs/design/plan/channel-message-queue.md
@@ -1,5 +1,22 @@
 # Channel Message Queue
 
+## Client surface
+
+All five SDKs expose a typed pending-message envelope containing the server UUIDv7
+and decoded Channel value. Client list operations preserve FIFO order, while
+Client deletion maps the channel-message-not-found substatus to a stable SDK
+error. RPC Contexts can stage deletion alongside other durable mutations.
+
+The RPC option is named `is_transactional` in snake-case APIs and
+`isTransactional` or `IsTransactional` where the language requires it. Attribute
+locks implicitly select the transactional server path. A Channel deletion must
+opt in explicitly when its existence check and the rest of the RPC writes need a
+single transaction.
+
+Dex Web and Dex CLI expose pending IDs and deletion. They identify the Cadence
+query-plus-signal behavior as best effort because it cannot provide Temporal's
+synchronous Update guarantee.
+
 ## Scope
 
 This design adds stable identities and pending-message management to Channels.

--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -1,5 +1,11 @@
 # Go SDK rewrite plan
 
+Pending Channel queues use `ChannelMessage[T]` envelopes. Client list methods
+decode into a caller-owned slice pointer, and deletion uses the server-assigned
+message ID. RPC handlers stage deletion through the Channel definition and set
+`InvokeOptions.IsTransactional` when existence validation must be atomic with all
+other RPC writes.
+
 Status: Phases 1 through 5 are implemented.
 
 ## Current source of truth

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -1,5 +1,17 @@
 # Dex Go SDK
 
+## Pending Channel messages
+
+`Client.GetChannelMessages` and `Client.GetChannelMapMessages` decode the current
+FIFO queue into a pointer to `[]dex.ChannelMessage[T]`. Delete a still-pending ID
+with `DeleteChannelMessage` or `DeleteChannelMapMessage`; a race with consumption
+returns `ChannelMessageNotFoundError`.
+
+An RPC can stage `channel.Delete(ctx, messageID)`. Set
+`dex.InvokeOptions{IsTransactional: true}` when a missing ID must abort every
+other RPC write. Attribute locking already selects transactional execution, while
+Channel deletion requires this explicit option.
+
 The Go SDK is being rewritten around the current Dex `Flow`, `Step`,
 `Attribute`, `Channel`, `Stream`, `WaitFor`, and `Execute` contracts.
 

--- a/sdk-go/dex/channel.go
+++ b/sdk-go/dex/channel.go
@@ -23,6 +23,17 @@ type Channel[T any] struct {
 	name string
 }
 
+// ChannelMessage identifies one pending Channel value returned by Client.GetChannelMessages.
+//
+// MessageID is assigned by Dex when the value is published. It can be passed to
+// Client.DeleteChannelMessage or Channel.Delete from a transactional RPC.
+type ChannelMessage[T any] struct {
+	// MessageID is the server-assigned UUIDv7 for this pending message.
+	MessageID string
+	// Value is the decoded Channel value.
+	Value T
+}
+
 // DefineChannel creates a typed Channel with a stable name without performing I/O.
 // "/" is reserved as the ChannelMap separator and is prohibited in Channel names.
 func DefineChannel[T any](name string) Channel[T] {
@@ -46,6 +57,16 @@ func (c Channel[T]) Publish(ctx Context, value T) error {
 		return errInvalidInvocationContext
 	}
 	return invocation.publishChannel(c.name, value)
+}
+
+// Delete stages one pending-message deletion from an RPC handler.
+// Use InvokeOptions.IsTransactional when a missing ID must abort all RPC writes.
+func (c Channel[T]) Delete(ctx Context, messageID string) error {
+	invocation, ok := ctx.(channelInvocation)
+	if !ok {
+		return errInvalidInvocationContext
+	}
+	return invocation.deleteChannelMessage(c.name, "", false, messageID)
 }
 
 // ForOne returns a Condition that consumes exactly one queued message.
@@ -141,6 +162,16 @@ func (c ChannelMap[T]) Publish(ctx Context, instance string, value T) error {
 		return errInvalidInvocationContext
 	}
 	return invocation.publishChannelMap(c.name, instance, value)
+}
+
+// Delete stages one pending-message deletion from a ChannelMap instance in an RPC handler.
+// Use InvokeOptions.IsTransactional when a missing ID must abort all RPC writes.
+func (c ChannelMap[T]) Delete(ctx Context, instance string, messageID string) error {
+	invocation, ok := ctx.(channelInvocation)
+	if !ok {
+		return errInvalidInvocationContext
+	}
+	return invocation.deleteChannelMessage(c.name, instance, true, messageID)
 }
 
 // ForOne returns an instance Condition that consumes exactly one message.
@@ -264,6 +295,7 @@ func (ChannelMap[T]) channelIsMap() bool {
 type channelInvocation interface {
 	publishChannel(name string, value any) error
 	publishChannelMap(name string, instance string, value any) error
+	deleteChannelMessage(name string, instance string, isMap bool, messageID string) error
 	channelSize(name string) int
 	channelMapSize(name string, instance string) int
 	channelMapKeys(name string) []string

--- a/sdk-go/dex/client.go
+++ b/sdk-go/dex/client.go
@@ -945,6 +945,54 @@ func (client *Client) PublishToChannelMap(
 	return client.publishToChannel(ctx, flowID, channel, instance, true, values)
 }
 
+// GetChannelMessages decodes every pending singleton Channel message into messagesPtr.
+//
+// messagesPtr must point to []ChannelMessage[T] for the Channel's value type. Results
+// preserve FIFO order. IDs remain valid only while their messages are pending.
+func (client *Client) GetChannelMessages(
+	ctx context.Context,
+	flowID string,
+	channel ChannelDef,
+	messagesPtr any,
+) error {
+	return client.getChannelMessages(ctx, flowID, channel, "", false, messagesPtr)
+}
+
+// GetChannelMapMessages decodes every pending message for one ChannelMap instance.
+//
+// messagesPtr must point to []ChannelMessage[T] for the ChannelMap's value type. Results
+// preserve FIFO order. IDs remain valid only while their messages are pending.
+func (client *Client) GetChannelMapMessages(
+	ctx context.Context,
+	flowID string,
+	channel ChannelDef,
+	instance string,
+	messagesPtr any,
+) error {
+	return client.getChannelMessages(ctx, flowID, channel, instance, true, messagesPtr)
+}
+
+// DeleteChannelMessage removes one pending singleton Channel message by server-assigned ID.
+func (client *Client) DeleteChannelMessage(
+	ctx context.Context,
+	flowID string,
+	channel ChannelDef,
+	messageID string,
+) error {
+	return client.deleteChannelMessage(ctx, flowID, channel, "", false, messageID)
+}
+
+// DeleteChannelMapMessage removes one pending message from a ChannelMap instance.
+func (client *Client) DeleteChannelMapMessage(
+	ctx context.Context,
+	flowID string,
+	channel ChannelDef,
+	instance string,
+	messageID string,
+) error {
+	return client.deleteChannelMessage(ctx, flowID, channel, instance, true, messageID)
+}
+
 func (client *Client) publishToChannel(
 	ctx context.Context,
 	flowID string,
@@ -983,6 +1031,112 @@ func (client *Client) publishToChannel(
 		Messages: messages,
 	})
 	return translateRPCError(err, "PublishToChannel", flowID, flowTargetActive)
+}
+
+func (client *Client) getChannelMessages(
+	ctx context.Context,
+	flowID string,
+	channel ChannelDef,
+	instance string,
+	isMap bool,
+	messagesPtr any,
+) error {
+	if err := client.validateFlowCall(ctx, flowID); err != nil {
+		return err
+	}
+	registered, err := client.registry.resolveChannel(channel, isMap)
+	if err != nil {
+		return err
+	}
+	name, err := physicalName(registered.name, instance, isMap)
+	if err != nil {
+		return err
+	}
+	target, valueType, err := channelMessagesTarget(messagesPtr)
+	if err != nil {
+		return err
+	}
+	response, err := client.service.GetChannelMessages(ctx, &dexpb.GetChannelMessagesRequest{
+		FlowId:      flowID,
+		ChannelName: name,
+	})
+	if err != nil {
+		return translateRPCError(err, "GetChannelMessages", flowID, flowTargetExisting)
+	}
+	if response == nil {
+		return fmt.Errorf("dex: GetChannelMessages response is nil")
+	}
+	result := reflect.MakeSlice(target.Type(), 0, len(response.Messages))
+	for _, message := range response.Messages {
+		if message == nil || message.MessageId == "" || message.Value == nil {
+			return fmt.Errorf("dex: GetChannelMessages response contains an incomplete message")
+		}
+		if err := client.hydrateValues(ctx, []**dexpb.Value{&message.Value}); err != nil {
+			return err
+		}
+		decoded, err := decodeReflectValue(message.Value, valueType)
+		if err != nil {
+			return err
+		}
+		envelope := reflect.New(target.Type().Elem()).Elem()
+		envelope.FieldByName("MessageID").SetString(message.MessageId)
+		envelope.FieldByName("Value").Set(decoded)
+		result = reflect.Append(result, envelope)
+	}
+	target.Set(result)
+	return nil
+}
+
+func (client *Client) deleteChannelMessage(
+	ctx context.Context,
+	flowID string,
+	channel ChannelDef,
+	instance string,
+	isMap bool,
+	messageID string,
+) error {
+	if err := client.validateFlowCall(ctx, flowID); err != nil {
+		return err
+	}
+	if messageID == "" {
+		return fmt.Errorf("dex: Channel message ID must not be empty")
+	}
+	registered, err := client.registry.resolveChannel(channel, isMap)
+	if err != nil {
+		return err
+	}
+	name, err := physicalName(registered.name, instance, isMap)
+	if err != nil {
+		return err
+	}
+	requestID, err := newRequestID()
+	if err != nil {
+		return err
+	}
+	_, err = client.service.DeleteChannelMessage(ctx, &dexpb.DeleteChannelMessageRequest{
+		FlowId:      flowID,
+		ChannelName: name,
+		MessageId:   messageID,
+		RequestId:   requestID,
+	})
+	return translateRPCError(err, "DeleteChannelMessage", flowID, flowTargetActive)
+}
+
+func channelMessagesTarget(messagesPtr any) (reflect.Value, reflect.Type, error) {
+	if messagesPtr == nil {
+		return reflect.Value{}, nil, fmt.Errorf("dex: Channel messages target must be a non-nil pointer")
+	}
+	target := reflect.ValueOf(messagesPtr)
+	if target.Kind() != reflect.Pointer || target.IsNil() || target.Elem().Kind() != reflect.Slice {
+		return reflect.Value{}, nil, fmt.Errorf("dex: Channel messages target must point to a slice")
+	}
+	elementType := target.Elem().Type().Elem()
+	if elementType.Kind() != reflect.Struct || elementType.NumField() != 2 ||
+		elementType.Field(0).Name != "MessageID" || elementType.Field(0).Type.Kind() != reflect.String ||
+		elementType.Field(1).Name != "Value" {
+		return reflect.Value{}, nil, fmt.Errorf("dex: Channel messages target must point to []ChannelMessage[T]")
+	}
+	return target.Elem(), elementType.Field(1).Type, nil
 }
 
 // WriteStream appends one best-effort message with client-supplied source metadata.
@@ -1534,6 +1688,7 @@ func (client *Client) InvokeRPC(
 		TimeoutSeconds:    timeout,
 		LockAttributeKeys: locks,
 		RequestId:         requestID,
+		IsTransactional:   options.IsTransactional,
 	})
 	if err != nil {
 		return translateRPCError(err, "InvokeRPC", flowID, flowTargetActive)

--- a/sdk-go/dex/client_integration_test.go
+++ b/sdk-go/dex/client_integration_test.go
@@ -130,6 +130,32 @@ type clientTestFlowService struct {
 	getAttributesRequest *dexpb.GetAttributesRequest
 	writeStreamRequests  []*dexpb.WriteStreamRequest
 	readStreamRequest    *dexpb.ReadStreamRequest
+	getMessagesRequest   *dexpb.GetChannelMessagesRequest
+	deleteMessageRequest *dexpb.DeleteChannelMessageRequest
+}
+
+func (service *clientTestFlowService) GetChannelMessages(
+	_ context.Context,
+	request *dexpb.GetChannelMessagesRequest,
+) (*dexpb.GetChannelMessagesResponse, error) {
+	service.getMessagesRequest = request
+	value, err := encodeValue("queued")
+	if err != nil {
+		return nil, err
+	}
+	return &dexpb.GetChannelMessagesResponse{Messages: []*dexpb.ChannelMessage{{
+		ChannelName: request.ChannelName,
+		MessageId:   "0198-message",
+		Value:       value,
+	}}}, nil
+}
+
+func (service *clientTestFlowService) DeleteChannelMessage(
+	_ context.Context,
+	request *dexpb.DeleteChannelMessageRequest,
+) (*emptypb.Empty, error) {
+	service.deleteMessageRequest = request
+	return &emptypb.Empty{}, nil
 }
 
 func (service *clientTestFlowService) WriteStream(
@@ -521,6 +547,11 @@ func TestClientFlowAndPersistenceTransport(t *testing.T) {
 	require.Len(t, service.publishRequest.Messages, 2)
 	require.NoError(t, client.PublishToChannelMap(ctx, "order-1", clientTestByOrder, "order-1", "pack"))
 	require.Equal(t, "commands-by-order/order-1", service.publishRequest.Messages[0].ChannelName)
+	var pending []ChannelMessage[string]
+	require.NoError(t, client.GetChannelMessages(ctx, "order-1", clientTestCommands, &pending))
+	require.Equal(t, []ChannelMessage[string]{{MessageID: "0198-message", Value: "queued"}}, pending)
+	require.NoError(t, client.DeleteChannelMessage(ctx, "order-1", clientTestCommands, pending[0].MessageID))
+	require.Equal(t, "0198-message", service.deleteMessageRequest.MessageId)
 
 	var status string
 	found, err := client.GetAttribute(ctx, "order-1", clientTestStatus, &status)
@@ -678,9 +709,13 @@ func TestClientRPCResultsAndAdministrativeTransport(t *testing.T) {
 		clientTestFlow{}.Update,
 		clientTestRPCInput{Status: "updated"},
 		&output,
-		InvokeOptions{LockAttributes: []AttributeLock{LockAttribute(clientTestStatus)}},
+		InvokeOptions{
+			LockAttributes:  []AttributeLock{LockAttribute(clientTestStatus)},
+			IsTransactional: true,
+		},
 	)
 	require.NoError(t, err)
+	require.True(t, service.invokeRequest.IsTransactional)
 	require.Equal(t, "updated", output.Status)
 	_, err = uuid.Parse(service.invokeRequest.RequestId)
 	require.NoError(t, err)

--- a/sdk-go/dex/errors.go
+++ b/sdk-go/dex/errors.go
@@ -240,6 +240,17 @@ type LongPollTimeoutError struct {
 	*ServiceError
 }
 
+// ChannelMessageNotFoundError reports a pending message ID that no longer exists.
+type ChannelMessageNotFoundError struct {
+	// ServiceError contains the failed deletion metadata.
+	*ServiceError
+}
+
+// Unwrap returns the shared service failure.
+func (e *ChannelMessageNotFoundError) Unwrap() error {
+	return e.ServiceError
+}
+
 // Unwrap returns the shared service failure.
 func (e *LongPollTimeoutError) Unwrap() error {
 	return e.ServiceError
@@ -269,6 +280,8 @@ const (
 	ErrorSubStatusWorkerAPI
 	// ErrorSubStatusLongPollTimeout identifies an active wait whose deadline elapsed.
 	ErrorSubStatusLongPollTimeout
+	// ErrorSubStatusChannelMessageNotFound identifies a pending message that no longer exists.
+	ErrorSubStatusChannelMessageNotFound
 )
 
 type flowTargetRequirement uint8
@@ -344,6 +357,8 @@ func translateRPCError(
 		}
 	case ErrorSubStatusLongPollTimeout:
 		return &LongPollTimeoutError{ServiceError: serviceError}
+	case ErrorSubStatusChannelMessageNotFound:
+		return &ChannelMessageNotFoundError{ServiceError: serviceError}
 	default:
 		return serviceError
 	}
@@ -372,6 +387,8 @@ func mapErrorSubStatus(subStatus dexpb.ErrorSubStatus) ErrorSubStatus {
 		return ErrorSubStatusWorkerAPI
 	case dexpb.ErrorSubStatus_ERROR_SUB_STATUS_LONG_POLL_TIME_OUT:
 		return ErrorSubStatusLongPollTimeout
+	case dexpb.ErrorSubStatus_ERROR_SUB_STATUS_CHANNEL_MESSAGE_NOT_FOUND:
+		return ErrorSubStatusChannelMessageNotFound
 	default:
 		return ErrorSubStatusUncategorized
 	}

--- a/sdk-go/dex/invocation.go
+++ b/sdk-go/dex/invocation.go
@@ -58,6 +58,7 @@ type invocationContext struct {
 	events         map[string]struct{}
 	recordedEvents []*dexpb.KV
 	publications   []*dexpb.ChannelMessage
+	deletions      []*dexpb.ChannelMessageDeletion
 
 	conditionResults *dexpb.ConditionResults
 	channelSizes     map[string]int
@@ -650,6 +651,32 @@ func (invocation *invocationContext) publishChannelValue(
 	})
 	if invocation.method == invocationRPC {
 		invocation.channelSizes[physical]++
+	}
+	return nil
+}
+
+func (invocation *invocationContext) deleteChannelMessage(
+	name string,
+	instance string,
+	isMap bool,
+	messageID string,
+) error {
+	if err := invocation.requireActive(invocationRPC); err != nil {
+		return err
+	}
+	if messageID == "" {
+		return fmt.Errorf("dex: Channel message ID must not be empty")
+	}
+	physical, err := invocation.resolveChannel(name, instance, isMap)
+	if err != nil {
+		return err
+	}
+	invocation.deletions = append(invocation.deletions, &dexpb.ChannelMessageDeletion{
+		ChannelName: physical,
+		MessageId:   messageID,
+	})
+	if invocation.channelSizes[physical] > 0 {
+		invocation.channelSizes[physical]--
 	}
 	return nil
 }

--- a/sdk-go/dex/options.go
+++ b/sdk-go/dex/options.go
@@ -264,6 +264,9 @@ type InvokeOptions struct {
 	Timeout time.Duration
 	// LockAttributes are acquired atomically for the RPC invocation.
 	LockAttributes []AttributeLock
+	// IsTransactional requests transactional reads and writes without requiring Attribute locks.
+	// Channel deletions require this option to make a missing message abort all RPC writes.
+	IsTransactional bool
 }
 
 // WaitForFlowOptions controls Flow-result hydration.

--- a/sdk-go/dex/worker_service.go
+++ b/sdk-go/dex/worker_service.go
@@ -376,6 +376,7 @@ func (service *workerService) invokeWorkerRPC(
 	response.UpsertAttributes = invocation.mappedAttributeWrites()
 	response.RecordEvents = invocation.recordedEvents
 	response.PublishToChannel = invocation.publications
+	response.DeleteFromChannel = invocation.deletions
 	return response, nil
 }
 

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -1,5 +1,16 @@
 # dex-sdk (Java)
 
+## Pending Channel messages
+
+`Client.getChannelMessages` returns typed `ChannelMessage<T>` values in FIFO
+order. `Client.deleteChannelMessage` deletes a still-pending ID and throws
+`ChannelMessageNotFoundException` if it has already been consumed or deleted.
+
+An RPC can stage `channel.delete(context, messageId)`. Annotate it with
+`@RPC(isTransactional = true)` when a missing ID must abort every other RPC
+write. Attribute locks already select transactional execution, but Channel
+deletion does not do so implicitly.
+
 Java SDK for [Dex workflow engine](https://github.com/superdurable/dex)
 
 See [samples](../examples/java) for how to use this SDK to build your workflow.

--- a/sdk-java/src/main/java/io/superdurable/dex/Channel.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Channel.java
@@ -77,6 +77,16 @@ public final class Channel<T> extends PersistenceDefinition {
     }
 
     /**
+     * Stages deletion of one pending message from an RPC handler.
+     *
+     * @param context the RPC invocation context
+     * @param messageId the nonblank server-assigned message ID
+     */
+    public void delete(final Context context, final String messageId) {
+        context.deleteChannelMessage(this, messageId);
+    }
+
+    /**
      * Returns the number of messages currently visible to this invocation.
      *
      * @param context the Step or RPC invocation context

--- a/sdk-java/src/main/java/io/superdurable/dex/ChannelMap.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/ChannelMap.java
@@ -72,6 +72,17 @@ public final class ChannelMap<T> extends PersistenceDefinition {
     }
 
     /**
+     * Stages deletion of one pending message from a Channel-map instance in an RPC handler.
+     *
+     * @param context the RPC invocation context
+     * @param instance the nonblank Channel-map instance
+     * @param messageId the nonblank server-assigned message ID
+     */
+    public void delete(final Context context, final String instance, final String messageId) {
+        context.deleteChannelMessage(this, instance, messageId);
+    }
+
+    /**
      * Returns the number of messages visible in one map instance.
      *
      * @param context the Step or RPC invocation context

--- a/sdk-java/src/main/java/io/superdurable/dex/ChannelMessage.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/ChannelMessage.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Licensed under the Super Durable Source License 1.0.
+ * You may not use this file except in compliance with the License.
+ * See the LICENSE file in the repository root.
+ *
+ * SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+ */
+
+package io.superdurable.dex;
+
+/**
+ * Identifies one typed value that is still pending in a Channel.
+ *
+ * @param <T> the decoded Channel value type
+ */
+public final class ChannelMessage<T> {
+    private final String messageId;
+    private final T value;
+
+    ChannelMessage(final String messageId, final T value) {
+        this.messageId = messageId;
+        this.value = value;
+    }
+
+    /**
+     * Returns the UUIDv7 assigned by Dex when the message was published.
+     *
+     * @return the server-assigned message ID
+     */
+    public String getMessageId() {
+        return messageId;
+    }
+
+    /**
+     * Returns the decoded Channel value.
+     *
+     * @return the message value
+     */
+    public T getValue() {
+        return value;
+    }
+}

--- a/sdk-java/src/main/java/io/superdurable/dex/Client.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Client.java
@@ -36,11 +36,14 @@ import io.superdurable.gen.FlowResetStepMethod;
 import io.superdurable.gen.FlowResetType;
 import io.superdurable.gen.FlowServiceGrpc;
 import io.superdurable.gen.FlowStartOptions;
+import io.superdurable.gen.GetChannelMessagesRequest;
+import io.superdurable.gen.GetChannelMessagesResponse;
 import io.superdurable.gen.GetAttributesRequest;
 import io.superdurable.gen.GetAttributesResponse;
 import io.superdurable.gen.GetFlowSummaryRequest;
 import io.superdurable.gen.GetFlowSummaryResponse;
 import io.superdurable.gen.InvokeRPCRequest;
+import io.superdurable.gen.DeleteChannelMessageRequest;
 import io.superdurable.gen.KV;
 import io.superdurable.gen.PublishToChannelRequest;
 import io.superdurable.gen.ReadStreamRequest;
@@ -578,6 +581,74 @@ public final class Client implements AutoCloseable {
     }
 
     /**
+     * Returns all pending messages for a singleton Channel in FIFO order.
+     *
+     * @param flowId the target Flow ID
+     * @param channel the typed singleton Channel
+     * @param <T> the Channel message type
+     * @return immutable pending message envelopes
+     */
+    public <T> List<ChannelMessage<T>> getChannelMessages(
+            final String flowId,
+            final Channel<T> channel) {
+        return getChannelMessages(flowId, "", channel.getName(), channel.getValueType());
+    }
+
+    /**
+     * Returns all pending messages for one Channel-map instance in FIFO order.
+     *
+     * @param flowId the target Flow ID
+     * @param channel the typed Channel map
+     * @param instance the nonblank Channel-map instance
+     * @param <T> the Channel message type
+     * @return immutable pending message envelopes
+     */
+    public <T> List<ChannelMessage<T>> getChannelMessages(
+            final String flowId,
+            final ChannelMap<T> channel,
+            final String instance) {
+        return getChannelMessages(
+                flowId,
+                "",
+                Registry.physicalName(channel.getName(), instance),
+                channel.getValueType());
+    }
+
+    /**
+     * Deletes one pending singleton Channel message by its server-assigned ID.
+     *
+     * @param flowId the target Flow ID
+     * @param channel the singleton Channel
+     * @param messageId the nonblank server-assigned message ID
+     */
+    public void deleteChannelMessage(
+            final String flowId,
+            final Channel<?> channel,
+            final String messageId) {
+        deleteChannelMessage(flowId, "", channel.getName(), messageId);
+    }
+
+    /**
+     * Deletes one pending message from a Channel-map instance by server-assigned ID.
+     *
+     * @param flowId the target Flow ID
+     * @param channel the Channel map
+     * @param instance the nonblank Channel-map instance
+     * @param messageId the nonblank server-assigned message ID
+     */
+    public void deleteChannelMessage(
+            final String flowId,
+            final ChannelMap<?> channel,
+            final String instance,
+            final String messageId) {
+        deleteChannelMessage(
+                flowId,
+                "",
+                Registry.physicalName(channel.getName(), instance),
+                messageId);
+    }
+
+    /**
      * Appends one typed best-effort Stream message with producer metadata.
      *
      * <p>Each call appends a new message. The source is informational and may be reused, including
@@ -1062,6 +1133,7 @@ public final class Client implements AutoCloseable {
                 .setTimeoutSeconds(rpc.getAnnotation().timeoutSeconds())
                 .addAllLockAttributeKeys(rpc.getLocks())
                 .setRequestId(UUID.randomUUID().toString())
+                .setIsTransactional(rpc.getAnnotation().isTransactional())
                 .build();
         final io.superdurable.gen.Value output = hydrator.hydrate(
                 call(
@@ -1149,6 +1221,45 @@ public final class Client implements AutoCloseable {
         }
         call(
                 () -> service.publishToChannel(request.build()),
+                FlowTargetRequirement.ACTIVE,
+                flowId);
+    }
+
+    private <T> List<ChannelMessage<T>> getChannelMessages(
+            final String flowId,
+            final String runId,
+            final String channelName,
+            final Class<T> valueType) {
+        final GetChannelMessagesResponse response = call(
+                () -> service.getChannelMessages(GetChannelMessagesRequest.newBuilder()
+                        .setFlowId(Attribute.requireName(flowId))
+                        .setRunId(runId)
+                        .setChannelName(channelName)
+                        .build()),
+                FlowTargetRequirement.EXISTING,
+                flowId);
+        final List<ChannelMessage<T>> messages = new ArrayList<ChannelMessage<T>>();
+        for (io.superdurable.gen.ChannelMessage message : response.getMessagesList()) {
+            messages.add(new ChannelMessage<T>(
+                    message.getMessageId(),
+                    values.decode(hydrator.hydrate(message.getValue()), valueType)));
+        }
+        return Collections.unmodifiableList(messages);
+    }
+
+    private void deleteChannelMessage(
+            final String flowId,
+            final String runId,
+            final String channelName,
+            final String messageId) {
+        call(
+                () -> service.deleteChannelMessage(DeleteChannelMessageRequest.newBuilder()
+                        .setFlowId(Attribute.requireName(flowId))
+                        .setRunId(runId)
+                        .setChannelName(channelName)
+                        .setMessageId(Attribute.requireName(messageId))
+                        .setRequestId(UUID.randomUUID().toString())
+                        .build()),
                 FlowTargetRequirement.ACTIVE,
                 flowId);
     }

--- a/sdk-java/src/main/java/io/superdurable/dex/Context.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Context.java
@@ -284,6 +284,23 @@ public interface Context {
     <T> void publish(ChannelMap<T> channel, String instance, T value);
 
     /**
+     * Stages deletion of one pending singleton Channel message from an RPC.
+     *
+     * @param channel the registered singleton Channel
+     * @param messageId the nonblank server-assigned message ID
+     */
+    void deleteChannelMessage(Channel<?> channel, String messageId);
+
+    /**
+     * Stages deletion of one pending Channel-map message from an RPC.
+     *
+     * @param channel the registered Channel map
+     * @param instance the nonblank Channel-map instance
+     * @param messageId the nonblank server-assigned message ID
+     */
+    void deleteChannelMessage(ChannelMap<?> channel, String instance, String messageId);
+
+    /**
      * Returns the visible message count for a Channel.
      *
      * @param channel the registered Channel

--- a/sdk-java/src/main/java/io/superdurable/dex/GrpcExceptionTranslator.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/GrpcExceptionTranslator.java
@@ -15,6 +15,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import io.superdurable.dex.exceptions.DexServiceException;
+import io.superdurable.dex.exceptions.ChannelMessageNotFoundException;
 import io.superdurable.dex.exceptions.ErrorSubStatus;
 import io.superdurable.dex.exceptions.FlowAlreadyStartedException;
 import io.superdurable.dex.exceptions.FlowNotActiveException;
@@ -65,6 +66,8 @@ final class GrpcExceptionTranslator {
                 return workerException(code, detail, exception, details);
             case LONG_POLL_TIMEOUT:
                 return new LongPollTimeoutException(code, detail, flowId, exception);
+            case CHANNEL_MESSAGE_NOT_FOUND:
+                return new ChannelMessageNotFoundException(code, detail, exception);
             default:
                 return new DexServiceException(code, subStatus, detail, exception);
         }
@@ -161,6 +164,8 @@ final class GrpcExceptionTranslator {
                 return ErrorSubStatus.WORKER_API_ERROR;
             case ERROR_SUB_STATUS_LONG_POLL_TIME_OUT:
                 return ErrorSubStatus.LONG_POLL_TIMEOUT;
+            case ERROR_SUB_STATUS_CHANNEL_MESSAGE_NOT_FOUND:
+                return ErrorSubStatus.CHANNEL_MESSAGE_NOT_FOUND;
             default:
                 return ErrorSubStatus.UNCATEGORIZED;
         }

--- a/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
@@ -17,7 +17,7 @@ package io.superdurable.dex;
 import io.superdurable.gen.AttributeSyncConfig;
 import io.superdurable.gen.AttributeWrite;
 import io.superdurable.gen.ChannelInfo;
-import io.superdurable.gen.ChannelMessage;
+import io.superdurable.gen.ChannelMessageDeletion;
 import io.superdurable.gen.ChannelResult;
 import io.superdurable.gen.ConditionResults;
 import io.superdurable.gen.ConditionStatus;
@@ -65,7 +65,10 @@ final class InvocationContext implements Context {
     private final Map<String, KV> localWrites = new LinkedHashMap<String, KV>();
     private final List<KV> events = new ArrayList<KV>();
     private final Set<String> eventNames = new HashSet<String>();
-    private final List<ChannelMessage> publications = new ArrayList<ChannelMessage>();
+    private final List<io.superdurable.gen.ChannelMessage> publications =
+            new ArrayList<io.superdurable.gen.ChannelMessage>();
+    private final List<ChannelMessageDeletion> channelDeletions =
+            new ArrayList<ChannelMessageDeletion>();
     private final List<StepOutputFinalizer> stepOutputFinalizers =
             new ArrayList<StepOutputFinalizer>();
     private boolean stepOutputsFinalized;
@@ -415,6 +418,19 @@ final class InvocationContext implements Context {
     }
 
     @Override
+    public void deleteChannelMessage(final Channel<?> channel, final String messageId) {
+        deleteChannelMessageValue(channel, null, messageId);
+    }
+
+    @Override
+    public void deleteChannelMessage(
+            final ChannelMap<?> channel,
+            final String instance,
+            final String messageId) {
+        deleteChannelMessageValue(channel, instance, messageId);
+    }
+
+    @Override
     public int channelSize(final Channel<?> channel) {
         return channelSizeValue(channel, null);
     }
@@ -500,8 +516,12 @@ final class InvocationContext implements Context {
         return Collections.unmodifiableList(events);
     }
 
-    List<ChannelMessage> getPublications() {
+    List<io.superdurable.gen.ChannelMessage> getPublications() {
         return Collections.unmodifiableList(publications);
+    }
+
+    List<ChannelMessageDeletion> getChannelDeletions() {
+        return Collections.unmodifiableList(channelDeletions);
     }
 
     private <T> T getAttributeValue(
@@ -572,7 +592,7 @@ final class InvocationContext implements Context {
             final Object value) {
         requireRegistered(definition);
         final String name = physicalName(definition, instance);
-        publications.add(ChannelMessage.newBuilder()
+        publications.add(io.superdurable.gen.ChannelMessage.newBuilder()
                 .setChannelName(name)
                 .setValue(values.encode(value))
                 .build());
@@ -580,6 +600,27 @@ final class InvocationContext implements Context {
             final ChannelInfo existing = channelInfos.get(name);
             final int size = existing == null ? 0 : existing.getSize();
             channelInfos.put(name, ChannelInfo.newBuilder().setSize(size + 1).build());
+        }
+    }
+
+    private void deleteChannelMessageValue(
+            final PersistenceDefinition definition,
+            final String instance,
+            final String messageId) {
+        if (method != Method.RPC) {
+            throw new IllegalStateException("Channel message deletion requires an RPC Context");
+        }
+        requireRegistered(definition);
+        final String name = physicalName(definition, instance);
+        channelDeletions.add(ChannelMessageDeletion.newBuilder()
+                .setChannelName(name)
+                .setMessageId(Attribute.requireName(messageId))
+                .build());
+        final ChannelInfo existing = channelInfos.get(name);
+        if (existing != null && existing.getSize() > 0) {
+            channelInfos.put(
+                    name,
+                    ChannelInfo.newBuilder().setSize(existing.getSize() - 1).build());
         }
     }
 

--- a/sdk-java/src/main/java/io/superdurable/dex/RPC.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/RPC.java
@@ -68,4 +68,14 @@ public @interface RPC {
      * @return map-instance lock annotations; defaults to an empty array
      */
     RPCAttributeMapLock[] lockAttributeMaps() default {};
+
+    /**
+     * Requests transactional reads and writes without requiring Attribute locks.
+     *
+     * <p>Set this for an RPC that deletes a Channel message when a missing ID must prevent every
+     * other staged write from committing.
+     *
+     * @return {@code true} to request transactional execution; defaults to {@code false}
+     */
+    boolean isTransactional() default false;
 }

--- a/sdk-java/src/main/java/io/superdurable/dex/WorkerDispatcher.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/WorkerDispatcher.java
@@ -215,7 +215,8 @@ final class WorkerDispatcher {
         final InvokeWorkerRPCResponse.Builder response = InvokeWorkerRPCResponse.newBuilder()
                 .addAllUpsertAttributes(context.getAttributeWrites())
                 .addAllRecordEvents(context.getEvents())
-                .addAllPublishToChannel(context.getPublications());
+                .addAllPublishToChannel(context.getPublications())
+                .addAllDeleteFromChannel(context.getChannelDeletions());
         if (returned instanceof RPCResult) {
             final RPCResult<?> result = (RPCResult<?>) returned;
             response.setOutput(values.encode(result.getOutput()));

--- a/sdk-java/src/main/java/io/superdurable/dex/exceptions/ChannelMessageNotFoundException.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/exceptions/ChannelMessageNotFoundException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Super Durable, Inc.
+ *
+ * Licensed under the Super Durable Source License 1.0.
+ * You may not use this file except in compliance with the License.
+ * See the LICENSE file in the repository root.
+ *
+ * SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+ */
+
+package io.superdurable.dex.exceptions;
+
+import io.grpc.Status;
+
+/** Thrown when a requested Channel message is no longer pending. */
+public final class ChannelMessageNotFoundException extends DexServiceException {
+    /**
+     * Creates the exception from Dex service status metadata.
+     *
+     * @param code the gRPC status code returned by Dex
+     * @param detail the server-provided failure detail
+     * @param cause the original transport failure
+     */
+    public ChannelMessageNotFoundException(
+            final Status.Code code,
+            final String detail,
+            final Throwable cause) {
+        super(code, ErrorSubStatus.CHANNEL_MESSAGE_NOT_FOUND, detail, cause);
+    }
+}

--- a/sdk-java/src/main/java/io/superdurable/dex/exceptions/ErrorSubStatus.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/exceptions/ErrorSubStatus.java
@@ -31,5 +31,8 @@ public enum ErrorSubStatus {
     WORKER_API_ERROR,
 
     /** Indicates that a long-poll operation reached its wait timeout. */
-    LONG_POLL_TIMEOUT
+    LONG_POLL_TIMEOUT,
+
+    /** Indicates that a pending Channel message ID no longer exists. */
+    CHANNEL_MESSAGE_NOT_FOUND
 }

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -1,6 +1,19 @@
 
 # Dex SDK for Python
 
+## Pending Channel messages
+
+`Client.get_channel_messages(flow_id, channel)` returns typed `ChannelMessage`
+envelopes in FIFO order. Each envelope contains the decoded value and the UUIDv7
+assigned by Dex. `Client.delete_channel_message` deletes only a still-pending
+message and raises `ChannelMessageNotFoundError` after consumption or another
+deletion.
+
+RPC handlers can stage `channel.delete(context, message_id)`. Declare the RPC as
+`@rpc(is_transactional=True)` when a missing message must abort its other writes.
+Attribute locks already select transactional execution, but Channel deletion
+itself does not.
+
 Python SDK for [Dex workflow engine](https://github.com/superdurable/dex)
 
 ## New user contracts

--- a/sdk-python/dex/__init__.py
+++ b/sdk-python/dex/__init__.py
@@ -19,7 +19,7 @@ from dex.attribute import (
     IndexType,
 )
 from dex.blob_cache import BlobCache, BlobCacheConfig, open_blob_cache
-from dex.channel import Channel, ChannelMap
+from dex.channel import Channel, ChannelMap, ChannelMessage
 from dex.client import Client
 from dex.client_options import ClientOptions
 from dex.codec import (
@@ -68,6 +68,7 @@ from dex.runtime_errors import (
     FlowNotFoundError,
     InvalidStepResultError,
     LongPollTimeoutError,
+    ChannelMessageNotFoundError,
     RpcLockConflictError,
     ValueMappingError,
     WorkerInvocationError,
@@ -124,6 +125,8 @@ __all__ = [
     "BufferedTextStream",
     "Channel",
     "ChannelMap",
+    "ChannelMessage",
+    "ChannelMessageNotFoundError",
     "Client",
     "ClientOptions",
     "Codec",

--- a/sdk-python/dex/_async_worker_dispatcher.py
+++ b/sdk-python/dex/_async_worker_dispatcher.py
@@ -306,6 +306,7 @@ class AsyncWorkerDispatcher(WorkerDispatcher):
             response = pb.InvokeWorkerRPCResponse(
                 upsert_attributes=list(context.attribute_writes.values()),
                 record_events=context.events,
+                delete_from_channel=context.channel_deletions,
                 publish_to_channel=context.publications,
             )
             if isinstance(returned, RPCResult):

--- a/sdk-python/dex/_grpc_errors.py
+++ b/sdk-python/dex/_grpc_errors.py
@@ -19,6 +19,7 @@ from grpc_status import rpc_status
 
 from dex.dexpb import dex_pb2 as pb
 from dex.runtime_errors import (
+    ChannelMessageNotFoundError,
     DexServiceError,
     ErrorSubStatus,
     FlowAlreadyStartedError,
@@ -136,6 +137,8 @@ def translate_rpc_error(
         )
     if sub_status is ErrorSubStatus.LONG_POLL_TIMEOUT:
         return LongPollTimeoutError(*parameters)
+    if sub_status is ErrorSubStatus.CHANNEL_MESSAGE_NOT_FOUND:
+        return ChannelMessageNotFoundError(*parameters)
     return DexServiceError(*parameters)
 
 
@@ -219,5 +222,8 @@ def _map_sub_status(value: int) -> ErrorSubStatus:
         int(pb.ERROR_SUB_STATUS_FLOW_NOT_EXISTS): ErrorSubStatus.FLOW_NOT_EXISTS,
         int(pb.ERROR_SUB_STATUS_WORKER_API_ERROR): ErrorSubStatus.WORKER_API_ERROR,
         int(pb.ERROR_SUB_STATUS_LONG_POLL_TIME_OUT): ErrorSubStatus.LONG_POLL_TIMEOUT,
+        int(
+            pb.ERROR_SUB_STATUS_CHANNEL_MESSAGE_NOT_FOUND
+        ): ErrorSubStatus.CHANNEL_MESSAGE_NOT_FOUND,
     }
     return statuses.get(value, ErrorSubStatus.UNCATEGORIZED)

--- a/sdk-python/dex/_invocation_context.py
+++ b/sdk-python/dex/_invocation_context.py
@@ -82,6 +82,7 @@ class InvocationContext:
         self.attribute_writes: dict[str, pb.AttributeWrite] = {}
         self.local_writes: dict[str, pb.KV] = {}
         self.events: list[pb.KV] = []
+        self.channel_deletions: list[pb.ChannelMessageDeletion] = []
         self.publications: list[pb.ChannelMessage] = []
         self._event_names: set[str] = set()
         self._step_output_finalizers: list[_StepOutputFinalizer] = []
@@ -348,6 +349,26 @@ class InvocationContext:
             self._channel_infos[name] = pb.ChannelInfo(
                 size=(current.size if current is not None else 0) + 1
             )
+
+    def _delete_channel_message(
+        self,
+        definition: Channel[object] | ChannelMap[object],
+        instance: str | None,
+        message_id: str,
+    ) -> None:
+        if self._method is not InvocationMethod.RPC:
+            raise ValueError("Channel message deletion requires an RPC Context")
+        self._require_registered(definition)
+        name = self._physical_name(definition, instance)
+        self.channel_deletions.append(
+            pb.ChannelMessageDeletion(
+                channel_name=name,
+                message_id=require_name(message_id),
+            )
+        )
+        current = self._channel_infos.get(name)
+        if current is not None and current.size > 0:
+            self._channel_infos[name] = pb.ChannelInfo(size=current.size - 1)
 
     def _attribute_map_keys(
         self,

--- a/sdk-python/dex/_worker_dispatcher.py
+++ b/sdk-python/dex/_worker_dispatcher.py
@@ -233,6 +233,7 @@ class WorkerDispatcher:
             response = pb.InvokeWorkerRPCResponse(
                 upsert_attributes=list(context.attribute_writes.values()),
                 record_events=context.events,
+                delete_from_channel=context.channel_deletions,
                 publish_to_channel=context.publications,
             )
             if isinstance(returned, RPCResult):

--- a/sdk-python/dex/async_client.py
+++ b/sdk-python/dex/async_client.py
@@ -24,7 +24,7 @@ from dex._value_mapper import ValueMapper
 from dex._worker_dispatcher import WorkerDispatcher
 from dex.attribute import Attribute, AttributeMap, _apply_attribute_store_sync
 from dex.blob_cache import BlobCache
-from dex.channel import Channel, ChannelMap
+from dex.channel import Channel, ChannelMap, ChannelMessage
 from dex.client_options import ClientOptions
 from dex.context import Context
 from dex.dexpb import dex_pb2 as pb
@@ -273,6 +273,7 @@ class AsyncClient:
                     timeout_seconds=timeout,
                     lock_attribute_keys=rpc.locks,
                     request_id=str(uuid4()),
+                    is_transactional=rpc.options.is_transactional,
                 ),
                 "invoke_rpc",
                 flow_id,
@@ -542,6 +543,148 @@ class AsyncClient:
             "write_stream",
             flow_id,
             "none",
+        )
+
+    @overload
+    async def get_channel_messages(
+        self,
+        flow_id: str,
+        channel: Channel[ValueT],
+        /,
+        *,
+        run_id: str = "",
+    ) -> tuple[ChannelMessage[ValueT], ...]: ...
+
+    @overload
+    async def get_channel_messages(
+        self,
+        flow_id: str,
+        channel: ChannelMap[ValueT],
+        instance: str,
+        /,
+        *,
+        run_id: str = "",
+    ) -> tuple[ChannelMessage[ValueT], ...]: ...
+
+    async def get_channel_messages(
+        self,
+        flow_id: str,
+        channel: Channel[Any] | ChannelMap[Any],
+        instance: str | None = None,
+        /,
+        *,
+        run_id: str = "",
+    ) -> tuple[ChannelMessage[Any], ...]:
+        """Return every pending message for a Channel in FIFO order.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            channel: A typed singleton Channel or ChannelMap definition.
+            instance: Required ChannelMap instance; omit for a singleton Channel.
+            run_id: Optional exact run; ``""`` targets the current run.
+
+        Returns:
+            Immutable typed message envelopes with server-assigned IDs.
+
+        Raises:
+            ValueMappingError: If a pending value cannot be decoded.
+            FlowNotFoundError: If the selected Flow run does not exist.
+            DexServiceError: If FlowService cannot read the queue.
+        """
+        name = self._definition_name(channel, instance)
+        response = cast(
+            pb.GetChannelMessagesResponse,
+            await self._call(
+                self._service.GetChannelMessages,
+                pb.GetChannelMessagesRequest(
+                    flow_id=require_name(flow_id),
+                    run_id=run_id,
+                    channel_name=name,
+                ),
+                "get_channel_messages",
+                flow_id,
+                "existing",
+            ),
+        )
+        codec = self._values.codec(channel.value_type)
+        messages: list[ChannelMessage[Any]] = []
+        for message in response.messages:
+            messages.append(
+                ChannelMessage(
+                    message_id=message.message_id,
+                    value=self._values.decode(
+                        await self._hydrator.hydrate(message.value),
+                        codec,
+                    ),
+                )
+            )
+        return tuple(messages)
+
+    @overload
+    async def delete_channel_message(
+        self,
+        flow_id: str,
+        channel: Channel[Any],
+        message_id: str,
+        /,
+        *,
+        run_id: str = "",
+    ) -> None: ...
+
+    @overload
+    async def delete_channel_message(
+        self,
+        flow_id: str,
+        channel: ChannelMap[Any],
+        instance: str,
+        message_id: str,
+        /,
+        *,
+        run_id: str = "",
+    ) -> None: ...
+
+    async def delete_channel_message(
+        self,
+        flow_id: str,
+        channel: Channel[Any] | ChannelMap[Any],
+        instance_or_message_id: str,
+        message_id: str | None = None,
+        /,
+        *,
+        run_id: str = "",
+    ) -> None:
+        """Delete one pending Channel message by its server-assigned ID.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            channel: A typed singleton Channel or ChannelMap definition.
+            instance_or_message_id: Singleton message ID or ChannelMap instance.
+            message_id: ChannelMap message ID; omit for a singleton Channel.
+            run_id: Optional exact run; ``""`` targets the active run.
+
+        Raises:
+            ChannelMessageNotFoundError: If the message is no longer pending.
+            FlowNotActiveError: If the selected Flow run is closed.
+            DexServiceError: If FlowService cannot delete the message.
+        """
+        instance = instance_or_message_id if isinstance(channel, ChannelMap) else None
+        resolved_message_id = (
+            message_id if instance is not None else instance_or_message_id
+        )
+        if resolved_message_id is None:
+            raise ValueError("ChannelMap message ID is required")
+        await self._call(
+            self._service.DeleteChannelMessage,
+            pb.DeleteChannelMessageRequest(
+                flow_id=require_name(flow_id),
+                run_id=run_id,
+                channel_name=self._definition_name(channel, instance),
+                message_id=require_name(resolved_message_id),
+                request_id=str(uuid4()),
+            ),
+            "delete_channel_message",
+            flow_id,
+            "active",
         )
 
     async def read_stream(

--- a/sdk-python/dex/channel.py
+++ b/sdk-python/dex/channel.py
@@ -21,6 +21,19 @@ ValueT = TypeVar("ValueT")
 
 
 @dataclass(frozen=True)
+class ChannelMessage(Generic[ValueT]):
+    """Represent one pending Channel message and its server-assigned identity.
+
+    Attributes:
+        message_id: UUIDv7 assigned by Dex when the message was published.
+        value: The decoded Channel value.
+    """
+
+    message_id: str
+    value: ValueT
+
+
+@dataclass(frozen=True)
 class Channel(Generic[ValueT]):
     """Define a typed, durable singleton message stream owned by a Flow.
 
@@ -52,6 +65,19 @@ class Channel(Generic[ValueT]):
             value: A value compatible with ``value_type``.
         """
         context._publish_channel(self, None, value)
+
+    def delete(self, context: Context, message_id: str) -> None:
+        """Stage deletion of one pending message from an RPC handler.
+
+        Use ``@rpc(is_transactional=True)`` when a missing message must fail the
+        entire RPC without committing its other writes. Step Contexts reject this
+        operation.
+
+        Args:
+            context: The current RPC Context.
+            message_id: Non-empty ID returned by a Client pending-message read.
+        """
+        context._delete_channel_message(self, None, message_id)
 
     def size(self, context: Context) -> int:
         """Return the current number of queued values.
@@ -197,6 +223,16 @@ class ChannelMap(Generic[ValueT]):
             value: A value compatible with ``value_type``.
         """
         context._publish_channel(self, instance, value)
+
+    def delete(self, context: Context, instance: str, message_id: str) -> None:
+        """Stage deletion of one pending message from a ChannelMap instance.
+
+        Args:
+            context: The current RPC Context.
+            instance: The non-empty logical map key.
+            message_id: Non-empty ID returned by a Client pending-message read.
+        """
+        context._delete_channel_message(self, instance, message_id)
 
     def size(self, context: Context, instance: str) -> int:
         """Return the queued value count for one instance.

--- a/sdk-python/dex/client.py
+++ b/sdk-python/dex/client.py
@@ -24,7 +24,7 @@ from dex._value_mapper import ValueMapper
 from dex._worker_dispatcher import WorkerDispatcher
 from dex.attribute import Attribute, AttributeMap, _apply_attribute_store_sync
 from dex.blob_cache import BlobCache
-from dex.channel import Channel, ChannelMap
+from dex.channel import Channel, ChannelMap, ChannelMessage
 from dex.client_options import ClientOptions
 from dex.context import Context
 from dex.dexpb import dex_pb2 as pb
@@ -273,6 +273,7 @@ class Client:
                     timeout_seconds=timeout,
                     lock_attribute_keys=rpc.locks,
                     request_id=str(uuid4()),
+                    is_transactional=rpc.options.is_transactional,
                 ),
                 "invoke_rpc",
                 flow_id,
@@ -543,6 +544,146 @@ class Client:
             "write_stream",
             flow_id,
             "none",
+        )
+
+    @overload
+    def get_channel_messages(
+        self,
+        flow_id: str,
+        channel: Channel[ValueT],
+        /,
+        *,
+        run_id: str = "",
+    ) -> tuple[ChannelMessage[ValueT], ...]: ...
+
+    @overload
+    def get_channel_messages(
+        self,
+        flow_id: str,
+        channel: ChannelMap[ValueT],
+        instance: str,
+        /,
+        *,
+        run_id: str = "",
+    ) -> tuple[ChannelMessage[ValueT], ...]: ...
+
+    def get_channel_messages(
+        self,
+        flow_id: str,
+        channel: Channel[Any] | ChannelMap[Any],
+        instance: str | None = None,
+        /,
+        *,
+        run_id: str = "",
+    ) -> tuple[ChannelMessage[Any], ...]:
+        """Return every pending message for a Channel in FIFO order.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            channel: A typed singleton Channel or ChannelMap definition.
+            instance: Required ChannelMap instance; omit for a singleton Channel.
+            run_id: Optional exact run; ``""`` targets the current run.
+
+        Returns:
+            Immutable typed message envelopes with server-assigned IDs.
+
+        Raises:
+            ValueMappingError: If a pending value cannot be decoded.
+            FlowNotFoundError: If the selected Flow run does not exist.
+            DexServiceError: If FlowService cannot read the queue.
+        """
+        name = self._definition_name(channel, instance)
+        response = cast(
+            pb.GetChannelMessagesResponse,
+            self._call(
+                self._service.GetChannelMessages,
+                pb.GetChannelMessagesRequest(
+                    flow_id=require_name(flow_id),
+                    run_id=run_id,
+                    channel_name=name,
+                ),
+                "get_channel_messages",
+                flow_id,
+                "existing",
+            ),
+        )
+        codec = self._values.codec(channel.value_type)
+        return tuple(
+            ChannelMessage(
+                message_id=message.message_id,
+                value=self._values.decode(
+                    self._hydrator.hydrate(message.value),
+                    codec,
+                ),
+            )
+            for message in response.messages
+        )
+
+    @overload
+    def delete_channel_message(
+        self,
+        flow_id: str,
+        channel: Channel[Any],
+        message_id: str,
+        /,
+        *,
+        run_id: str = "",
+    ) -> None: ...
+
+    @overload
+    def delete_channel_message(
+        self,
+        flow_id: str,
+        channel: ChannelMap[Any],
+        instance: str,
+        message_id: str,
+        /,
+        *,
+        run_id: str = "",
+    ) -> None: ...
+
+    def delete_channel_message(
+        self,
+        flow_id: str,
+        channel: Channel[Any] | ChannelMap[Any],
+        instance_or_message_id: str,
+        message_id: str | None = None,
+        /,
+        *,
+        run_id: str = "",
+    ) -> None:
+        """Delete one pending Channel message by its server-assigned ID.
+
+        Args:
+            flow_id: The non-empty target Flow ID.
+            channel: A typed singleton Channel or ChannelMap definition.
+            instance_or_message_id: Singleton message ID or ChannelMap instance.
+            message_id: ChannelMap message ID; omit for a singleton Channel.
+            run_id: Optional exact run; ``""`` targets the active run.
+
+        Raises:
+            ChannelMessageNotFoundError: If the message is no longer pending.
+            FlowNotActiveError: If the selected Flow run is closed.
+            DexServiceError: If FlowService cannot delete the message.
+        """
+        instance = instance_or_message_id if isinstance(channel, ChannelMap) else None
+        resolved_message_id = (
+            message_id if instance is not None else instance_or_message_id
+        )
+        if resolved_message_id is None:
+            raise ValueError("ChannelMap message ID is required")
+        self._call(
+            self._service.DeleteChannelMessage,
+            pb.DeleteChannelMessageRequest(
+                flow_id=require_name(flow_id),
+                run_id=run_id,
+                channel_name=self._definition_name(channel, instance),
+                message_id=require_name(resolved_message_id),
+                request_id=str(uuid4()),
+            ),
+            "delete_channel_message",
+            flow_id,
+            "active",
         )
 
     def read_stream(

--- a/sdk-python/dex/context.py
+++ b/sdk-python/dex/context.py
@@ -10,7 +10,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Protocol, Sequence, TypeVar
 
 if TYPE_CHECKING:
     from dex.attribute import Attribute, AttributeMap
@@ -208,6 +208,13 @@ class Context(Protocol):
         definition: Channel[ValueT] | ChannelMap[ValueT],
         instance: str | None,
         value: ValueT,
+    ) -> None: ...
+
+    def _delete_channel_message(
+        self,
+        definition: Channel[Any] | ChannelMap[Any],
+        instance: str | None,
+        message_id: str,
     ) -> None: ...
 
     def _channel_size(

--- a/sdk-python/dex/flow.py
+++ b/sdk-python/dex/flow.py
@@ -58,6 +58,7 @@ class _RPCOptions:
     name: str | None
     timeout: timedelta | None
     lock_attributes: tuple[AttributeLock, ...]
+    is_transactional: bool
 
 
 @overload
@@ -70,6 +71,7 @@ def rpc(
     name: str | None = None,
     timeout: timedelta | None = None,
     lock_attributes: Sequence[AttributeLock] = (),
+    is_transactional: bool = False,
 ) -> Callable[[CallableT], CallableT]: ...
 
 
@@ -79,6 +81,7 @@ def rpc(
     name: str | None = None,
     timeout: timedelta | None = None,
     lock_attributes: Sequence[AttributeLock] = (),
+    is_transactional: bool = False,
 ) -> CallableT | Callable[[CallableT], CallableT]:
     """Mark a Flow method as a typed RPC handler.
 
@@ -91,6 +94,7 @@ def rpc(
         name: Optional protocol RPC name; defaults to the method name.
         timeout: Optional non-negative handler timeout.
         lock_attributes: Attribute locks held for the entire handler invocation.
+        is_transactional: Request transactional reads and writes even without locks.
 
     Returns:
         The original handler, or a decorator that returns it after attaching options.
@@ -114,7 +118,7 @@ def rpc(
         setattr(
             handler,
             "__dex_rpc_options__",
-            _RPCOptions(name, timeout, tuple(lock_attributes)),
+            _RPCOptions(name, timeout, tuple(lock_attributes), is_transactional),
         )
         return handler
 

--- a/sdk-python/dex/runtime_errors.py
+++ b/sdk-python/dex/runtime_errors.py
@@ -23,6 +23,7 @@ class ErrorSubStatus(Enum):
         FLOW_NOT_EXISTS: No Flow with the requested ID exists.
         WORKER_API_ERROR: An application Worker rejected or failed an invocation.
         LONG_POLL_TIMEOUT: A wait ended without observing its condition.
+        CHANNEL_MESSAGE_NOT_FOUND: A pending Channel message ID no longer exists.
     """
 
     UNCATEGORIZED = "uncategorized"
@@ -30,6 +31,7 @@ class ErrorSubStatus(Enum):
     FLOW_NOT_EXISTS = "flow_not_exists"
     WORKER_API_ERROR = "worker_api_error"
     LONG_POLL_TIMEOUT = "long_poll_timeout"
+    CHANNEL_MESSAGE_NOT_FOUND = "channel_message_not_found"
 
 
 class FlowErrorType(Enum):
@@ -157,6 +159,12 @@ class RpcLockConflictError(DexServiceError):
 
 class LongPollTimeoutError(DexServiceError):
     """Indicate that a retryable long poll ended before its condition was observed."""
+
+    pass
+
+
+class ChannelMessageNotFoundError(DexServiceError):
+    """Indicate that a pending Channel message ID no longer exists."""
 
     pass
 

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -1,5 +1,16 @@
 # Dex Rust SDK
 
+## Pending Channel messages
+
+`Client::get_channel_messages` and `Client::get_channel_map_messages` return typed
+`ChannelMessage<T>` envelopes in FIFO order. Deleting an already-consumed ID
+returns `SdkError::ChannelMessageNotFound`.
+
+An RPC can stage `channel.delete(context, message_id)`. Define it with
+`Rpc::is_transactional()` when a missing ID must abort all other RPC writes.
+Attribute locks already select transactional execution, while Channel deletion
+requires the explicit option.
+
 [![Rust SDK CI](https://github.com/superdurable/dex/actions/workflows/sdk-rust-ci.yml/badge.svg?branch=main)](https://github.com/superdurable/dex/actions/workflows/sdk-rust-ci.yml)
 
 This workspace contains the synchronous Rust SDK, the shared DXBC BlobCache,

--- a/sdk-rust/crates/dex-sdk/src/channel.rs
+++ b/sdk-rust/crates/dex-sdk/src/channel.rs
@@ -10,6 +10,15 @@ use std::marker::PhantomData;
 
 use crate::{Condition, Context, HandlerResult, Value};
 
+/// Identifies one typed value that is still pending in a Channel.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChannelMessage<T> {
+    /// UUIDv7 assigned by Dex when the message was published.
+    pub message_id: String,
+    /// Decoded Channel value.
+    pub value: T,
+}
+
 /// Defines one durable FIFO queue of typed messages.
 ///
 /// Add the Channel to [`crate::PersistenceSchema`]. Clients and handlers may publish messages;
@@ -48,6 +57,11 @@ impl<T> Channel<T> {
         T: Value,
     {
         context.publish(self, value)
+    }
+
+    /// Stages deletion of one pending message from an RPC handler.
+    pub fn delete(&self, context: &mut Context, message_id: &str) -> HandlerResult<()> {
+        context.delete_channel_message(self, message_id)
     }
 
     /// Returns the invocation snapshot's queued-message count.
@@ -142,6 +156,16 @@ impl<T> ChannelMap<T> {
         T: Value,
     {
         context.publish_map(self, instance, value)
+    }
+
+    /// Stages deletion of one pending message from a Channel-map instance in an RPC.
+    pub fn delete(
+        &self,
+        context: &mut Context,
+        instance: &str,
+        message_id: &str,
+    ) -> HandlerResult<()> {
+        context.delete_channel_map_message(self, instance, message_id)
     }
 
     /// Returns the invocation snapshot's message count for `instance`.

--- a/sdk-rust/crates/dex-sdk/src/client.rs
+++ b/sdk-rust/crates/dex-sdk/src/client.rs
@@ -14,9 +14,10 @@ use std::time::{Duration, SystemTime};
 use dex_protocol::dex::flow_service_client::FlowServiceClient;
 use dex_protocol::dex::{
     ActiveStepSearchMode as ProtoSearchMode, AttributeStoreNames, AttributeWrite,
-    FlowAlreadyStartedOptions, FlowConfig as ProtoFlowConfig, FlowResetStepMethod, FlowResetType,
-    FlowRetryPolicy, FlowStartOptions, FlowStatus as ProtoFlowStatus,
-    FlowTimeoutPolicy as ProtoFlowTimeoutPolicy, GetAttributesRequest, GetFlowSummaryRequest,
+    DeleteChannelMessageRequest, FlowAlreadyStartedOptions, FlowConfig as ProtoFlowConfig,
+    FlowResetStepMethod, FlowResetType, FlowRetryPolicy, FlowStartOptions,
+    FlowStatus as ProtoFlowStatus, FlowTimeoutPolicy as ProtoFlowTimeoutPolicy,
+    GetAttributesRequest, GetChannelMessagesRequest, GetFlowSummaryRequest,
     IdReusePolicy as ProtoIdReusePolicy, InvokeRpcRequest, PublishToChannelRequest,
     ReadStreamRequest, ResetFlowRequest, SearchFlowsRequest, SetAttributesRequest,
     SkipTimerRequest, StartFlowRequest, StepDurability as ProtoStepDurability, StopFlowRequest,
@@ -36,11 +37,12 @@ use crate::value_hydrator::ValueHydrator;
 use crate::value_mapper;
 use crate::worker_dispatcher::map_step_options;
 use crate::{
-    ActiveStepSearchMode, Attribute, AttributeMap, BlobCache, Channel, ChannelMap, ClientOptions,
-    Flow, FlowConfig, FlowErrorType, FlowInfo, FlowResult, FlowStatus, FlowTimeoutPolicy,
-    IdReusePolicy, Registry, RetryPolicy, Rpc, SdkError, SdkResult, SearchFlowEntry,
-    SearchFlowsPage, StartFlowOptions, StepCompletion, StepDurability, StepExecutionId,
-    StopFlowOptions, Stream, StreamMessage, TimeTravelOptions, TimerId, Value, WorkerTarget,
+    ActiveStepSearchMode, Attribute, AttributeMap, BlobCache, Channel, ChannelMap, ChannelMessage,
+    ClientOptions, Flow, FlowConfig, FlowErrorType, FlowInfo, FlowResult, FlowStatus,
+    FlowTimeoutPolicy, IdReusePolicy, Registry, RetryPolicy, Rpc, SdkError, SdkResult,
+    SearchFlowEntry, SearchFlowsPage, StartFlowOptions, StepCompletion, StepDurability,
+    StepExecutionId, StopFlowOptions, Stream, StreamMessage, TimeTravelOptions, TimerId, Value,
+    WorkerTarget,
 };
 
 /// Provides blocking, typed control of registered Dex Flows.
@@ -329,6 +331,53 @@ impl Client {
             flow_id,
             &crate::registry::physical_name(channel.name(), instance),
             values,
+        )
+    }
+
+    /// Returns every pending singleton Channel message in FIFO order.
+    pub fn get_channel_messages<T: Value>(
+        &self,
+        flow_id: &str,
+        channel: &Channel<T>,
+    ) -> SdkResult<Vec<ChannelMessage<T>>> {
+        self.get_channel_messages_value(flow_id, channel.name())
+    }
+
+    /// Returns every pending message for one Channel-map instance in FIFO order.
+    pub fn get_channel_map_messages<T: Value>(
+        &self,
+        flow_id: &str,
+        channel: &ChannelMap<T>,
+        instance: &str,
+    ) -> SdkResult<Vec<ChannelMessage<T>>> {
+        self.get_channel_messages_value(
+            flow_id,
+            &crate::registry::physical_name(channel.name(), instance),
+        )
+    }
+
+    /// Deletes one pending singleton Channel message by server-assigned ID.
+    pub fn delete_channel_message<T>(
+        &self,
+        flow_id: &str,
+        channel: &Channel<T>,
+        message_id: &str,
+    ) -> SdkResult<()> {
+        self.delete_channel_message_value(flow_id, channel.name(), message_id)
+    }
+
+    /// Deletes one pending message from a Channel-map instance by server-assigned ID.
+    pub fn delete_channel_map_message<T>(
+        &self,
+        flow_id: &str,
+        channel: &ChannelMap<T>,
+        instance: &str,
+        message_id: &str,
+    ) -> SdkResult<()> {
+        self.delete_channel_message_value(
+            flow_id,
+            &crate::registry::physical_name(channel.name(), instance),
+            message_id,
         )
     }
 
@@ -830,7 +879,7 @@ impl Client {
             timeout_seconds: optional_seconds(rpc.timeout)?,
             lock_attribute_keys: rpc.locks.iter().map(|lock| lock.physical_name()).collect(),
             request_id: Uuid::new_v4().to_string(),
-            is_transactional: false,
+            is_transactional: rpc.is_transactional,
         };
         let mut service = self.service.clone();
         let output = self.runtime.block_on(async {
@@ -940,6 +989,73 @@ impl Client {
                         flow_id: flow_id.to_string(),
                         run_id: String::new(),
                         messages,
+                    })
+                    .await
+            },
+        )
+    }
+
+    fn get_channel_messages_value<T: Value>(
+        &self,
+        flow_id: &str,
+        channel_name: &str,
+    ) -> SdkResult<Vec<ChannelMessage<T>>> {
+        let mut service = self.service.clone();
+        let response = self.runtime.block_on(async {
+            service
+                .get_channel_messages(GetChannelMessagesRequest {
+                    flow_id: flow_id.to_string(),
+                    run_id: String::new(),
+                    channel_name: channel_name.to_string(),
+                })
+                .await
+                .map(|response| response.into_inner())
+                .map_err(|status| {
+                    SdkError::from_status(
+                        status,
+                        "get_channel_messages",
+                        Some(flow_id),
+                        FlowTargetRequirement::Existing,
+                    )
+                })
+        })?;
+        response
+            .messages
+            .into_iter()
+            .map(|message| {
+                let value = message
+                    .value
+                    .ok_or_else(|| invalid("GetChannelMessages returned an empty Value"))?;
+                let value = self.runtime.block_on(self.hydrator.hydrate(value))?;
+                Ok(ChannelMessage {
+                    message_id: message.message_id,
+                    value: value_mapper::decode(&value)?,
+                })
+            })
+            .collect()
+    }
+
+    fn delete_channel_message_value(
+        &self,
+        flow_id: &str,
+        channel_name: &str,
+        message_id: &str,
+    ) -> SdkResult<()> {
+        if message_id.is_empty() {
+            return Err(invalid("Channel message ID must not be empty"));
+        }
+        self.call_empty(
+            "delete_channel_message",
+            Some(flow_id),
+            FlowTargetRequirement::Active,
+            |mut service| async move {
+                service
+                    .delete_channel_message(DeleteChannelMessageRequest {
+                        flow_id: flow_id.to_string(),
+                        run_id: String::new(),
+                        channel_name: channel_name.to_string(),
+                        message_id: message_id.to_string(),
+                        request_id: Uuid::new_v4().to_string(),
                     })
                     .await
             },

--- a/sdk-rust/crates/dex-sdk/src/context.rs
+++ b/sdk-rust/crates/dex-sdk/src/context.rs
@@ -12,8 +12,8 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, SystemTime};
 
 use dex_protocol::dex::{
-    AttributeWrite, ChannelInfo, ChannelMessage, ConditionResults, ConditionStatus,
-    Context as ProtoContext, Kv, StepStreamWrite, Value as ProtoValue, value,
+    AttributeWrite, ChannelInfo, ChannelMessage, ChannelMessageDeletion, ConditionResults,
+    ConditionStatus, Context as ProtoContext, Kv, StepStreamWrite, Value as ProtoValue, value,
 };
 
 use crate::persistence::PersistenceKind;
@@ -42,6 +42,14 @@ pub(crate) struct ContextInput {
     pub(crate) channel_infos: HashMap<String, ChannelInfo>,
 }
 
+pub(crate) struct InvocationOutputs {
+    pub(crate) attributes: Vec<AttributeWrite>,
+    pub(crate) locals: Vec<Kv>,
+    pub(crate) events: Vec<Kv>,
+    pub(crate) publications: Vec<ChannelMessage>,
+    pub(crate) channel_deletions: Vec<ChannelMessageDeletion>,
+}
+
 /// Provides invocation metadata and staged durable changes to Step and RPC handlers.
 ///
 /// A Context belongs to one handler attempt and must not outlive the call. Attribute writes,
@@ -61,6 +69,7 @@ pub struct Context {
     events: Vec<Kv>,
     event_names: HashSet<String>,
     publications: Vec<ChannelMessage>,
+    channel_deletions: Vec<ChannelMessageDeletion>,
     cancellation: InvocationCancellation,
     runtime: Option<tokio::runtime::Handle>,
     step_output_finalizers: Vec<Arc<dyn StepOutputFinalizer>>,
@@ -91,6 +100,7 @@ impl Context {
             events: Vec::new(),
             event_names: HashSet::new(),
             publications: Vec::new(),
+            channel_deletions: Vec::new(),
             cancellation,
             runtime: tokio::runtime::Handle::try_current().ok(),
             step_output_finalizers: Vec::new(),
@@ -644,15 +654,14 @@ impl Context {
         self.cancellation.clone()
     }
 
-    pub(crate) fn take_outputs(
-        self,
-    ) -> (Vec<AttributeWrite>, Vec<Kv>, Vec<Kv>, Vec<ChannelMessage>) {
-        (
-            self.attribute_writes.into_values().collect(),
-            self.local_writes.into_values().collect(),
-            self.events,
-            self.publications,
-        )
+    pub(crate) fn take_outputs(self) -> InvocationOutputs {
+        InvocationOutputs {
+            attributes: self.attribute_writes.into_values().collect(),
+            locals: self.local_writes.into_values().collect(),
+            events: self.events,
+            publications: self.publications,
+            channel_deletions: self.channel_deletions,
+        }
     }
 
     fn step_output_emitter(&self) -> HandlerResult<&StepOutputEmitter> {
@@ -738,6 +747,65 @@ impl Context {
                 .entry(channel_name)
                 .and_modify(|info| info.size += 1)
                 .or_insert(ChannelInfo { size: 1 });
+        }
+        Ok(())
+    }
+
+    /// Stages deletion of one singleton Channel message from an RPC.
+    pub fn delete_channel_message<T>(
+        &mut self,
+        channel: &Channel<T>,
+        message_id: &str,
+    ) -> HandlerResult<()> {
+        self.delete_channel_message_value(
+            channel.name(),
+            PersistenceKind::Channel,
+            None,
+            message_id,
+        )
+    }
+
+    /// Stages deletion of one Channel-map message from an RPC.
+    pub fn delete_channel_map_message<T>(
+        &mut self,
+        channel: &ChannelMap<T>,
+        instance: &str,
+        message_id: &str,
+    ) -> HandlerResult<()> {
+        self.delete_channel_message_value(
+            channel.name(),
+            PersistenceKind::ChannelMap,
+            Some(instance),
+            message_id,
+        )
+    }
+
+    fn delete_channel_message_value(
+        &mut self,
+        name: &str,
+        kind: PersistenceKind,
+        instance: Option<&str>,
+        message_id: &str,
+    ) -> HandlerResult<()> {
+        if self.method != InvocationMethod::Rpc {
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "Channel message deletion requires an RPC Context",
+            ));
+        }
+        if message_id.is_empty() {
+            return Err(HandlerError::new(
+                "dex_sdk::HandlerError",
+                "Channel message ID must not be empty",
+            ));
+        }
+        let channel_name = self.registered_name(name, kind, instance)?;
+        self.channel_deletions.push(ChannelMessageDeletion {
+            channel_name: channel_name.clone(),
+            message_id: message_id.to_string(),
+        });
+        if let Some(info) = self.channel_infos.get_mut(&channel_name) {
+            info.size = info.size.saturating_sub(1);
         }
         Ok(())
     }

--- a/sdk-rust/crates/dex-sdk/src/lib.rs
+++ b/sdk-rust/crates/dex-sdk/src/lib.rs
@@ -48,7 +48,7 @@ mod worker_options;
 mod worker_output;
 
 pub use attribute::{Attribute, AttributeIndex, AttributeMap};
-pub use channel::{Channel, ChannelGuard, ChannelMap};
+pub use channel::{Channel, ChannelGuard, ChannelMap, ChannelMessage};
 pub use client::Client;
 pub use client_options::ClientOptions;
 pub use context::Context;

--- a/sdk-rust/crates/dex-sdk/src/rpc.rs
+++ b/sdk-rust/crates/dex-sdk/src/rpc.rs
@@ -69,6 +69,11 @@ impl<Input, Output> Rpc<Input, Output> {
         RpcDefinition::from(self).lock(lock)
     }
 
+    /// Requests transactional reads and writes for this RPC.
+    pub fn is_transactional(self) -> RpcDefinition<Input, Output> {
+        RpcDefinition::from(self).is_transactional()
+    }
+
     pub(crate) fn name(&self) -> &'static str {
         self.name
     }
@@ -90,6 +95,7 @@ pub struct RpcDefinition<Input, Output> {
     rpc: Rpc<Input, Output>,
     timeout: Option<Duration>,
     locks: Vec<AttributeLock>,
+    is_transactional: bool,
 }
 
 impl<Input, Output> RpcDefinition<Input, Output> {
@@ -104,6 +110,12 @@ impl<Input, Output> RpcDefinition<Input, Output> {
         self.locks.push(lock);
         self
     }
+
+    /// Requests transactional reads and writes even when no Attribute lock is configured.
+    pub fn is_transactional(mut self) -> Self {
+        self.is_transactional = true;
+        self
+    }
 }
 
 impl<Input, Output> From<Rpc<Input, Output>> for RpcDefinition<Input, Output> {
@@ -112,6 +124,7 @@ impl<Input, Output> From<Rpc<Input, Output>> for RpcDefinition<Input, Output> {
             rpc,
             timeout: None,
             locks: Vec::new(),
+            is_transactional: false,
         }
     }
 }
@@ -278,6 +291,7 @@ pub(crate) struct RegisteredRpc {
     pub(crate) name: &'static str,
     pub(crate) timeout: Option<Duration>,
     pub(crate) locks: Vec<AttributeLock>,
+    pub(crate) is_transactional: bool,
     pub(crate) handler: Arc<dyn ErasedRpc>,
 }
 
@@ -453,6 +467,7 @@ fn registered_rpc<Input, Output>(
         name: definition.rpc.name,
         timeout: definition.timeout,
         locks: definition.locks,
+        is_transactional: definition.is_transactional,
         handler,
     }
 }

--- a/sdk-rust/crates/dex-sdk/src/sdk_error.rs
+++ b/sdk-rust/crates/dex-sdk/src/sdk_error.rs
@@ -32,6 +32,8 @@ pub enum ErrorSubStatus {
     WorkerApiError,
     /// A long-poll deadline elapsed while the Flow remained active.
     LongPollTimeout,
+    /// A pending Channel message ID no longer exists.
+    ChannelMessageNotFound,
 }
 
 #[derive(Debug)]
@@ -164,6 +166,11 @@ pub enum SdkError {
         /// Structured timeout failure.
         service: ServiceError,
     },
+    /// A requested Channel message is no longer pending.
+    ChannelMessageNotFound {
+        /// Structured deletion failure.
+        service: ServiceError,
+    },
     /// A registered Flow, Step, RPC, or persistence definition is invalid.
     FlowDefinition {
         /// Developer-actionable contract violation.
@@ -198,7 +205,8 @@ impl Display for SdkError {
             | Self::FlowNotFound { service }
             | Self::FlowNotActive { service }
             | Self::RpcLockConflict { service }
-            | Self::LongPollTimeout { service } => Display::fmt(service, formatter),
+            | Self::LongPollTimeout { service }
+            | Self::ChannelMessageNotFound { service } => Display::fmt(service, formatter),
             Self::WorkerInvocation { service, .. } => Display::fmt(service, formatter),
             Self::InvalidStepResult { detail, .. } => formatter.write_str(detail),
             Self::FlowDefinition { message }
@@ -226,7 +234,8 @@ impl SdkError {
             | Self::FlowNotFound { service }
             | Self::FlowNotActive { service }
             | Self::RpcLockConflict { service }
-            | Self::LongPollTimeout { service } => Some(service),
+            | Self::LongPollTimeout { service }
+            | Self::ChannelMessageNotFound { service } => Some(service),
             Self::WorkerInvocation { service, .. } => Some(service),
             _ => None,
         }
@@ -290,6 +299,7 @@ impl SdkError {
                 }
             }
             ErrorSubStatus::LongPollTimeout => Self::LongPollTimeout { service },
+            ErrorSubStatus::ChannelMessageNotFound => Self::ChannelMessageNotFound { service },
             ErrorSubStatus::Uncategorized => Self::Service { service },
         }
     }
@@ -337,6 +347,7 @@ fn map_sub_status(value: i32) -> ErrorSubStatus {
         Some(ProtoErrorSubStatus::FlowNotExists) => ErrorSubStatus::FlowNotExists,
         Some(ProtoErrorSubStatus::WorkerApiError) => ErrorSubStatus::WorkerApiError,
         Some(ProtoErrorSubStatus::LongPollTimeOut) => ErrorSubStatus::LongPollTimeout,
+        Some(ProtoErrorSubStatus::ChannelMessageNotFound) => ErrorSubStatus::ChannelMessageNotFound,
         _ => ErrorSubStatus::Uncategorized,
     }
 }

--- a/sdk-rust/crates/dex-sdk/src/worker_dispatcher.rs
+++ b/sdk-rust/crates/dex-sdk/src/worker_dispatcher.rs
@@ -124,14 +124,14 @@ impl WorkerDispatcher {
                 })
             });
             let waiting_condition = context.finalize_step_outputs(handler_result)?;
-            let (attributes, locals, events, publications) = context.take_outputs();
+            let outputs = context.take_outputs();
             Ok(InvokeWaitForMethodResponse {
                 local_activity_metadata: None,
-                upsert_attributes: attributes,
+                upsert_attributes: outputs.attributes,
                 waiting_condition,
-                upsert_step_exe_locals: locals,
-                record_events: events,
-                publish_to_channel: publications,
+                upsert_step_exe_locals: outputs.locals,
+                record_events: outputs.events,
+                publish_to_channel: outputs.publications,
             })
         })
         .await
@@ -211,14 +211,14 @@ impl WorkerDispatcher {
                 })
             });
             let decision = context.finalize_step_outputs(handler_result)?;
-            let (attributes, locals, events, publications) = context.take_outputs();
+            let outputs = context.take_outputs();
             Ok(InvokeExecuteMethodResponse {
                 local_activity_metadata: None,
                 step_decision: Some(decision),
-                upsert_attributes: attributes,
-                record_events: events,
-                upsert_step_exe_locals: locals,
-                publish_to_channel: publications,
+                upsert_attributes: outputs.attributes,
+                record_events: outputs.events,
+                upsert_step_exe_locals: outputs.locals,
+                publish_to_channel: outputs.publications,
             })
         })
         .await
@@ -271,14 +271,14 @@ impl WorkerDispatcher {
                     error,
                 )
             })?;
-            let (attributes, locals, events, publications) = context.take_outputs();
+            let outputs = context.take_outputs();
             Ok(InvokeExecuteMethodResponse {
                 local_activity_metadata: None,
                 step_decision: Some(decision),
-                upsert_attributes: attributes,
-                record_events: events,
-                upsert_step_exe_locals: locals,
-                publish_to_channel: publications,
+                upsert_attributes: outputs.attributes,
+                record_events: outputs.events,
+                upsert_step_exe_locals: outputs.locals,
+                publish_to_channel: outputs.publications,
             })
         })
         .await
@@ -338,14 +338,14 @@ impl WorkerDispatcher {
                     cancel_sibling_step_types: Vec::new(),
                 })
             };
-            let (attributes, _, events, publications) = context.take_outputs();
+            let outputs = context.take_outputs();
             Ok(InvokeWorkerRpcResponse {
                 output: Some(output),
                 step_decision: decision,
-                upsert_attributes: attributes,
-                record_events: events,
-                delete_from_channel: Vec::new(),
-                publish_to_channel: publications,
+                upsert_attributes: outputs.attributes,
+                record_events: outputs.events,
+                delete_from_channel: outputs.channel_deletions,
+                publish_to_channel: outputs.publications,
             })
         })
         .await

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -1,5 +1,16 @@
 # Dex SDK for TypeScript
 
+## Pending Channel messages
+
+`Client.getChannelMessages` returns typed `ChannelMessage<T>` envelopes in FIFO
+order. `Client.deleteChannelMessage` deletes a still-pending ID and rejects with
+`ChannelMessageNotFoundError` after consumption or another deletion.
+
+An RPC can stage `channel.delete(context, messageId)`. Set the decorator option
+`isTransactional: true` when a missing ID must abort all other RPC writes.
+Attribute locks already select transactional execution; Channel deletion requires
+the explicit option.
+
 This package targets Node.js 22 and 24. It provides strongly typed workflow
 contracts and a Promise-based gRPC Client. The Client and Worker runtime use
 `@grpc/grpc-js`. Blob caching uses the shared Rust DXBC implementation through

--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -24,6 +24,7 @@ import {
   IndexType as ProtoIndexType,
   ExecuteMethodFailurePolicy,
   type GetAttributesResponse,
+  type GetChannelMessagesResponse,
   type GetFlowSummaryResponse,
   type InvokeRPCResponse,
   type ReadStreamResponse,
@@ -85,7 +86,7 @@ import type { RPCResult } from "./rpc.js";
 import type { RetryPolicy, StepOptions } from "./step.js";
 import { requireName } from "./validation.js";
 import { codecOrJson, decodeUnknown, decodeValue, encodeValue, ValueHydrator } from "./value-mapper.js";
-import { ChannelMap, type Channel } from "./wait.js";
+import { ChannelMap, type Channel, type ChannelMessage } from "./wait.js";
 import type { Stream, StreamMessage } from "./stream.js";
 
 const defaultServerAddress = "localhost:8801";
@@ -290,7 +291,7 @@ export class Client {
             physicalName(lock.attribute.name, lock.instance),
           ),
           requestId: crypto.randomUUID(),
-          isTransactional: false,
+          isTransactional: rpc.options.isTransactional ?? false,
         },
         callback,
       ),
@@ -497,6 +498,120 @@ export class Client {
             value: encodeValue(channel.codec, value),
             messageId: "",
           })),
+        },
+        callback,
+      ),
+    );
+  }
+
+  /**
+   * Returns every pending singleton Channel message in FIFO order.
+   * @typeParam T - Channel value type.
+   * @param flowId - Non-empty existing Flow ID.
+   * @param channel - Registered singleton Channel.
+   * @returns Typed pending message envelopes.
+   */
+  public getChannelMessages<T>(
+    flowId: string,
+    channel: Channel<T>,
+  ): Promise<readonly ChannelMessage<T>[]>;
+
+  /**
+   * Returns every pending message for one ChannelMap instance in FIFO order.
+   * @typeParam T - Channel value type.
+   * @param flowId - Non-empty existing Flow ID.
+   * @param channel - Registered ChannelMap.
+   * @param instance - Non-empty ChannelMap instance.
+   * @returns Typed pending message envelopes.
+   */
+  public getChannelMessages<T>(
+    flowId: string,
+    channel: ChannelMap<T>,
+    instance: string,
+  ): Promise<readonly ChannelMessage<T>[]>;
+
+  /**
+   * Implements singleton and ChannelMap pending-message reads.
+   * @typeParam T - Channel value type.
+   * @param flowId - Non-empty existing Flow ID.
+   * @param channel - Registered singleton or map definition.
+   * @param instance - Required ChannelMap instance; omitted for a singleton.
+   * @returns Typed pending message envelopes in FIFO order.
+   */
+  public async getChannelMessages<T>(
+    flowId: string,
+    channel: Channel<T> | ChannelMap<T>,
+    instance?: string,
+  ): Promise<readonly ChannelMessage<T>[]> {
+    const response = await unary<GetChannelMessagesResponse>(
+      { operation: "getChannelMessages", flowId, requirement: "existing" },
+      (callback) => this.service.getChannelMessages(
+        {
+          flowId: requireName(flowId),
+          runId: "",
+          channelName: physicalName(channel.name, instance),
+        },
+        callback,
+      ),
+    );
+    return Promise.all(response.messages.map(async (message) => ({
+      messageId: message.messageId,
+      value: decodeValue(channel.codec, await this.hydrator.hydrate(message.value)),
+    })));
+  }
+
+  /**
+   * Deletes one pending singleton Channel message by its server-assigned ID.
+   * @param flowId - Non-empty active Flow ID.
+   * @param channel - Registered singleton Channel.
+   * @param messageId - Non-empty server-assigned message ID.
+   */
+  public deleteChannelMessage(
+    flowId: string,
+    channel: Channel<unknown>,
+    messageId: string,
+  ): Promise<void>;
+
+  /**
+   * Deletes one pending message from a ChannelMap instance by server-assigned ID.
+   * @param flowId - Non-empty active Flow ID.
+   * @param channel - Registered ChannelMap.
+   * @param instance - Non-empty ChannelMap instance.
+   * @param messageId - Non-empty server-assigned message ID.
+   */
+  public deleteChannelMessage(
+    flowId: string,
+    channel: ChannelMap<unknown>,
+    instance: string,
+    messageId: string,
+  ): Promise<void>;
+
+  /**
+   * Implements singleton and ChannelMap pending-message deletion.
+   * @param flowId - Non-empty active Flow ID.
+   * @param channel - Registered singleton or map definition.
+   * @param instanceOrMessageId - Map instance or singleton message ID.
+   * @param mapMessageId - Required message ID for a ChannelMap.
+   * @returns A promise resolved after Dex accepts the deletion.
+   */
+  public async deleteChannelMessage(
+    flowId: string,
+    channel: Channel<unknown> | ChannelMap<unknown>,
+    instanceOrMessageId: string,
+    mapMessageId?: string,
+  ): Promise<void> {
+    const isMap = channel instanceof ChannelMap;
+    const instance = isMap ? instanceOrMessageId : undefined;
+    const messageId = isMap ? mapMessageId : instanceOrMessageId;
+    await unary<Empty>(
+      { operation: "deleteChannelMessage", flowId, requirement: "active" },
+      (callback) => this.service.deleteChannelMessage(
+        {
+          flowId: requireName(flowId),
+          runId: "",
+          channelName: physicalName(channel.name, instance),
+          messageId: requireName(messageId ?? ""),
+          requestId: crypto.randomUUID(),
         },
         callback,
       ),

--- a/sdk-typescript/src/context.ts
+++ b/sdk-typescript/src/context.ts
@@ -126,6 +126,17 @@ export interface Context {
    */
   publish<T>(channel: Channel<T> | ChannelMap<T>, value: T, instance?: string): void;
   /**
+   * Stages deletion of one pending Channel message from an RPC handler.
+   * @param channel - Registered singleton or map definition.
+   * @param messageId - Non-empty server-assigned message ID.
+   * @param instance - Required ChannelMap instance; omitted for a singleton.
+   */
+  deleteChannelMessage(
+    channel: Channel<unknown> | ChannelMap<unknown>,
+    messageId: string,
+    instance?: string,
+  ): void;
+  /**
    * Returns a Channel's current queued value count.
    * @param channel - Registered singleton or map definition.
    * @param instance - Required ChannelMap instance; omitted for a singleton.

--- a/sdk-typescript/src/errors.ts
+++ b/sdk-typescript/src/errors.ts
@@ -24,6 +24,8 @@ export const ErrorSubStatus = Object.freeze({
   WORKER_API_ERROR: "workerApiError",
   /** A retryable long poll ended without observing its condition. */
   LONG_POLL_TIMEOUT: "longPollTimeout",
+  /** A pending Channel message ID no longer exists. */
+  CHANNEL_MESSAGE_NOT_FOUND: "channelMessageNotFound",
 } as const);
 
 /** Represents a value from {@link ErrorSubStatus}. */
@@ -115,6 +117,9 @@ export class RpcLockConflictError extends DexServiceError {}
 
 /** Indicates that a retryable long poll ended before its condition was observed. */
 export class LongPollTimeoutError extends DexServiceError {}
+
+/** Indicates that a requested Channel message is no longer pending. */
+export class ChannelMessageNotFoundError extends DexServiceError {}
 
 /** Indicates that Registry construction found an invalid Flow definition. */
 export class FlowDefinitionError extends Error {

--- a/sdk-typescript/src/grpc-status.ts
+++ b/sdk-typescript/src/grpc-status.ts
@@ -21,6 +21,7 @@ import {
   FlowNotActiveError,
   FlowNotFoundError,
   LongPollTimeoutError,
+  ChannelMessageNotFoundError,
   RpcLockConflictError,
   WorkerInvocationError,
   type ErrorSubStatus as ErrorSubStatusValue,
@@ -125,6 +126,8 @@ export function translateServiceError(
       );
     case ErrorSubStatus.LONG_POLL_TIMEOUT:
       return new LongPollTimeoutError(...parameters);
+    case ErrorSubStatus.CHANNEL_MESSAGE_NOT_FOUND:
+      return new ChannelMessageNotFoundError(...parameters);
     default:
       return new DexServiceError(...parameters);
   }
@@ -162,6 +165,8 @@ function mapSubStatus(value: ProtoErrorSubStatus): ErrorSubStatusValue {
       return ErrorSubStatus.WORKER_API_ERROR;
     case ProtoErrorSubStatus.ERROR_SUB_STATUS_LONG_POLL_TIME_OUT:
       return ErrorSubStatus.LONG_POLL_TIMEOUT;
+    case ProtoErrorSubStatus.ERROR_SUB_STATUS_CHANNEL_MESSAGE_NOT_FOUND:
+      return ErrorSubStatus.CHANNEL_MESSAGE_NOT_FOUND;
     default:
       return ErrorSubStatus.UNCATEGORIZED;
   }

--- a/sdk-typescript/src/invocation-context.ts
+++ b/sdk-typescript/src/invocation-context.ts
@@ -14,7 +14,8 @@ import {
   IndexType as ProtoIndexType,
   type AttributeWrite,
   type ChannelInfo,
-  type ChannelMessage,
+  type ChannelMessage as ProtoChannelMessage,
+  type ChannelMessageDeletion,
   type ConditionResults,
   type Context as ProtoContext,
   type IndexConfig,
@@ -59,7 +60,8 @@ export class InvocationContext implements AsyncContext {
   private readonly localWrites = new Map<string, KV>();
   private readonly events: KV[] = [];
   private readonly eventNames = new Set<string>();
-  private readonly publications: ChannelMessage[] = [];
+  private readonly publications: ProtoChannelMessage[] = [];
+  private readonly channelDeletions: ChannelMessageDeletion[] = [];
   private readonly lastHeartbeatValue: Value | undefined;
   private readonly stepOutputFinalizers: StepOutputFinalizer[] = [];
   private stepOutputsFinalized = false;
@@ -306,6 +308,23 @@ export class InvocationContext implements AsyncContext {
     }
   }
 
+  public deleteChannelMessage(
+    channel: Channel<unknown> | ChannelMap<unknown>,
+    messageId: string,
+    instance?: string,
+  ): void {
+    if (this.method !== "rpc") {
+      throw new TypeError("Channel message deletion requires an RPC Context");
+    }
+    this.requireRegistered(channel);
+    const name = definitionName(channel, instance);
+    this.channelDeletions.push({ channelName: name, messageId: requireName(messageId) });
+    const size = this.channelInfos.get(name)?.size ?? 0;
+    if (size > 0) {
+      this.channelInfos.set(name, { size: size - 1 });
+    }
+  }
+
   public channelSize(
     channel: Channel<unknown> | ChannelMap<unknown>,
     instance?: string,
@@ -353,8 +372,12 @@ export class InvocationContext implements AsyncContext {
     return this.events;
   }
 
-  public getPublications(): readonly ChannelMessage[] {
+  public getPublications(): readonly ProtoChannelMessage[] {
     return this.publications;
+  }
+
+  public getChannelDeletions(): readonly ChannelMessageDeletion[] {
+    return this.channelDeletions;
   }
 
   private requireRegistered(

--- a/sdk-typescript/src/rpc.ts
+++ b/sdk-typescript/src/rpc.ts
@@ -58,6 +58,8 @@ export interface RPCOptions<Input = unknown, Output = unknown> {
   readonly timeoutMs?: number;
   /** Attribute locks held for the entire invocation. */
   readonly lockAttributes?: readonly AttributeLock[];
+  /** Requests transactional reads and writes even when no Attribute lock is configured. */
+  readonly isTransactional?: boolean;
 }
 
 export interface RegisteredRPC {

--- a/sdk-typescript/src/wait.ts
+++ b/sdk-typescript/src/wait.ts
@@ -81,6 +81,17 @@ export const Timer = Object.freeze({
 });
 
 /**
+ * Identifies one typed value that is still pending in a Channel.
+ * @typeParam T - Decoded Channel value type.
+ */
+export interface ChannelMessage<T> {
+  /** UUIDv7 assigned by Dex when the message was published. */
+  readonly messageId: string;
+  /** Decoded Channel value. */
+  readonly value: T;
+}
+
+/**
  * Defines a typed, durable singleton message stream owned by a Flow.
  * @typeParam T - Type of every published value.
  */
@@ -104,6 +115,15 @@ export class Channel<T> {
    */
   public publish(context: Context, value: T): void {
     context.publish(this, value);
+  }
+
+  /**
+   * Stages deletion of one pending message from an RPC.
+   * @param context - Current RPC Context.
+   * @param messageId - Non-empty server-assigned message ID.
+   */
+  public delete(context: Context, messageId: string): void {
+    context.deleteChannelMessage(this as Channel<unknown>, messageId);
   }
 
   /**
@@ -208,6 +228,16 @@ export class ChannelMap<T> {
    */
   public publish(context: Context, instance: string, value: T): void {
     context.publish(this, value, instance);
+  }
+
+  /**
+   * Stages deletion of one pending message from a ChannelMap instance in an RPC.
+   * @param context - Current RPC Context.
+   * @param instance - Non-empty ChannelMap instance.
+   * @param messageId - Non-empty server-assigned message ID.
+   */
+  public delete(context: Context, instance: string, messageId: string): void {
+    context.deleteChannelMessage(this as ChannelMap<unknown>, messageId, instance);
   }
 
   /**

--- a/sdk-typescript/src/worker-dispatcher.ts
+++ b/sdk-typescript/src/worker-dispatcher.ts
@@ -249,6 +249,7 @@ export class WorkerDispatcher {
         upsertAttributes: [...context.getAttributeWrites()],
         recordEvents: [...context.getEvents()],
         publishToChannel: [...context.getPublications()],
+        deleteFromChannel: [...context.getChannelDeletions()],
       });
     } catch (failure) {
       throw invalidStepResult(flow.name, undefined, "rpc", failure);

--- a/web/README.md
+++ b/web/README.md
@@ -1,5 +1,10 @@
 # Dex Web
 
+The live Flow overview lists pending Channel messages with their server-assigned
+IDs and decoded values. Operators can delete a pending message. Temporal performs
+the deletion atomically; the Cadence query-plus-signal fallback is best effort and
+can race message consumption.
+
 Dex Web searches flows and displays Dex semantic history, step topology,
 live flow state, time travel points, and stop controls.
 

--- a/web/api/handlers.go
+++ b/web/api/handlers.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/superdurable/dex/gen/dexpb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -44,12 +45,37 @@ func RegisterHandlers(mux *http.ServeMux, client dexpb.FlowServiceClient) {
 	mux.HandleFunc("GET /api/flows/summary", handler.getFlowSummary)
 	mux.HandleFunc("GET /api/flows/history", handler.getHistoryEvents)
 	mux.HandleFunc("GET /api/flows/state", handler.getFlowState)
+	mux.HandleFunc("DELETE /api/flows/channels/messages", handler.deleteChannelMessage)
 	mux.HandleFunc("GET /api/flows/wait", handler.waitForHistoryEvent)
 	mux.HandleFunc("GET /api/flows/stream", handler.readStream)
 	mux.HandleFunc("POST /api/flows/time-travel", handler.timeTravelFlow)
 	mux.HandleFunc("POST /api/flows/stop", handler.stopFlow)
 	mux.HandleFunc("POST /api/blobs/load", handler.loadBlobs)
 	mux.HandleFunc("GET /healthz", health)
+}
+
+func (h *handler) deleteChannelMessage(response http.ResponseWriter, request *http.Request) {
+	var body deleteChannelMessageRequest
+	if err := decodeJSON(response, request, &body); err != nil {
+		WriteError(response, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+	if body.FlowID == "" || body.ChannelName == "" || body.MessageID == "" {
+		WriteError(response, http.StatusBadRequest, "flowId, channelName, and messageId are required", nil)
+		return
+	}
+	_, err := h.client.DeleteChannelMessage(request.Context(), &dexpb.DeleteChannelMessageRequest{
+		FlowId:      body.FlowID,
+		RunId:       body.RunID,
+		ChannelName: body.ChannelName,
+		MessageId:   body.MessageID,
+		RequestId:   uuid.NewString(),
+	})
+	if err != nil {
+		writeGRPCError(response, err, "DeleteChannelMessage")
+		return
+	}
+	writeJSON(response, http.StatusOK, map[string]bool{"deleted": true})
 }
 
 func (h *handler) searchFlows(response http.ResponseWriter, request *http.Request) {

--- a/web/api/types.go
+++ b/web/api/types.go
@@ -87,6 +87,13 @@ type flowState struct {
 	CompletedSteps         []interface{}          `json:"completedSteps"`
 }
 
+type deleteChannelMessageRequest struct {
+	FlowID      string `json:"flowId"`
+	RunID       string `json:"runId"`
+	ChannelName string `json:"channelName"`
+	MessageID   string `json:"messageId"`
+}
+
 type streamMessage struct {
 	Value       interface{} `json:"value"`
 	ResumeToken string      `json:"resumeToken"`

--- a/web/app/flows/RunDetailsPage.tsx
+++ b/web/app/flows/RunDetailsPage.tsx
@@ -88,6 +88,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
   const [selectedEvent, setSelectedEvent] = useState<FlowHistoryEvent | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [deletingChannelMessage, setDeletingChannelMessage] = useState('');
   const [error, setError] = useState('');
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [timeTravelOpen, setTimeTravelOpen] = useState(false);
@@ -173,6 +174,24 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
       setError(stateError instanceof Error ? stateError.message : 'State query failed');
     }
   }, [addDataWarning, stateURL]);
+
+  const deleteChannelMessage = useCallback(async (channelName: string, messageId: string) => {
+    if (!summary) return;
+    setDeletingChannelMessage(messageId);
+    setError('');
+    try {
+      await readResponseJSON(await fetch('/api/flows/channels/messages', {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ flowId, runId, channelName, messageId }),
+      }));
+    } catch (deleteError) {
+      setError(deleteError instanceof Error ? deleteError.message : 'Channel deletion failed');
+    } finally {
+      setDeletingChannelMessage('');
+      await loadState(summary.flowStatusCode);
+    }
+  }, [flowId, loadState, runId, summary]);
 
   const hydrateEvent = useCallback(async (event: FlowHistoryEvent) => {
     if (hydratedEventIDs.current.has(event.eventId)
@@ -494,6 +513,8 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
               events={displayedHistory}
               state={state}
               selectedEvent={selected}
+              deletingChannelMessage={deletingChannelMessage}
+              onDeleteChannelMessage={deleteChannelMessage}
             />
           )}
           {tab === 'steps' && (

--- a/web/app/flows/details/FlowOverview.test.tsx
+++ b/web/app/flows/details/FlowOverview.test.tsx
@@ -127,4 +127,41 @@ describe('live Flow state failures', () => {
     expect(markup).toContain('second');
     expect(markup).toContain('<details class="semantic-record semantic-map-entry">');
   });
+
+  it('shows pending Channel message IDs and deletion controls', () => {
+    const state: FlowState = {
+      flowConfig: {},
+      attributes: [],
+      activeStepExecutions: [],
+      queuedSteps: [],
+      pendingChannelMessages: {
+        approvals: { values: [{ messageId: '0198-message', value: 'approve' }] },
+      },
+      completedSteps: [],
+    };
+    const summary: FlowSummary = {
+      flowId: 'flow-1',
+      runId: 'run-1',
+      firstRunId: 'run-1',
+      requestId: 'request-1',
+      flowType: 'PaymentFlow',
+      flowStatus: 'Running',
+      flowStatusCode: 1,
+      startTime: '2026-08-10T00:00:00Z',
+      closeTime: null,
+    };
+    const markup = renderToStaticMarkup(
+      <FlowOverview
+        summary={summary}
+        events={[]}
+        state={state}
+        selectedEvent={null}
+        onDeleteChannelMessage={async () => {}}
+      />,
+    );
+
+    expect(markup).toContain('0198-message');
+    expect(markup).toContain('Delete');
+    expect(markup).toContain('Cadence deletion is best effort');
+  });
 });

--- a/web/app/flows/details/FlowOverview.tsx
+++ b/web/app/flows/details/FlowOverview.tsx
@@ -55,11 +55,15 @@ export function FlowOverview({
   events,
   state,
   selectedEvent,
+  deletingChannelMessage,
+  onDeleteChannelMessage,
 }: {
   summary: FlowSummary;
   events: FlowHistoryEvent[];
   state: FlowState | null;
   selectedEvent: FlowHistoryEvent | null;
+  deletingChannelMessage?: string;
+  onDeleteChannelMessage?: (channelName: string, messageId: string) => Promise<void>;
 }) {
   const started = events.find((event) => event.type === 'FlowStartedOrContinued');
   const closed = events.findLast((event) => event.type === 'FlowClosed');
@@ -72,6 +76,7 @@ export function FlowOverview({
   const activeStepIds = state?.activeStepExecutions.map((step) => step.stepExecutionId) ?? [];
   const allActiveStepsExpanded = activeStepIds.length > 0
     && activeStepIds.every((stepExecutionId) => !collapsedActiveStepIds.has(stepExecutionId));
+  const pendingMessages = pendingChannelEntries(state?.pendingChannelMessages ?? {});
 
   const setAllActiveStepsExpanded = (expanded: boolean) => {
     setCollapsedActiveStepIds((current) => {
@@ -215,6 +220,34 @@ export function FlowOverview({
                   forceOpen={channelsExpand.expanded || undefined}
                   collapseNonce={channelsExpand.collapseNonce}
                 />
+                {pendingMessages.length > 0 && (
+                  <div className="channel-message-list">
+                    {pendingMessages.map((message) => (
+                      <div className="channel-message-row" key={`${message.channelName}:${message.messageId}`}>
+                        <div>
+                          <b>{message.channelName}</b>
+                          <code>{message.messageId}</code>
+                          <JsonView value={message.value} label="Value" />
+                        </div>
+                        {onDeleteChannelMessage && (
+                          <button
+                            className="button danger"
+                            disabled={deletingChannelMessage === message.messageId}
+                            onClick={() => void onDeleteChannelMessage(
+                              message.channelName,
+                              message.messageId,
+                            )}
+                          >
+                            {deletingChannelMessage === message.messageId ? 'Deleting…' : 'Delete'}
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                    <p className="muted">
+                      Temporal deletes are atomic. Cadence deletion is best effort and may race consumption.
+                    </p>
+                  </div>
+                )}
                 <JsonView
                   value={state.pendingChannelMessages}
                   label="Pending channel messages"
@@ -313,4 +346,24 @@ export function FlowOverview({
       </div>
     </div>
   );
+}
+
+interface PendingChannelEntry {
+  channelName: string;
+  messageId: string;
+  value: unknown;
+}
+
+function pendingChannelEntries(channels: Record<string, unknown>): PendingChannelEntry[] {
+  return Object.entries(channels).flatMap(([channelName, entry]) => {
+    if (typeof entry !== 'object' || entry === null) return [];
+    const values = 'values' in entry ? (entry as { values?: unknown }).values : undefined;
+    if (!Array.isArray(values)) return [];
+    return values.flatMap((message) => {
+      if (typeof message !== 'object' || message === null) return [];
+      const envelope = message as { messageId?: unknown; value?: unknown };
+      if (typeof envelope.messageId !== 'string' || envelope.messageId.length === 0) return [];
+      return [{ channelName, messageId: envelope.messageId, value: envelope.value }];
+    });
+  });
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -493,6 +493,27 @@ h3 {
   background: var(--danger);
 }
 
+.channel-message-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.channel-message-row {
+  align-items: start;
+  border: 1px solid var(--line);
+  border-radius: 0.75rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 0.75rem;
+}
+
+.channel-message-row code {
+  display: block;
+  margin-top: 0.25rem;
+}
+
 .saved-query-panel {
   display: grid;
   grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
## Summary

- add typed pending Channel message list/delete APIs to the Python, Go, Java, TypeScript, and Rust SDKs
- let RPC handlers stage Channel message deletions and expose the `is_transactional` / `isTransactional` / `IsTransactional` option
- map missing pending messages to stable SDK-specific errors
- add Dex Web pending-message inspection and deletion controls with Cadence best-effort guidance
- add dexcli Channel message list/delete commands and raw `isTransactional` RPC input support
- update SDK, Web, CLI, and design documentation

## Rationale and user impact

Applications can now inspect durable pending Channel queues, identify messages by their server-assigned UUIDv7 IDs, and remove individual pending messages. Transactional RPCs can combine Channel deletion with other reads and writes so a missing message aborts the RPC on Temporal. Attribute locks continue to select transactional execution automatically; deletion by itself requires the explicit transactional option. Cadence retains its documented query-and-signal best-effort behavior.

## Validation

- `make -C sdk-go unitTests`
- `./sdk-java/gradlew -p sdk-java check`
- `uv run --project sdk-python --python 3.11 pytest tests/test_contracts.py`
- `uv run --project sdk-python --python 3.11 mypy --strict tests/typecheck_contracts.py tests/integ`
- `uv run --project sdk-python --python 3.11 pyright tests/typecheck_contracts.py tests/integ`
- Python pre-commit hooks on all changed Phase 2 files
- `make -C sdk-rust test`
- `make -C sdk-rust docs-check`
- `make -C sdk-rust lint`
- `npm --prefix sdk-typescript test`
- `npm --prefix sdk-typescript run docs:check`
- `npm --prefix sdk-typescript run typecheck`
- `npm --prefix web run check`
- `npm --prefix web run build`
- `GOWORK=off go test ./...` in `web/`
- `make -C cli test`
- `make generated-code-check`
- `make copyright-check`
- `make docs-prose-check`
