### PR TITLE
Add changed-component release orchestrator

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -3,6 +3,12 @@ name: Release Dex CLI
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: CLI semantic version without the v prefix
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -16,6 +22,7 @@ permissions:
 jobs:
   release:
     if: >
+      github.event_name == 'workflow_call' ||
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.release.tag_name, 'cli-v')
     runs-on: ubuntu-latest
@@ -37,12 +44,15 @@ jobs:
         id: version
         shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_call" ]; then
+            version="v${{ inputs.version }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             version="${{ inputs.version }}"
           else
             version="${GITHUB_REF_NAME#cli-}"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=cli-$version" >> "$GITHUB_OUTPUT"
       - name: Build embedded Web assets
         working-directory: web
         run: |
@@ -71,7 +81,7 @@ jobs:
             rm -r "dist/${name}"
           done
           cd dist
-          sha256sum *.tar.gz > checksums.txt
+          sha256sum -- ./*.tar.gz > checksums.txt
       - name: Generate Homebrew formula
         working-directory: cli
         env:
@@ -92,19 +102,19 @@ jobs:
             -e "s/@LINUX_AMD64_SHA256@/${linux_amd64}/g" \
             homebrew/dexcli.rb.tmpl > dist/dexcli.rb
       - name: Upload release assets
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'workflow_call'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "$GITHUB_REF_NAME" cli/dist/* --clobber
+        run: gh release upload '${{ steps.version.outputs.tag }}' cli/dist/* --clobber
       - name: Checkout Homebrew tap
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'workflow_call'
         uses: actions/checkout@v7
         with:
           repository: superdurable/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
       - name: Publish Homebrew formula
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'workflow_call'
         env:
           VERSION: ${{ steps.version.outputs.version }}
         shell: bash

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -3,6 +3,12 @@ name: Push Docker images (release)
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: Docker image semantic version without the v prefix
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -15,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     # Monorepo: only publish on server-v* release tags, or manual dispatch.
     if: >
+      github.event_name == 'workflow_call' ||
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.release.tag_name, 'server-v')
     steps:
@@ -22,7 +29,9 @@ jobs:
       - name: Resolve image tag
         id: meta
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_call" ]; then
+            echo "tag=v${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           else
             # server-v1.2.3 -> v1.2.3

--- a/.github/workflows/release-changed-components.yml
+++ b/.github/workflows/release-changed-components.yml
@@ -1,0 +1,233 @@
+name: Release changed components
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Shared semantic version for every changed component
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-changed-components
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Plan releases
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.plan.outputs.version }}
+      go: ${{ steps.plan.outputs.go }}
+      go_tag: ${{ steps.plan.outputs.go_tag }}
+      rust: ${{ steps.plan.outputs.rust }}
+      rust_tag: ${{ steps.plan.outputs.rust_tag }}
+      java: ${{ steps.plan.outputs.java }}
+      java_tag: ${{ steps.plan.outputs.java_tag }}
+      python: ${{ steps.plan.outputs.python }}
+      python_tag: ${{ steps.plan.outputs.python_tag }}
+      typescript: ${{ steps.plan.outputs.typescript }}
+      typescript_tag: ${{ steps.plan.outputs.typescript_tag }}
+      server: ${{ steps.plan.outputs.server }}
+      server_tag: ${{ steps.plan.outputs.server_tag }}
+      cli: ${{ steps.plan.outputs.cli }}
+      cli_tag: ${{ steps.plan.outputs.cli_tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Verify main branch
+        env:
+          RELEASE_REF: ${{ github.ref }}
+        run: |
+          if [[ "${RELEASE_REF}" != "refs/heads/main" ]]; then
+            echo "Changed-component releases can run only from main" >&2
+            exit 1
+          fi
+      - name: Detect changes and preflight tags
+        id: plan
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: python3 script/release/changed_components.py "${RELEASE_VERSION}" --output "${GITHUB_OUTPUT}"
+
+  reject-non-main:
+    name: Reject non-main dispatch
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Changed-component releases can run only from main" >&2
+          exit 1
+
+  create-releases:
+    name: Create selected releases
+    needs: plan
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Create GitHub Releases
+        shell: bash
+        env:
+          GO_SELECTED: ${{ needs.plan.outputs.go }}
+          GO_TAG: ${{ needs.plan.outputs.go_tag }}
+          RUST_SELECTED: ${{ needs.plan.outputs.rust }}
+          RUST_TAG: ${{ needs.plan.outputs.rust_tag }}
+          JAVA_SELECTED: ${{ needs.plan.outputs.java }}
+          JAVA_TAG: ${{ needs.plan.outputs.java_tag }}
+          PYTHON_SELECTED: ${{ needs.plan.outputs.python }}
+          PYTHON_TAG: ${{ needs.plan.outputs.python_tag }}
+          TYPESCRIPT_SELECTED: ${{ needs.plan.outputs.typescript }}
+          TYPESCRIPT_TAG: ${{ needs.plan.outputs.typescript_tag }}
+          SERVER_SELECTED: ${{ needs.plan.outputs.server }}
+          SERVER_TAG: ${{ needs.plan.outputs.server_tag }}
+          CLI_SELECTED: ${{ needs.plan.outputs.cli }}
+          CLI_TAG: ${{ needs.plan.outputs.cli_tag }}
+        run: |
+          selected=(
+            "${GO_SELECTED}:${GO_TAG}"
+            "${RUST_SELECTED}:${RUST_TAG}"
+            "${JAVA_SELECTED}:${JAVA_TAG}"
+            "${PYTHON_SELECTED}:${PYTHON_TAG}"
+            "${TYPESCRIPT_SELECTED}:${TYPESCRIPT_TAG}"
+            "${SERVER_SELECTED}:${SERVER_TAG}"
+            "${CLI_SELECTED}:${CLI_TAG}"
+          )
+          for release in "${selected[@]}"; do
+            if [[ "${release%%:*}" == "true" ]]; then
+              tag="${release#*:}"
+              gh release create "${tag}" --target "${GITHUB_SHA}" --title "${tag}" --generate-notes
+            fi
+          done
+
+  publish-java:
+    name: Publish Java SDK
+    needs: [plan, create-releases]
+    if: needs.plan.outputs.java == 'true'
+    uses: ./.github/workflows/sdk-java-publish.yml
+    with:
+      version: ${{ needs.plan.outputs.version }}
+    secrets: inherit
+
+  publish-python:
+    name: Publish Python SDK
+    needs: [plan, create-releases]
+    if: needs.plan.outputs.python == 'true'
+    uses: ./.github/workflows/sdk-python-publish.yml
+    with:
+      version: ${{ needs.plan.outputs.version }}
+      publish: true
+    secrets: inherit
+
+  publish-rust:
+    name: Publish Rust SDK
+    needs: [plan, create-releases]
+    if: needs.plan.outputs.rust == 'true'
+    uses: ./.github/workflows/sdk-rust-publish.yml
+    with:
+      version: ${{ needs.plan.outputs.version }}
+      publish: true
+    secrets: inherit
+
+  publish-typescript:
+    name: Publish TypeScript SDK
+    needs: [plan, create-releases]
+    if: needs.plan.outputs.typescript == 'true'
+    uses: ./.github/workflows/sdk-typescript-publish.yml
+    with:
+      version: ${{ needs.plan.outputs.version }}
+    secrets: inherit
+
+  publish-server:
+    name: Publish server
+    needs: [plan, create-releases]
+    if: needs.plan.outputs.server == 'true'
+    uses: ./.github/workflows/docker-image-release.yml
+    with:
+      version: ${{ needs.plan.outputs.version }}
+    secrets: inherit
+
+  publish-cli:
+    name: Publish CLI
+    needs: [plan, create-releases]
+    if: needs.plan.outputs.cli == 'true'
+    uses: ./.github/workflows/cli-release.yml
+    with:
+      version: ${{ needs.plan.outputs.version }}
+    secrets: inherit
+
+  complete:
+    name: Verify publications
+    if: always() && needs.plan.result != 'skipped'
+    needs:
+      - plan
+      - create-releases
+      - publish-java
+      - publish-python
+      - publish-rust
+      - publish-typescript
+      - publish-server
+      - publish-cli
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report results
+        shell: bash
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          RELEASE_RESULT: ${{ needs.create-releases.result }}
+          GO_SELECTED: ${{ needs.plan.outputs.go }}
+          JAVA_SELECTED: ${{ needs.plan.outputs.java }}
+          JAVA_RESULT: ${{ needs.publish-java.result }}
+          PYTHON_SELECTED: ${{ needs.plan.outputs.python }}
+          PYTHON_RESULT: ${{ needs.publish-python.result }}
+          RUST_SELECTED: ${{ needs.plan.outputs.rust }}
+          RUST_RESULT: ${{ needs.publish-rust.result }}
+          TYPESCRIPT_SELECTED: ${{ needs.plan.outputs.typescript }}
+          TYPESCRIPT_RESULT: ${{ needs.publish-typescript.result }}
+          SERVER_SELECTED: ${{ needs.plan.outputs.server }}
+          SERVER_RESULT: ${{ needs.publish-server.result }}
+          CLI_SELECTED: ${{ needs.plan.outputs.cli }}
+          CLI_RESULT: ${{ needs.publish-cli.result }}
+        run: |
+          {
+            echo "### Publication results"
+            echo
+            echo "| Component | Result |"
+            echo "|---|---|"
+            [[ "${GO_SELECTED}" == "true" ]] && echo "| Go SDK | released |" || echo "| Go SDK | skipped |"
+            for result in \
+              "Java SDK:${JAVA_SELECTED}:${JAVA_RESULT}" \
+              "Python SDK:${PYTHON_SELECTED}:${PYTHON_RESULT}" \
+              "Rust SDK:${RUST_SELECTED}:${RUST_RESULT}" \
+              "TypeScript SDK:${TYPESCRIPT_SELECTED}:${TYPESCRIPT_RESULT}" \
+              "Server:${SERVER_SELECTED}:${SERVER_RESULT}" \
+              "CLI:${CLI_SELECTED}:${CLI_RESULT}"; do
+              name="${result%%:*}"
+              remainder="${result#*:}"
+              selected="${remainder%%:*}"
+              outcome="${remainder#*:}"
+              [[ "${selected}" == "true" ]] || outcome="skipped"
+              echo "| ${name} | ${outcome} |"
+            done
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [[ "${PLAN_RESULT}" != "success" || "${RELEASE_RESULT}" != "success" ]]; then
+            exit 1
+          fi
+          for result in \
+            "${JAVA_SELECTED}:${JAVA_RESULT}" \
+            "${PYTHON_SELECTED}:${PYTHON_RESULT}" \
+            "${RUST_SELECTED}:${RUST_RESULT}" \
+            "${TYPESCRIPT_SELECTED}:${TYPESCRIPT_RESULT}" \
+            "${SERVER_SELECTED}:${SERVER_RESULT}" \
+            "${CLI_SELECTED}:${CLI_RESULT}"; do
+            if [[ "${result%%:*}" == "true" && "${result#*:}" != "success" ]]; then
+              exit 1
+            fi
+          done

--- a/.github/workflows/sdk-java-publish.yml
+++ b/.github/workflows/sdk-java-publish.yml
@@ -3,6 +3,12 @@ name: Publish Java SDK to Maven Central
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: Maven release version
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -21,6 +27,7 @@ jobs:
   native:
     name: Native ${{ matrix.platform }}
     if: >
+      github.event_name == 'workflow_call' ||
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.release.tag_name, 'sdk-java/v')
     strategy:

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -3,6 +3,17 @@ name: Publish Python SDK to PyPI
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: Python SDK release version
+        required: true
+        type: string
+      publish:
+        description: Publish the validated distributions to PyPI
+        required: false
+        default: true
+        type: boolean
   pull_request:
     paths:
       - "sdk-python/pyproject.toml"
@@ -37,6 +48,7 @@ jobs:
     name: Validate release
     if: >
       github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_call' ||
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.release.tag_name, 'sdk-python/v')
     runs-on: ubuntu-latest
@@ -68,7 +80,7 @@ jobs:
               echo "Release tag must point to a commit on main" >&2
               exit 1
             fi
-          elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" || "${EVENT_NAME}" == "workflow_call" ]]; then
             version="${DISPATCH_VERSION}"
             if [[ "${DISPATCH_PUBLISH}" == "true" && "${RELEASE_REF}" != "refs/heads/main" ]]; then
               echo "Manual publishing is allowed only from main" >&2

--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -3,6 +3,17 @@ name: Publish Rust SDK to crates.io
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: Rust SDK release version
+        required: true
+        type: string
+      publish:
+        description: Publish the validated crates to crates.io
+        required: false
+        default: true
+        type: boolean
   pull_request:
     paths:
       - "sdk-rust/**"
@@ -35,6 +46,7 @@ jobs:
     name: Validate release
     if: >
       github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_call' ||
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.release.tag_name, 'sdk-rust/v')
     runs-on: ubuntu-latest
@@ -69,7 +81,7 @@ jobs:
               echo "Release tag must point to a commit on main" >&2
               exit 1
             fi
-          elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" || "${EVENT_NAME}" == "workflow_call" ]]; then
             version="${DISPATCH_VERSION}"
             if [[ "${DISPATCH_PUBLISH}" == "true" && "${RELEASE_REF}" != "refs/heads/main" ]]; then
               echo "Manual publishing is allowed only from main" >&2

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -3,19 +3,27 @@ name: Publish TypeScript SDK to npm
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: TypeScript SDK release version
+        required: true
+        type: string
 
 permissions:
   contents: read
   id-token: write
 
 concurrency:
-  group: sdk-typescript-publish-${{ github.event.release.tag_name }}
+  group: sdk-typescript-publish-${{ github.event.release.tag_name || inputs.version }}
   cancel-in-progress: false
 
 jobs:
   native:
     name: Native ${{ matrix.platform }}
-    if: startsWith(github.event.release.tag_name, 'sdk-typescript/v')
+    if: >
+      github.event_name == 'workflow_call' ||
+      startsWith(github.event.release.tag_name, 'sdk-typescript/v')
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +71,9 @@ jobs:
   publish:
     name: Publish @superdurable/dex
     needs: native
-    if: startsWith(github.event.release.tag_name, 'sdk-typescript/v')
+    if: >
+      github.event_name == 'workflow_call' ||
+      startsWith(github.event.release.tag_name, 'sdk-typescript/v')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -86,9 +96,19 @@ jobs:
         id: release
         shell: bash
         env:
+          EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          CALL_VERSION: ${{ inputs.version }}
         run: |
-          release_version="${RELEASE_TAG#sdk-typescript/v}"
+          if [[ "${EVENT_NAME}" == "release" ]]; then
+            release_version="${RELEASE_TAG#sdk-typescript/v}"
+          else
+            release_version="${CALL_VERSION}"
+          fi
+          if [[ ! "${release_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+            echo "Invalid npm release version: ${release_version}" >&2
+            exit 1
+          fi
           npm version "${release_version}" --no-git-tag-version --allow-same-version
           if [[ "$(node -p "require('./package.json').version")" != "${release_version}" ]]; then
             echo "npm did not resolve release version ${release_version}" >&2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,24 @@ To run every CI workflow against the latest `main` commit, dispatch **Main CI (a
 
 Each component has its own version and tag prefix. Create a GitHub Release for that tag only — workflows filter on the prefix so one release does not publish another component.
 
+For coordinated releases, run **Release changed components** from the **main** branch and enter one semantic version. The workflow applies that version to every selected component. It compares each component with its own latest reachable release tag, preflights every selected target tag, creates the GitHub Releases, and directly invokes each publisher. The run succeeds only after every selected registry, Docker, CLI asset, and Homebrew publication succeeds. Go SDK publication is complete when its module tag and GitHub Release exist.
+
+Components without relevant changes are skipped. A run with no relevant changes succeeds without creating tags. Documentation and workflow changes alone do not select a product release. A missing component baseline is treated as its first release.
+
+The dependency-aware paths are:
+
+| Component | Relevant paths |
+|-----------|----------------|
+| Go SDK | `sdk-go/**` |
+| Rust SDK | `sdk-rust/**` |
+| Java SDK | `sdk-java/**`, shared Rust manifests and Blob Cache core, and `dex-blob-cache-jni/**` |
+| Python SDK | `sdk-python/**`, shared Rust manifests and Blob Cache core, and `dex-blob-cache-python/**` |
+| TypeScript SDK | `sdk-typescript/**`, shared Rust manifests and Blob Cache core, and `dex-blob-cache-node/**` |
+| Server | `server/**`, `protos/**` |
+| CLI | `cli/**`, `web/**`, `server/**`, `protos/**`, `go.work` |
+
+Server baselines may use either historical `server/vX.Y.Z` tags or current `server-vX.Y.Z` tags. New server releases always use `server-vX.Y.Z`.
+
 | Component | Tag format | Example | What it publishes |
 |-----------|------------|---------|-------------------|
 | Server / Docker | `server-vX.Y.Z` | `server-v1.0.0` | Docker Hub `dex-server:v1.0.0` |

--- a/script/release/changed_components.py
+++ b/script/release/changed_components.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Super Durable Source License 1.0.
+# You may not use this file except in compliance with the License.
+# See the LICENSE file in the repository root.
+#
+# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+VERSION_PATTERN = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+    r"(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$"
+)
+
+
+@dataclass(frozen=True)
+class Component:
+    key: str
+    name: str
+    tag_prefix: str
+    baseline_patterns: tuple[str, ...]
+    paths: tuple[str, ...]
+
+
+SHARED_RUST_PATHS = (
+    "sdk-rust/Cargo.toml",
+    "sdk-rust/Cargo.lock",
+    "sdk-rust/crates/dex-blob-cache",
+)
+
+COMPONENTS = (
+    Component("go", "Go SDK", "sdk-go/v", ("sdk-go/v*",), ("sdk-go",)),
+    Component("rust", "Rust SDK", "sdk-rust/v", ("sdk-rust/v*",), ("sdk-rust",)),
+    Component(
+        "java",
+        "Java SDK",
+        "sdk-java/v",
+        ("sdk-java/v*",),
+        ("sdk-java", *SHARED_RUST_PATHS, "sdk-rust/crates/dex-blob-cache-jni"),
+    ),
+    Component(
+        "python",
+        "Python SDK",
+        "sdk-python/v",
+        ("sdk-python/v*",),
+        ("sdk-python", *SHARED_RUST_PATHS, "sdk-rust/crates/dex-blob-cache-python"),
+    ),
+    Component(
+        "typescript",
+        "TypeScript SDK",
+        "sdk-typescript/v",
+        ("sdk-typescript/v*",),
+        ("sdk-typescript", *SHARED_RUST_PATHS, "sdk-rust/crates/dex-blob-cache-node"),
+    ),
+    Component(
+        "server",
+        "Server",
+        "server-v",
+        ("server-v*", "server/v*"),
+        ("server", "protos"),
+    ),
+    Component(
+        "cli",
+        "CLI",
+        "cli-v",
+        ("cli-v*",),
+        ("cli", "web", "server", "protos", "go.work"),
+    ),
+)
+
+
+def git(*arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ("git", *arguments),
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def latest_reachable_tag(component: Component) -> str | None:
+    result = git(
+        "for-each-ref",
+        "--merged=HEAD",
+        "--format=%(refname:short)",
+        *(f"refs/tags/{pattern}" for pattern in component.baseline_patterns),
+    )
+    tags = [line for line in result.stdout.splitlines() if line]
+    versioned_tags = [
+        (version_key, tag)
+        for tag in tags
+        if (version_key := tag_version_key(component, tag)) is not None
+    ]
+    return max(versioned_tags)[1] if versioned_tags else None
+
+
+def tag_version_key(component: Component, tag: str) -> tuple[object, ...] | None:
+    version = next(
+        tag[len(pattern) - 1 :]
+        for pattern in component.baseline_patterns
+        if tag.startswith(pattern[:-1])
+    )
+    if not VERSION_PATTERN.fullmatch(version):
+        return None
+    core, separator, prerelease = version.partition("-")
+    major, minor, patch = (int(part) for part in core.split("."))
+    if not separator:
+        return major, minor, patch, 1
+    identifiers = tuple(
+        (0, int(identifier)) if identifier.isdigit() else (1, identifier)
+        for identifier in prerelease.split(".")
+    )
+    return major, minor, patch, 0, identifiers
+
+
+def has_changes(component: Component, baseline: str | None) -> bool:
+    if baseline is None:
+        result = git("ls-files", "--", *component.paths)
+    else:
+        result = git("diff", "--name-only", f"{baseline}..HEAD", "--", *component.paths)
+    return bool(result.stdout.strip())
+
+
+def tag_exists(tag: str) -> bool:
+    result = git("show-ref", "--verify", "--quiet", f"refs/tags/{tag}", check=False)
+    return result.returncode == 0
+
+
+def append_summary(lines: list[str]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with Path(summary_path).open("a", encoding="utf-8") as summary:
+            summary.write("\n".join(lines) + "\n")
+
+
+def write_outputs(output_path: Path, version: str) -> int:
+    selections: list[tuple[Component, str | None, bool, str]] = []
+    collisions: list[str] = []
+
+    for component in COMPONENTS:
+        baseline = latest_reachable_tag(component)
+        selected = has_changes(component, baseline)
+        target = f"{component.tag_prefix}{version}"
+        selections.append((component, baseline, selected, target))
+        if selected and tag_exists(target):
+            collisions.append(target)
+
+    summary = ["### Changed-component release plan", "", "| Component | Baseline | Result |", "|---|---|---|"]
+    output_lines = [f"version={version}"]
+    for component, baseline, selected, target in selections:
+        output_lines.extend(
+            (
+                f"{component.key}={'true' if selected else 'false'}",
+                f"{component.key}_tag={target}",
+            )
+        )
+        baseline_text = baseline or "none (first release)"
+        result_text = f"release {target}" if selected else "skip (no changes)"
+        summary.append(f"| {component.name} | {baseline_text} | {result_text} |")
+
+    append_summary(summary)
+    if collisions:
+        print("Target release tags already exist:", file=sys.stderr)
+        for collision in collisions:
+            print(f"- {collision}", file=sys.stderr)
+        return 1
+
+    output_path.write_text("\n".join(output_lines) + "\n", encoding="utf-8")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    parser.add_argument("--output", type=Path, required=True)
+    arguments = parser.parse_args()
+
+    if not VERSION_PATTERN.fullmatch(arguments.version):
+        print(f"Invalid semantic version: {arguments.version}", file=sys.stderr)
+        return 1
+
+    return write_outputs(arguments.output, arguments.version)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/release/changed_components_integ_test.py
+++ b/script/release/changed_components_integ_test.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026 Super Durable, Inc.
+#
+# Licensed under the Super Durable Source License 1.0.
+# You may not use this file except in compliance with the License.
+# See the LICENSE file in the repository root.
+#
+# SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("changed_components.py")
+COMPONENT_KEYS = ("go", "rust", "java", "python", "typescript", "server", "cli")
+BASELINE_TAGS = (
+    "sdk-go/v0.1.0",
+    "sdk-rust/v0.1.0",
+    "sdk-java/v0.1.0",
+    "sdk-python/v0.1.0",
+    "sdk-typescript/v0.1.0",
+    "server/v0.1.0",
+    "cli-v0.1.0",
+)
+INITIAL_FILES = (
+    "sdk-go/client.go",
+    "sdk-rust/Cargo.toml",
+    "sdk-rust/Cargo.lock",
+    "sdk-rust/crates/dex-blob-cache/src/lib.rs",
+    "sdk-rust/crates/dex-blob-cache-jni/src/lib.rs",
+    "sdk-rust/crates/dex-blob-cache-python/src/lib.rs",
+    "sdk-rust/crates/dex-blob-cache-node/src/lib.rs",
+    "sdk-java/build.gradle",
+    "sdk-python/pyproject.toml",
+    "sdk-typescript/package.json",
+    "server/main.go",
+    "protos/api.proto",
+    "cli/main.go",
+    "web/package.json",
+    "go.work",
+)
+
+
+class ChangedComponentsIntegrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.repository = Path(self.temporary_directory.name)
+        self.git("init", "-b", "main")
+        self.git("config", "user.name", "Release Test")
+        self.git("config", "user.email", "release-test@example.com")
+        for relative_path in INITIAL_FILES:
+            path = self.repository / relative_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("initial\n", encoding="utf-8")
+        self.commit("initial")
+        for tag in BASELINE_TAGS:
+            self.git("tag", tag)
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def git(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ("git", *arguments),
+            cwd=self.repository,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def commit(self, message: str) -> None:
+        self.git("add", ".")
+        self.git("commit", "-m", message)
+
+    def change(self, relative_path: str) -> None:
+        path = self.repository / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as changed_file:
+            changed_file.write("changed\n")
+        self.commit(f"change {relative_path}")
+
+    def plan(self, version: str = "1.2.3") -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+        output = self.repository / "release-output"
+        result = subprocess.run(
+            ("python3", str(SCRIPT), version, "--output", str(output)),
+            cwd=self.repository,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        values: dict[str, str] = {}
+        if output.exists():
+            values = dict(line.split("=", 1) for line in output.read_text().splitlines())
+        return result, values
+
+    def assert_selected(self, values: dict[str, str], *selected: str) -> None:
+        selected_keys = set(selected)
+        for key in COMPONENT_KEYS:
+            self.assertEqual(values[key], "true" if key in selected_keys else "false", key)
+
+    def test_no_component_changes(self) -> None:
+        result, values = self.plan()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_selected(values)
+
+    def test_one_sdk_change(self) -> None:
+        self.change("sdk-go/client.go")
+        result, values = self.plan()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_selected(values, "go")
+
+    def test_shared_native_change_triggers_dependent_sdks(self) -> None:
+        self.change("sdk-rust/crates/dex-blob-cache/src/lib.rs")
+        result, values = self.plan()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_selected(values, "rust", "java", "python", "typescript")
+
+    def test_server_change_triggers_server_and_cli(self) -> None:
+        self.change("server/main.go")
+        result, values = self.plan()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_selected(values, "server", "cli")
+
+    def test_current_server_tag_is_preferred_over_historical_tag(self) -> None:
+        self.change("server/main.go")
+        self.git("tag", "server-v0.2.0")
+        self.change("web/package.json")
+        result, values = self.plan()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_selected(values, "cli")
+
+    def test_web_change_triggers_only_cli(self) -> None:
+        self.change("web/package.json")
+        result, values = self.plan()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_selected(values, "cli")
+
+    def test_mixed_changes_select_multiple_releases(self) -> None:
+        self.change("sdk-go/client.go")
+        self.change("sdk-typescript/package.json")
+        self.change("protos/api.proto")
+        result, values = self.plan()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_selected(values, "go", "typescript", "server", "cli")
+
+    def test_missing_baseline_selects_first_release(self) -> None:
+        self.git("tag", "-d", "sdk-go/v0.1.0")
+        result, values = self.plan()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_selected(values, "go")
+
+    def test_existing_target_tag_fails_preflight(self) -> None:
+        self.git("tag", "sdk-go/v1.2.3")
+        self.change("sdk-go/client.go")
+        result, _ = self.plan()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("sdk-go/v1.2.3", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a main-only manual release orchestrator with one shared semantic-version input
- detect component changes from each component's latest reachable release tag and preflight every selected target tag
- directly call reusable SDK, server, and CLI publishers and report selected/skipped outcomes
- document dependency-aware release paths and add temporary-repository integration coverage for release planning

## Why

GitHub Releases created with `GITHUB_TOKEN` do not start nested release workflows. The orchestrator therefore creates all selected Releases after a global tag preflight, then explicitly invokes the existing publishers and waits for every publication to finish.

## User impact

Maintainers can publish all changed SDKs, the server, and the CLI from one manual action. Unchanged components are skipped, and documentation/workflow-only changes do not create product releases.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 script/release/changed_components_integ_test.py`
- `actionlint .github/workflows/release-changed-components.yml .github/workflows/sdk-java-publish.yml .github/workflows/sdk-python-publish.yml .github/workflows/sdk-rust-publish.yml .github/workflows/sdk-typescript-publish.yml .github/workflows/docker-image-release.yml .github/workflows/cli-release.yml`
- `make ci-runner-check`
- `make copyright-check`
- `git diff --check`
