### PR TITLE
Expose timeout recovery errors in all SDKs

### DIFF
--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -1795,6 +1795,7 @@ type Context interface {
 	FlowStartedAt() time.Time
 	StepExecutionID() string
 	FromStepExecutionID() string
+	RecoveryError() *RecoveryErrorInfo
 	FirstAttemptAt() time.Time
 	Attempt() int32
 
@@ -1826,7 +1827,7 @@ Semantics:
   Flow timeout handlers; RPC invocation contexts reject it.
 - Step-method `Attempt` starts at one. RPC returns zero `Attempt` and a zero
   `FirstAttemptAt` because its request carries no attempt metadata.
-- writes, events, and channel publishes are buffered until the method returns
+- writes, events, channel deletions, and channel publishes are buffered until the method returns
   successfully;
 - attribute reads observe earlier writes in the same invocation.
 
@@ -2252,6 +2253,16 @@ type StepOptions struct {
 	ExecuteDurability  StepDurability
 	WaitForLockAttributes []AttributeLock
 	ExecuteLockAttributes []AttributeLock
+	WaitForLoadAttributeMaps []AttributeDef
+	WaitForLoadAttributeMapInstances []AttributeMapLoad
+	WaitForLoadChannels []ChannelDef
+	WaitForLoadChannelMaps []ChannelDef
+	WaitForLoadChannelMapInstances []ChannelMapLoad
+	ExecuteLoadAttributeMaps []AttributeDef
+	ExecuteLoadAttributeMapInstances []AttributeMapLoad
+	ExecuteLoadChannels []ChannelDef
+	ExecuteLoadChannelMaps []ChannelDef
+	ExecuteLoadChannelMapInstances []ChannelMapLoad
 }
 ```
 
@@ -2265,6 +2276,12 @@ signed int32 range. The server enforces a configurable minimum that defaults to
 ten seconds. Local activities ignore it, and an asynchronous regular fallback
 uses it. Worker heartbeat output may include a typed checkpoint Value. The next
 regular attempt exposes the last checkpoint through its Context.
+
+Ordinary Attributes and Channel size metadata load for every Step method.
+AttributeMap contents and pending Channel messages require method-specific
+selections. WaitFor and Execute use independent snapshots. Execute loads after
+the winning Wait consumes messages, and retries reuse the initial snapshot for
+one logical method execution. Attribute locks never imply state loading.
 
 The server defaults Step durability to sync and retry total duration to four
 hours. Regular attempts default to two hours. Async durability first uses at
@@ -2709,6 +2726,14 @@ timeout uses `TimeoutHandler` when the registered Flow implements
 `FlowErrorTypeFlowTimeout` and permits Flow retry, while `TimeoutCancel` does
 not retry. Continue-as-new preserves the absolute deadline; retry runs receive
 a new budget.
+`StartFlowOptions.TimeoutHandlerOptions` and the matching SubFlow field are
+valid only for a positive timeout whose resolved policy is `TimeoutHandler`.
+They configure Execute-style method and heartbeat timeouts, retry, durability,
+Attribute locks, selective state loading, and exhausted-retry routing to a
+registered `Step[None]`. The recovery Step receives normalized `None` input and
+reads the final failure through `Context.RecoveryError`. Handler timing starts
+when the soft timeout fires and may extend beyond that deadline. Continue-as-new
+and Flow retry preserve the options.
 `StartFlowOptions.StartDelay == nil` omits the start delay. Starting-step
 options come from the step wrapped by `DefineStartStep`; StartFlow has no
 separate step-options override.

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -38,6 +38,37 @@ atomic commit and Channel deletion validation. Attribute locks add isolation
 only among cooperating Steps and RPCs using the same lock. Write-only publish
 and delete operations do not require loading.
 
+## Step and timeout-handler state loading
+
+`StepOptions` provides the same five selections independently for `WaitFor` and
+`Execute`: all AttributeMap instances, exact AttributeMap instances, Channels,
+all ChannelMap instances, and exact ChannelMap instances. The two methods receive
+independent snapshots. Execute reads after the winning Wait consumes messages;
+retries of one logical method call reuse its first snapshot.
+
+`FlowTimeoutHandlerOptions` provides Execute-style timeouts, heartbeat detection,
+retry, durability, Attribute locks, and the same state selections. Set it on
+`StartFlowOptions` or `SubFlowOptions` only for a positive timeout using the
+handler policy. Exhausted retries may proceed to a registered `Step[None]`; read
+the final failure with `Context.RecoveryError`.
+
+```go
+type timeoutRecoveryStep struct {
+	dex.StepDefaultsNoWaitFor[dex.None]
+}
+
+func (timeoutRecoveryStep) Execute(
+	ctx dex.Context,
+	_ dex.None,
+) (*dex.StepDecision, error) {
+	failure := ctx.RecoveryError()
+	if failure == nil {
+		return dex.ForceFail("timeout recovery has no failure"), nil
+	}
+	return dex.ForceFail(failure.Detail), nil
+}
+```
+
 The Go SDK is being rewritten around the current Dex `Flow`, `Step`,
 `Attribute`, `Channel`, `Stream`, `WaitFor`, and `Execute` contracts.
 

--- a/sdk-go/dex/context.go
+++ b/sdk-go/dex/context.go
@@ -15,6 +15,15 @@ import (
 	"time"
 )
 
+// RecoveryErrorInfo describes the final failure that selected a recovery path.
+// Worker failures preserve their detail and error type. Backend failures use the backend failure type.
+type RecoveryErrorInfo struct {
+	// Detail is the failure message supplied by the Worker or backend.
+	Detail string
+	// ErrorType is the original Worker error type or backend failure type.
+	ErrorType string
+}
+
 // Context provides invocation metadata and stages durable mutations for Step and RPC handlers.
 //
 // A Context belongs to one handler attempt and must not outlive it. Attribute writes, Channel
@@ -33,6 +42,8 @@ type Context interface {
 	StepExecutionID() string
 	// FromStepExecutionID returns the predecessor Step execution ID, or empty when absent.
 	FromStepExecutionID() string
+	// RecoveryError returns the final failure that selected this recovery path, or nil when absent.
+	RecoveryError() *RecoveryErrorInfo
 	// FirstAttemptAt returns when the first attempt of this handler invocation started.
 	FirstAttemptAt() time.Time
 	// Attempt returns the one-based handler attempt number.

--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -429,6 +429,7 @@ func compileContextOperations(ctx dex.Context) error {
 	_ = ctx.HasTimerFired()
 	_ = ctx.HasTimerFiredByIndex(0)
 	_ = ctx.WaitForMethodFailed()
+	_ = ctx.RecoveryError()
 	_ = itemsAttribute.MapSize(ctx)
 	_ = itemsAttribute.AllInstanceKeys(ctx)
 	_ = commandByOrder.MapSize(ctx)

--- a/sdk-go/dex/invocation.go
+++ b/sdk-go/dex/invocation.go
@@ -43,6 +43,7 @@ type invocationContext struct {
 	flowStartedAt       time.Time
 	stepExecutionID     string
 	fromStepExecutionID string
+	recoveryError       *RecoveryErrorInfo
 	firstAttemptAt      time.Time
 	attempt             int32
 	lastHeartbeatValue  *dexpb.Value
@@ -136,6 +137,12 @@ func newInvocationContext(
 	if method != invocationRPC {
 		invocation.stepExecutionID = metadata.StepExecutionId
 		invocation.fromStepExecutionID = metadata.FromStepExecutionId
+		if metadata.RecoveryError != nil {
+			invocation.recoveryError = &RecoveryErrorInfo{
+				Detail:    metadata.RecoveryError.Detail,
+				ErrorType: metadata.RecoveryError.ErrorType,
+			}
+		}
 		invocation.attempt = metadata.Attempt
 		invocation.firstAttemptAt = time.Unix(metadata.FirstAttemptTimestamp, 0)
 		invocation.lastHeartbeatValue = metadata.LastHeartbeatValue
@@ -313,6 +320,10 @@ func (invocation *invocationContext) StepExecutionID() string {
 
 func (invocation *invocationContext) FromStepExecutionID() string {
 	return invocation.fromStepExecutionID
+}
+
+func (invocation *invocationContext) RecoveryError() *RecoveryErrorInfo {
+	return invocation.recoveryError
 }
 
 func (invocation *invocationContext) FirstAttemptAt() time.Time {

--- a/sdk-go/dex/registration_test.go
+++ b/sdk-go/dex/registration_test.go
@@ -282,6 +282,10 @@ func (registrationContext) FromStepExecutionID() string {
 	return ""
 }
 
+func (registrationContext) RecoveryError() *RecoveryErrorInfo {
+	return nil
+}
+
 func (registrationContext) FirstAttemptAt() time.Time {
 	return time.Time{}
 }

--- a/sdk-go/dex/worker_integration_test.go
+++ b/sdk-go/dex/worker_integration_test.go
@@ -687,6 +687,38 @@ func TestBufferedTextStreamFlushesOnTimerAndInvocationFinish(t *testing.T) {
 	require.ErrorIs(t, writer.Write("late"), errInvalidInvocationContext)
 }
 
+func TestInvocationContextExposesRecoveryError(t *testing.T) {
+	registry, err := NewRegistry([]Flow{workerFlow})
+	require.NoError(t, err)
+	registeredFlow, found := registry.lookupFlow(GetFinalFlowType(workerFlow))
+	require.True(t, found)
+	metadata := workerStepContext()
+	metadata.RecoveryError = &dexpb.RecoveryErrorInfo{
+		Detail:    "handler exhausted retries",
+		ErrorType: "TimeoutError",
+	}
+	invocation, err := newInvocationContext(
+		context.Background(),
+		invocationExecute,
+		registeredFlow,
+		nil,
+		metadata,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, &RecoveryErrorInfo{
+		Detail:    "handler exhausted retries",
+		ErrorType: "TimeoutError",
+	}, invocation.RecoveryError())
+}
+
 func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 	client, closeService := newWorkerTestClient(t, nil)
 	defer closeService()

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -43,6 +43,29 @@ atomic commit and Channel deletion validation. Attribute locks add isolation
 only among cooperating Steps and RPCs using the same lock. Write-only publish
 and delete operations do not require loading.
 
+## Step and timeout-handler state loading
+
+`StepOptions` provides the same five selections independently for `wait_for` and
+`execute`: all AttributeMap instances, exact AttributeMap instances, Channels,
+all ChannelMap instances, and exact ChannelMap instances. The methods receive
+independent snapshots. Execute reads after the winning Wait consumes messages;
+retries of one logical method call reuse its first snapshot.
+
+`FlowTimeoutHandlerOptions` provides Execute-style timeouts, heartbeat detection,
+retry, durability, Attribute locks, and the same state selections. Set it on
+`StartFlowOptions` or `SubFlowOptions` only for a positive timeout using `HANDLER`.
+Exhausted retries may proceed to a registered `Step[None]`; read the final
+failure from `Context.recovery_error`.
+
+```python
+class TimeoutRecoveryStep(Step[None]):
+    def execute(self, context: Context, input: None) -> StepDecision:
+        failure = context.recovery_error
+        if failure is None:
+            return force_fail("timeout recovery has no failure")
+        return force_fail(failure.detail)
+```
+
 Python SDK for [Dex workflow engine](https://github.com/superdurable/dex)
 
 ## New user contracts

--- a/sdk-python/dex/__init__.py
+++ b/sdk-python/dex/__init__.py
@@ -36,7 +36,7 @@ from dex.codec import (
     WireKind,
 )
 from dex.condition import ConditionCombination
-from dex.context import AsyncContext, Context
+from dex.context import AsyncContext, Context, RecoveryErrorInfo
 from dex.flow import Flow, PersistenceSchema, Registry, RPCResult, rpc
 from dex.flow_config import ActiveStepSearchMode, FlowConfig
 from dex.flow_info import (
@@ -163,6 +163,7 @@ __all__ = [
     "LongPollTimeoutError",
     "PersistenceSchema",
     "RPCResult",
+    "RecoveryErrorInfo",
     "RetryAfterError",
     "RpcLockConflictError",
     "Registry",

--- a/sdk-python/dex/_invocation_context.py
+++ b/sdk-python/dex/_invocation_context.py
@@ -17,6 +17,7 @@ from dex._value_mapper import ValueMapper
 from dex.attribute import Attribute, AttributeMap, _apply_attribute_store_sync
 from dex.channel import Channel, ChannelMap, ChannelMessage
 from dex.codec import Codec
+from dex.context import RecoveryErrorInfo
 from dex.dexpb import dex_pb2 as pb
 from dex.flow import Registry, _RegisteredFlow
 from dex.flow_result import FlowResult, flow_result_from_proto
@@ -115,6 +116,15 @@ class InvocationContext:
     @property
     def from_step_execution_id(self) -> str:
         return self._metadata.from_step_execution_id
+
+    @property
+    def recovery_error(self) -> RecoveryErrorInfo | None:
+        if not self._metadata.HasField("recovery_error"):
+            return None
+        return RecoveryErrorInfo(
+            detail=self._metadata.recovery_error.detail,
+            error_type=self._metadata.recovery_error.error_type,
+        )
 
     @property
     def attempt(self) -> int:

--- a/sdk-python/dex/context.py
+++ b/sdk-python/dex/context.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, Sequence, TypeVar
 
 if TYPE_CHECKING:
@@ -25,6 +26,19 @@ if TYPE_CHECKING:
 
 
 ValueT = TypeVar("ValueT")
+
+
+@dataclass(frozen=True)
+class RecoveryErrorInfo:
+    """Describe the final failure that selected a recovery path.
+
+    Attributes:
+        detail: Failure message supplied by the Worker or backend.
+        error_type: Original Worker error type or backend failure type.
+    """
+
+    detail: str
+    error_type: str
 
 
 class Context(Protocol):
@@ -69,6 +83,15 @@ class Context(Protocol):
 
         Returns:
             The originating identifier, or an empty string at Flow start.
+        """
+        ...
+
+    @property
+    def recovery_error(self) -> RecoveryErrorInfo | None:
+        """Return the final failure that selected this recovery path.
+
+        Returns:
+            Recovery information, or ``None`` outside a recovery path.
         """
         ...
 

--- a/sdk-python/tests/test_contracts.py
+++ b/sdk-python/tests/test_contracts.py
@@ -1272,6 +1272,28 @@ def test_context_decodes_last_heartbeat_presence() -> None:
         incompatible.get_last_heartbeat_value(int)
 
 
+def test_context_exposes_recovery_error() -> None:
+    class RecoveryFlow(Flow[None]):
+        pass
+
+    registry = Registry((RecoveryFlow(),))
+    context = InvocationContext(
+        InvocationMethod.EXECUTE,
+        registry._flow_by_type("RecoveryFlow"),
+        pb.Context(
+            recovery_error=pb.RecoveryErrorInfo(
+                detail="handler exhausted retries",
+                error_type="TimeoutError",
+            )
+        ),
+        ValueMapper(registry.codec_registry),
+        (),
+    )
+    assert context.recovery_error is not None
+    assert context.recovery_error.detail == "handler exhausted retries"
+    assert context.recovery_error.error_type == "TimeoutError"
+
+
 def test_async_step_outputs_preserve_call_order() -> None:
     asyncio.run(_assert_async_step_outputs_preserve_call_order())
 

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -40,6 +40,35 @@ atomic commit and Channel deletion validation. Attribute locks add isolation
 only among cooperating Steps and RPCs using the same lock. Write-only publish
 and delete operations do not require loading.
 
+## Step and timeout-handler state loading
+
+`StepOptions` provides the same five selections independently for `waitFor` and
+`execute`: all AttributeMap instances, exact AttributeMap instances, Channels,
+all ChannelMap instances, and exact ChannelMap instances. The methods receive
+independent snapshots. Execute reads after the winning Wait consumes messages;
+retries of one logical method call reuse its first snapshot.
+
+`FlowTimeoutHandlerOptions` provides Execute-style timeouts, heartbeat detection,
+retry, durability, Attribute locks, and the same state selections. Set it on
+`StartFlowOptions` or `SubFlowOptions` only for a positive timeout using `HANDLER`.
+Exhausted retries may proceed to a registered `Step<void>` using `voidCodec`;
+read the final failure from `Context.recoveryError`.
+
+```typescript
+class TimeoutRecoveryStep implements Step<void> {
+  public readonly inputCodec = voidCodec;
+
+  public getStepType(): string {
+    return "TimeoutRecoveryStep";
+  }
+
+  public execute(context: Context, _input: void): StepDecision {
+    const failure = context.recoveryError;
+    return forceFail(failure?.detail ?? "timeout recovery has no failure");
+  }
+}
+```
+
 This package targets Node.js 22 and 24. It provides strongly typed workflow
 contracts and a Promise-based gRPC Client. The Client and Worker runtime use
 `@grpc/grpc-js`. Blob caching uses the shared Rust DXBC implementation through

--- a/sdk-typescript/src/context.ts
+++ b/sdk-typescript/src/context.ts
@@ -11,6 +11,14 @@ import type { Channel, ChannelMap, ChannelMessage } from "./wait.js";
 import type { Codec } from "./codec.js";
 import type { Stream } from "./stream.js";
 
+/** Describes the final failure that selected a recovery path. */
+export interface RecoveryErrorInfo {
+  /** Failure message supplied by the Worker or backend. */
+  readonly detail: string;
+  /** Original Worker error type or backend failure type. */
+  readonly errorType: string;
+}
+
 /**
  * Exposes execution metadata and decision-local persistence operations.
  * Dex supplies a Context to each Step or RPC handler; do not retain it afterward.
@@ -26,6 +34,8 @@ export interface Context {
   readonly stepExecutionId: string;
   /** Predecessor Step execution ID, or an empty string at Flow start. */
   readonly fromStepExecutionId: string;
+  /** Final failure that selected this recovery path, or `undefined` when absent. */
+  readonly recoveryError: RecoveryErrorInfo | undefined;
   /** UTC timestamp of the first handler attempt. */
   readonly firstAttemptAt: Date;
   /** One-based handler retry attempt number. */

--- a/sdk-typescript/src/invocation-context.ts
+++ b/sdk-typescript/src/invocation-context.ts
@@ -8,7 +8,7 @@
 
 import type { Codec } from "./codec.js";
 import { mapAttributeStoreSync } from "./attribute-store-sync.js";
-import type { AsyncContext } from "./context.js";
+import type { AsyncContext, RecoveryErrorInfo } from "./context.js";
 import {
   ConditionStatus,
   IndexType as ProtoIndexType,
@@ -54,6 +54,7 @@ export class InvocationContext implements AsyncContext {
   public readonly flowStartedAt: Date;
   public readonly stepExecutionId: string;
   public readonly fromStepExecutionId: string;
+  public readonly recoveryError: RecoveryErrorInfo | undefined;
   public readonly firstAttemptAt: Date;
   public readonly attempt: number;
   public readonly cancellationSignal: AbortSignal;
@@ -98,6 +99,7 @@ export class InvocationContext implements AsyncContext {
     this.flowStartedAt = secondsDate(metadata.flowStartedTimestamp);
     this.stepExecutionId = metadata.stepExecutionId;
     this.fromStepExecutionId = metadata.fromStepExecutionId;
+    this.recoveryError = metadata.recoveryError;
     this.firstAttemptAt = secondsDate(metadata.firstAttemptTimestamp);
     this.attempt = metadata.attempt;
     this.lastHeartbeatValue = metadata.lastHeartbeatValue;

--- a/sdk-typescript/src/options.ts
+++ b/sdk-typescript/src/options.ts
@@ -56,7 +56,7 @@ export const FlowTimeoutPolicy = Object.freeze({
   FAIL: "fail",
   /** Cancels without retrying the Flow. */
   CANCEL: "cancel",
-  /** Invokes `Flow.handleTimeout` once after the durable timer fires or is skipped. */
+  /** Starts one logical `Flow.handleTimeout` execution after the durable timer fires or is skipped. */
   HANDLER: "handler",
 } as const);
 

--- a/sdk-typescript/test/contracts.test.ts
+++ b/sdk-typescript/test/contracts.test.ts
@@ -729,6 +729,34 @@ test("Async Step Context preserves heartbeat Value presence and codecs", async (
   }
 });
 
+test("Context exposes the recovery error", () => {
+  class RecoveryFlow implements Flow<void> {
+    public getFlowType(): string {
+      return "RecoveryFlow";
+    }
+
+    public getSteps(): StepList<void> {
+      return StepList.empty();
+    }
+  }
+  const flow = new RecoveryFlow();
+  const context = new InvocationContext(
+    "execute",
+    registeredFlowByName(new Registry([flow]), flow.getFlowType()),
+    ProtoContext.create({
+      recoveryError: {
+        detail: "handler exhausted retries",
+        errorType: "TimeoutError",
+      },
+    }),
+    [],
+  );
+  assert.deepEqual(context.recoveryError, {
+    detail: "handler exhausted retries",
+    errorType: "TimeoutError",
+  });
+});
+
 class UnsupportedSynchronousHeartbeatStep implements Step<string> {
   public getStepType(): string {
     return "UnsupportedSynchronousHeartbeatStep";


### PR DESCRIPTION
## Summary

- expose timeout-handler recovery failures through Go, Python, and TypeScript Context APIs, matching Java and Rust
- add contract coverage and public SDK documentation for the recovery value
- document the complete selective Step loading and timeout-handler contracts in the affected SDK READMEs and Go design plan

## Rationale

The timeout-handler failure routing added in #453 promises that a no-input recovery Step can inspect the final handler failure. Java and Rust exposed that metadata, but Go, Python, and TypeScript did not. Without this patch, recovery examples in those languages cannot report the failure that exhausted timeout-handler retries.

## User impact

Applications can read the normalized timeout-handler failure in every SDK: `Context.RecoveryError` in Go, `Context.recovery_error` in Python, and `Context.recoveryError` in TypeScript.

## Validation

- `make -C sdk-go unitTests`
- `make -C sdk-go docsCheck`
- `uv run --frozen pytest tests/test_contracts.py -q`
- `uv run --frozen mypy --strict tests/typecheck_contracts.py tests/integ`
- `uv run --frozen pyright tests/typecheck_contracts.py tests/integ`
- Python SDK pre-commit hooks for changed files under Python 3.11
- `npm test` in `sdk-typescript`
- `npm run typecheck` in `sdk-typescript`
- `npm run docs:check` in `sdk-typescript`
- `make copyright-check`
