### PR TITLE
Reject slash-containing map instances in SDKs

### DIFF
--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -81,6 +81,8 @@ one requires equivalent updates to all three in the same commit.
   interface, class, method, function, constructor, field, constant, enum value,
   struct member, annotation element, and equivalent language construct. Do not
   document non-public or generated declarations.
+- Keep documentation direct. Put one idea in each sentence. Split behavior,
+  constraints, and rationale into separate sentences.
 - Write SDK API documentation from the application developer's perspective.
   Start with a one-sentence summary, then explain when and how to use the API.
   Give a complete language-native example for each related API family;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,9 @@ interface, class, method, function, constructor, field, constant, enum value,
 struct member, annotation element, and equivalent language construct. Do not
 add API documentation to non-public or generated declarations.
 
+Keep documentation direct. Put one idea in each sentence. Split behavior,
+constraints, and rationale into separate sentences.
+
 Write each API document from the application developer's perspective. Start
 with a one-sentence summary, then explain when and how the API is used. Give a
 complete language-native example for each related API family; overloads and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ one requires equivalent updates to all three in the same commit.
   interface, class, method, function, constructor, field, constant, enum value,
   struct member, annotation element, and equivalent language construct. Do not
   document non-public or generated declarations.
+- Keep documentation direct. Put one idea in each sentence. Split behavior,
+  constraints, and rationale into separate sentences.
 - Write SDK API documentation from the application developer's perspective.
   Start with a one-sentence summary, then explain when and how to use the API.
   Give a complete language-native example for each related API family;

--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -729,8 +729,8 @@ definition by logical name and verify static/map kind. The runtime uses the
 registered index configuration rather than trusting a same-name lookalike
 handle.
 
-Map operations derive the physical key with the Phase 2 escaping rule. Get
-first observes the invocation's latest buffered write:
+Map operations derive the physical key from the definition name and instance.
+Get first observes the invocation's latest buffered write:
 
 - a buffered Set decodes that value;
 - a buffered Delete returns `*AttributeNotFoundError`;
@@ -1901,7 +1901,8 @@ func DefineAttributeMap[T any](
 ```
 
 `AttributeMap` maps an application instance key to one flat server attribute
-key. Physical keys and their escaping are internal SDK details.
+key. Slash is prohibited in instance keys because it is a reserved character.
+Physical keys are internal SDK details.
 
 Invocation operations take `Context` explicitly:
 

--- a/docs/design/plan/rpc-selective-state-loading.md
+++ b/docs/design/plan/rpc-selective-state-loading.md
@@ -12,15 +12,16 @@ contents explicitly.
 `InvokeRPCRequest` has three collection selectors:
 
 - `load_attribute_map_selectors` loads every current entry with `AttributeMap/`
-  or one entry with `AttributeMap/<escaped-instance>`.
+  or one entry with `AttributeMap/<instance>`.
 - `load_channel_names` loads pending envelopes for each selected Channel
   definition.
 - `load_channel_map_selectors` loads pending envelopes for every current instance
-  with `ChannelMap/`, or one instance with `ChannelMap/<escaped-instance>`.
+  with `ChannelMap/`, or one instance with `ChannelMap/<instance>`.
 
 Singleton Channel selectors are definition names. Map selectors contain exactly
-one `/`: a trailing separator selects all instances and an escaped suffix selects
-one instance. Selectors must be non-empty and unique. Dex sorts them before
+one `/`. A trailing separator selects all instances. The suffix selects one
+instance. Slash is prohibited in instance keys because it is a reserved
+character. Selectors must be non-empty and unique. Dex sorts them before
 preparing the Worker request. Pagination and silent truncation are unsupported.
 
 ## Worker state projection

--- a/protos/README.md
+++ b/protos/README.md
@@ -45,7 +45,7 @@ for every known Channel and ChannelMap instance. AttributeMap entries and
 pending Channel message envelopes are loaded only when the caller selects their
 state with `load_attribute_map_selectors`, `load_channel_names`, or
 `load_channel_map_selectors`. A map selector ending in `/` loads every instance;
-otherwise its escaped suffix identifies one instance.
+otherwise its percent-encoded suffix identifies one instance.
 
 The worker request echoes validated, sorted selectors so an empty loaded collection is distinct from
 one that was not loaded. Pending messages retain FIFO order, server-generated

--- a/protos/README.md
+++ b/protos/README.md
@@ -44,8 +44,8 @@ Worker RPC requests always contain ordinary Attribute values and size metadata
 for every known Channel and ChannelMap instance. AttributeMap entries and
 pending Channel message envelopes are loaded only when the caller selects their
 state with `load_attribute_map_selectors`, `load_channel_names`, or
-`load_channel_map_selectors`. A map selector ending in `/` loads every instance;
-otherwise its percent-encoded suffix identifies one instance.
+`load_channel_map_selectors`. A map selector ending in `/` loads every instance.
+The suffix selects one instance.
 
 The worker request echoes validated, sorted selectors so an empty loaded collection is distinct from
 one that was not loaded. Pending messages retain FIFO order, server-generated

--- a/protos/dex.proto
+++ b/protos/dex.proto
@@ -810,12 +810,12 @@ message InvokeRPCRequest {
   // automatically. Channel deletion alone does not; callers must opt in.
   bool is_transactional = 8;
   // AttributeMap selectors whose entries are loaded for the RPC handler.
-  // A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+  // A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
   repeated string load_attribute_map_selectors = 9;
   // Channel definitions whose pending messages are loaded for the RPC handler.
   repeated string load_channel_names = 10;
   // ChannelMap selectors whose pending messages are loaded for the RPC handler.
-  // A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+  // A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
   repeated string load_channel_map_selectors = 11;
 }
 

--- a/protos/dex.proto
+++ b/protos/dex.proto
@@ -810,12 +810,12 @@ message InvokeRPCRequest {
   // automatically. Channel deletion alone does not; callers must opt in.
   bool is_transactional = 8;
   // AttributeMap selectors whose entries are loaded for the RPC handler.
-  // A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+  // A trailing slash selects every instance. The suffix selects one instance.
   repeated string load_attribute_map_selectors = 9;
   // Channel definitions whose pending messages are loaded for the RPC handler.
   repeated string load_channel_names = 10;
   // ChannelMap selectors whose pending messages are loaded for the RPC handler.
-  // A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+  // A trailing slash selects every instance. The suffix selects one instance.
   repeated string load_channel_map_selectors = 11;
 }
 

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -248,6 +248,7 @@ distinct Conditions are rejected.
 Clients wait on singleton Attribute equality in the current run with
 `WaitForAttributeEqual` or `WaitForAttributeMapInstanceEqual`. Client-side map
 reads and writes use `GetAttributeMapInstance` and `SetAttributeMapInstance`.
+Every AttributeMap and ChannelMap instance must be non-empty and must not contain `/`.
 Expected values must encode as string, bool, integer, or double; JSON, bytes,
 and null fail before the RPC is sent.
 

--- a/sdk-go/dex/attribute.go
+++ b/sdk-go/dex/attribute.go
@@ -114,8 +114,8 @@ func (a Attribute[T]) attributeSyncToAttributeStore() bool {
 
 // AttributeMap defines keyed typed persisted values.
 //
-// Register the map once in PersistenceSchema, then supply a non-empty, slash-free instance string
-// for every access and lock.
+// Register the map once in PersistenceSchema, then supply an instance string for every access and lock.
+// Slash is prohibited in instance keys because it is a reserved character.
 // String values require valid UTF-8; use []byte for arbitrary bytes.
 type AttributeMap[T any] struct {
 	name                 string
@@ -306,8 +306,8 @@ type InitialAttributeDef interface {
 }
 
 // InitialAttributeMapValue encodes one Attribute-map instance for StartFlowOptions.Attributes.
-// The instance must be non-empty and slash-free. It returns ValueMappingError when the value is
-// unsupported or incompatible with its index.
+// The instance identifies the map entry. Slash is prohibited in instance keys because it is a reserved character.
+// It returns ValueMappingError when the value is unsupported or incompatible with its index.
 func InitialAttributeMapValue[T any](
 	attribute AttributeMap[T],
 	instance string,

--- a/sdk-go/dex/attribute.go
+++ b/sdk-go/dex/attribute.go
@@ -114,8 +114,8 @@ func (a Attribute[T]) attributeSyncToAttributeStore() bool {
 
 // AttributeMap defines keyed typed persisted values.
 //
-// Register the map once in PersistenceSchema, then supply an instance string for every access and
-// lock.
+// Register the map once in PersistenceSchema, then supply a non-empty, slash-free instance string
+// for every access and lock.
 // String values require valid UTF-8; use []byte for arbitrary bytes.
 type AttributeMap[T any] struct {
 	name                 string
@@ -306,12 +306,16 @@ type InitialAttributeDef interface {
 }
 
 // InitialAttributeMapValue encodes one Attribute-map instance for StartFlowOptions.Attributes.
-// It returns ValueMappingError when the value is unsupported or incompatible with its index.
+// The instance must be non-empty and slash-free. It returns ValueMappingError when the value is
+// unsupported or incompatible with its index.
 func InitialAttributeMapValue[T any](
 	attribute AttributeMap[T],
 	instance string,
 	value T,
 ) (InitialAttributeDef, error) {
+	if err := validateMapInstance(instance); err != nil {
+		return nil, err
+	}
 	encoded, indexConfig, err := encodeAttributeValue(value, attribute.index)
 	if err != nil {
 		return nil, err

--- a/sdk-go/dex/channel.go
+++ b/sdk-go/dex/channel.go
@@ -143,7 +143,8 @@ func (Channel[T]) channelIsMap() bool {
 }
 
 // ChannelMap defines independently queued Channel instances under one shared name.
-// Register the map once in PersistenceSchema and supply an instance string to each operation.
+// Register the map once in PersistenceSchema and supply a non-empty, slash-free instance string
+// to each operation.
 type ChannelMap[T any] struct {
 	name string
 }

--- a/sdk-go/dex/channel.go
+++ b/sdk-go/dex/channel.go
@@ -143,8 +143,8 @@ func (Channel[T]) channelIsMap() bool {
 }
 
 // ChannelMap defines independently queued Channel instances under one shared name.
-// Register the map once in PersistenceSchema and supply a non-empty, slash-free instance string
-// to each operation.
+// Register the map once in PersistenceSchema and supply an instance string to each operation.
+// Slash is prohibited in instance keys because it is a reserved character.
 type ChannelMap[T any] struct {
 	name string
 }

--- a/sdk-go/dex/client.go
+++ b/sdk-go/dex/client.go
@@ -931,7 +931,7 @@ func (client *Client) PublishToChannel(
 
 // PublishToChannelMap appends values to one instance of a registered ChannelMap.
 //
-// instance is the logical map key and must be non-empty. Every value must match the
+// instance is the logical map key and must be non-empty and slash-free. Every value must match the
 // ChannelMap's element type and is published in argument order. Supplying no values
 // is a successful no-op. The method returns validation, serialization, registration,
 // inactive-Flow, context, transport, or server errors.
@@ -1246,7 +1246,7 @@ func (client *Client) GetAttribute(
 
 // GetAttributeMapInstance decodes one AttributeMap instance into valuePtr.
 //
-// instance must be non-empty and valuePtr must be a non-nil pointer matching the
+// instance must be non-empty and slash-free. valuePtr must be a non-nil pointer matching the
 // registered value type. The result is false with a nil error when that instance has
 // not been set; valuePtr is then unchanged. Validation, decoding, registration,
 // hydration, not-found Flow, context, transport, and server failures return errors.
@@ -1342,7 +1342,7 @@ func (client *Client) SetAttribute(
 
 // SetAttributeMapInstance writes one AttributeMap instance on an active Flow.
 //
-// instance must be non-empty and value must match the registered value type. The
+// instance must be non-empty and slash-free. value must match the registered value type. The
 // server applies the write atomically for this instance. Validation, serialization,
 // registration, inactive-Flow, context, transport, and server failures return errors.
 func (client *Client) SetAttributeMapInstance(
@@ -1524,7 +1524,7 @@ func (client *Client) WaitForAttributeEqual(
 
 // WaitForAttributeMapInstanceEqual blocks until one AttributeMap instance equals expected.
 //
-// instance must be non-empty and expected must match the registered type. A nil error means equality
+// instance must be non-empty and slash-free. expected must match the registered type. A nil error means equality
 // was observed. LongPollTimeoutError is retryable. Use context.WithTimeout or
 // context.WithDeadline for a shorter Go-side wait.
 func (client *Client) WaitForAttributeMapInstanceEqual(

--- a/sdk-go/dex/client.go
+++ b/sdk-go/dex/client.go
@@ -931,8 +931,8 @@ func (client *Client) PublishToChannel(
 
 // PublishToChannelMap appends values to one instance of a registered ChannelMap.
 //
-// instance is the logical map key and must be non-empty and slash-free. Every value must match the
-// ChannelMap's element type and is published in argument order. Supplying no values
+// instance identifies the map entry. Slash is prohibited in instance keys because it is a reserved character.
+// Every value must match the ChannelMap's element type and is published in argument order. Supplying no values
 // is a successful no-op. The method returns validation, serialization, registration,
 // inactive-Flow, context, transport, or server errors.
 func (client *Client) PublishToChannelMap(
@@ -1246,8 +1246,8 @@ func (client *Client) GetAttribute(
 
 // GetAttributeMapInstance decodes one AttributeMap instance into valuePtr.
 //
-// instance must be non-empty and slash-free. valuePtr must be a non-nil pointer matching the
-// registered value type. The result is false with a nil error when that instance has
+// instance identifies the map entry. Slash is prohibited in instance keys because it is a reserved character.
+// valuePtr must be a non-nil pointer matching the registered value type. The result is false with a nil error when that instance has
 // not been set; valuePtr is then unchanged. Validation, decoding, registration,
 // hydration, not-found Flow, context, transport, and server failures return errors.
 func (client *Client) GetAttributeMapInstance(
@@ -1342,8 +1342,8 @@ func (client *Client) SetAttribute(
 
 // SetAttributeMapInstance writes one AttributeMap instance on an active Flow.
 //
-// instance must be non-empty and slash-free. value must match the registered value type. The
-// server applies the write atomically for this instance. Validation, serialization,
+// instance identifies the map entry. Slash is prohibited in instance keys because it is a reserved character.
+// value must match the registered value type. The server applies the write atomically for this instance. Validation, serialization,
 // registration, inactive-Flow, context, transport, and server failures return errors.
 func (client *Client) SetAttributeMapInstance(
 	ctx context.Context,
@@ -1524,8 +1524,8 @@ func (client *Client) WaitForAttributeEqual(
 
 // WaitForAttributeMapInstanceEqual blocks until one AttributeMap instance equals expected.
 //
-// instance must be non-empty and slash-free. expected must match the registered type. A nil error means equality
-// was observed. LongPollTimeoutError is retryable. Use context.WithTimeout or
+// instance identifies the map entry. Slash is prohibited in instance keys because it is a reserved character.
+// expected must match the registered type. A nil error means equality was observed. LongPollTimeoutError is retryable. Use context.WithTimeout or
 // context.WithDeadline for a shorter Go-side wait.
 func (client *Client) WaitForAttributeMapInstanceEqual(
 	ctx context.Context,

--- a/sdk-go/dex/invocation.go
+++ b/sdk-go/dex/invocation.go
@@ -717,6 +717,9 @@ func sortedInstanceKeys(
 		if err != nil {
 			panic(fmt.Errorf("dex: invalid map instance key %q: %w", physical, err))
 		}
+		if err := validateMapInstance(instance); err != nil {
+			panic(fmt.Errorf("dex: invalid map instance key %q: %w", physical, err))
+		}
 		keys = append(keys, instance)
 	}
 	sort.Strings(keys)

--- a/sdk-go/dex/proto_mapper.go
+++ b/sdk-go/dex/proto_mapper.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/superdurable/dex/sdk-go/dex/ptr"
@@ -1228,10 +1229,20 @@ func physicalName(name string, instance string, isMap bool) (string, error) {
 	if !isMap {
 		return name, nil
 	}
-	if instance == "" {
-		return "", fmt.Errorf("dex: map instance must not be empty")
+	if err := validateMapInstance(instance); err != nil {
+		return "", err
 	}
 	return name + "/" + url.PathEscape(instance), nil
+}
+
+func validateMapInstance(instance string) error {
+	if instance == "" {
+		return fmt.Errorf("dex: map instance must not be empty")
+	}
+	if strings.Contains(instance, "/") {
+		return fmt.Errorf("dex: map instance must not contain '/'")
+	}
+	return nil
 }
 
 func mapWaitForFailurePolicy(

--- a/sdk-go/dex/proto_mapper_test.go
+++ b/sdk-go/dex/proto_mapper_test.go
@@ -82,6 +82,7 @@ func TestWaitMappingAssignsStableConditionIDs(t *testing.T) {
 
 func TestWaitMappingRejectsInvalidConditions(t *testing.T) {
 	channel := DefineChannel[string]("commands")
+	channelMap := DefineChannelMap[string]("commands-by-order")
 	_, err := mapWait(nil)
 	require.ErrorContains(t, err, "must not be nil")
 
@@ -114,6 +115,9 @@ func TestWaitMappingRejectsInvalidConditions(t *testing.T) {
 
 	_, err = mapWait(AllOf(channel.AtLeastAtMost(2, 1)))
 	require.ErrorContains(t, err, "below at_least")
+
+	_, err = mapWait(AllOf(channelMap.ForOne("tenant/order")))
+	require.ErrorContains(t, err, "map instance must not contain '/'")
 }
 
 func TestStepDecisionAndOptionsMapping(t *testing.T) {
@@ -194,6 +198,8 @@ func TestStartAndFlowConfigMappingPreservesPresence(t *testing.T) {
 	attributeMap := DefineAttributeMap[string]("status-by-tenant", SyncToAttributeStore())
 	initialMap, err := InitialAttributeMapValue(attributeMap, "tenant-1", "ready")
 	require.NoError(t, err)
+	_, err = InitialAttributeMapValue(attributeMap, "tenant/order", "ready")
+	require.ErrorContains(t, err, "map instance must not contain '/'")
 	flowTimeout, timeoutPolicy, options, err := mapStartFlowOptions(StartFlowOptions{
 		Timeout:       &timeout,
 		TimeoutPolicy: TimeoutFail,

--- a/sdk-go/dex/registration_test.go
+++ b/sdk-go/dex/registration_test.go
@@ -765,6 +765,15 @@ func TestRegistryValidatesStepOptions(t *testing.T) {
 			error: "map instance must not be empty",
 		},
 		{
+			name: "slash map instance",
+			options: &StepOptions{
+				ExecuteLockAttributes: []AttributeLock{
+					LockAttributeMap(items, "tenant/order"),
+				},
+			},
+			error: "map instance must not contain '/'",
+		},
+		{
 			name: "unregistered fallback",
 			options: &StepOptions{
 				ExecuteFailure: ProceedToOnExecuteFailure(

--- a/sdk-go/dex/worker_integration_test.go
+++ b/sdk-go/dex/worker_integration_test.go
@@ -307,11 +307,11 @@ func (workerTestFlow) Update(
 	if input.Mode == "introspection" {
 		if keys := workerTestItems.AllInstanceKeys(ctx); !reflect.DeepEqual(
 			keys,
-			[]string{"initial / key", input.OrderID},
+			[]string{"initial % key", input.OrderID},
 		) || workerTestItems.MapSize(ctx) != len(keys) {
 			return nil, fmt.Errorf("unexpected AttributeMap keys %v", keys)
 		}
-		if err := workerTestItems.Delete(ctx, "initial / key"); err != nil {
+		if err := workerTestItems.Delete(ctx, "initial % key"); err != nil {
 			return nil, err
 		}
 		if keys := workerTestItems.AllInstanceKeys(ctx); !reflect.DeepEqual(
@@ -322,7 +322,7 @@ func (workerTestFlow) Update(
 		}
 		if keys := workerTestByOrder.AllInstanceKeys(ctx); !reflect.DeepEqual(
 			keys,
-			[]string{"initial / key"},
+			[]string{"initial % key"},
 		) || workerTestByOrder.MapSize(ctx) != len(keys) {
 			return nil, fmt.Errorf("unexpected ChannelMap keys %v", keys)
 		}
@@ -331,7 +331,7 @@ func (workerTestFlow) Update(
 		}
 		if keys := workerTestByOrder.AllInstanceKeys(ctx); !reflect.DeepEqual(
 			keys,
-			[]string{"initial / key", input.OrderID},
+			[]string{"initial % key", input.OrderID},
 		) || workerTestByOrder.MapSize(ctx) != len(keys) {
 			return nil, fmt.Errorf("unexpected updated ChannelMap keys %v", keys)
 		}
@@ -458,13 +458,13 @@ func TestWorkerServiceDispatchesWaitExecuteAndRPC(t *testing.T) {
 			RpcName:  "Update",
 			Input:    mustEncodeWorkerTestValue(t, rpcInput),
 			Attributes: []*dexpb.KV{{
-				Key:   "items/initial%20%2F%20key",
+				Key:   "items/initial%20%25%20key",
 				Value: mustEncodeWorkerTestValue(t, 1),
 			}},
 			ChannelInfos: map[string]*dexpb.ChannelInfo{
 				"commands":                              {Size: 2},
 				"commands-by-order/empty":               {Size: 0},
-				"commands-by-order/initial%20%2F%20key": {Size: 1},
+				"commands-by-order/initial%20%25%20key": {Size: 1},
 			},
 		},
 	)

--- a/sdk-go/gen/dexpb/dex.pb.go
+++ b/sdk-go/gen/dexpb/dex.pb.go
@@ -6720,12 +6720,12 @@ type InvokeRPCRequest struct {
 	// automatically. Channel deletion alone does not; callers must opt in.
 	IsTransactional bool `protobuf:"varint,8,opt,name=is_transactional,json=isTransactional,proto3" json:"is_transactional,omitempty"`
 	// AttributeMap selectors whose entries are loaded for the RPC handler.
-	// A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+	// A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
 	LoadAttributeMapSelectors []string `protobuf:"bytes,9,rep,name=load_attribute_map_selectors,json=loadAttributeMapSelectors,proto3" json:"load_attribute_map_selectors,omitempty"`
 	// Channel definitions whose pending messages are loaded for the RPC handler.
 	LoadChannelNames []string `protobuf:"bytes,10,rep,name=load_channel_names,json=loadChannelNames,proto3" json:"load_channel_names,omitempty"`
 	// ChannelMap selectors whose pending messages are loaded for the RPC handler.
-	// A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+	// A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
 	LoadChannelMapSelectors []string `protobuf:"bytes,11,rep,name=load_channel_map_selectors,json=loadChannelMapSelectors,proto3" json:"load_channel_map_selectors,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache

--- a/sdk-go/gen/dexpb/dex.pb.go
+++ b/sdk-go/gen/dexpb/dex.pb.go
@@ -6720,12 +6720,12 @@ type InvokeRPCRequest struct {
 	// automatically. Channel deletion alone does not; callers must opt in.
 	IsTransactional bool `protobuf:"varint,8,opt,name=is_transactional,json=isTransactional,proto3" json:"is_transactional,omitempty"`
 	// AttributeMap selectors whose entries are loaded for the RPC handler.
-	// A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+	// A trailing slash selects every instance. The suffix selects one instance.
 	LoadAttributeMapSelectors []string `protobuf:"bytes,9,rep,name=load_attribute_map_selectors,json=loadAttributeMapSelectors,proto3" json:"load_attribute_map_selectors,omitempty"`
 	// Channel definitions whose pending messages are loaded for the RPC handler.
 	LoadChannelNames []string `protobuf:"bytes,10,rep,name=load_channel_names,json=loadChannelNames,proto3" json:"load_channel_names,omitempty"`
 	// ChannelMap selectors whose pending messages are loaded for the RPC handler.
-	// A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+	// A trailing slash selects every instance. The suffix selects one instance.
 	LoadChannelMapSelectors []string `protobuf:"bytes,11,rep,name=load_channel_map_selectors,json=loadChannelMapSelectors,proto3" json:"load_channel_map_selectors,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache

--- a/sdk-go/integ/rpc_test.go
+++ b/sdk-go/integ/rpc_test.go
@@ -100,7 +100,7 @@ func (rpcFlow) SetWaitTargets(
 	if err := rpcFlowWaitStatus.Set(ctx, "ready"); err != nil {
 		return nil, err
 	}
-	if err := rpcFlowWaitMap.Set(ctx, "special / key", "mapped"); err != nil {
+	if err := rpcFlowWaitMap.Set(ctx, "special % key", "mapped"); err != nil {
 		return nil, err
 	}
 	return &dex.RPCResult[dex.None]{}, nil
@@ -182,7 +182,7 @@ func TestRPCFlow(t *testing.T) {
 			ctx,
 			flowID,
 			rpcFlowWaitMap,
-			"special / key",
+			"special % key",
 			"mapped",
 		)
 	}()

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -337,7 +337,8 @@ their parent closes.
 
 `client.waitForAttributeEqual(...)` overloads cover singleton Attributes and
 AttributeMap instances in the current run. Only String,
-boolean, integer, and floating-point wire values are accepted; objects, bytes,
+boolean, integer, and floating-point wire values are accepted. Every AttributeMap
+and ChannelMap instance must be nonblank and must not contain `/`. Objects, bytes,
 and null fail locally. `AttributeMap.getMapSize/getAllInstanceKeys` reflect
 buffered sets and deletes. The corresponding `ChannelMap` methods are RPC-only,
 include buffered publishes, and omit empty instances. Returned keys are decoded

--- a/sdk-java/src/main/java/io/superdurable/dex/Attribute.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Attribute.java
@@ -164,4 +164,12 @@ public final class Attribute<T> extends PersistenceDefinition {
         }
         return value;
     }
+
+    static String requireMapInstance(final String instance) {
+        final String value = requireName(instance);
+        if (value.contains("/")) {
+            throw new IllegalArgumentException("map instances must not contain '/'");
+        }
+        return value;
+    }
 }

--- a/sdk-java/src/main/java/io/superdurable/dex/AttributeLock.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/AttributeLock.java
@@ -49,7 +49,7 @@ public final class AttributeLock {
      * Locks one instance of an Attribute map.
      *
      * @param attribute the registered Attribute map
-     * @param instance the nonblank, slash-free map instance to lock
+     * @param instance the map instance to lock. Slash is prohibited because it is a reserved character
      * @return a lock definition for that map instance
      * @throws IllegalArgumentException if {@code instance} is {@code null}, blank, or contains {@code /}
      */

--- a/sdk-java/src/main/java/io/superdurable/dex/AttributeLock.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/AttributeLock.java
@@ -49,12 +49,12 @@ public final class AttributeLock {
      * Locks one instance of an Attribute map.
      *
      * @param attribute the registered Attribute map
-     * @param instance the nonblank map instance to lock
+     * @param instance the nonblank, slash-free map instance to lock
      * @return a lock definition for that map instance
-     * @throws IllegalArgumentException if {@code instance} is {@code null} or blank
+     * @throws IllegalArgumentException if {@code instance} is {@code null}, blank, or contains {@code /}
      */
     public static AttributeLock of(final AttributeMap<?> attribute, final String instance) {
-        return new AttributeLock(attribute.getName(), Attribute.requireName(instance));
+        return new AttributeLock(attribute.getName(), Attribute.requireMapInstance(instance));
     }
 
     String getAttribute() {

--- a/sdk-java/src/main/java/io/superdurable/dex/AttributeMap.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/AttributeMap.java
@@ -19,7 +19,8 @@ import java.util.Objects;
  * the definition once in the Flow's {@link PersistenceSchema}, then supply an instance name for
  * each read, write, delete, or lock. Each key/value pair is stored as a separate blob, so updating
  * one entry does not rewrite a large Attribute containing the entire logical map. Each value is
- * serialized with the definition's concrete {@link Class}.
+ * serialized with the definition's concrete {@link Class}. Instance names must be nonblank and
+ * must not contain {@code /}.
  *
  * <pre>{@code
  * private final AttributeMap<String> orderStatus =

--- a/sdk-java/src/main/java/io/superdurable/dex/ChannelMap.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/ChannelMap.java
@@ -18,7 +18,8 @@ import java.util.Objects;
  *
  * <p>Use a Channel map when the instance key is selected at runtime, such as one Channel per order
  * or tenant. Register the definition once in the Flow's {@link PersistenceSchema}, then pass the
- * same instance key when publishing, waiting, and reading condition results.
+ * same instance key when publishing, waiting, and reading condition results. Instance keys must
+ * be nonblank and must not contain {@code /}.
  *
  * <pre>{@code
  * private final ChannelMap<String> commands =

--- a/sdk-java/src/main/java/io/superdurable/dex/Condition.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Condition.java
@@ -87,11 +87,14 @@ public final class Condition {
         if (atLeast == null && atMost == null) {
             throw new IllegalArgumentException("channel condition requires a bound");
         }
+        final String validatedInstance = instance == null
+                ? null
+                : Attribute.requireMapInstance(instance);
         return new Condition(
                 Kind.CHANNEL,
                 conditionId,
                 channelName,
-                instance,
+                validatedInstance,
                 atLeast,
                 atMost,
                 null,

--- a/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/InvocationContext.java
@@ -499,7 +499,8 @@ final class InvocationContext implements Context {
         final List<String> keys = new ArrayList<String>(physicalKeys.size());
         for (String physical : physicalKeys) {
             try {
-                keys.add(URLDecoder.decode(physical.substring(prefix.length()), "UTF-8"));
+                keys.add(Attribute.requireMapInstance(
+                        URLDecoder.decode(physical.substring(prefix.length()), "UTF-8")));
             } catch (UnsupportedEncodingException impossible) {
                 throw new IllegalStateException(impossible);
             }

--- a/sdk-java/src/main/java/io/superdurable/dex/Registry.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/Registry.java
@@ -478,7 +478,7 @@ public final class Registry {
     }
 
     static String physicalName(final String name, final String instance) {
-        final String value = Attribute.requireName(instance);
+        final String value = Attribute.requireMapInstance(instance);
         try {
             return name + "/" + java.net.URLEncoder.encode(value, "UTF-8").replace("+", "%20");
         } catch (java.io.UnsupportedEncodingException impossible) {

--- a/sdk-java/src/main/java/io/superdurable/dex/StartFlowOptions.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StartFlowOptions.java
@@ -208,7 +208,7 @@ public final class StartFlowOptions {
          * Adds an initial Attribute-map value atomically with Flow start.
          *
          * @param attributeMap the nonnull registered Attribute map
-         * @param instance the nonblank, slash-free map instance
+         * @param instance the map instance. Slash is prohibited because it is a reserved character
          * @param value the typed initial value
          * @param <T> the Attribute value type
          * @return this builder

--- a/sdk-java/src/main/java/io/superdurable/dex/StartFlowOptions.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/StartFlowOptions.java
@@ -208,12 +208,12 @@ public final class StartFlowOptions {
          * Adds an initial Attribute-map value atomically with Flow start.
          *
          * @param attributeMap the nonnull registered Attribute map
-         * @param instance the nonblank map instance
+         * @param instance the nonblank, slash-free map instance
          * @param value the typed initial value
          * @param <T> the Attribute value type
          * @return this builder
          * @throws NullPointerException if {@code attributeMap} is {@code null}
-         * @throws IllegalArgumentException if {@code instance} is {@code null} or blank
+         * @throws IllegalArgumentException if {@code instance} is {@code null}, blank, or contains {@code /}
          */
         public <T> Builder addAttribute(
                 final AttributeMap<T> attributeMap,
@@ -221,7 +221,7 @@ public final class StartFlowOptions {
                 final T value) {
             attributes.add(new AttributeInitialization(
                     Objects.requireNonNull(attributeMap, "attributeMap"),
-                    Attribute.requireName(instance),
+                    Attribute.requireMapInstance(instance),
                     value));
             return this;
         }

--- a/sdk-java/src/main/java/io/superdurable/dex/SubFlowOptions.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/SubFlowOptions.java
@@ -187,7 +187,7 @@ public final class SubFlowOptions {
          * Adds one initial Attribute-map value to the SubFlow start.
          *
          * @param attribute an Attribute map registered by the target SubFlow
-         * @param instance the nonblank, slash-free map instance
+         * @param instance the map instance. Slash is prohibited because it is a reserved character
          * @param value the initial value, including {@code null} when supported by its value type
          * @param <T> the Attribute value type
          * @return this builder

--- a/sdk-java/src/main/java/io/superdurable/dex/SubFlowOptions.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/SubFlowOptions.java
@@ -187,12 +187,12 @@ public final class SubFlowOptions {
          * Adds one initial Attribute-map value to the SubFlow start.
          *
          * @param attribute an Attribute map registered by the target SubFlow
-         * @param instance the nonblank map instance
+         * @param instance the nonblank, slash-free map instance
          * @param value the initial value, including {@code null} when supported by its value type
          * @param <T> the Attribute value type
          * @return this builder
          * @throws NullPointerException if {@code attribute} is {@code null}
-         * @throws IllegalArgumentException if {@code instance} is blank
+         * @throws IllegalArgumentException if {@code instance} is blank or contains {@code /}
          */
         public <T> Builder addAttribute(
                 final AttributeMap<T> attribute,
@@ -200,7 +200,7 @@ public final class SubFlowOptions {
                 final T value) {
             attributes.add(new AttributeInitialization(
                     Objects.requireNonNull(attribute, "attribute"),
-                    Attribute.requireName(instance),
+                    Attribute.requireMapInstance(instance),
                     value));
             return this;
         }

--- a/sdk-java/src/main/java/io/superdurable/gen/InvokeRPCRequest.java
+++ b/sdk-java/src/main/java/io/superdurable/gen/InvokeRPCRequest.java
@@ -350,7 +350,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -363,7 +363,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -375,7 +375,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -388,7 +388,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -460,7 +460,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -473,7 +473,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -485,7 +485,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -498,7 +498,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -1819,7 +1819,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1833,7 +1833,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1845,7 +1845,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1858,7 +1858,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1872,7 +1872,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1892,7 +1892,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1911,7 +1911,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1930,7 +1930,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1946,7 +1946,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -2122,7 +2122,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2136,7 +2136,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2148,7 +2148,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2161,7 +2161,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2175,7 +2175,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2195,7 +2195,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2214,7 +2214,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2233,7 +2233,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2249,7 +2249,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+     * A trailing slash selects every instance. The suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>

--- a/sdk-java/src/main/java/io/superdurable/gen/InvokeRPCRequest.java
+++ b/sdk-java/src/main/java/io/superdurable/gen/InvokeRPCRequest.java
@@ -350,7 +350,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -363,7 +363,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -375,7 +375,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -388,7 +388,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -460,7 +460,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -473,7 +473,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -485,7 +485,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -498,7 +498,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -1819,7 +1819,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1833,7 +1833,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1845,7 +1845,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1858,7 +1858,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1872,7 +1872,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1892,7 +1892,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1911,7 +1911,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1930,7 +1930,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -1946,7 +1946,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * AttributeMap selectors whose entries are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -2122,7 +2122,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2136,7 +2136,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2148,7 +2148,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2161,7 +2161,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2175,7 +2175,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2195,7 +2195,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2214,7 +2214,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2233,7 +2233,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -2249,7 +2249,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-     * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+     * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
      * </pre>
      *
      * <code>repeated string load_channel_map_selectors = 11;</code>

--- a/sdk-java/src/main/java/io/superdurable/gen/InvokeRPCRequestOrBuilder.java
+++ b/sdk-java/src/main/java/io/superdurable/gen/InvokeRPCRequestOrBuilder.java
@@ -154,7 +154,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -165,7 +165,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -175,7 +175,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -186,7 +186,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -240,7 +240,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -251,7 +251,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -261,7 +261,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -272,7 +272,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>

--- a/sdk-java/src/main/java/io/superdurable/gen/InvokeRPCRequestOrBuilder.java
+++ b/sdk-java/src/main/java/io/superdurable/gen/InvokeRPCRequestOrBuilder.java
@@ -154,7 +154,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -165,7 +165,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -175,7 +175,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -186,7 +186,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_attribute_map_selectors = 9;</code>
@@ -240,7 +240,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -251,7 +251,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -261,7 +261,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>
@@ -272,7 +272,7 @@ public interface InvokeRPCRequestOrBuilder extends
   /**
    * <pre>
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    * </pre>
    *
    * <code>repeated string load_channel_map_selectors = 11;</code>

--- a/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/WorkerServiceIntegrationTest.java
@@ -280,7 +280,7 @@ final class WorkerServiceIntegrationTest {
         };
         final Registry registry = new Registry(Collections.<Flow<?>>singletonList(flow));
         final ValueMapper values = new ValueMapper(new ObjectMapper());
-        final String special = "special / key";
+        final String special = "special % key";
         final Map<String, ChannelInfo> channelInfos = new HashMap<String, ChannelInfo>();
         channelInfos.put(
                 Registry.physicalName("messages", special),

--- a/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/contracts/UserContractsTest.java
@@ -16,6 +16,7 @@ package io.superdurable.dex.contracts;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.superdurable.dex.Attribute;
+import io.superdurable.dex.AttributeLock;
 import io.superdurable.dex.AttributeMap;
 import io.superdurable.dex.BlobCache;
 import io.superdurable.dex.BlobCacheConfig;
@@ -96,6 +97,14 @@ public class UserContractsTest {
                 IllegalArgumentException.class,
                 () -> ChannelMap.define("orders/by-id", String.class));
 
+        final ChannelMap<String> messages = ChannelMap.define("messages", String.class);
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> messages.forOne("orders/by-id"));
+        final AttributeMap<String> items = AttributeMap.define("items", String.class);
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> AttributeLock.of(items, "orders/by-id"));
     }
 
     @Test

--- a/sdk-java/src/test/java/io/superdurable/dex/integ/PersistenceTest.java
+++ b/sdk-java/src/test/java/io/superdurable/dex/integ/PersistenceTest.java
@@ -173,7 +173,7 @@ public final class PersistenceTest {
                     () -> environment.client().waitForAttributeEqual(
                             flowId,
                             SET_ATTRIBUTES_WORKFLOW.dataMap,
-                            "special / key",
+                            "special % key",
                             "mapped-value",
                             Duration.ofSeconds(30)));
             environment.client().setAttribute(
@@ -184,7 +184,7 @@ public final class PersistenceTest {
             environment.client().setAttribute(
                     flowId,
                     SET_ATTRIBUTES_WORKFLOW.dataMap,
-                    "special / key",
+                    "special % key",
                     "mapped-value");
             waitingMap.get(30, TimeUnit.SECONDS);
             assertThrows(

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -277,7 +277,8 @@ combinations.
 Both `Client` and `AsyncClient` provide singleton and AttributeMap-instance
 overloads of `wait_for_attribute_equal`. They target the current run and accept
 only string, bool, int, or float wire values. JSON objects, bytes, and null fail
-before transport. `AttributeMap.get_map_size/get_all_instance_keys` include
+before transport. Every AttributeMap and ChannelMap instance must be non-empty
+and must not contain `/`. `AttributeMap.get_map_size/get_all_instance_keys` include
 buffered sets and deletes. The matching `ChannelMap` methods are RPC-only,
 include buffered publishes, and omit empty instances. Keys are decoded and
 sorted. Use `force_complete_if_channels_empty(...)` for conditional completion.

--- a/sdk-python/dex/_invocation_context.py
+++ b/sdk-python/dex/_invocation_context.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import Any, Callable, Protocol, Sequence, TypeVar, cast
 from urllib.parse import unquote
 
-from dex._utils import require_name
+from dex._utils import require_map_instance, require_name
 from dex._value_mapper import ValueMapper
 from dex.attribute import Attribute, AttributeMap, _apply_attribute_store_sync
 from dex.channel import Channel, ChannelMap
@@ -384,7 +384,12 @@ class InvocationContext:
                 physical_keys.discard(key)
             else:
                 physical_keys.add(key)
-        return tuple(sorted(unquote(key[len(prefix) :]) for key in physical_keys))
+        return tuple(
+            sorted(
+                require_map_instance(unquote(key[len(prefix) :]))
+                for key in physical_keys
+            )
+        )
 
     def _channel_map_keys(
         self,
@@ -396,7 +401,7 @@ class InvocationContext:
         prefix = f"{definition.name}/"
         return tuple(
             sorted(
-                unquote(key[len(prefix) :])
+                require_map_instance(unquote(key[len(prefix) :]))
                 for key, info in self._channel_infos.items()
                 if key.startswith(prefix) and info.size > 0
             )

--- a/sdk-python/dex/_utils.py
+++ b/sdk-python/dex/_utils.py
@@ -20,6 +20,13 @@ def require_persistence_definition_name(name: str) -> str:
     return name
 
 
+def require_map_instance(instance: str) -> str:
+    require_name(instance)
+    if "/" in instance:
+        raise ValueError("map instances must not contain '/'")
+    return instance
+
+
 def validate_condition_id(condition_id: str | None) -> None:
     if condition_id is not None and not condition_id:
         raise ValueError("condition ID must not be empty")

--- a/sdk-python/dex/async_client.py
+++ b/sdk-python/dex/async_client.py
@@ -319,7 +319,7 @@ class AsyncClient:
         Args:
             flow_id: The non-empty target Flow ID.
             attribute: A typed singleton Attribute or AttributeMap definition.
-            instance: The non-empty, slash-free map key; omit for a singleton Attribute.
+            instance: The map instance. Omit it for a singleton Attribute. Slash is prohibited because it is a reserved character.
             run_id: Optional exact run; ``""`` targets the current run.
 
         Returns:
@@ -1068,7 +1068,7 @@ class AsyncClient:
         Args:
             flow_id: The non-empty active Flow ID.
             attribute: The registered AttributeMap to observe.
-            instance: The non-empty, slash-free logical map key to observe.
+            instance: The map instance to observe. Slash is prohibited because it is a reserved character.
             expected: The string, bool, int, or float value to await.
             timeout: The non-negative server-side wait duration.
 

--- a/sdk-python/dex/async_client.py
+++ b/sdk-python/dex/async_client.py
@@ -319,7 +319,7 @@ class AsyncClient:
         Args:
             flow_id: The non-empty target Flow ID.
             attribute: A typed singleton Attribute or AttributeMap definition.
-            instance: The non-empty map key; omit for a singleton Attribute.
+            instance: The non-empty, slash-free map key; omit for a singleton Attribute.
             run_id: Optional exact run; ``""`` targets the current run.
 
         Returns:
@@ -1068,7 +1068,7 @@ class AsyncClient:
         Args:
             flow_id: The non-empty active Flow ID.
             attribute: The registered AttributeMap to observe.
-            instance: The non-empty logical map key to observe.
+            instance: The non-empty, slash-free logical map key to observe.
             expected: The string, bool, int, or float value to await.
             timeout: The non-negative server-side wait duration.
 

--- a/sdk-python/dex/attribute.py
+++ b/sdk-python/dex/attribute.py
@@ -177,7 +177,7 @@ class AttributeMap(Generic[ValueT]):
 
         Args:
             context: The current handler Context.
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
 
         Returns:
             The decoded instance value.
@@ -193,7 +193,7 @@ class AttributeMap(Generic[ValueT]):
 
         Args:
             context: The current handler Context.
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
             value: A value compatible with ``value_type``.
         """
         context._set_attribute(self, instance, value)
@@ -203,7 +203,7 @@ class AttributeMap(Generic[ValueT]):
 
         Args:
             context: The current handler Context.
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
         """
         context._delete_attribute(cast(AttributeMap[object], self), instance)
 
@@ -233,7 +233,7 @@ class AttributeMap(Generic[ValueT]):
         """Return a lock request for one map instance.
 
         Args:
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
 
         Returns:
             A lock for ``instance``.

--- a/sdk-python/dex/attribute.py
+++ b/sdk-python/dex/attribute.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Generic, TypeVar, cast
 
-from dex._utils import require_name, require_persistence_definition_name
+from dex._utils import require_map_instance, require_persistence_definition_name
 from dex.context import Context
 from dex.dexpb import dex_pb2 as pb
 
@@ -145,6 +145,7 @@ class AttributeMap(Generic[ValueT]):
 
     AttributeMap instances share one schema definition while keeping independent
     values and locks. Declare the map in ``PersistenceSchema`` before using it.
+    Instance keys must be non-empty and must not contain ``/``.
     Synced instances use their physical Attribute names as target columns. Projection
     is asynchronous and latest-state only, deletion projects SQL NULL, and failures
     do not roll back Flow Attributes.
@@ -176,14 +177,14 @@ class AttributeMap(Generic[ValueT]):
 
         Args:
             context: The current handler Context.
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
 
         Returns:
             The decoded instance value.
 
         Raises:
             KeyError: If the instance has no value.
-            ValueError: If ``instance`` is empty.
+            ValueError: If ``instance`` is empty or contains ``/``.
         """
         return context._get_attribute(self, instance)
 
@@ -192,7 +193,7 @@ class AttributeMap(Generic[ValueT]):
 
         Args:
             context: The current handler Context.
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
             value: A value compatible with ``value_type``.
         """
         context._set_attribute(self, instance, value)
@@ -202,7 +203,7 @@ class AttributeMap(Generic[ValueT]):
 
         Args:
             context: The current handler Context.
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
         """
         context._delete_attribute(cast(AttributeMap[object], self), instance)
 
@@ -232,15 +233,15 @@ class AttributeMap(Generic[ValueT]):
         """Return a lock request for one map instance.
 
         Args:
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
 
         Returns:
             A lock for ``instance``.
 
         Raises:
-            ValueError: If ``instance`` is empty.
+            ValueError: If ``instance`` is empty or contains ``/``.
         """
-        require_name(instance)
+        require_map_instance(instance)
         return AttributeLock(self, instance)
 
 
@@ -255,6 +256,10 @@ class AttributeLock:
 
     attribute: Attribute[Any] | AttributeMap[Any]
     instance: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.instance is not None:
+            require_map_instance(self.instance)
 
 
 def _apply_attribute_store_sync(

--- a/sdk-python/dex/channel.py
+++ b/sdk-python/dex/channel.py
@@ -226,7 +226,7 @@ class ChannelMap(Generic[ValueT]):
 
         Args:
             context: The current Step or RPC Context.
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
             value: A value compatible with ``value_type``.
         """
         context._publish_channel(self, instance, value)
@@ -236,7 +236,7 @@ class ChannelMap(Generic[ValueT]):
 
         Args:
             context: The current RPC Context.
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
             message_id: Non-empty ID returned by a Client pending-message read.
         """
         context._delete_channel_message(self, instance, message_id)
@@ -246,7 +246,7 @@ class ChannelMap(Generic[ValueT]):
 
         Args:
             context: The current Step or RPC Context.
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
 
         Returns:
             The non-negative number of queued values for ``instance``.
@@ -280,7 +280,7 @@ class ChannelMap(Generic[ValueT]):
 
         Args:
             context: The current Step Context.
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
 
         Returns:
             An ordered, read-only sequence for this Step execution.
@@ -296,7 +296,7 @@ class ChannelMap(Generic[ValueT]):
         """Create an instance condition that consumes exactly one value.
 
         Args:
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
             condition_id: Optional stable condition identifier.
 
         Returns:
@@ -319,7 +319,7 @@ class ChannelMap(Generic[ValueT]):
         """Create an instance condition that consumes exactly ``count`` values.
 
         Args:
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
             count: The required non-negative value count.
             condition_id: Optional stable condition identifier.
 
@@ -343,7 +343,7 @@ class ChannelMap(Generic[ValueT]):
         """Create an instance condition requiring at least ``count`` values.
 
         Args:
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
             count: The inclusive, non-negative lower bound.
             condition_id: Optional stable condition identifier.
 
@@ -370,7 +370,7 @@ class ChannelMap(Generic[ValueT]):
         queued for the instance at that time. An empty queue produces no values.
 
         Args:
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
             count: The inclusive, non-negative upper bound.
             condition_id: Optional stable condition identifier.
 
@@ -398,7 +398,7 @@ class ChannelMap(Generic[ValueT]):
         the condition complete immediately.
 
         Args:
-            instance: The non-empty, slash-free logical map key.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
             at_least: Optional inclusive lower bound.
             at_most: Optional inclusive upper bound.
             condition_id: Optional stable identifier unique within the Wait tree.

--- a/sdk-python/dex/channel.py
+++ b/sdk-python/dex/channel.py
@@ -203,6 +203,7 @@ class ChannelMap(Generic[ValueT]):
 
     Each ``instance`` has an independent queue and may be waited on separately.
     Add the ChannelMap definition to the Flow's ``PersistenceSchema``.
+    Instance keys must be non-empty and must not contain ``/``.
 
     Attributes:
         name: The non-empty Channel name without ``/``, unique within its Flow.
@@ -225,7 +226,7 @@ class ChannelMap(Generic[ValueT]):
 
         Args:
             context: The current Step or RPC Context.
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
             value: A value compatible with ``value_type``.
         """
         context._publish_channel(self, instance, value)
@@ -235,7 +236,7 @@ class ChannelMap(Generic[ValueT]):
 
         Args:
             context: The current RPC Context.
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
             message_id: Non-empty ID returned by a Client pending-message read.
         """
         context._delete_channel_message(self, instance, message_id)
@@ -245,7 +246,7 @@ class ChannelMap(Generic[ValueT]):
 
         Args:
             context: The current Step or RPC Context.
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
 
         Returns:
             The non-negative number of queued values for ``instance``.
@@ -279,7 +280,7 @@ class ChannelMap(Generic[ValueT]):
 
         Args:
             context: The current Step Context.
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
 
         Returns:
             An ordered, read-only sequence for this Step execution.
@@ -295,7 +296,7 @@ class ChannelMap(Generic[ValueT]):
         """Create an instance condition that consumes exactly one value.
 
         Args:
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
             condition_id: Optional stable condition identifier.
 
         Returns:
@@ -318,7 +319,7 @@ class ChannelMap(Generic[ValueT]):
         """Create an instance condition that consumes exactly ``count`` values.
 
         Args:
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
             count: The required non-negative value count.
             condition_id: Optional stable condition identifier.
 
@@ -342,7 +343,7 @@ class ChannelMap(Generic[ValueT]):
         """Create an instance condition requiring at least ``count`` values.
 
         Args:
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
             count: The inclusive, non-negative lower bound.
             condition_id: Optional stable condition identifier.
 
@@ -369,7 +370,7 @@ class ChannelMap(Generic[ValueT]):
         queued for the instance at that time. An empty queue produces no values.
 
         Args:
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
             count: The inclusive, non-negative upper bound.
             condition_id: Optional stable condition identifier.
 
@@ -397,7 +398,7 @@ class ChannelMap(Generic[ValueT]):
         the condition complete immediately.
 
         Args:
-            instance: The non-empty logical map key.
+            instance: The non-empty, slash-free logical map key.
             at_least: Optional inclusive lower bound.
             at_most: Optional inclusive upper bound.
             condition_id: Optional stable identifier unique within the Wait tree.

--- a/sdk-python/dex/client.py
+++ b/sdk-python/dex/client.py
@@ -319,7 +319,7 @@ class Client:
         Args:
             flow_id: The non-empty target Flow ID.
             attribute: A typed singleton Attribute or AttributeMap definition.
-            instance: The non-empty map key; omit for a singleton Attribute.
+            instance: The non-empty, slash-free map key; omit for a singleton Attribute.
             run_id: Optional exact run; ``""`` targets the current run.
 
         Returns:
@@ -1065,7 +1065,7 @@ class Client:
         Args:
             flow_id: The non-empty active Flow ID.
             attribute: The registered AttributeMap to observe.
-            instance: The non-empty logical map key to observe.
+            instance: The non-empty, slash-free logical map key to observe.
             expected: The string, bool, int, or float value to await.
             timeout: The non-negative server-side wait duration.
 

--- a/sdk-python/dex/client.py
+++ b/sdk-python/dex/client.py
@@ -319,7 +319,7 @@ class Client:
         Args:
             flow_id: The non-empty target Flow ID.
             attribute: A typed singleton Attribute or AttributeMap definition.
-            instance: The non-empty, slash-free map key; omit for a singleton Attribute.
+            instance: The map instance. Omit it for a singleton Attribute. Slash is prohibited because it is a reserved character.
             run_id: Optional exact run; ``""`` targets the current run.
 
         Returns:
@@ -1065,7 +1065,7 @@ class Client:
         Args:
             flow_id: The non-empty active Flow ID.
             attribute: The registered AttributeMap to observe.
-            instance: The non-empty, slash-free logical map key to observe.
+            instance: The map instance to observe. Slash is prohibited because it is a reserved character.
             expected: The string, bool, int, or float value to await.
             timeout: The non-negative server-side wait duration.
 

--- a/sdk-python/dex/condition.py
+++ b/sdk-python/dex/condition.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from dex._utils import validate_condition_id
+from dex._utils import require_map_instance, validate_condition_id
 
 if TYPE_CHECKING:
     from dex.channel import Channel, ChannelMap
@@ -53,6 +53,8 @@ class ChannelCondition(Condition, Generic[ValueT]):
         super().__post_init__()
         if self.channel is None:
             raise ValueError("channel condition requires a channel")
+        if self.instance is not None:
+            require_map_instance(self.instance)
         if self.at_least is None and self.at_most is None:
             raise ValueError("channel condition requires a bound")
         if self.at_least is not None and self.at_least < 0:

--- a/sdk-python/dex/flow.py
+++ b/sdk-python/dex/flow.py
@@ -754,14 +754,14 @@ class Registry:
 
     @staticmethod
     def physical_name(name: str, instance: str) -> str:
-        """Return the escaped physical name for a map definition instance.
+        """Return the physical name for a map instance.
 
         Args:
-            name: The logical AttributeMap or ChannelMap name.
-            instance: The non-empty, slash-free logical instance key.
+            name: The AttributeMap or ChannelMap name.
+            instance: The map instance. Slash is prohibited because it is a reserved character.
 
         Returns:
-            ``name`` followed by a slash and percent-encoded instance.
+            The physical name.
 
         Raises:
             ValueError: If ``instance`` is empty or contains ``/``.

--- a/sdk-python/dex/flow.py
+++ b/sdk-python/dex/flow.py
@@ -34,7 +34,7 @@ from typing import (
 )
 from urllib.parse import quote
 
-from dex._utils import require_name
+from dex._utils import require_map_instance, require_name
 from dex.attribute import Attribute, AttributeLock, AttributeMap
 from dex.channel import Channel, ChannelMap
 from dex.codec import Codec, CodecRegistry
@@ -625,7 +625,7 @@ class Registry:
                     raise ValueError(
                         f"RPC {rpc_name} attribute-map lock needs an instance"
                     )
-                require_name(lock.instance)
+                require_map_instance(lock.instance)
             elif lock.instance is not None:
                 raise ValueError(
                     f"RPC {rpc_name} attribute lock cannot have an instance"
@@ -758,15 +758,15 @@ class Registry:
 
         Args:
             name: The logical AttributeMap or ChannelMap name.
-            instance: The non-empty logical instance key.
+            instance: The non-empty, slash-free logical instance key.
 
         Returns:
             ``name`` followed by a slash and percent-encoded instance.
 
         Raises:
-            ValueError: If ``instance`` is empty.
+            ValueError: If ``instance`` is empty or contains ``/``.
         """
-        require_name(instance)
+        require_map_instance(instance)
         return f"{name}/{quote(instance, safe='')}"
 
     @staticmethod

--- a/sdk-python/dex/flow_options.py
+++ b/sdk-python/dex/flow_options.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, TypeVar, overload
 
-from dex._utils import require_name
+from dex._utils import require_map_instance
 from dex.attribute import Attribute, AttributeMap
 from dex.flow_config import FlowConfig
 from dex.step import RetryPolicy
@@ -156,7 +156,7 @@ class StartFlowOptions:
 
         Raises:
             TypeError: If arguments do not match either supported form.
-            ValueError: If an AttributeMap instance is empty.
+            ValueError: If an AttributeMap instance is empty or contains ``/``.
         """
         if isinstance(attribute, Attribute) and len(args) == 1:
             initialization = _AttributeInitialization(attribute, None, args[0])
@@ -164,7 +164,7 @@ class StartFlowOptions:
             instance = args[0]
             if not isinstance(instance, str):
                 raise TypeError("attribute-map instance must be a string")
-            require_name(instance)
+            require_map_instance(instance)
             initialization = _AttributeInitialization(attribute, instance, args[1])
         else:
             raise TypeError("with_attribute received invalid arguments")
@@ -249,7 +249,7 @@ class SubFlowOptions:
 
         Raises:
             TypeError: If arguments do not match either supported form.
-            ValueError: If an AttributeMap instance is empty.
+            ValueError: If an AttributeMap instance is empty or contains ``/``.
         """
         if isinstance(attribute, Attribute) and len(args) == 1:
             initialization = _AttributeInitialization(attribute, None, args[0])
@@ -257,7 +257,7 @@ class SubFlowOptions:
             instance = args[0]
             if not isinstance(instance, str):
                 raise TypeError("attribute-map instance must be a string")
-            require_name(instance)
+            require_map_instance(instance)
             initialization = _AttributeInitialization(attribute, instance, args[1])
         else:
             raise TypeError("with_attribute received invalid arguments")

--- a/sdk-python/tests/integ/test_persistence_runtime_async.py
+++ b/sdk-python/tests/integ/test_persistence_runtime_async.py
@@ -40,11 +40,11 @@ async def test_async_wait_for_attribute_equal() -> None:
         await waiting
         waiting_map = asyncio.create_task(
             environment.client.wait_for_attribute_equal(
-                flow_id, flow.data_map, "special / key", "mapped", timeout
+                flow_id, flow.data_map, "special % key", "mapped", timeout
             )
         )
         await environment.client.set_attribute(
-            flow_id, flow.data_map, "special / key", "mapped"
+            flow_id, flow.data_map, "special % key", "mapped"
         )
         await waiting_map
         with pytest.raises(ValueError, match="only string, boolean, or number values"):

--- a/sdk-python/tests/test_contracts.py
+++ b/sdk-python/tests/test_contracts.py
@@ -98,6 +98,14 @@ def test_persistence_definition_names_reserve_slash(definition: Any) -> None:
         definition()
 
 
+def test_map_instances_reserve_slash() -> None:
+    with pytest.raises(ValueError, match="map instances must not contain"):
+        ChannelMap("messages", str).for_one("orders/by-id")
+
+    with pytest.raises(ValueError, match="map instances must not contain"):
+        AttributeMap("items", str).lock("orders/by-id")
+
+
 class ApproveOrder(Step[OrderInput]):
     def get_step_type(self) -> str:
         return "ApproveOrder"
@@ -480,7 +488,7 @@ def test_map_introspection_tracks_buffered_changes() -> None:
 
     registry = Registry((MapFlow(),))
     values = ValueMapper(registry.codec_registry)
-    special = "special / key"
+    special = "special % key"
     context = InvocationContext(
         InvocationMethod.RPC,
         registry._flow_by_type("MapFlow"),

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -52,7 +52,8 @@ Client-side map reads and writes use `get_attribute_map_instance` and
 `set_attribute_map_instance`. `Client::wait_for_attribute_equal` and
 `Client::wait_for_attribute_map_instance_equal` target the current run and
 accept only string, bool, integer, or double wire values. JSON, bytes, and null
-return a local `InvalidArgument`. `AttributeMap::map_size/all_instance_keys` include
+return a local `InvalidArgument`. Every AttributeMap and ChannelMap instance must
+be non-empty and must not contain `/`. `AttributeMap::map_size/all_instance_keys` include
 buffered sets and deletes. The matching `ChannelMap` methods are RPC-only,
 include buffered publishes, and omit empty instances. Keys are decoded and
 sorted. Conditional completion is

--- a/sdk-rust/crates/dex-sdk/src/attribute.rs
+++ b/sdk-rust/crates/dex-sdk/src/attribute.rs
@@ -151,7 +151,7 @@ impl<T> Clone for Attribute<T> {
 /// Defines keyed durable values sharing one Attribute name.
 ///
 /// Each `instance` identifies an independent stored value and lock. Add the map definition once to
-/// [`crate::PersistenceSchema`]; pass an instance name on each access.
+/// [`crate::PersistenceSchema`]; pass a non-empty, slash-free instance name on each access.
 pub struct AttributeMap<T> {
     name: String,
     index: Option<AttributeIndex>,
@@ -245,9 +245,11 @@ impl<T> AttributeMap<T> {
 
     /// Creates a lock request scoped to one map instance.
     pub fn lock(&self, instance: impl Into<String>) -> AttributeLock {
+        let instance = instance.into();
+        crate::registry::assert_map_instance(&instance);
         AttributeLock {
             attribute: self.name.clone(),
-            instance: Some(instance.into()),
+            instance: Some(instance),
         }
     }
 

--- a/sdk-rust/crates/dex-sdk/src/attribute.rs
+++ b/sdk-rust/crates/dex-sdk/src/attribute.rs
@@ -34,7 +34,9 @@ pub struct Attribute<T> {
 }
 
 impl<T> Attribute<T> {
-    /// Defines an unindexed Attribute with stable slash-free `name`.
+    /// Defines an unindexed Attribute with a stable `name`.
+    ///
+    /// Slash is prohibited because it is a reserved character.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -151,7 +153,8 @@ impl<T> Clone for Attribute<T> {
 /// Defines keyed durable values sharing one Attribute name.
 ///
 /// Each `instance` identifies an independent stored value and lock. Add the map definition once to
-/// [`crate::PersistenceSchema`]; pass a non-empty, slash-free instance name on each access.
+/// [`crate::PersistenceSchema`], then pass an instance on each access.
+/// Slash is prohibited in instance keys because it is a reserved character.
 pub struct AttributeMap<T> {
     name: String,
     index: Option<AttributeIndex>,
@@ -160,7 +163,9 @@ pub struct AttributeMap<T> {
 }
 
 impl<T> AttributeMap<T> {
-    /// Defines an unindexed Attribute map with stable slash-free `name`.
+    /// Defines an unindexed Attribute map with a stable `name`.
+    ///
+    /// Slash is prohibited because it is a reserved character.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),

--- a/sdk-rust/crates/dex-sdk/src/channel.rs
+++ b/sdk-rust/crates/dex-sdk/src/channel.rs
@@ -39,7 +39,9 @@ pub struct Channel<T> {
 }
 
 impl<T> Channel<T> {
-    /// Defines a Channel with stable slash-free `name`.
+    /// Defines a Channel with a stable `name`.
+    ///
+    /// Slash is prohibited because it is a reserved character.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -137,14 +139,17 @@ impl<T> Clone for Channel<T> {
 /// Defines independently queued Channel instances under one name.
 ///
 /// Supply an instance string for every publish, read, condition, and completion guard. Add the map
-/// definition once to [`crate::PersistenceSchema`]. Instances must be non-empty and slash-free.
+/// definition once to [`crate::PersistenceSchema`].
+/// Slash is prohibited in instance keys because it is a reserved character.
 pub struct ChannelMap<T> {
     name: String,
     marker: PhantomData<fn() -> T>,
 }
 
 impl<T> ChannelMap<T> {
-    /// Defines a Channel map with stable slash-free `name`.
+    /// Defines a Channel map with a stable `name`.
+    ///
+    /// Slash is prohibited because it is a reserved character.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),

--- a/sdk-rust/crates/dex-sdk/src/channel.rs
+++ b/sdk-rust/crates/dex-sdk/src/channel.rs
@@ -137,7 +137,7 @@ impl<T> Clone for Channel<T> {
 /// Defines independently queued Channel instances under one name.
 ///
 /// Supply an instance string for every publish, read, condition, and completion guard. Add the map
-/// definition once to [`crate::PersistenceSchema`].
+/// definition once to [`crate::PersistenceSchema`]. Instances must be non-empty and slash-free.
 pub struct ChannelMap<T> {
     name: String,
     marker: PhantomData<fn() -> T>,
@@ -234,6 +234,7 @@ impl<T> ChannelMap<T> {
         at_least: Option<usize>,
         at_most: Option<usize>,
     ) -> Condition {
+        crate::registry::assert_map_instance(instance);
         Condition::channel(
             self.name.clone(),
             Some(instance.to_string()),
@@ -244,6 +245,7 @@ impl<T> ChannelMap<T> {
 
     /// Creates a conditional-completion guard requiring `instance` to be empty.
     pub fn when_empty(&self, instance: &str) -> ChannelGuard {
+        crate::registry::assert_map_instance(instance);
         ChannelGuard {
             name: self.name.clone(),
             instance: Some(instance.to_string()),

--- a/sdk-rust/crates/dex-sdk/src/client.rs
+++ b/sdk-rust/crates/dex-sdk/src/client.rs
@@ -252,10 +252,7 @@ impl Client {
         attribute: &AttributeMap<T>,
         instance: &str,
     ) -> SdkResult<Option<T>> {
-        self.get_attribute_value(
-            flow_id,
-            &crate::registry::physical_name(attribute.name(), instance),
-        )
+        self.get_attribute_value(flow_id, &map_physical_name(attribute.name(), instance)?)
     }
 
     /// Writes one Attribute on an active Flow.
@@ -292,7 +289,7 @@ impl Client {
     ) -> SdkResult<()> {
         self.set_attribute_value(
             flow_id,
-            &crate::registry::physical_name(attribute.name(), instance),
+            &map_physical_name(attribute.name(), instance)?,
             &value,
             attribute.index().map(|index| index.proto_config(true)),
             attribute.sync_config(),
@@ -329,7 +326,7 @@ impl Client {
     ) -> SdkResult<()> {
         self.publish_values(
             flow_id,
-            &crate::registry::physical_name(channel.name(), instance),
+            &map_physical_name(channel.name(), instance)?,
             values,
         )
     }
@@ -350,10 +347,7 @@ impl Client {
         channel: &ChannelMap<T>,
         instance: &str,
     ) -> SdkResult<Vec<ChannelMessage<T>>> {
-        self.get_channel_messages_value(
-            flow_id,
-            &crate::registry::physical_name(channel.name(), instance),
-        )
+        self.get_channel_messages_value(flow_id, &map_physical_name(channel.name(), instance)?)
     }
 
     /// Deletes one pending singleton Channel message by server-assigned ID.
@@ -376,7 +370,7 @@ impl Client {
     ) -> SdkResult<()> {
         self.delete_channel_message_value(
             flow_id,
-            &crate::registry::physical_name(channel.name(), instance),
+            &map_physical_name(channel.name(), instance)?,
             message_id,
         )
     }
@@ -763,7 +757,7 @@ impl Client {
     ) -> SdkResult<()> {
         self.wait_for_attribute_value(
             flow_id,
-            &crate::registry::physical_name(attribute.name(), instance),
+            &map_physical_name(attribute.name(), instance)?,
             &expected,
             timeout,
         )
@@ -1450,6 +1444,11 @@ fn require_name(value: &str, kind: &str) -> SdkResult<()> {
     } else {
         Ok(())
     }
+}
+
+fn map_physical_name(name: &str, instance: &str) -> SdkResult<String> {
+    crate::registry::validate_map_instance(instance).map_err(invalid)?;
+    Ok(crate::registry::physical_name(name, instance))
 }
 
 fn sdk_handler_error(error: impl std::fmt::Display) -> SdkError {

--- a/sdk-rust/crates/dex-sdk/src/context.rs
+++ b/sdk-rust/crates/dex-sdk/src/context.rs
@@ -17,7 +17,7 @@ use dex_protocol::dex::{
 };
 
 use crate::persistence::PersistenceKind;
-use crate::registry::{RegisteredFlow, decode_instance, physical_name};
+use crate::registry::{RegisteredFlow, decode_instance, physical_name, validate_map_instance};
 use crate::value_mapper;
 use crate::worker_output::StepOutputEmitter;
 use crate::{
@@ -865,14 +865,17 @@ impl Context {
             ));
         }
         match kind {
-            PersistenceKind::AttributeMap | PersistenceKind::ChannelMap => instance
-                .map(|instance| physical_name(name, instance))
-                .ok_or_else(|| {
+            PersistenceKind::AttributeMap | PersistenceKind::ChannelMap => {
+                let instance = instance.ok_or_else(|| {
                     HandlerError::new(
                         "dex_sdk::HandlerError",
                         format!("{name} requires an instance"),
                     )
-                }),
+                })?;
+                validate_map_instance(instance)
+                    .map_err(|error| HandlerError::new("dex_sdk::HandlerError", error))?;
+                Ok(physical_name(name, instance))
+            }
             PersistenceKind::Attribute | PersistenceKind::Channel if instance.is_none() => {
                 Ok(name.to_string())
             }
@@ -1024,7 +1027,7 @@ mod tests {
         let registered = registry.flow("MapFlow").expect("lookup map Flow").clone();
         let attributes = AttributeMap::<String>::new("items");
         let channels = ChannelMap::<String>::new("messages");
-        let special = "special / key";
+        let special = "special % key";
         let mut context = Context::new(
             ContextInput {
                 method: InvocationMethod::Rpc,
@@ -1051,6 +1054,17 @@ mod tests {
             InvocationCancellation::new(),
         )
         .expect("create RPC Context");
+
+        assert!(
+            attributes
+                .set(&mut context, "tenant/order", "invalid".to_string())
+                .is_err()
+        );
+        assert!(
+            channels
+                .publish(&mut context, "tenant/order", "invalid".to_string())
+                .is_err()
+        );
 
         assert_eq!(
             vec![special.to_string(), "z".to_string()],

--- a/sdk-rust/crates/dex-sdk/src/registry.rs
+++ b/sdk-rust/crates/dex-sdk/src/registry.rs
@@ -393,9 +393,7 @@ fn definition_error(message: impl Into<String>) -> SdkError {
 }
 
 pub(crate) fn physical_name(name: &str, instance: &str) -> String {
-    if instance.is_empty() {
-        panic!("persistence instance is required");
-    }
+    assert_map_instance(instance);
     let mut encoded = String::new();
     for byte in instance.bytes() {
         if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
@@ -428,7 +426,25 @@ pub(crate) fn decode_instance(physical_name: &str, prefix: &str) -> Result<Strin
             index += 1;
         }
     }
-    String::from_utf8(decoded).map_err(|error| error.to_string())
+    let instance = String::from_utf8(decoded).map_err(|error| error.to_string())?;
+    validate_map_instance(&instance)?;
+    Ok(instance)
+}
+
+pub(crate) fn assert_map_instance(instance: &str) {
+    if let Err(error) = validate_map_instance(instance) {
+        panic!("{error}");
+    }
+}
+
+pub(crate) fn validate_map_instance(instance: &str) -> Result<(), String> {
+    if instance.is_empty() {
+        return Err("map instance is required".to_string());
+    }
+    if instance.contains('/') {
+        return Err("map instances must not contain '/'".to_string());
+    }
+    Ok(())
 }
 
 fn hex_value(byte: u8) -> Result<u8, String> {
@@ -469,9 +485,6 @@ mod tests {
             assert!(result.is_err());
         }
 
-        assert_eq!(
-            physical_name("messages", "orders/by-id"),
-            "messages/orders%2Fby-id"
-        );
+        assert!(std::panic::catch_unwind(|| physical_name("messages", "orders/by-id")).is_err());
     }
 }

--- a/sdk-rust/crates/dex-sdk/src/start_flow_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/start_flow_options.rs
@@ -162,7 +162,7 @@ impl StartFlowOptions {
         self
     }
 
-    /// Adds an initial value for one Attribute-map instance.
+    /// Adds an initial value for one non-empty, slash-free Attribute-map instance.
     pub fn initial_attribute_map<T: Value>(
         mut self,
         attribute: &AttributeMap<T>,

--- a/sdk-rust/crates/dex-sdk/src/start_flow_options.rs
+++ b/sdk-rust/crates/dex-sdk/src/start_flow_options.rs
@@ -162,7 +162,8 @@ impl StartFlowOptions {
         self
     }
 
-    /// Adds an initial value for one non-empty, slash-free Attribute-map instance.
+    /// Adds an initial value for one Attribute-map instance.
+    /// Slash is prohibited in instance keys because it is a reserved character.
     pub fn initial_attribute_map<T: Value>(
         mut self,
         attribute: &AttributeMap<T>,

--- a/sdk-rust/crates/dex-sdk/src/sub_flow.rs
+++ b/sdk-rust/crates/dex-sdk/src/sub_flow.rs
@@ -107,7 +107,7 @@ impl SubFlowOptions {
         self
     }
 
-    /// Adds one initial Attribute-map value owned by the target SubFlow.
+    /// Adds one initial Attribute-map value with a non-empty, slash-free instance.
     pub fn initial_attribute_map<T: Value>(
         mut self,
         attribute: &AttributeMap<T>,

--- a/sdk-rust/crates/dex-sdk/src/sub_flow.rs
+++ b/sdk-rust/crates/dex-sdk/src/sub_flow.rs
@@ -107,7 +107,8 @@ impl SubFlowOptions {
         self
     }
 
-    /// Adds one initial Attribute-map value with a non-empty, slash-free instance.
+    /// Adds one initial Attribute-map value for an instance.
+    /// Slash is prohibited in instance keys because it is a reserved character.
     pub fn initial_attribute_map<T: Value>(
         mut self,
         attribute: &AttributeMap<T>,

--- a/sdk-rust/crates/dex-sdk/tests/integ/persistence_test.rs
+++ b/sdk-rust/crates/dex-sdk/tests/integ/persistence_test.rs
@@ -252,7 +252,7 @@ fn test_set_data_attributes() {
             environment.client.wait_for_attribute_map_instance_equal(
                 &flow_id,
                 &workflow.data_map,
-                "special / key",
+                "special % key",
                 "mapped-value".to_string(),
                 Duration::from_secs(30),
             )
@@ -262,7 +262,7 @@ fn test_set_data_attributes() {
             .set_attribute_map_instance(
                 &flow_id,
                 &workflow.data_map,
-                "special / key",
+                "special % key",
                 "mapped-value".to_string(),
             )
             .expect("set special AttributeMap entry");

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -154,8 +154,9 @@ the same Condition object may be reused across combinations.
 
 `Client.waitForAttributeEqual` overloads target the current
 run and accept only string, boolean, integer, or double wire values. JSON,
-bytes, and null reject before transport. `AttributeMap.getMapSize` and
-`getAllInstanceKeys` include buffered sets and deletes. The matching
+bytes, and null reject before transport. Every AttributeMap and ChannelMap
+instance must be non-empty and must not contain `/`. `AttributeMap.getMapSize`
+and `getAllInstanceKeys` include buffered sets and deletes. The matching
 `ChannelMap` methods are RPC-only, include buffered publishes, and omit empty
 instances. Keys are decoded and sorted. Use
 `forceCompleteIfChannelsEmpty(...)` for conditional completion.

--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -84,7 +84,7 @@ import {
 import { Attribute, AttributeMap, IndexType } from "./persistence.js";
 import type { RPCResult } from "./rpc.js";
 import type { RetryPolicy, StepOptions } from "./step.js";
-import { requireName } from "./validation.js";
+import { requireMapInstance, requireName } from "./validation.js";
 import { codecOrJson, decodeUnknown, decodeValue, encodeValue, ValueHydrator } from "./value-mapper.js";
 import { ChannelMap, type Channel, type ChannelMessage } from "./wait.js";
 import type { Stream, StreamMessage } from "./stream.js";
@@ -327,7 +327,7 @@ export class Client {
    * @typeParam T - Attribute value type.
    * @param flowId - Non-empty existing Flow ID.
    * @param attribute - Typed AttributeMap definition.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @param runId - Optional exact run; targets the current run when omitted.
    * @returns The decoded value, or `undefined` when unset.
    */
@@ -394,7 +394,7 @@ export class Client {
    * @typeParam T - Attribute value type.
    * @param flowId - Non-empty active Flow ID.
    * @param attribute - Typed AttributeMap definition.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @param value - Value encoded by the Attribute codec.
    * @param runId - Optional exact run; targets the active run when omitted.
    * @returns A promise resolved after Dex applies the write.
@@ -463,7 +463,7 @@ export class Client {
    * @typeParam T - Channel element type.
    * @param flowId - Non-empty active Flow ID.
    * @param channel - Typed ChannelMap definition.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @param values - Values appended in argument order.
    * @returns A promise resolved after Dex accepts the batch.
    */
@@ -524,7 +524,7 @@ export class Client {
    * @typeParam T - Channel value type.
    * @param flowId - Non-empty existing Flow ID.
    * @param channel - Registered ChannelMap.
-   * @param instance - Non-empty ChannelMap instance.
+   * @param instance - Non-empty, slash-free ChannelMap instance.
    * @returns Typed pending message envelopes.
    */
   public getChannelMessages<T>(
@@ -579,7 +579,7 @@ export class Client {
    * Deletes one pending message from a ChannelMap instance by server-assigned ID.
    * @param flowId - Non-empty active Flow ID.
    * @param channel - Registered ChannelMap.
-   * @param instance - Non-empty ChannelMap instance.
+   * @param instance - Non-empty, slash-free ChannelMap instance.
    * @param messageId - Non-empty server-assigned message ID.
    */
   public deleteChannelMessage(
@@ -914,7 +914,7 @@ export class Client {
    * @typeParam T - AttributeMap value type.
    * @param flowId - Non-empty active Flow ID.
    * @param attribute - Registered AttributeMap to observe.
-   * @param instance - Non-empty logical map key to observe.
+   * @param instance - Non-empty, slash-free logical map key to observe.
    * @param expected - String, boolean, integer, or number value to await.
    * @param timeoutMs - Non-negative server-side wait duration in milliseconds.
    */
@@ -1296,7 +1296,7 @@ function physicalName(name: string, instance?: string): string {
   if (instance === undefined) {
     return name;
   }
-  requireName(instance);
+  requireMapInstance(instance);
   const encoded = encodeURIComponent(instance).replace(/[!'()*]/g, (character) =>
     `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
   );

--- a/sdk-typescript/src/client.ts
+++ b/sdk-typescript/src/client.ts
@@ -327,7 +327,7 @@ export class Client {
    * @typeParam T - Attribute value type.
    * @param flowId - Non-empty existing Flow ID.
    * @param attribute - Typed AttributeMap definition.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @param runId - Optional exact run; targets the current run when omitted.
    * @returns The decoded value, or `undefined` when unset.
    */
@@ -394,7 +394,7 @@ export class Client {
    * @typeParam T - Attribute value type.
    * @param flowId - Non-empty active Flow ID.
    * @param attribute - Typed AttributeMap definition.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @param value - Value encoded by the Attribute codec.
    * @param runId - Optional exact run; targets the active run when omitted.
    * @returns A promise resolved after Dex applies the write.
@@ -463,7 +463,7 @@ export class Client {
    * @typeParam T - Channel element type.
    * @param flowId - Non-empty active Flow ID.
    * @param channel - Typed ChannelMap definition.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @param values - Values appended in argument order.
    * @returns A promise resolved after Dex accepts the batch.
    */
@@ -524,7 +524,7 @@ export class Client {
    * @typeParam T - Channel value type.
    * @param flowId - Non-empty existing Flow ID.
    * @param channel - Registered ChannelMap.
-   * @param instance - Non-empty, slash-free ChannelMap instance.
+   * @param instance - The ChannelMap instance. Slash is prohibited because it is a reserved character.
    * @returns Typed pending message envelopes.
    */
   public getChannelMessages<T>(
@@ -579,7 +579,7 @@ export class Client {
    * Deletes one pending message from a ChannelMap instance by server-assigned ID.
    * @param flowId - Non-empty active Flow ID.
    * @param channel - Registered ChannelMap.
-   * @param instance - Non-empty, slash-free ChannelMap instance.
+   * @param instance - The ChannelMap instance. Slash is prohibited because it is a reserved character.
    * @param messageId - Non-empty server-assigned message ID.
    */
   public deleteChannelMessage(
@@ -914,7 +914,7 @@ export class Client {
    * @typeParam T - AttributeMap value type.
    * @param flowId - Non-empty active Flow ID.
    * @param attribute - Registered AttributeMap to observe.
-   * @param instance - Non-empty, slash-free logical map key to observe.
+   * @param instance - The map instance to observe. Slash is prohibited because it is a reserved character.
    * @param expected - String, boolean, integer, or number value to await.
    * @param timeoutMs - Non-negative server-side wait duration in milliseconds.
    */

--- a/sdk-typescript/src/gen/dex.ts
+++ b/sdk-typescript/src/gen/dex.ts
@@ -844,14 +844,14 @@ export interface InvokeRPCRequest {
   isTransactional: boolean;
   /**
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    */
   loadAttributeMapSelectors: string[];
   /** Channel definitions whose pending messages are loaded for the RPC handler. */
   loadChannelNames: string[];
   /**
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
    */
   loadChannelMapSelectors: string[];
 }

--- a/sdk-typescript/src/gen/dex.ts
+++ b/sdk-typescript/src/gen/dex.ts
@@ -844,14 +844,14 @@ export interface InvokeRPCRequest {
   isTransactional: boolean;
   /**
    * AttributeMap selectors whose entries are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    */
   loadAttributeMapSelectors: string[];
   /** Channel definitions whose pending messages are loaded for the RPC handler. */
   loadChannelNames: string[];
   /**
    * ChannelMap selectors whose pending messages are loaded for the RPC handler.
-   * A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+   * A trailing slash selects every instance. The suffix selects one instance.
    */
   loadChannelMapSelectors: string[];
 }

--- a/sdk-typescript/src/invocation-context.ts
+++ b/sdk-typescript/src/invocation-context.ts
@@ -27,7 +27,7 @@ import { requireFlowStream, type RegisteredFlow } from "./flow.js";
 import { createFlowResultFromProto, type FlowResult } from "./flow-result.js";
 import { AttributeMap, IndexType, type Attribute } from "./persistence.js";
 import { codecOrJson, decodeValue, deletionValue, encodeValue } from "./value-mapper.js";
-import { requireName } from "./validation.js";
+import { requireMapInstance, requireName } from "./validation.js";
 import { ChannelMap, type Channel } from "./wait.js";
 import type { Stream } from "./stream.js";
 
@@ -291,7 +291,7 @@ export class InvocationContext implements AsyncContext {
       }
     }
     return [...physicalKeys]
-      .map((key) => decodeURIComponent(key.slice(prefix.length)))
+      .map((key) => requireMapInstance(decodeURIComponent(key.slice(prefix.length))))
       .sort();
   }
 
@@ -341,7 +341,7 @@ export class InvocationContext implements AsyncContext {
     const prefix = `${channel.name}/`;
     return [...this.channelInfos]
       .filter(([key, info]) => key.startsWith(prefix) && info.size > 0)
-      .map(([key]) => decodeURIComponent(key.slice(prefix.length)))
+      .map(([key]) => requireMapInstance(decodeURIComponent(key.slice(prefix.length))))
       .sort();
   }
 
@@ -405,7 +405,7 @@ function definitionName(
     if (instance === undefined) {
       throw new TypeError(`map definition ${definition.name} requires an instance`);
     }
-    requireName(instance);
+    requireMapInstance(instance);
     return `${definition.name}/${encodeURIComponent(instance).replace(/[!'()*]/g, encodeCharacter)}`;
   }
   if (instance !== undefined) {

--- a/sdk-typescript/src/options.ts
+++ b/sdk-typescript/src/options.ts
@@ -8,7 +8,7 @@
 
 import type { Attribute, AttributeMap } from "./persistence.js";
 import type { RetryPolicy, StepDurability } from "./step.js";
-import { requireName } from "./validation.js";
+import { requireMapInstance, requireName } from "./validation.js";
 
 /** Configures FlowService connectivity and default Flow routing. */
 export interface ClientOptions {
@@ -92,7 +92,7 @@ export interface FlowConfig {
 export interface InitialAttribute<T> {
   /** Registered singleton Attribute or AttributeMap definition. */
   readonly attribute: Attribute<T> | AttributeMap<T>;
-  /** Required non-empty map key; omitted for a singleton Attribute. */
+  /** Required non-empty, slash-free map key; omitted for a singleton Attribute. */
   readonly instance?: string;
   /** Typed initial value. */
   readonly value: T;
@@ -114,7 +114,7 @@ export const InitialAttribute = Object.freeze({
    * Creates an AttributeMap instance initialization.
    * @typeParam T - Attribute value type.
    * @param attribute - Registered AttributeMap.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @param value - Typed initial value.
    * @returns The AttributeMap initialization value.
    */
@@ -123,7 +123,7 @@ export const InitialAttribute = Object.freeze({
     instance: string,
     value: T,
   ): InitialAttribute<T> {
-    requireName(instance);
+    requireMapInstance(instance);
     return { attribute, instance, value };
   },
 });

--- a/sdk-typescript/src/options.ts
+++ b/sdk-typescript/src/options.ts
@@ -92,7 +92,7 @@ export interface FlowConfig {
 export interface InitialAttribute<T> {
   /** Registered singleton Attribute or AttributeMap definition. */
   readonly attribute: Attribute<T> | AttributeMap<T>;
-  /** Required non-empty, slash-free map key; omitted for a singleton Attribute. */
+  /** The map instance. Omit it for a singleton Attribute. Slash is prohibited because it is a reserved character. */
   readonly instance?: string;
   /** Typed initial value. */
   readonly value: T;
@@ -114,7 +114,7 @@ export const InitialAttribute = Object.freeze({
    * Creates an AttributeMap instance initialization.
    * @typeParam T - Attribute value type.
    * @param attribute - Registered AttributeMap.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @param value - Typed initial value.
    * @returns The AttributeMap initialization value.
    */

--- a/sdk-typescript/src/persistence.ts
+++ b/sdk-typescript/src/persistence.ts
@@ -11,7 +11,7 @@ import { markAttributeStoreSynced } from "./attribute-store-sync.js";
 import type { Codec } from "./codec.js";
 import type { Context } from "./context.js";
 import type { Stream } from "./stream.js";
-import { requirePersistenceDefinitionName, requireName } from "./validation.js";
+import { requireMapInstance, requirePersistenceDefinitionName } from "./validation.js";
 
 /** Selects how Dex indexes an Attribute for Flow search. */
 export const IndexType = Object.freeze({
@@ -124,7 +124,7 @@ export class Attribute<T> {
 }
 
 /**
- * Defines a typed family of durable values keyed by map instance.
+ * Defines a typed family of durable values keyed by non-empty, slash-free map instance.
  * @typeParam T - Value encoded for every map instance.
  */
 export class AttributeMap<T> {
@@ -145,7 +145,7 @@ export class AttributeMap<T> {
   /**
    * Reads one map instance from handler decision state.
    * @param context - Current Step or RPC Context.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @returns The decoded instance value.
    */
   public get(context: Context, instance: string): T {
@@ -155,7 +155,7 @@ export class AttributeMap<T> {
   /**
    * Stages one map-instance write.
    * @param context - Current Step or RPC Context.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @param value - Typed value to persist.
    */
   public set(context: Context, instance: string, value: T): void {
@@ -165,7 +165,7 @@ export class AttributeMap<T> {
   /**
    * Stages deletion of one map instance.
    * @param context - Current Step or RPC Context.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    */
   public delete(context: Context, instance: string): void {
     context.deleteAttribute(this as AttributeMap<unknown>, instance);
@@ -203,11 +203,11 @@ export class AttributeMap<T> {
 
   /**
    * Creates a lock request scoped to one map instance.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @returns A lock for the requested instance.
    */
   public lock(instance: string): AttributeLock {
-    requireName(instance);
+    requireMapInstance(instance);
     return { attribute: this as AttributeMap<unknown>, instance };
   }
 }

--- a/sdk-typescript/src/persistence.ts
+++ b/sdk-typescript/src/persistence.ts
@@ -124,7 +124,8 @@ export class Attribute<T> {
 }
 
 /**
- * Defines a typed family of durable values keyed by non-empty, slash-free map instance.
+ * Defines a typed family of durable values keyed by instance.
+ * Slash is prohibited in instance keys because it is a reserved character.
  * @typeParam T - Value encoded for every map instance.
  */
 export class AttributeMap<T> {
@@ -145,7 +146,7 @@ export class AttributeMap<T> {
   /**
    * Reads one map instance from handler decision state.
    * @param context - Current Step or RPC Context.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @returns The decoded instance value.
    */
   public get(context: Context, instance: string): T {
@@ -155,7 +156,7 @@ export class AttributeMap<T> {
   /**
    * Stages one map-instance write.
    * @param context - Current Step or RPC Context.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @param value - Typed value to persist.
    */
   public set(context: Context, instance: string, value: T): void {
@@ -165,7 +166,7 @@ export class AttributeMap<T> {
   /**
    * Stages deletion of one map instance.
    * @param context - Current Step or RPC Context.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    */
   public delete(context: Context, instance: string): void {
     context.deleteAttribute(this as AttributeMap<unknown>, instance);
@@ -203,7 +204,7 @@ export class AttributeMap<T> {
 
   /**
    * Creates a lock request scoped to one map instance.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @returns A lock for the requested instance.
    */
   public lock(instance: string): AttributeLock {

--- a/sdk-typescript/src/validation.ts
+++ b/sdk-typescript/src/validation.ts
@@ -21,6 +21,14 @@ export function requirePersistenceDefinitionName(name: string): string {
   return name;
 }
 
+export function requireMapInstance(instance: string): string {
+  requireName(instance);
+  if (instance.includes("/")) {
+    throw new TypeError("map instances must not contain '/'");
+  }
+  return instance;
+}
+
 export function requireConditionId(conditionId: string | undefined): void {
   if (conditionId !== undefined && conditionId.length === 0) {
     throw new TypeError("condition ID must not be empty");

--- a/sdk-typescript/src/wait.ts
+++ b/sdk-typescript/src/wait.ts
@@ -28,7 +28,7 @@ export interface Condition {
   readonly durationMs?: number;
   /** Physical Channel name for a Channel condition. */
   readonly channelName?: string;
-  /** Non-empty, slash-free ChannelMap instance for a map condition. */
+  /** The ChannelMap instance for a map condition. Slash is prohibited because it is a reserved character. */
   readonly instance?: string;
   /** Inclusive lower queued-value bound. */
   readonly atLeast?: number;
@@ -228,7 +228,7 @@ export class ChannelMap<T> {
   /**
    * Stages one value for a ChannelMap instance.
    * @param context - Current Step or RPC Context.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @param value - Typed value to append.
    */
   public publish(context: Context, instance: string, value: T): void {
@@ -238,7 +238,7 @@ export class ChannelMap<T> {
   /**
    * Stages deletion of one pending message from a ChannelMap instance in an RPC.
    * @param context - Current RPC Context.
-   * @param instance - Non-empty, slash-free ChannelMap instance.
+   * @param instance - The ChannelMap instance. Slash is prohibited because it is a reserved character.
    * @param messageId - Non-empty server-assigned message ID.
    */
   public delete(context: Context, instance: string, messageId: string): void {
@@ -248,7 +248,7 @@ export class ChannelMap<T> {
   /**
    * Returns one instance's queued value count.
    * @param context - Current Step or RPC Context.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @returns Non-negative queued value count.
    */
   public size(context: Context, instance: string): number {
@@ -276,7 +276,7 @@ export class ChannelMap<T> {
   /**
    * Returns values selected for one instance by the satisfied condition.
    * @param context - Current Step Context.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @returns Ordered values for this Step execution.
    */
   public results(context: Context, instance: string): readonly T[] {
@@ -285,7 +285,7 @@ export class ChannelMap<T> {
 
   /**
    * Creates an instance condition consuming exactly one value.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @param conditionId - Optional stable condition identifier.
    * @returns An exact-one instance condition.
    */
@@ -295,7 +295,7 @@ export class ChannelMap<T> {
 
   /**
    * Creates an instance condition consuming exactly `count` values.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @param count - Required non-negative count.
    * @param conditionId - Optional stable condition identifier.
    * @returns A condition with equal bounds.
@@ -306,7 +306,7 @@ export class ChannelMap<T> {
 
   /**
    * Creates an instance condition requiring at least `count` values.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @param count - Inclusive non-negative lower bound.
    * @param conditionId - Optional stable condition identifier.
    * @returns A condition without an upper bound.
@@ -318,7 +318,7 @@ export class ChannelMap<T> {
   /**
    * Creates a non-blocking instance condition consuming up to `count` queued values.
    * When its surrounding Wait completes, it consumes values queued then; an empty queue yields none.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @param count - Inclusive non-negative upper bound.
    * @param conditionId - Optional stable condition identifier.
    * @returns A condition without a positive lower bound.
@@ -331,7 +331,7 @@ export class ChannelMap<T> {
    * Creates a bounded condition for one ChannelMap instance.
    * Dex waits only for `atLeast`, then consumes currently queued values up to `atMost`.
    * Omitting `atLeast` makes the condition complete immediately.
-   * @param instance - Non-empty, slash-free logical map key.
+   * @param instance - The map instance. Slash is prohibited because it is a reserved character.
    * @param atLeast - Optional inclusive lower bound.
    * @param atMost - Optional inclusive upper bound.
    * @param conditionId - Optional stable condition identifier.

--- a/sdk-typescript/src/wait.ts
+++ b/sdk-typescript/src/wait.ts
@@ -12,6 +12,7 @@ import type { Flow } from "./flow.js";
 import type { SubFlowOptions } from "./subflow.js";
 import {
   requireConditionId,
+  requireMapInstance,
   requireName,
   requirePersistenceDefinitionName,
   validateChannelBounds,
@@ -27,7 +28,7 @@ export interface Condition {
   readonly durationMs?: number;
   /** Physical Channel name for a Channel condition. */
   readonly channelName?: string;
-  /** ChannelMap instance for a map condition. */
+  /** Non-empty, slash-free ChannelMap instance for a map condition. */
   readonly instance?: string;
   /** Inclusive lower queued-value bound. */
   readonly atLeast?: number;
@@ -208,6 +209,7 @@ export class Channel<T> {
 
 /**
  * Defines keyed Channel instances that share one typed schema.
+ * Instance keys must be non-empty and must not contain `/`.
  * @typeParam T - Type of every published value.
  */
 export class ChannelMap<T> {
@@ -226,7 +228,7 @@ export class ChannelMap<T> {
   /**
    * Stages one value for a ChannelMap instance.
    * @param context - Current Step or RPC Context.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @param value - Typed value to append.
    */
   public publish(context: Context, instance: string, value: T): void {
@@ -236,7 +238,7 @@ export class ChannelMap<T> {
   /**
    * Stages deletion of one pending message from a ChannelMap instance in an RPC.
    * @param context - Current RPC Context.
-   * @param instance - Non-empty ChannelMap instance.
+   * @param instance - Non-empty, slash-free ChannelMap instance.
    * @param messageId - Non-empty server-assigned message ID.
    */
   public delete(context: Context, instance: string, messageId: string): void {
@@ -246,7 +248,7 @@ export class ChannelMap<T> {
   /**
    * Returns one instance's queued value count.
    * @param context - Current Step or RPC Context.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @returns Non-negative queued value count.
    */
   public size(context: Context, instance: string): number {
@@ -274,7 +276,7 @@ export class ChannelMap<T> {
   /**
    * Returns values selected for one instance by the satisfied condition.
    * @param context - Current Step Context.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @returns Ordered values for this Step execution.
    */
   public results(context: Context, instance: string): readonly T[] {
@@ -283,7 +285,7 @@ export class ChannelMap<T> {
 
   /**
    * Creates an instance condition consuming exactly one value.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @param conditionId - Optional stable condition identifier.
    * @returns An exact-one instance condition.
    */
@@ -293,7 +295,7 @@ export class ChannelMap<T> {
 
   /**
    * Creates an instance condition consuming exactly `count` values.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @param count - Required non-negative count.
    * @param conditionId - Optional stable condition identifier.
    * @returns A condition with equal bounds.
@@ -304,7 +306,7 @@ export class ChannelMap<T> {
 
   /**
    * Creates an instance condition requiring at least `count` values.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @param count - Inclusive non-negative lower bound.
    * @param conditionId - Optional stable condition identifier.
    * @returns A condition without an upper bound.
@@ -316,7 +318,7 @@ export class ChannelMap<T> {
   /**
    * Creates a non-blocking instance condition consuming up to `count` queued values.
    * When its surrounding Wait completes, it consumes values queued then; an empty queue yields none.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @param count - Inclusive non-negative upper bound.
    * @param conditionId - Optional stable condition identifier.
    * @returns A condition without a positive lower bound.
@@ -329,7 +331,7 @@ export class ChannelMap<T> {
    * Creates a bounded condition for one ChannelMap instance.
    * Dex waits only for `atLeast`, then consumes currently queued values up to `atMost`.
    * Omitting `atLeast` makes the condition complete immediately.
-   * @param instance - Non-empty logical map key.
+   * @param instance - Non-empty, slash-free logical map key.
    * @param atLeast - Optional inclusive lower bound.
    * @param atMost - Optional inclusive upper bound.
    * @param conditionId - Optional stable condition identifier.
@@ -343,6 +345,7 @@ export class ChannelMap<T> {
   ): Condition {
     validateChannelBounds(atLeast, atMost);
     requireConditionId(conditionId);
+    requireMapInstance(instance);
     return {
       kind: "channel",
       channelName: this.name,

--- a/sdk-typescript/src/worker-dispatcher.ts
+++ b/sdk-typescript/src/worker-dispatcher.ts
@@ -73,6 +73,7 @@ import {
   type ValueHydrator,
 } from "./value-mapper.js";
 import { Channel, ChannelMap, type Condition, type Wait } from "./wait.js";
+import { requireMapInstance } from "./validation.js";
 
 const timeoutHandlerStepType = "sys:timeout_handler";
 
@@ -884,9 +885,10 @@ function requireValue(value: Value | undefined, kind: string): Value {
 }
 
 function physicalName(name: string, instance: string | undefined): string {
-  if (instance === undefined || instance === "") {
+  if (instance === undefined) {
     throw new TypeError(`map definition ${name} requires an instance`);
   }
+  requireMapInstance(instance);
   return `${name}/${encodeURIComponent(instance).replace(/[!'()*]/g, (character) =>
     `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
   )}`;

--- a/sdk-typescript/test/contracts.test.ts
+++ b/sdk-typescript/test/contracts.test.ts
@@ -757,7 +757,7 @@ test("map introspection tracks buffered changes", () => {
     }
   }
   const registry = new Registry([new MapFlow()]);
-  const special = "special / key";
+  const special = "special % key";
   const physical = (name: string, instance: string) =>
     `${name}/${encodeURIComponent(instance).replace(/[!'()*]/g, (character) =>
       `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
@@ -788,14 +788,16 @@ test("map introspection tracks buffered changes", () => {
   assert.equal(channels.getMapSize(context), 2);
 });
 
-test("persistence definitions reserve slash while map instances keep it", () => {
+test("persistence definitions and map instances reserve slash", () => {
   assert.throws(() => new Attribute("orders/by-id", stringCodec), TypeError);
   assert.throws(() => new AttributeMap("orders/by-id", stringCodec), TypeError);
   assert.throws(() => new Channel("orders/by-id", stringCodec), TypeError);
   assert.throws(() => new ChannelMap("orders/by-id", stringCodec), TypeError);
 
   const messages = new ChannelMap("messages", stringCodec);
-  assert.equal(messages.forOne("orders/by-id").instance, "orders/by-id");
+  assert.throws(() => messages.forOne("orders/by-id"), /map instances must not contain/);
+  const items = new AttributeMap("items", stringCodec);
+  assert.throws(() => items.lock("orders/by-id"), /map instances must not contain/);
 });
 
 test("blob cache contract opens the native DXBC cache", () => {

--- a/sdk-typescript/test/integ/persistence.integration.test.ts
+++ b/sdk-typescript/test/integ/persistence.integration.test.ts
@@ -93,12 +93,12 @@ test("Client sets primitive, mapped, and model data attributes", async () => {
     const waitingMap = client.waitForAttributeEqual(
       id,
       flow.dataMap,
-      "special / key",
+      "special % key",
       "mapped-value",
       30_000,
     );
     await client.setAttribute(id, flow.dataMap, "one", "mapped-value");
-    await client.setAttribute(id, flow.dataMap, "special / key", "mapped-value");
+    await client.setAttribute(id, flow.dataMap, "special % key", "mapped-value");
     await waitingMap;
     await assert.rejects(
       client.waitForAttributeEqual(id, flow.model, { value: 8 }, 30_000),

--- a/server/README.md
+++ b/server/README.md
@@ -18,8 +18,8 @@ does not provide the same atomicity.
 Worker RPCs receive ordinary Attributes and all Channel size metadata by
 default. Callers explicitly select AttributeMap definitions and Channel or
 ChannelMap definitions when the handler needs their entries or pending message
-envelopes. A trailing-slash map selector loads every instance; a percent-encoded
-suffix selects one instance. Empty selections
+envelopes. A trailing-slash map selector loads every instance. The suffix selects
+one instance. Empty selections
 are echoed separately from their loaded data.
 
 State loading controls only the Worker request projection. Transactional

--- a/server/README.md
+++ b/server/README.md
@@ -18,8 +18,8 @@ does not provide the same atomicity.
 Worker RPCs receive ordinary Attributes and all Channel size metadata by
 default. Callers explicitly select AttributeMap definitions and Channel or
 ChannelMap definitions when the handler needs their entries or pending message
-envelopes. A trailing-slash map selector loads every instance; an escaped suffix
-loads one instance. Empty selections
+envelopes. A trailing-slash map selector loads every instance; a percent-encoded
+suffix selects one instance. Empty selections
 are echoed separately from their loaded data.
 
 State loading controls only the Worker request projection. Transactional

--- a/server/gen/dexpb/dex.pb.go
+++ b/server/gen/dexpb/dex.pb.go
@@ -6720,12 +6720,12 @@ type InvokeRPCRequest struct {
 	// automatically. Channel deletion alone does not; callers must opt in.
 	IsTransactional bool `protobuf:"varint,8,opt,name=is_transactional,json=isTransactional,proto3" json:"is_transactional,omitempty"`
 	// AttributeMap selectors whose entries are loaded for the RPC handler.
-	// A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+	// A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
 	LoadAttributeMapSelectors []string `protobuf:"bytes,9,rep,name=load_attribute_map_selectors,json=loadAttributeMapSelectors,proto3" json:"load_attribute_map_selectors,omitempty"`
 	// Channel definitions whose pending messages are loaded for the RPC handler.
 	LoadChannelNames []string `protobuf:"bytes,10,rep,name=load_channel_names,json=loadChannelNames,proto3" json:"load_channel_names,omitempty"`
 	// ChannelMap selectors whose pending messages are loaded for the RPC handler.
-	// A trailing slash selects every instance; otherwise the suffix selects one escaped instance.
+	// A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
 	LoadChannelMapSelectors []string `protobuf:"bytes,11,rep,name=load_channel_map_selectors,json=loadChannelMapSelectors,proto3" json:"load_channel_map_selectors,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache

--- a/server/gen/dexpb/dex.pb.go
+++ b/server/gen/dexpb/dex.pb.go
@@ -6720,12 +6720,12 @@ type InvokeRPCRequest struct {
 	// automatically. Channel deletion alone does not; callers must opt in.
 	IsTransactional bool `protobuf:"varint,8,opt,name=is_transactional,json=isTransactional,proto3" json:"is_transactional,omitempty"`
 	// AttributeMap selectors whose entries are loaded for the RPC handler.
-	// A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+	// A trailing slash selects every instance. The suffix selects one instance.
 	LoadAttributeMapSelectors []string `protobuf:"bytes,9,rep,name=load_attribute_map_selectors,json=loadAttributeMapSelectors,proto3" json:"load_attribute_map_selectors,omitempty"`
 	// Channel definitions whose pending messages are loaded for the RPC handler.
 	LoadChannelNames []string `protobuf:"bytes,10,rep,name=load_channel_names,json=loadChannelNames,proto3" json:"load_channel_names,omitempty"`
 	// ChannelMap selectors whose pending messages are loaded for the RPC handler.
-	// A trailing slash selects every instance. Otherwise, the percent-encoded suffix selects one instance.
+	// A trailing slash selects every instance. The suffix selects one instance.
 	LoadChannelMapSelectors []string `protobuf:"bytes,11,rep,name=load_channel_map_selectors,json=loadChannelMapSelectors,proto3" json:"load_channel_map_selectors,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache


### PR DESCRIPTION
## Summary

- reject `/` in AttributeMap and ChannelMap instance keys across the Go, Java, Python, TypeScript, and Rust SDKs
- validate instance keys at client, handler, condition, lock, initial-value, and decoded-key boundaries
- update SDK documentation and replace slash-containing positive fixtures
- clarify RPC selectors. A trailing slash selects all instances. The suffix selects one instance

## Rationale

`/` separates a persistence definition name from its map instance. It is reserved in instance keys.

## User impact

This is a breaking SDK validation change. Applications must replace AttributeMap or ChannelMap instance keys containing `/` before upgrading.

The Server behavior is unchanged. It validates selector structure, not the encoded spelling of the suffix.

## Validation

- `make -C server unitTests`
- `make -C sdk-go tests`
- `make -C sdk-go docsCheck`
- `cd sdk-java && ./gradlew test`
- `cd sdk-java && ./gradlew check javadoc`
- `cd sdk-python && uv run pytest --ignore=tests/integ`
- `cd sdk-python && uv run mypy dex`
- targeted Ruff checks for changed Python sources and tests
- `cd sdk-typescript && npm test`
- `cd sdk-typescript && npm run typecheck`
- `cd sdk-typescript && npm run docs:check`
- `make -C sdk-rust test`
- `make -C sdk-rust fmt`
- `make -C sdk-rust lint`
- `make -C sdk-rust docs-check`
- `make generated-code`
- `make copyright-check`
