### PR TITLE
Document selective RPC loading errors

### DIFF
--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -164,8 +164,9 @@ let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 ## Selective RPC state loading
 
 An RPC annotation or **Client** invoke option requests **AttributeMap** entries or pending
-**Channel** messages. Dex Server returns the actual loaded scope with the RPC snapshot. The SDK
-checks that returned scope when an RPC reads a selectively loaded collection.
+**Channel** messages. Dex Server validates that request and derives the loaded scope. It returns
+that scope with the RPC snapshot. The SDK checks the returned scope when an RPC reads a
+selectively loaded collection.
 
 For an **AttributeMap** entry or instance enumeration outside that scope, the SDK raises
 **AttributeMapNotLoadedError**. For pending messages outside that scope, it raises
@@ -175,7 +176,7 @@ For an **AttributeMap** entry or instance enumeration outside that scope, the SD
 An explicitly loaded collection can be empty. That is not an error. An empty pending-message
 snapshot returns an empty list. An absent **AttributeMap** entry uses the SDK's normal
 absent-value behavior. The not-loaded errors mean Dex Server did not return a loading guarantee
-for that collection.
+for that collection. In normal operation, the returned scope matches the requested loads.
 
 ## Transactional reads and writes {#transactional-reads-and-writes}
 

--- a/docs/content/primitives/rpc.mdx
+++ b/docs/content/primitives/rpc.mdx
@@ -161,6 +161,22 @@ let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 </SdkSnippet>
 </SdkTabs>
 
+## Selective RPC state loading
+
+An RPC annotation or **Client** invoke option requests **AttributeMap** entries or pending
+**Channel** messages. Dex Server returns the actual loaded scope with the RPC snapshot. The SDK
+checks that returned scope when an RPC reads a selectively loaded collection.
+
+For an **AttributeMap** entry or instance enumeration outside that scope, the SDK raises
+**AttributeMapNotLoadedError**. For pending messages outside that scope, it raises
+**ChannelMessagesNotLoadedError**. Java uses **AttributeMapNotLoadedException** and
+**ChannelMessagesNotLoadedException**.
+
+An explicitly loaded collection can be empty. That is not an error. An empty pending-message
+snapshot returns an empty list. An absent **AttributeMap** entry uses the SDK's normal
+absent-value behavior. The not-loaded errors mean Dex Server did not return a loading guarantee
+for that collection.
+
 ## Transactional reads and writes {#transactional-reads-and-writes}
 
 A transactional RPC performs its reads and writes as one atomic operation.

--- a/docs/design/plan/rpc-selective-state-loading.md
+++ b/docs/design/plan/rpc-selective-state-loading.md
@@ -35,8 +35,11 @@ Clients escape logical map instances and sort the resulting physical names.
 
 RPC Context APIs return typed FIFO message envelopes and support lookup by
 server-assigned message ID. A loaded empty collection returns an empty result.
-Reading a collection that was not loaded raises a stable state-not-loaded
-usage error. Staged publications and deletions do not mutate the input snapshot.
+Reading an unloaded AttributeMap entry or enumerating unloaded AttributeMap
+instances raises `AttributeMapNotLoadedError` (`AttributeMapNotLoadedException`
+in Java). Reading unloaded pending Channel messages raises
+`ChannelMessagesNotLoadedError` (`ChannelMessagesNotLoadedException` in Java).
+Staged publications and deletions do not mutate the input snapshot.
 
 ## Worker state projection
 

--- a/docs/design/plan/rpc-selective-state-loading.md
+++ b/docs/design/plan/rpc-selective-state-loading.md
@@ -55,8 +55,9 @@ Every `InvokeWorkerRPCRequest` contains:
 ChannelInfo contains only queue size metadata. Reading Channel size or
 ChannelMap keys and sizes does not require loading pending messages.
 
-The echoed names distinguish a loaded collection with no entries from a
-collection that was not loaded. An explicitly loaded empty Channel or exact
+The server derives and echoes the validated requested names. The echoed names
+distinguish a loaded collection with no entries from a collection that was not
+loaded. An explicitly loaded empty Channel or exact
 ChannelMap instance has an empty `ChannelValues` entry. An empty all-instance
 ChannelMap load is represented only by its echoed instance name.
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -165,8 +165,8 @@ let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 ## 选择性加载 RPC 状态
 
 RPC annotation 或 **Client** invoke option 会请求 **AttributeMap** entry 或 pending
-**Channel** message。Dex Server 会随 RPC snapshot 返回实际已加载的范围。RPC 读取
-选择性加载的 collection 时，SDK 会检查这个返回范围。
+**Channel** message。Dex Server 会验证请求并推导已加载范围，再随 RPC snapshot 返回。
+RPC 读取选择性加载的 collection 时，SDK 会检查这个返回范围。
 
 如果 **AttributeMap** entry 或 instance 不在该范围内，SDK 会抛出
 **AttributeMapNotLoadedError**。如果 pending message 不在该范围内，SDK 会抛出
@@ -175,7 +175,7 @@ RPC annotation 或 **Client** invoke option 会请求 **AttributeMap** entry 或
 
 显式加载的 collection 可以为空，这不是错误。空的 pending-message snapshot 会返回空列表。
 不存在的 **AttributeMap** entry 会使用 SDK 正常的缺失值语义。not-loaded error 表示
-Dex Server 没有为该 collection 返回加载保证。
+Dex Server 没有为该 collection 返回加载保证。正常情况下，返回范围与请求的加载项一致。
 
 ## Transactional read 与 write {#transactional-reads-and-writes}
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/rpc.mdx
@@ -162,6 +162,21 @@ let result = client.invoke_rpc(&workflow_id, RPC_TRIGGER, message)?;
 </SdkSnippet>
 </SdkTabs>
 
+## 选择性加载 RPC 状态
+
+RPC annotation 或 **Client** invoke option 会请求 **AttributeMap** entry 或 pending
+**Channel** message。Dex Server 会随 RPC snapshot 返回实际已加载的范围。RPC 读取
+选择性加载的 collection 时，SDK 会检查这个返回范围。
+
+如果 **AttributeMap** entry 或 instance 不在该范围内，SDK 会抛出
+**AttributeMapNotLoadedError**。如果 pending message 不在该范围内，SDK 会抛出
+**ChannelMessagesNotLoadedError**。Java 使用 **AttributeMapNotLoadedException** 和
+**ChannelMessagesNotLoadedException**。
+
+显式加载的 collection 可以为空，这不是错误。空的 pending-message snapshot 会返回空列表。
+不存在的 **AttributeMap** entry 会使用 SDK 正常的缺失值语义。not-loaded error 表示
+Dex Server 没有为该 collection 返回加载保证。
+
 ## Transactional read 与 write {#transactional-reads-and-writes}
 
 Transactional RPC 会把 RPC 的 read 和 write 作为一个 atomic operation 执行。


### PR DESCRIPTION
## Summary

Document selective RPC state loading in the English and Simplified Chinese RPC guides.

## Rationale

The SDK error split needs clear user-facing guidance on the difference between requested loads, server-returned loaded scope, and an explicitly loaded empty snapshot.

## User impact

Developers can distinguish **AttributeMapNotLoadedError** from **ChannelMessagesNotLoadedError** and understand that an empty loaded collection is valid.

## Validation

- `cd docs && npm run check`
