### PR TITLE
Fix orchestrated TypeScript SDK releases

### DIFF
--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -23,6 +23,7 @@ jobs:
     name: Native ${{ matrix.platform }}
     if: >
       github.event_name == 'workflow_call' ||
+      github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.release.tag_name, 'sdk-typescript/v')
     strategy:
       fail-fast: false
@@ -73,6 +74,7 @@ jobs:
     needs: native
     if: >
       github.event_name == 'workflow_call' ||
+      github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.release.tag_name, 'sdk-typescript/v')
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Summary

- allow orchestrated TypeScript native builds to run under the caller's `workflow_dispatch` event
- allow the dependent npm publication job to run under the same event

## Rationale

Reusable workflows inherit the caller's event context. The changed-component release orchestrator is manually dispatched, so the TypeScript jobs were skipped even though the release plan selected the SDK.

## User impact

Changed-component releases can publish the selected TypeScript SDK instead of failing the final publication verification with a skipped result.

## Validation

- `actionlint .github/workflows/sdk-typescript-publish.yml .github/workflows/release-changed-components.yml`
- `python3 -m unittest script.release.changed_components_integ_test`
- `npm test` in `sdk-typescript`
