### PR TITLE
Generate release notes from component baselines

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "cli/**"
       - "web/**"
+      - "packages/flow-definition-renderer/**"
       - "server/**"
       - "protos/**"
       - "go.work"
@@ -14,6 +15,7 @@ on:
     paths:
       - "cli/**"
       - "web/**"
+      - "packages/flow-definition-renderer/**"
       - "server/**"
       - "protos/**"
       - "go.work"

--- a/.github/workflows/release-changed-components.yml
+++ b/.github/workflows/release-changed-components.yml
@@ -25,18 +25,25 @@ jobs:
       version: ${{ steps.plan.outputs.version }}
       go: ${{ steps.plan.outputs.go }}
       go_tag: ${{ steps.plan.outputs.go_tag }}
+      go_baseline: ${{ steps.plan.outputs.go_baseline }}
       rust: ${{ steps.plan.outputs.rust }}
       rust_tag: ${{ steps.plan.outputs.rust_tag }}
+      rust_baseline: ${{ steps.plan.outputs.rust_baseline }}
       java: ${{ steps.plan.outputs.java }}
       java_tag: ${{ steps.plan.outputs.java_tag }}
+      java_baseline: ${{ steps.plan.outputs.java_baseline }}
       python: ${{ steps.plan.outputs.python }}
       python_tag: ${{ steps.plan.outputs.python_tag }}
+      python_baseline: ${{ steps.plan.outputs.python_baseline }}
       typescript: ${{ steps.plan.outputs.typescript }}
       typescript_tag: ${{ steps.plan.outputs.typescript_tag }}
+      typescript_baseline: ${{ steps.plan.outputs.typescript_baseline }}
       server: ${{ steps.plan.outputs.server }}
       server_tag: ${{ steps.plan.outputs.server_tag }}
+      server_baseline: ${{ steps.plan.outputs.server_baseline }}
       cli: ${{ steps.plan.outputs.cli }}
       cli_tag: ${{ steps.plan.outputs.cli_tag }}
+      cli_baseline: ${{ steps.plan.outputs.cli_baseline }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -77,32 +84,45 @@ jobs:
         env:
           GO_SELECTED: ${{ needs.plan.outputs.go }}
           GO_TAG: ${{ needs.plan.outputs.go_tag }}
+          GO_BASELINE: ${{ needs.plan.outputs.go_baseline }}
           RUST_SELECTED: ${{ needs.plan.outputs.rust }}
           RUST_TAG: ${{ needs.plan.outputs.rust_tag }}
+          RUST_BASELINE: ${{ needs.plan.outputs.rust_baseline }}
           JAVA_SELECTED: ${{ needs.plan.outputs.java }}
           JAVA_TAG: ${{ needs.plan.outputs.java_tag }}
+          JAVA_BASELINE: ${{ needs.plan.outputs.java_baseline }}
           PYTHON_SELECTED: ${{ needs.plan.outputs.python }}
           PYTHON_TAG: ${{ needs.plan.outputs.python_tag }}
+          PYTHON_BASELINE: ${{ needs.plan.outputs.python_baseline }}
           TYPESCRIPT_SELECTED: ${{ needs.plan.outputs.typescript }}
           TYPESCRIPT_TAG: ${{ needs.plan.outputs.typescript_tag }}
+          TYPESCRIPT_BASELINE: ${{ needs.plan.outputs.typescript_baseline }}
           SERVER_SELECTED: ${{ needs.plan.outputs.server }}
           SERVER_TAG: ${{ needs.plan.outputs.server_tag }}
+          SERVER_BASELINE: ${{ needs.plan.outputs.server_baseline }}
           CLI_SELECTED: ${{ needs.plan.outputs.cli }}
           CLI_TAG: ${{ needs.plan.outputs.cli_tag }}
+          CLI_BASELINE: ${{ needs.plan.outputs.cli_baseline }}
         run: |
           selected=(
-            "${GO_SELECTED}:${GO_TAG}"
-            "${RUST_SELECTED}:${RUST_TAG}"
-            "${JAVA_SELECTED}:${JAVA_TAG}"
-            "${PYTHON_SELECTED}:${PYTHON_TAG}"
-            "${TYPESCRIPT_SELECTED}:${TYPESCRIPT_TAG}"
-            "${SERVER_SELECTED}:${SERVER_TAG}"
-            "${CLI_SELECTED}:${CLI_TAG}"
+            "${GO_SELECTED}:${GO_TAG}:${GO_BASELINE}"
+            "${RUST_SELECTED}:${RUST_TAG}:${RUST_BASELINE}"
+            "${JAVA_SELECTED}:${JAVA_TAG}:${JAVA_BASELINE}"
+            "${PYTHON_SELECTED}:${PYTHON_TAG}:${PYTHON_BASELINE}"
+            "${TYPESCRIPT_SELECTED}:${TYPESCRIPT_TAG}:${TYPESCRIPT_BASELINE}"
+            "${SERVER_SELECTED}:${SERVER_TAG}:${SERVER_BASELINE}"
+            "${CLI_SELECTED}:${CLI_TAG}:${CLI_BASELINE}"
           )
           for release in "${selected[@]}"; do
             if [[ "${release%%:*}" == "true" ]]; then
-              tag="${release#*:}"
-              gh release create "${tag}" --target "${GITHUB_SHA}" --title "${tag}" --generate-notes
+              release="${release#*:}"
+              tag="${release%%:*}"
+              baseline="${release#*:}"
+              arguments=(--target "${GITHUB_SHA}" --title "${tag}" --generate-notes)
+              if [[ -n "${baseline}" ]]; then
+                arguments+=(--notes-start-tag "${baseline}")
+              fi
+              gh release create "${tag}" "${arguments[@]}"
             fi
           done
 

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
     paths:
       - "web/**"
+      - "packages/flow-definition-renderer/**"
       - "server/**"
       - "protos/**"
       - ".github/workflows/web-ci.yml"
   pull_request:
     paths:
       - "web/**"
+      - "packages/flow-definition-renderer/**"
       - "server/**"
       - "protos/**"
       - ".github/workflows/web-ci.yml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ The dependency-aware paths are:
 | Python SDK | `sdk-python/**`, shared Rust manifests and Blob Cache core, and `dex-blob-cache-python/**` |
 | TypeScript SDK | `sdk-typescript/**`, shared Rust manifests and Blob Cache core, and `dex-blob-cache-node/**` |
 | Server | `server/**`, `protos/**` |
-| CLI | `cli/**`, `web/**`, `server/**`, `protos/**`, `go.work` |
+| CLI | `cli/**`, `web/**`, `packages/flow-definition-renderer/**`, `server/**`, `protos/**`, `go.work` |
 
 Server baselines may use either historical `server/vX.Y.Z` tags or current `server-vX.Y.Z` tags. New server releases always use `server-vX.Y.Z`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ To run every CI workflow against the latest `main` commit, dispatch **Main CI (a
 
 Each component has its own version and tag prefix. Create a GitHub Release for that tag only — workflows filter on the prefix so one release does not publish another component.
 
-For coordinated releases, run **Release changed components** from the **main** branch and enter one semantic version. The workflow applies that version to every selected component. It compares each component with its own latest reachable release tag, preflights every selected target tag, creates the GitHub Releases, and directly invokes each publisher. The run succeeds only after every selected registry, Docker, CLI asset, and Homebrew publication succeeds. Go SDK publication is complete when its module tag and GitHub Release exist.
+For coordinated releases, run **Release changed components** from the **main** branch and enter one semantic version. The workflow applies that version to every selected component. It compares each component with its own latest reachable release tag, uses that tag as the start of the component's generated release notes, preflights every selected target tag, creates the GitHub Releases, and directly invokes each publisher. The run succeeds only after every selected registry, Docker, CLI asset, and Homebrew publication succeeds. Go SDK publication is complete when its module tag and GitHub Release exist.
 
 Components without relevant changes are skipped. A run with no relevant changes succeeds without creating tags. Documentation and workflow changes alone do not select a product release. A missing component baseline is treated as its first release.
 

--- a/script/release/changed_components.py
+++ b/script/release/changed_components.py
@@ -163,6 +163,7 @@ def write_outputs(output_path: Path, version: str) -> int:
             (
                 f"{component.key}={'true' if selected else 'false'}",
                 f"{component.key}_tag={target}",
+                f"{component.key}_baseline={baseline or ''}",
             )
         )
         baseline_text = baseline or "none (first release)"

--- a/script/release/changed_components.py
+++ b/script/release/changed_components.py
@@ -74,7 +74,7 @@ COMPONENTS = (
         "CLI",
         "cli-v",
         ("cli-v*",),
-        ("cli", "web", "server", "protos", "go.work"),
+        ("cli", "web", "packages/flow-definition-renderer", "server", "protos", "go.work"),
     ),
 )
 

--- a/script/release/changed_components_integ_test.py
+++ b/script/release/changed_components_integ_test.py
@@ -40,6 +40,7 @@ INITIAL_FILES = (
     "protos/api.proto",
     "cli/main.go",
     "web/package.json",
+    "packages/flow-definition-renderer/src/index.ts",
     "go.work",
 )
 
@@ -138,6 +139,12 @@ class ChangedComponentsIntegrationTest(unittest.TestCase):
 
     def test_web_change_triggers_only_cli(self) -> None:
         self.change("web/package.json")
+        result, values = self.plan()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_selected(values, "cli")
+
+    def test_flow_definition_renderer_change_triggers_only_cli(self) -> None:
+        self.change("packages/flow-definition-renderer/src/index.ts")
         result, values = self.plan()
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_selected(values, "cli")

--- a/script/release/changed_components_integ_test.py
+++ b/script/release/changed_components_integ_test.py
@@ -125,6 +125,7 @@ class ChangedComponentsIntegrationTest(unittest.TestCase):
         result, values = self.plan()
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_selected(values, "server", "cli")
+        self.assertEqual(values["server_baseline"], "server/v0.1.0")
 
     def test_current_server_tag_is_preferred_over_historical_tag(self) -> None:
         self.change("server/main.go")
@@ -133,6 +134,7 @@ class ChangedComponentsIntegrationTest(unittest.TestCase):
         result, values = self.plan()
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_selected(values, "cli")
+        self.assertEqual(values["server_baseline"], "server-v0.2.0")
 
     def test_web_change_triggers_only_cli(self) -> None:
         self.change("web/package.json")
@@ -153,6 +155,7 @@ class ChangedComponentsIntegrationTest(unittest.TestCase):
         result, values = self.plan()
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_selected(values, "go")
+        self.assertEqual(values["go_baseline"], "")
 
     def test_existing_target_tag_fails_preflight(self) -> None:
         self.git("tag", "sdk-go/v1.2.3")


### PR DESCRIPTION
## Summary

- expose each selected component's latest reachable release tag from the release planner
- pass that component-specific tag to `gh release create --notes-start-tag`
- preserve automatic generated notes for first releases without a baseline
- document and test historical/current Server tag baselines

## Why

GitHub otherwise generates notes from the repository's globally previous Release. In this monorepo, that can be a different SDK, Server, or CLI release and produces the wrong commit range.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 script/release/changed_components_integ_test.py`
- `actionlint .github/workflows/release-changed-components.yml`
- `make ci-runner-check`
- `make copyright-check`
- `git diff --check`
