### PR TITLE
Document selective Step state loading

### DIFF
--- a/docs/content/design-patterns/failure-handling/graceful-timeout.mdx
+++ b/docs/content/design-patterns/failure-handling/graceful-timeout.mdx
@@ -8,13 +8,13 @@ import flowDefinition from '@site/src/data/flow-definitions/design-patterns/grac
 
 Use Dex's built-in graceful timeout when an overall Flow deadline needs application-defined handling. The timeout belongs to the Flow execution, not to a competing Step.
 
-**FlowGracefulTimeout** starts **LongWaitStep**. A positive timeout in **StartFlowOptions** uses the Flow's timeout handler. When the durable deadline expires, Dex invokes **handleTimeout** once and applies its decision with normal Execute semantics.
+**FlowGracefulTimeout** starts **LongWaitStep**. When the Flow deadline expires, Dex runs **handleTimeout**. The handler response uses Execute semantics.
 
 <DocsFlowDefinitionGraph graph={flowDefinition} />
 
 ## Core implementation
 
-The complete Flow definition registers **LongWaitStep** through its start Step and registers the timeout hook by implementing the Flow timeout-handler method. Start the Flow with a positive timeout; **HANDLER** is explicit below and is also the default when the Flow provides the hook.
+The complete Flow definition registers **LongWaitStep** and the timeout hook. Start the Flow with a positive timeout; **HANDLER** is explicit below and is also the default when the Flow provides the hook. The example gives the hook its own attempt timeout and retry policy with **FlowTimeoutHandlerOptions**.
 
 <SdkTabs examples={{
   python: 'examples/python/dex_examples/patterns/timeout/flow_graceful_timeout.py',
@@ -27,11 +27,14 @@ The complete Flow definition registers **LongWaitStep** through its start Step a
 
 ```python
 class LongWaitStep(Step[bool]):
-    def wait_for(self, context: Context, successful: bool) -> Wait:
-        return Wait.skip_immediately() if successful else Wait.until(Timer.by_duration(timedelta(seconds=65)))
+    def wait_for(self, context: Context, input: bool) -> Wait:
+        if input:
+            return Wait.skip_immediately()
+        return Wait.until(Timer.by_duration(SLOW_TASK_DURATION))
 
-    def execute(self, context: Context, successful: bool) -> StepDecision:
+    def execute(self, context: Context, input: bool) -> StepDecision:
         return force_complete("Workflow completed successfully")
+
 
 class FlowGracefulTimeout(Flow[bool]):
     def __init__(self) -> None:
@@ -45,13 +48,17 @@ class FlowGracefulTimeout(Flow[bool]):
 ```
 
 ```python
-await client.start_flow(
-    flow,
+await app_state.client.start_flow(
+    app_state.timeout,
     flow_id,
-    successful,
+    optional_query("successfulWorkflow", "true").lower() == "true",
     StartFlowOptions(
         timeout=timedelta(minutes=1),
         timeout_policy=FlowTimeoutPolicy.HANDLER,
+        timeout_handler_options=FlowTimeoutHandlerOptions(
+            method_timeout=timedelta(seconds=30),
+            retry=RetryPolicy(maximum_attempts=3),
+        ),
     ),
 )
 ```
@@ -88,20 +95,23 @@ func (longWaitStep) Execute(_ dex.Context, _ bool) (*dex.StepDecision, error) {
 func (*FlowGracefulTimeout) HandleTimeout(_ dex.Context) (*dex.StepDecision, error) {
 	return dex.ForceFail("Workflow did not finish the task in time"), nil
 }
+
 ```
 
 ```go
-timeout := time.Minute
-_, err := client.StartFlow(
-	ctx,
-	flow,
-	flowID,
-	successful,
-	dex.StartFlowOptions{
+func patternStartOptions() sdk.StartFlowOptions {
+	timeout := time.Minute
+	return sdk.StartFlowOptions{
 		Timeout:       &timeout,
-		TimeoutPolicy: dex.TimeoutHandler,
-	},
-)
+		TimeoutPolicy: sdk.TimeoutHandler,
+		TimeoutHandlerOptions: &sdk.FlowTimeoutHandlerOptions{
+			MethodTimeout: 30 * time.Second,
+			Retry: &sdk.RetryPolicy{
+				MaximumAttempts: 3,
+			},
+		},
+	}
+}
 ```
 
 </SdkSnippet>
@@ -150,6 +160,10 @@ client.startFlow(
         StartFlowOptions.newBuilder()
                 .timeout(Duration.ofMinutes(1))
                 .timeoutPolicy(FlowTimeoutPolicy.HANDLER)
+                .timeoutHandlerOptions(FlowTimeoutHandlerOptions.newBuilder()
+                        .methodTimeout(Duration.ofSeconds(30))
+                        .retry(RetryPolicy.newBuilder().maximumAttempts(3).build())
+                        .build())
                 .build());
 ```
 
@@ -193,6 +207,10 @@ class FlowGracefulTimeout implements Flow<boolean> {
 await client.startFlow(flowGracefulTimeout, workflowId, successful, {
   timeoutMs: 60_000,
   timeoutPolicy: FlowTimeoutPolicy.HANDLER,
+  timeoutHandlerOptions: {
+    methodTimeoutMs: 30_000,
+    retry: { maximumAttempts: 3 },
+  },
 });
 ```
 
@@ -231,6 +249,12 @@ impl Step for LongWaitStep {
 }
 
 impl FlowGracefulTimeout {
+    pub(crate) fn timeout_handler_options(&self) -> FlowTimeoutHandlerOptions {
+        FlowTimeoutHandlerOptions::new()
+            .method_timeout(Duration::from_secs(30))
+            .retry(RetryPolicy::new().maximum_attempts(3))
+    }
+
     fn handle_timeout(&self, _context: &mut Context) -> HandlerResult<StepDecision> {
         Ok(StepDecision::force_fail("task exceeded graceful timeout"))
     }
@@ -238,18 +262,22 @@ impl FlowGracefulTimeout {
 ```
 
 ```rust
+let timeout_handler_options = flow.timeout_handler_options();
 client.start_flow_with_options(
     &flow,
     &flow_id,
     successful,
     StartFlowOptions::new()
         .timeout(Duration::from_secs(60))
-        .timeout_policy(FlowTimeoutPolicy::Handler),
+        .timeout_policy(FlowTimeoutPolicy::Handler)
+        .timeout_handler_options(timeout_handler_options),
 )?;
 ```
 
 </SdkSnippet>
 </SdkTabs>
+
+If the timeout handler succeeds, Dex applies its staged writes, best-effort Channel deletions, Channel publications, and decision. If it exhausts the configured retries, Dex fails the Flow.
 
 ## Related
 

--- a/docs/content/primitives/channel.mdx
+++ b/docs/content/primitives/channel.mdx
@@ -38,8 +38,12 @@ class MoveMessage:
 
 
 class ChannelWaitStep(Step[int]):
-    def __init__(self, approval: Channel[str]) -> None:
+    def __init__(self, approval: Channel[str], queued: Channel[str]) -> None:
         self.approval = approval
+        self.queued = queued
+
+    def get_step_options(self) -> StepOptions:
+        return StepOptions(execute_load_channels=(self.queued,))
 
     def wait_for(self, context: Context, input: int) -> Wait:
         return Wait.any_of(
@@ -48,6 +52,10 @@ class ChannelWaitStep(Step[int]):
         )
 
     def execute(self, context: Context, input: int) -> StepDecision:
+        pending = self.queued.pending_messages(context)
+        if pending:
+            self.queued.delete(context, pending[0].message_id)
+            return graceful_complete(pending[0].value)
         if context.has_timer_fired():
             return graceful_complete("approval timed out")
         approvals = self.approval.results(context)
@@ -60,7 +68,7 @@ class ChannelFlow(Flow[int]):
     moved = Channel("Moved", str)
 
     def __init__(self) -> None:
-        self.wait_for_approval = ChannelWaitStep(self.approval)
+        self.wait_for_approval = ChannelWaitStep(self.approval, self.queued)
 
     def get_steps(self) -> StepList[int]:
         return StepList.start_step(self.wait_for_approval)
@@ -112,6 +120,12 @@ type channelWaitStep struct {
 	dex.StepDefaults
 }
 
+func (channelWaitStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		ExecuteLoadChannels: []dex.ChannelDef{Queued},
+	}
+}
+
 func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 	return dex.AnyOf(
 		Approval.ForOne(),
@@ -120,6 +134,16 @@ func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 }
 
 func (channelWaitStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
+	pending, err := Queued.PendingMessages(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(pending) > 0 {
+		if err := Queued.Delete(ctx, pending[0].MessageID); err != nil {
+			return nil, err
+		}
+		return dex.GracefulComplete(pending[0].Value), nil
+	}
 	if ctx.HasTimerFired() {
 		return dex.GracefulComplete("approval timed out"), nil
 	}
@@ -207,6 +231,13 @@ public class ChannelFlow implements Flow<Integer> {
         }
 
         @Override
+        public StepOptions getStepOptions() {
+            return StepOptions.newBuilder()
+                    .addExecuteLoadChannel(queued)
+                    .build();
+        }
+
+        @Override
         public Wait waitFor(final Context context, final Integer input) {
             return Wait.anyOf(
                     approval.forOne(),
@@ -215,6 +246,11 @@ public class ChannelFlow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
+            final List<ChannelMessage<String>> pending = queued.pendingMessages(context);
+            if (!pending.isEmpty()) {
+                queued.delete(context, pending.get(0).getMessageId());
+                return StepDecision.gracefulComplete(pending.get(0).getValue());
+            }
             if (context.hasTimerFired()) {
                 return StepDecision.gracefulComplete("approval timed out");
             }
@@ -246,6 +282,10 @@ class ChannelWait implements Step<number> {
     return "ChannelWait";
   }
 
+  public getStepOptions(): StepOptions {
+    return { executeLoadChannels: [queued] };
+  }
+
   public waitFor(_context: Context, input: number): Wait {
     return Wait.anyOf(
       approval.forOne(),
@@ -254,6 +294,11 @@ class ChannelWait implements Step<number> {
   }
 
   public execute(context: Context, _input: number): StepDecision {
+    const pending = queued.pendingMessages(context);
+    if (pending.length > 0) {
+      queued.delete(context, pending[0]!.messageId);
+      return gracefulComplete(pending[0]!.value);
+    }
     if (context.hasTimerFired()) {
       return gracefulComplete("approval timed out");
     }
@@ -359,6 +404,10 @@ struct ChannelWait;
 impl Step for ChannelWait {
     type Input = i32;
 
+    fn options(&self) -> StepOptions<Self::Input> {
+        StepOptions::new().execute_load_channel(&QUEUED)
+    }
+
     fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
             APPROVAL.for_one(),
@@ -367,6 +416,11 @@ impl Step for ChannelWait {
     }
 
     fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
+        let pending = QUEUED.pending_messages(context)?;
+        if let Some(message) = pending.first() {
+            QUEUED.delete(context, &message.message_id)?;
+            return Ok(StepDecision::graceful_complete(message.value.clone()));
+        }
         if context.has_any_timer_fired() {
             return Ok(StepDecision::graceful_complete(
                 "approval timed out".to_owned(),
@@ -411,7 +465,9 @@ Dex assigns a UUIDv7 message ID when it accepts each publication. A Client can l
 
 This is queue state, not Flow history. After a Step consumes a message, it disappears from the Channel even though the publication and consumption remain observable in Flow history until retention removes them.
 
-An RPC always receives Channel size metadata. It must explicitly load pending messages before reading their IDs or Values. Loading a Channel creates one invocation snapshot and does not consume messages. A loaded empty Channel returns an empty list; reading pending messages without loading the Channel is a usage error.
+Every Step method, timeout handler, and RPC always receives Channel size metadata. It must explicitly load pending messages before reading their IDs or Values. Deleting a message whose ID is already known does not require loading it. **StepOptions** selects state separately for **WaitFor** and **Execute**; **FlowTimeoutHandlerOptions** selects state for the timeout handler. Loading a Channel creates one invocation snapshot and does not consume messages. A loaded empty Channel returns an empty list; reading pending messages without loading the Channel is a usage error.
+
+A Step or timeout handler can stage deletion with its other side effects. Dex applies successful handler effects in this order: Attribute writes, best-effort Channel deletions, then Channel publications, followed by the Step decision. If another operation already consumed or deleted a selected message, deletion is a no-op and the remaining effects still apply. **StepDecision** describes only control flow; it does not contain deletions.
 
 <SdkTabs
 examples={{

--- a/docs/content/primitives/flow/flow-options.mdx
+++ b/docs/content/primitives/flow/flow-options.mdx
@@ -19,6 +19,7 @@ Dex allows you to customize the behavior of a Flow execution.
 |-------|------------------------------------------------------------------------|
 | **Timeout** | Flow timeout. Omit it or set zero to disable it.                       |
 | **TimeoutPolicy** | What happens when the flow timeout fires.                              |
+| **TimeoutHandlerOptions** | Execution, retry, recovery, durability, locking, and state loading for a timeout handler. |
 | **IDReusePolicy** | How to reuse existing Flow ID to start                                 |
 | **RequestID** | Idempotency key for retrying one start request.                        |
 | **AlreadyStartedOptions** | How to handle an already-started Flow.                                 |
@@ -179,9 +180,15 @@ pub fn example_start_flow_options() -> StartFlowOptions {
 
 - **FAIL** — fail the Flow with a timeout error. **RetryPolicy** can retry it.
 - **CANCEL** — cancel the Flow. It does not retry.
-- **HANDLER** — run the Flow timeout handler once.
+- **HANDLER** — run one logical Flow timeout-handler execution.
 
 With a positive **Timeout**, a Dex SDK uses **FAIL** by default. If the Flow has a timeout handler, it uses **HANDLER** instead. **HANDLER** is invalid when the Flow has no handler. A retry starts with a new timeout budget.
+
+**TimeoutHandlerOptions** is valid only with a positive **Timeout** and a final **HANDLER** policy. It uses Execute semantics: a method timeout limits each attempt, **Retry** can run multiple attempts, **HeartbeatTimeout** detects stalled regular attempts, and **Failure** can route exhausted retries to a registered no-input Step. The recovery Step receives null or unit input and reads the final error from the handler **Context**.
+
+The handler's attempt and retry clocks begin when the soft Flow timeout fires. They may extend past the original Flow deadline. If no failure target is configured, an exhausted handler fails the Flow.
+
+Ordinary Attributes and all Channel size metadata load automatically. AttributeMap values and pending Channel messages require explicit selections in **TimeoutHandlerOptions**. The handler may stage Attribute writes, Channel deletions, and Channel publications before returning its decision. Continue-as-new and Flow retries preserve the options; a Flow retry starts a new soft-timeout budget.
 
 Set **TimeoutPolicy** to **HANDLER** to run this code when the timeout fires. This handler records why the Flow ended, then fails it with an application reason.
 

--- a/docs/content/primitives/step/step-options.mdx
+++ b/docs/content/primitives/step/step-options.mdx
@@ -326,6 +326,77 @@ fn execute(&self, context: &mut Context, batches: Self::Input) -> HandlerResult<
 
 A heartbeat helps deliver cancellation. A Step invocation is canceled only when it completes, fails, or records a heartbeat.
 
+## Selective state loading {#selective-state-loading}
+
+Every **WaitFor**, **Execute**, and timeout-handler call receives all ordinary Attributes and size metadata for every Channel and ChannelMap instance. AttributeMap values and pending Channel messages are not loaded unless that method selects them.
+
+**StepOptions** has separate selections for **WaitFor** and **Execute**. Select an entire AttributeMap or ChannelMap when the method must enumerate current instances. Select an exact map instance when its key is already known. An Attribute lock controls concurrency but does not load the AttributeMap value.
+
+The two methods receive independent snapshots. **Execute** reads its snapshot after the winning Wait conditions consume their messages, so it does not see those consumed messages again. Retries of one logical method call reuse its first snapshot.
+
+This Step loads pending **Queued** messages only for **Execute**. It deletes the first pending message in the same successful handler response.
+
+<SdkTabs
+  examples={{
+    python: 'examples/python/dex_examples/primitives/channel/channel_flow.py',
+    go: 'examples/go/primitives/channel/workflow.go',
+    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java',
+    typescript: 'examples/typescript/src/primitives/channel/channel-flow.ts',
+    rust: 'examples/rust/src/primitives/channel/flow.rs',
+  }}>
+  <SdkSnippet lang="python">
+
+```python
+def get_step_options(self) -> StepOptions:
+    return StepOptions(execute_load_channels=(self.queued,))
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="go">
+
+```go
+func (channelWaitStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		ExecuteLoadChannels: []dex.ChannelDef{Queued},
+	}
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="java">
+
+```java
+@Override
+public StepOptions getStepOptions() {
+    return StepOptions.newBuilder()
+            .addExecuteLoadChannel(queued)
+            .build();
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="typescript">
+
+```typescript
+public getStepOptions(): StepOptions {
+  return { executeLoadChannels: [queued] };
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="rust">
+
+```rust
+fn options(&self) -> StepOptions<Self::Input> {
+    StepOptions::new().execute_load_channel(&QUEUED)
+}
+```
+
+</SdkSnippet>
+</SdkTabs>
+
+Reading an unselected AttributeMap value or pending Channel message returns the SDK's existing not-loaded error. A selected empty Channel returns an empty message list. Size and map-key introspection remains available without loading message bodies.
+
 ## Attribute locks
 
 Concurrent Steps and RPC invocations can read and write the same Attribute. This can lead to race conditions. To avoid this, use Attribute locks. Dex Server ensures only one Step execution or RPC handling can acquire the lock at a time.

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/failure-handling/graceful-timeout.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design-patterns/failure-handling/graceful-timeout.mdx
@@ -8,13 +8,13 @@ import flowDefinition from '@site/src/data/flow-definitions/design-patterns/grac
 
 当整个 Flow 的截止时间需要应用代码处理时，使用 Dex 内置的 graceful timeout。超时属于 Flow execution，而不是与业务 Step 竞争的另一个 Step。
 
-**FlowGracefulTimeout** 启动 **LongWaitStep**。**StartFlowOptions** 中的正超时会使用 Flow 的 timeout handler。持久化截止时间到达后，Dex 调用一次 **handleTimeout**，并使用普通 Execute 语义应用其决策。
+**FlowGracefulTimeout** 启动 **LongWaitStep**。Flow 截止时间到达后，Dex 运行 **handleTimeout**。Handler response 使用 Execute 语义。
 
 <DocsFlowDefinitionGraph graph={flowDefinition} />
 
 ## 核心实现
 
-完整的 Flow 定义通过 start Step 注册 **LongWaitStep**，并通过实现 Flow 的 timeout-handler 方法注册 timeout hook。使用正超时启动 Flow；以下示例显式选择 **HANDLER**，而当 Flow 提供 hook 时它也是默认策略。
+完整的 Flow 定义会注册 **LongWaitStep** 和 timeout hook。使用正超时启动 Flow；以下示例显式选择 **HANDLER**，而当 Flow 提供 hook 时它也是默认策略。示例通过 **FlowTimeoutHandlerOptions** 为 hook 设置自己的 attempt timeout 和 retry policy。
 
 <SdkTabs examples={{
   python: 'examples/python/dex_examples/patterns/timeout/flow_graceful_timeout.py',
@@ -27,11 +27,14 @@ import flowDefinition from '@site/src/data/flow-definitions/design-patterns/grac
 
 ```python
 class LongWaitStep(Step[bool]):
-    def wait_for(self, context: Context, successful: bool) -> Wait:
-        return Wait.skip_immediately() if successful else Wait.until(Timer.by_duration(timedelta(seconds=65)))
+    def wait_for(self, context: Context, input: bool) -> Wait:
+        if input:
+            return Wait.skip_immediately()
+        return Wait.until(Timer.by_duration(SLOW_TASK_DURATION))
 
-    def execute(self, context: Context, successful: bool) -> StepDecision:
+    def execute(self, context: Context, input: bool) -> StepDecision:
         return force_complete("Workflow completed successfully")
+
 
 class FlowGracefulTimeout(Flow[bool]):
     def __init__(self) -> None:
@@ -45,13 +48,17 @@ class FlowGracefulTimeout(Flow[bool]):
 ```
 
 ```python
-await client.start_flow(
-    flow,
+await app_state.client.start_flow(
+    app_state.timeout,
     flow_id,
-    successful,
+    optional_query("successfulWorkflow", "true").lower() == "true",
     StartFlowOptions(
         timeout=timedelta(minutes=1),
         timeout_policy=FlowTimeoutPolicy.HANDLER,
+        timeout_handler_options=FlowTimeoutHandlerOptions(
+            method_timeout=timedelta(seconds=30),
+            retry=RetryPolicy(maximum_attempts=3),
+        ),
     ),
 )
 ```
@@ -88,20 +95,23 @@ func (longWaitStep) Execute(_ dex.Context, _ bool) (*dex.StepDecision, error) {
 func (*FlowGracefulTimeout) HandleTimeout(_ dex.Context) (*dex.StepDecision, error) {
 	return dex.ForceFail("Workflow did not finish the task in time"), nil
 }
+
 ```
 
 ```go
-timeout := time.Minute
-_, err := client.StartFlow(
-	ctx,
-	flow,
-	flowID,
-	successful,
-	dex.StartFlowOptions{
+func patternStartOptions() sdk.StartFlowOptions {
+	timeout := time.Minute
+	return sdk.StartFlowOptions{
 		Timeout:       &timeout,
-		TimeoutPolicy: dex.TimeoutHandler,
-	},
-)
+		TimeoutPolicy: sdk.TimeoutHandler,
+		TimeoutHandlerOptions: &sdk.FlowTimeoutHandlerOptions{
+			MethodTimeout: 30 * time.Second,
+			Retry: &sdk.RetryPolicy{
+				MaximumAttempts: 3,
+			},
+		},
+	}
+}
 ```
 
 </SdkSnippet>
@@ -150,6 +160,10 @@ client.startFlow(
         StartFlowOptions.newBuilder()
                 .timeout(Duration.ofMinutes(1))
                 .timeoutPolicy(FlowTimeoutPolicy.HANDLER)
+                .timeoutHandlerOptions(FlowTimeoutHandlerOptions.newBuilder()
+                        .methodTimeout(Duration.ofSeconds(30))
+                        .retry(RetryPolicy.newBuilder().maximumAttempts(3).build())
+                        .build())
                 .build());
 ```
 
@@ -193,6 +207,10 @@ class FlowGracefulTimeout implements Flow<boolean> {
 await client.startFlow(flowGracefulTimeout, workflowId, successful, {
   timeoutMs: 60_000,
   timeoutPolicy: FlowTimeoutPolicy.HANDLER,
+  timeoutHandlerOptions: {
+    methodTimeoutMs: 30_000,
+    retry: { maximumAttempts: 3 },
+  },
 });
 ```
 
@@ -231,6 +249,12 @@ impl Step for LongWaitStep {
 }
 
 impl FlowGracefulTimeout {
+    pub(crate) fn timeout_handler_options(&self) -> FlowTimeoutHandlerOptions {
+        FlowTimeoutHandlerOptions::new()
+            .method_timeout(Duration::from_secs(30))
+            .retry(RetryPolicy::new().maximum_attempts(3))
+    }
+
     fn handle_timeout(&self, _context: &mut Context) -> HandlerResult<StepDecision> {
         Ok(StepDecision::force_fail("task exceeded graceful timeout"))
     }
@@ -238,18 +262,22 @@ impl FlowGracefulTimeout {
 ```
 
 ```rust
+let timeout_handler_options = flow.timeout_handler_options();
 client.start_flow_with_options(
     &flow,
     &flow_id,
     successful,
     StartFlowOptions::new()
         .timeout(Duration::from_secs(60))
-        .timeout_policy(FlowTimeoutPolicy::Handler),
+        .timeout_policy(FlowTimeoutPolicy::Handler)
+        .timeout_handler_options(timeout_handler_options),
 )?;
 ```
 
 </SdkSnippet>
 </SdkTabs>
+
+Timeout handler 成功时，Dex 会应用暂存的 write、best-effort Channel deletion、Channel publication 和 decision。如果它耗尽配置的重试，Dex 会让 Flow 失败。
 
 ## 相关内容
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/channel.mdx
@@ -39,8 +39,12 @@ class MoveMessage:
 
 
 class ChannelWaitStep(Step[int]):
-    def __init__(self, approval: Channel[str]) -> None:
+    def __init__(self, approval: Channel[str], queued: Channel[str]) -> None:
         self.approval = approval
+        self.queued = queued
+
+    def get_step_options(self) -> StepOptions:
+        return StepOptions(execute_load_channels=(self.queued,))
 
     def wait_for(self, context: Context, input: int) -> Wait:
         return Wait.any_of(
@@ -49,6 +53,10 @@ class ChannelWaitStep(Step[int]):
         )
 
     def execute(self, context: Context, input: int) -> StepDecision:
+        pending = self.queued.pending_messages(context)
+        if pending:
+            self.queued.delete(context, pending[0].message_id)
+            return graceful_complete(pending[0].value)
         if context.has_timer_fired():
             return graceful_complete("approval timed out")
         approvals = self.approval.results(context)
@@ -61,7 +69,7 @@ class ChannelFlow(Flow[int]):
     moved = Channel("Moved", str)
 
     def __init__(self) -> None:
-        self.wait_for_approval = ChannelWaitStep(self.approval)
+        self.wait_for_approval = ChannelWaitStep(self.approval, self.queued)
 
     def get_steps(self) -> StepList[int]:
         return StepList.start_step(self.wait_for_approval)
@@ -113,6 +121,12 @@ type channelWaitStep struct {
 	dex.StepDefaults
 }
 
+func (channelWaitStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		ExecuteLoadChannels: []dex.ChannelDef{Queued},
+	}
+}
+
 func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 	return dex.AnyOf(
 		Approval.ForOne(),
@@ -121,6 +135,16 @@ func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 }
 
 func (channelWaitStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
+	pending, err := Queued.PendingMessages(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(pending) > 0 {
+		if err := Queued.Delete(ctx, pending[0].MessageID); err != nil {
+			return nil, err
+		}
+		return dex.GracefulComplete(pending[0].Value), nil
+	}
 	if ctx.HasTimerFired() {
 		return dex.GracefulComplete("approval timed out"), nil
 	}
@@ -208,6 +232,13 @@ public class ChannelFlow implements Flow<Integer> {
         }
 
         @Override
+        public StepOptions getStepOptions() {
+            return StepOptions.newBuilder()
+                    .addExecuteLoadChannel(queued)
+                    .build();
+        }
+
+        @Override
         public Wait waitFor(final Context context, final Integer input) {
             return Wait.anyOf(
                     approval.forOne(),
@@ -216,6 +247,11 @@ public class ChannelFlow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
+            final List<ChannelMessage<String>> pending = queued.pendingMessages(context);
+            if (!pending.isEmpty()) {
+                queued.delete(context, pending.get(0).getMessageId());
+                return StepDecision.gracefulComplete(pending.get(0).getValue());
+            }
             if (context.hasTimerFired()) {
                 return StepDecision.gracefulComplete("approval timed out");
             }
@@ -247,6 +283,10 @@ class ChannelWait implements Step<number> {
     return "ChannelWait";
   }
 
+  public getStepOptions(): StepOptions {
+    return { executeLoadChannels: [queued] };
+  }
+
   public waitFor(_context: Context, input: number): Wait {
     return Wait.anyOf(
       approval.forOne(),
@@ -255,6 +295,11 @@ class ChannelWait implements Step<number> {
   }
 
   public execute(context: Context, _input: number): StepDecision {
+    const pending = queued.pendingMessages(context);
+    if (pending.length > 0) {
+      queued.delete(context, pending[0]!.messageId);
+      return gracefulComplete(pending[0]!.value);
+    }
     if (context.hasTimerFired()) {
       return gracefulComplete("approval timed out");
     }
@@ -360,6 +405,10 @@ struct ChannelWait;
 impl Step for ChannelWait {
     type Input = i32;
 
+    fn options(&self) -> StepOptions<Self::Input> {
+        StepOptions::new().execute_load_channel(&QUEUED)
+    }
+
     fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
             APPROVAL.for_one(),
@@ -368,6 +417,11 @@ impl Step for ChannelWait {
     }
 
     fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
+        let pending = QUEUED.pending_messages(context)?;
+        if let Some(message) = pending.first() {
+            QUEUED.delete(context, &message.message_id)?;
+            return Ok(StepDecision::graceful_complete(message.value.clone()));
+        }
         if context.has_any_timer_fired() {
             return Ok(StepDecision::graceful_complete(
                 "approval timed out".to_owned(),
@@ -412,7 +466,9 @@ Dex 接受每次 publication 时都会分配一个 UUIDv7 message ID。Client �
 
 这是 queue state，不是 Flow history。Step 消费 message 后，它会从 Channel 消失，但 publication 与 consumption 仍可在 Flow history 中观察，直到 retention 将它们清理。
 
-RPC 始终会收到 Channel size metadata。读取 pending message 的 ID 或 Value 前，必须显式加载对应 Channel。加载会建立一份 invocation snapshot，但不会消费 message。已加载的空 Channel 返回空列表；未加载就读取 pending message 会返回 usage error。
+每个 Step method、timeout handler 和 RPC 始终会收到 Channel size metadata。读取 pending message 的 ID 或 Value 前，必须显式加载对应 Channel。删除 ID 已知的 message 不需要加载它。**StepOptions** 为 **WaitFor** 和 **Execute** 分别选择状态；**FlowTimeoutHandlerOptions** 为 timeout handler 选择状态。加载会建立一份 invocation snapshot，但不会消费 message。已加载的空 Channel 返回空列表；未加载就读取 pending message 会返回 usage error。
+
+Step 或 timeout handler 可以把 deletion 与其他 side effect 一起暂存。成功的 handler effect 按 Attribute write、best-effort Channel deletion、Channel publication 的顺序应用，然后处理 Step decision。如果另一项操作已经消费或删除所选消息，deletion 是 no-op，其他 effect 仍会应用。**StepDecision** 只描述 control flow，不包含 deletion。
 
 <SdkTabs
 examples={{

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/flow-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/flow/flow-options.mdx
@@ -19,6 +19,7 @@ Dex 允许你自定义 Flow execution 的行为。
 |------|------|
 | **Timeout** | Flow timeout。省略或设为零可禁用。 |
 | **TimeoutPolicy** | Flow timeout 触发时的行为。 |
+| **TimeoutHandlerOptions** | Timeout handler 的 execution、retry、recovery、durability、locking 与 state loading。 |
 | **IDReusePolicy** | 启动时如何复用已有 Flow ID。 |
 | **RequestID** | 重试同一次启动请求的幂等键。 |
 | **AlreadyStartedOptions** | 如何处理已启动的 Flow。 |
@@ -179,9 +180,15 @@ pub fn example_start_flow_options() -> StartFlowOptions {
 
 - **FAIL** — 以 timeout error 失败 Flow。**RetryPolicy** 可以重试它。
 - **CANCEL** — 取消 Flow，不会重试。
-- **HANDLER** — 调用一次 Flow timeout handler。
+- **HANDLER** — 运行一次逻辑 Flow timeout-handler execution。
 
 提供正数 **Timeout** 时，Dex SDK 默认使用 **FAIL**。Flow 有 timeout handler 时，则使用 **HANDLER**。没有 handler 时使用 **HANDLER** 无效。一次 retry 会获得新的 timeout budget。
+
+只有 **Timeout** 为正数且最终 policy 为 **HANDLER** 时，才能设置 **TimeoutHandlerOptions**。它采用 Execute 语义：method timeout 限制单次 attempt，**Retry** 可以运行多次 attempt，**HeartbeatTimeout** 检测停滞的 regular attempt，**Failure** 可以在 retry 耗尽后进入已注册的无输入 Step。Recovery Step 会收到 null 或 unit input，并从 handler **Context** 读取最终 error。
+
+Handler 的 attempt 与 retry 计时从 soft Flow timeout 触发时开始，因此可以超过原始 Flow deadline。未配置 failure target 时，handler retry 耗尽会使 Flow 失败。
+
+普通 Attribute 和所有 Channel size metadata 会自动加载。AttributeMap value 与 pending Channel message 必须通过 **TimeoutHandlerOptions** 显式选择。Handler 可以先暂存 Attribute write、Channel deletion 与 Channel publication，再返回 decision。Continue-as-new 和 Flow retry 都会保留这些 options；Flow retry 会开始新的 soft-timeout budget。
 
 把 **TimeoutPolicy** 设为 **HANDLER**，timeout 触发时就会运行下面的代码。这个 handler 记录 Flow 结束的原因，再用应用自己的原因失败该 Flow。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/primitives/step/step-options.mdx
@@ -326,6 +326,77 @@ fn execute(&self, context: &mut Context, batches: Self::Input) -> HandlerResult<
 
 Heartbeat 有助于传递 cancellation。Step invocation 只会在完成、失败或记录 heartbeat 时被 cancel。
 
+## 选择性加载状态 {#selective-state-loading}
+
+每次 **WaitFor**、**Execute** 和 timeout handler 调用都会收到所有普通 Attribute，以及每个 Channel 和 ChannelMap instance 的 size metadata。除非对应方法显式选择，否则不会加载 AttributeMap value 和 pending Channel message。
+
+**StepOptions** 为 **WaitFor** 和 **Execute** 提供独立的 selection。方法需要枚举当前 instance 时，选择整个 AttributeMap 或 ChannelMap；已经知道 key 时，只选择精确的 map instance。Attribute lock 只控制并发，不会加载 AttributeMap value。
+
+两个方法收到独立的 snapshot。获胜的 Wait condition 消费消息之后，**Execute** 才读取自己的 snapshot，因此不会再次看到已经消费的消息。同一个逻辑方法调用的 retry 会复用首次 snapshot。
+
+下面的 Step 只为 **Execute** 加载 **Queued** 的 pending message，并在同一个成功的 handler response 中删除第一条消息。
+
+<SdkTabs
+  examples={{
+    python: 'examples/python/dex_examples/primitives/channel/channel_flow.py',
+    go: 'examples/go/primitives/channel/workflow.go',
+    java: 'examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java',
+    typescript: 'examples/typescript/src/primitives/channel/channel-flow.ts',
+    rust: 'examples/rust/src/primitives/channel/flow.rs',
+  }}>
+  <SdkSnippet lang="python">
+
+```python
+def get_step_options(self) -> StepOptions:
+    return StepOptions(execute_load_channels=(self.queued,))
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="go">
+
+```go
+func (channelWaitStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		ExecuteLoadChannels: []dex.ChannelDef{Queued},
+	}
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="java">
+
+```java
+@Override
+public StepOptions getStepOptions() {
+    return StepOptions.newBuilder()
+            .addExecuteLoadChannel(queued)
+            .build();
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="typescript">
+
+```typescript
+public getStepOptions(): StepOptions {
+  return { executeLoadChannels: [queued] };
+}
+```
+
+</SdkSnippet>
+  <SdkSnippet lang="rust">
+
+```rust
+fn options(&self) -> StepOptions<Self::Input> {
+    StepOptions::new().execute_load_channel(&QUEUED)
+}
+```
+
+</SdkSnippet>
+</SdkTabs>
+
+读取未选择的 AttributeMap value 或 pending Channel message 时，SDK 会返回已有的 not-loaded error。已选择但为空的 Channel 会返回空消息列表。不加载消息 body 也仍然可以读取 size 和 map key。
+
 ## Attribute locks
 
 并发 Step 和 RPC invocation 可以读取和写入同一个 Attribute。这可能导致 race condition。要避免它，使用 Attribute lock。Dex Server 会确保同一时间只有一个 Step execution 或 RPC handling 能 acquire 这个 lock。

--- a/docs/src/data/flow-definitions/ai-agent.json
+++ b/docs/src/data/flow-definitions/ai-agent.json
@@ -9,9 +9,9 @@
     "name": "AIAgentFlow",
     "startStepId": "step:Init",
     "span": {
-      "startLine": 722,
+      "startLine": 731,
       "startColumn": 1,
-      "endLine": 1420,
+      "endLine": 1429,
       "endColumn": 10
     }
   },
@@ -23,9 +23,9 @@
       "parentId": "rpc:approve_tool",
       "phase": "rpc",
       "span": {
-        "startLine": 1251,
+        "startLine": 1260,
         "startColumn": 5,
-        "endLine": 1267,
+        "endLine": 1276,
         "endColumn": 31
       }
     },
@@ -36,9 +36,9 @@
       "parentId": "rpc:execute_plan",
       "phase": "rpc",
       "span": {
-        "startLine": 1270,
+        "startLine": 1279,
         "startColumn": 5,
-        "endLine": 1298,
+        "endLine": 1307,
         "endColumn": 31
       }
     },
@@ -49,9 +49,9 @@
       "parentId": "rpc:history",
       "phase": "rpc",
       "span": {
-        "startLine": 1301,
+        "startLine": 1310,
         "startColumn": 5,
-        "endLine": 1316,
+        "endLine": 1325,
         "endColumn": 61
       }
     },
@@ -62,9 +62,9 @@
       "parentId": "rpc:send_message",
       "phase": "rpc",
       "span": {
-        "startLine": 1224,
+        "startLine": 1233,
         "startColumn": 5,
-        "endLine": 1228,
+        "endLine": 1237,
         "endColumn": 31
       }
     },
@@ -75,9 +75,9 @@
       "parentId": "rpc:steer_message",
       "phase": "rpc",
       "span": {
-        "startLine": 1234,
+        "startLine": 1243,
         "startColumn": 5,
-        "endLine": 1248,
+        "endLine": 1257,
         "endColumn": 31
       }
     },
@@ -88,9 +88,9 @@
       "parentId": "step:AwaitToolApproval",
       "phase": "execute",
       "span": {
-        "startLine": 579,
+        "startLine": 588,
         "startColumn": 5,
-        "endLine": 600,
+        "endLine": 609,
         "endColumn": 61
       }
     },
@@ -114,9 +114,9 @@
       "parentId": "step:CallModel",
       "phase": "execute",
       "span": {
-        "startLine": 267,
+        "startLine": 273,
         "startColumn": 5,
-        "endLine": 349,
+        "endLine": 355,
         "endColumn": 56
       }
     },
@@ -127,9 +127,9 @@
       "parentId": "step:CheckSteered",
       "phase": "execute",
       "span": {
-        "startLine": 361,
+        "startLine": 370,
         "startColumn": 5,
-        "endLine": 383,
+        "endLine": 392,
         "endColumn": 68
       }
     },
@@ -140,9 +140,9 @@
       "parentId": "step:DurableWait",
       "phase": "execute",
       "span": {
-        "startLine": 680,
+        "startLine": 689,
         "startColumn": 5,
-        "endLine": 719,
+        "endLine": 728,
         "endColumn": 61
       }
     },
@@ -153,9 +153,9 @@
       "parentId": "step:ExecuteTool",
       "phase": "execute",
       "span": {
-        "startLine": 610,
+        "startLine": 619,
         "startColumn": 5,
-        "endLine": 662,
+        "endLine": 671,
         "endColumn": 61
       }
     },
@@ -166,23 +166,23 @@
       "parentId": "step:RouteTool",
       "phase": "execute",
       "span": {
-        "startLine": 390,
+        "startLine": 399,
         "startColumn": 5,
-        "endLine": 561,
+        "endLine": 570,
         "endColumn": 58
       }
     },
     {
-      "id": "decision:rpc:approve_tool:1259:20",
+      "id": "decision:rpc:approve_tool:1268:20",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:approve_tool",
       "condition": "exception",
       "phase": "rpc",
       "span": {
-        "startLine": 1259,
+        "startLine": 1268,
         "startColumn": 20,
-        "endLine": 1259,
+        "endLine": 1268,
         "endColumn": 36
       },
       "decision": {
@@ -190,16 +190,16 @@
       }
     },
     {
-      "id": "decision:rpc:approve_tool:1261:20",
+      "id": "decision:rpc:approve_tool:1270:20",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:approve_tool",
       "condition": "pending.call_id != input.call_id",
       "phase": "rpc",
       "span": {
-        "startLine": 1261,
+        "startLine": 1270,
         "startColumn": 20,
-        "endLine": 1261,
+        "endLine": 1270,
         "endColumn": 36
       },
       "decision": {
@@ -207,16 +207,16 @@
       }
     },
     {
-      "id": "decision:rpc:approve_tool:1267:16",
+      "id": "decision:rpc:approve_tool:1276:16",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:approve_tool",
       "condition": "not (pending.call_id != input.call_id)",
       "phase": "rpc",
       "span": {
-        "startLine": 1267,
+        "startLine": 1276,
         "startColumn": 16,
-        "endLine": 1267,
+        "endLine": 1276,
         "endColumn": 31
       },
       "decision": {
@@ -224,15 +224,15 @@
       }
     },
     {
-      "id": "decision:rpc:describe:1320:16",
+      "id": "decision:rpc:describe:1329:16",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:describe",
       "phase": "rpc",
       "span": {
-        "startLine": 1320,
+        "startLine": 1329,
         "startColumn": 16,
-        "endLine": 1320,
+        "endLine": 1329,
         "endColumn": 53
       },
       "decision": {
@@ -240,16 +240,16 @@
       }
     },
     {
-      "id": "decision:rpc:execute_plan:1288:20",
+      "id": "decision:rpc:execute_plan:1297:20",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:execute_plan",
       "condition": "state is None or plan is None or state.status != STATUS_WAITING or (state.pending_plan_execution_revision is not None) or (_optional_attribute(self.pending_user_input, context) is not None) or (self.queued_user_messages.size(context) \u003e 0) or (self.steered_user_messages.size(context) \u003e 0) or (plan.revision != input.revision) or (plan.status not in {PLAN_DRAFT, PLAN_ACTIVE})",
       "phase": "rpc",
       "span": {
-        "startLine": 1288,
+        "startLine": 1297,
         "startColumn": 20,
-        "endLine": 1288,
+        "endLine": 1297,
         "endColumn": 36
       },
       "decision": {
@@ -257,16 +257,16 @@
       }
     },
     {
-      "id": "decision:rpc:execute_plan:1298:16",
+      "id": "decision:rpc:execute_plan:1307:16",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:execute_plan",
       "condition": "not (state is None or plan is None or state.status != STATUS_WAITING or (state.pending_plan_execution_revision is not None) or (_optional_attribute(self.pending_user_input, context) is not None) or (self.queued_user_messages.size(context) \u003e 0) or (self.steered_user_messages.size(context) \u003e 0) or (plan.revision != input.revision) or (plan.status not in {PLAN_DRAFT, PLAN_ACTIVE}))",
       "phase": "rpc",
       "span": {
-        "startLine": 1298,
+        "startLine": 1307,
         "startColumn": 16,
-        "endLine": 1298,
+        "endLine": 1307,
         "endColumn": 31
       },
       "decision": {
@@ -274,16 +274,16 @@
       }
     },
     {
-      "id": "decision:rpc:history:1304:20",
+      "id": "decision:rpc:history:1313:20",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:history",
       "condition": "state is None",
       "phase": "rpc",
       "span": {
-        "startLine": 1304,
+        "startLine": 1313,
         "startColumn": 20,
-        "endLine": 1304,
+        "endLine": 1313,
         "endColumn": 52
       },
       "decision": {
@@ -291,16 +291,16 @@
       }
     },
     {
-      "id": "decision:rpc:history:1316:16",
+      "id": "decision:rpc:history:1325:16",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:history",
       "condition": "not (state is None)",
       "phase": "rpc",
       "span": {
-        "startLine": 1316,
+        "startLine": 1325,
         "startColumn": 16,
-        "endLine": 1316,
+        "endLine": 1325,
         "endColumn": 61
       },
       "decision": {
@@ -308,16 +308,16 @@
       }
     },
     {
-      "id": "decision:rpc:send_message:1226:20",
+      "id": "decision:rpc:send_message:1235:20",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:send_message",
       "condition": "not input.content.strip()",
       "phase": "rpc",
       "span": {
-        "startLine": 1226,
+        "startLine": 1235,
         "startColumn": 20,
-        "endLine": 1226,
+        "endLine": 1235,
         "endColumn": 36
       },
       "decision": {
@@ -325,16 +325,16 @@
       }
     },
     {
-      "id": "decision:rpc:send_message:1228:16",
+      "id": "decision:rpc:send_message:1237:16",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:send_message",
       "condition": "not (not input.content.strip())",
       "phase": "rpc",
       "span": {
-        "startLine": 1228,
+        "startLine": 1237,
         "startColumn": 16,
-        "endLine": 1228,
+        "endLine": 1237,
         "endColumn": 31
       },
       "decision": {
@@ -342,15 +342,15 @@
       }
     },
     {
-      "id": "decision:rpc:snapshot:1338:16",
+      "id": "decision:rpc:snapshot:1347:16",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:snapshot",
       "phase": "rpc",
       "span": {
-        "startLine": 1338,
+        "startLine": 1347,
         "startColumn": 16,
-        "endLine": 1352,
+        "endLine": 1361,
         "endColumn": 10
       },
       "decision": {
@@ -358,16 +358,16 @@
       }
     },
     {
-      "id": "decision:rpc:steer_message:1240:20",
+      "id": "decision:rpc:steer_message:1249:20",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:steer_message",
       "condition": "not input.message_id.strip()",
       "phase": "rpc",
       "span": {
-        "startLine": 1240,
+        "startLine": 1249,
         "startColumn": 20,
-        "endLine": 1240,
+        "endLine": 1249,
         "endColumn": 36
       },
       "decision": {
@@ -375,16 +375,16 @@
       }
     },
     {
-      "id": "decision:rpc:steer_message:1248:16",
+      "id": "decision:rpc:steer_message:1257:16",
       "kind": "decision",
       "name": "rpcResult",
       "parentId": "rpc:steer_message",
       "condition": "not (not input.message_id.strip())",
       "phase": "rpc",
       "span": {
-        "startLine": 1248,
+        "startLine": 1257,
         "startColumn": 16,
-        "endLine": 1248,
+        "endLine": 1257,
         "endColumn": 31
       },
       "decision": {
@@ -392,16 +392,16 @@
       }
     },
     {
-      "id": "decision:step:AwaitToolApproval:583:20",
+      "id": "decision:step:AwaitToolApproval:592:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:AwaitToolApproval",
       "condition": "steered_messages",
       "phase": "execute",
       "span": {
-        "startLine": 583,
+        "startLine": 592,
         "startColumn": 20,
-        "endLine": 583,
+        "endLine": 592,
         "endColumn": 65
       },
       "decision": {
@@ -409,16 +409,16 @@
       }
     },
     {
-      "id": "decision:step:AwaitToolApproval:590:20",
+      "id": "decision:step:AwaitToolApproval:599:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:AwaitToolApproval",
       "condition": "not (steered_messages) and approvals[0].approved",
       "phase": "execute",
       "span": {
-        "startLine": 590,
+        "startLine": 599,
         "startColumn": 20,
-        "endLine": 590,
+        "endLine": 599,
         "endColumn": 62
       },
       "decision": {
@@ -426,16 +426,16 @@
       }
     },
     {
-      "id": "decision:step:AwaitToolApproval:598:20",
+      "id": "decision:step:AwaitToolApproval:607:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:AwaitToolApproval",
       "condition": "not (steered_messages) and not (approvals[0].approved) and self.flow.has_next_tool_call(context)",
       "phase": "execute",
       "span": {
-        "startLine": 598,
+        "startLine": 607,
         "startColumn": 20,
-        "endLine": 598,
+        "endLine": 607,
         "endColumn": 60
       },
       "decision": {
@@ -443,16 +443,16 @@
       }
     },
     {
-      "id": "decision:step:AwaitToolApproval:600:16",
+      "id": "decision:step:AwaitToolApproval:609:16",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:AwaitToolApproval",
       "condition": "not (steered_messages) and not (approvals[0].approved) and not (self.flow.has_next_tool_call(context))",
       "phase": "execute",
       "span": {
-        "startLine": 600,
+        "startLine": 609,
         "startColumn": 16,
-        "endLine": 600,
+        "endLine": 609,
         "endColumn": 61
       },
       "decision": {
@@ -528,16 +528,16 @@
       }
     },
     {
-      "id": "decision:step:CallModel:339:20",
+      "id": "decision:step:CallModel:345:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:CallModel",
       "condition": "not reply.tool_calls",
       "phase": "execute",
       "span": {
-        "startLine": 339,
+        "startLine": 345,
         "startColumn": 20,
-        "endLine": 339,
+        "endLine": 345,
         "endColumn": 60
       },
       "decision": {
@@ -545,16 +545,16 @@
       }
     },
     {
-      "id": "decision:step:CallModel:349:16",
+      "id": "decision:step:CallModel:355:16",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:CallModel",
       "condition": "not (not reply.tool_calls)",
       "phase": "execute",
       "span": {
-        "startLine": 349,
+        "startLine": 355,
         "startColumn": 16,
-        "endLine": 349,
+        "endLine": 355,
         "endColumn": 56
       },
       "decision": {
@@ -562,16 +562,16 @@
       }
     },
     {
-      "id": "decision:step:CheckSteered:369:24",
+      "id": "decision:step:CheckSteered:378:24",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:CheckSteered",
       "condition": "input == CONTINUE_COMPACT_CONTEXT and cutoff is not None",
       "phase": "execute",
       "span": {
-        "startLine": 369,
+        "startLine": 378,
         "startColumn": 24,
-        "endLine": 369,
+        "endLine": 378,
         "endColumn": 53
       },
       "decision": {
@@ -579,16 +579,16 @@
       }
     },
     {
-      "id": "decision:step:CheckSteered:370:20",
+      "id": "decision:step:CheckSteered:379:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:CheckSteered",
       "condition": "input == CONTINUE_COMPACT_CONTEXT and not (cutoff is not None)",
       "phase": "execute",
       "span": {
-        "startLine": 370,
+        "startLine": 379,
         "startColumn": 20,
-        "endLine": 370,
+        "endLine": 379,
         "endColumn": 42
       },
       "decision": {
@@ -596,16 +596,16 @@
       }
     },
     {
-      "id": "decision:step:CheckSteered:372:20",
+      "id": "decision:step:CheckSteered:381:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:CheckSteered",
       "condition": "not (input == CONTINUE_COMPACT_CONTEXT) and input == CONTINUE_AWAIT_USER",
       "phase": "execute",
       "span": {
-        "startLine": 372,
+        "startLine": 381,
         "startColumn": 20,
-        "endLine": 372,
+        "endLine": 381,
         "endColumn": 42
       },
       "decision": {
@@ -613,16 +613,16 @@
       }
     },
     {
-      "id": "decision:step:CheckSteered:374:20",
+      "id": "decision:step:CheckSteered:383:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:CheckSteered",
       "condition": "not (input == CONTINUE_COMPACT_CONTEXT) and not (input == CONTINUE_AWAIT_USER) and input == CONTINUE_CALL_MODEL",
       "phase": "execute",
       "span": {
-        "startLine": 374,
+        "startLine": 383,
         "startColumn": 20,
-        "endLine": 374,
+        "endLine": 383,
         "endColumn": 42
       },
       "decision": {
@@ -630,16 +630,16 @@
       }
     },
     {
-      "id": "decision:step:CheckSteered:376:20",
+      "id": "decision:step:CheckSteered:385:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:CheckSteered",
       "condition": "not (input == CONTINUE_COMPACT_CONTEXT) and not (input == CONTINUE_AWAIT_USER) and not (input == CONTINUE_CALL_MODEL) and input == CONTINUE_ROUTE_TOOL",
       "phase": "execute",
       "span": {
-        "startLine": 376,
+        "startLine": 385,
         "startColumn": 20,
-        "endLine": 376,
+        "endLine": 385,
         "endColumn": 42
       },
       "decision": {
@@ -647,16 +647,16 @@
       }
     },
     {
-      "id": "decision:step:CheckSteered:378:20",
+      "id": "decision:step:CheckSteered:387:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:CheckSteered",
       "condition": "not (input == CONTINUE_COMPACT_CONTEXT) and not (input == CONTINUE_AWAIT_USER) and not (input == CONTINUE_CALL_MODEL) and not (input == CONTINUE_ROUTE_TOOL) and input == CONTINUE_AWAIT_TOOL_APPROVAL",
       "phase": "execute",
       "span": {
-        "startLine": 378,
+        "startLine": 387,
         "startColumn": 20,
-        "endLine": 378,
+        "endLine": 387,
         "endColumn": 50
       },
       "decision": {
@@ -664,16 +664,16 @@
       }
     },
     {
-      "id": "decision:step:CheckSteered:380:20",
+      "id": "decision:step:CheckSteered:389:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:CheckSteered",
       "condition": "not (input == CONTINUE_COMPACT_CONTEXT) and not (input == CONTINUE_AWAIT_USER) and not (input == CONTINUE_CALL_MODEL) and not (input == CONTINUE_ROUTE_TOOL) and not (input == CONTINUE_AWAIT_TOOL_APPROVAL) and input == CONTINUE_EXECUTE_TOOL",
       "phase": "execute",
       "span": {
-        "startLine": 380,
+        "startLine": 389,
         "startColumn": 20,
-        "endLine": 380,
+        "endLine": 389,
         "endColumn": 44
       },
       "decision": {
@@ -681,16 +681,16 @@
       }
     },
     {
-      "id": "decision:step:CheckSteered:382:20",
+      "id": "decision:step:CheckSteered:391:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:CheckSteered",
       "condition": "not (input == CONTINUE_COMPACT_CONTEXT) and not (input == CONTINUE_AWAIT_USER) and not (input == CONTINUE_CALL_MODEL) and not (input == CONTINUE_ROUTE_TOOL) and not (input == CONTINUE_AWAIT_TOOL_APPROVAL) and not (input == CONTINUE_EXECUTE_TOOL) and input == CONTINUE_DURABLE_WAIT",
       "phase": "execute",
       "span": {
-        "startLine": 382,
+        "startLine": 391,
         "startColumn": 20,
-        "endLine": 382,
+        "endLine": 391,
         "endColumn": 44
       },
       "decision": {
@@ -698,15 +698,15 @@
       }
     },
     {
-      "id": "decision:step:CompactContext:257:16",
+      "id": "decision:step:CompactContext:260:16",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:CompactContext",
       "phase": "execute",
       "span": {
-        "startLine": 257,
+        "startLine": 260,
         "startColumn": 16,
-        "endLine": 257,
+        "endLine": 260,
         "endColumn": 56
       },
       "decision": {
@@ -714,16 +714,16 @@
       }
     },
     {
-      "id": "decision:step:DurableWait:699:20",
+      "id": "decision:step:DurableWait:708:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:DurableWait",
       "condition": "steered_messages",
       "phase": "execute",
       "span": {
-        "startLine": 699,
+        "startLine": 708,
         "startColumn": 20,
-        "endLine": 699,
+        "endLine": 708,
         "endColumn": 65
       },
       "decision": {
@@ -731,16 +731,16 @@
       }
     },
     {
-      "id": "decision:step:DurableWait:717:20",
+      "id": "decision:step:DurableWait:726:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:DurableWait",
       "condition": "not (steered_messages) and self.flow.has_next_tool_call(context)",
       "phase": "execute",
       "span": {
-        "startLine": 717,
+        "startLine": 726,
         "startColumn": 20,
-        "endLine": 717,
+        "endLine": 726,
         "endColumn": 60
       },
       "decision": {
@@ -748,16 +748,16 @@
       }
     },
     {
-      "id": "decision:step:DurableWait:719:16",
+      "id": "decision:step:DurableWait:728:16",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:DurableWait",
       "condition": "not (steered_messages) and not (self.flow.has_next_tool_call(context))",
       "phase": "execute",
       "span": {
-        "startLine": 719,
+        "startLine": 728,
         "startColumn": 16,
-        "endLine": 719,
+        "endLine": 728,
         "endColumn": 61
       },
       "decision": {
@@ -765,16 +765,16 @@
       }
     },
     {
-      "id": "decision:step:ExecuteTool:660:20",
+      "id": "decision:step:ExecuteTool:669:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:ExecuteTool",
       "condition": "self.flow.has_next_tool_call(context)",
       "phase": "execute",
       "span": {
-        "startLine": 660,
+        "startLine": 669,
         "startColumn": 20,
-        "endLine": 660,
+        "endLine": 669,
         "endColumn": 60
       },
       "decision": {
@@ -782,16 +782,16 @@
       }
     },
     {
-      "id": "decision:step:ExecuteTool:662:16",
+      "id": "decision:step:ExecuteTool:671:16",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:ExecuteTool",
       "condition": "not (self.flow.has_next_tool_call(context))",
       "phase": "execute",
       "span": {
-        "startLine": 662,
+        "startLine": 671,
         "startColumn": 16,
-        "endLine": 662,
+        "endLine": 671,
         "endColumn": 61
       },
       "decision": {
@@ -815,16 +815,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:415:24",
+      "id": "decision:step:RouteTool:424:24",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "exception and self.flow.has_next_tool_call(context)",
       "phase": "execute",
       "span": {
-        "startLine": 415,
+        "startLine": 424,
         "startColumn": 24,
-        "endLine": 415,
+        "endLine": 424,
         "endColumn": 64
       },
       "decision": {
@@ -832,16 +832,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:417:20",
+      "id": "decision:step:RouteTool:426:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "exception and not (self.flow.has_next_tool_call(context))",
       "phase": "execute",
       "span": {
-        "startLine": 417,
+        "startLine": 426,
         "startColumn": 20,
-        "endLine": 417,
+        "endLine": 426,
         "endColumn": 65
       },
       "decision": {
@@ -849,16 +849,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:433:28",
+      "id": "decision:step:RouteTool:442:28",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "call.name == 'write_todos' and sum((pending.name == 'write_todos' for pending in state.pending_tool_calls)) \u003e 1 and self.flow.has_next_tool_call(context)",
       "phase": "execute",
       "span": {
-        "startLine": 433,
+        "startLine": 442,
         "startColumn": 28,
-        "endLine": 433,
+        "endLine": 442,
         "endColumn": 68
       },
       "decision": {
@@ -866,16 +866,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:435:24",
+      "id": "decision:step:RouteTool:444:24",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "call.name == 'write_todos' and sum((pending.name == 'write_todos' for pending in state.pending_tool_calls)) \u003e 1 and not (self.flow.has_next_tool_call(context))",
       "phase": "execute",
       "span": {
-        "startLine": 435,
+        "startLine": 444,
         "startColumn": 24,
-        "endLine": 435,
+        "endLine": 444,
         "endColumn": 69
       },
       "decision": {
@@ -883,16 +883,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:456:28",
+      "id": "decision:step:RouteTool:465:28",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "call.name == 'write_todos' and not (sum((pending.name == 'write_todos' for pending in state.pending_tool_calls)) \u003e 1) and exception and self.flow.has_next_tool_call(context)",
       "phase": "execute",
       "span": {
-        "startLine": 456,
+        "startLine": 465,
         "startColumn": 28,
-        "endLine": 456,
+        "endLine": 465,
         "endColumn": 68
       },
       "decision": {
@@ -900,16 +900,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:458:24",
+      "id": "decision:step:RouteTool:467:24",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "call.name == 'write_todos' and not (sum((pending.name == 'write_todos' for pending in state.pending_tool_calls)) \u003e 1) and exception and not (self.flow.has_next_tool_call(context))",
       "phase": "execute",
       "span": {
-        "startLine": 458,
+        "startLine": 467,
         "startColumn": 24,
-        "endLine": 458,
+        "endLine": 467,
         "endColumn": 69
       },
       "decision": {
@@ -917,16 +917,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:476:24",
+      "id": "decision:step:RouteTool:485:24",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "call.name == 'write_todos' and not (sum((pending.name == 'write_todos' for pending in state.pending_tool_calls)) \u003e 1) and self.flow.has_next_tool_call(context)",
       "phase": "execute",
       "span": {
-        "startLine": 476,
+        "startLine": 485,
         "startColumn": 24,
-        "endLine": 476,
+        "endLine": 485,
         "endColumn": 64
       },
       "decision": {
@@ -934,16 +934,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:478:20",
+      "id": "decision:step:RouteTool:487:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "call.name == 'write_todos' and not (sum((pending.name == 'write_todos' for pending in state.pending_tool_calls)) \u003e 1) and not (self.flow.has_next_tool_call(context))",
       "phase": "execute",
       "span": {
-        "startLine": 478,
+        "startLine": 487,
         "startColumn": 20,
-        "endLine": 478,
+        "endLine": 487,
         "endColumn": 65
       },
       "decision": {
@@ -951,16 +951,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:494:28",
+      "id": "decision:step:RouteTool:503:28",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "not (call.name == 'write_todos') and call.name == 'durable_wait' and duration_seconds \u003c= 0 and self.flow.has_next_tool_call(context)",
       "phase": "execute",
       "span": {
-        "startLine": 494,
+        "startLine": 503,
         "startColumn": 28,
-        "endLine": 494,
+        "endLine": 503,
         "endColumn": 68
       },
       "decision": {
@@ -968,16 +968,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:496:24",
+      "id": "decision:step:RouteTool:505:24",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "not (call.name == 'write_todos') and call.name == 'durable_wait' and duration_seconds \u003c= 0 and not (self.flow.has_next_tool_call(context))",
       "phase": "execute",
       "span": {
-        "startLine": 496,
+        "startLine": 505,
         "startColumn": 24,
-        "endLine": 496,
+        "endLine": 505,
         "endColumn": 69
       },
       "decision": {
@@ -985,16 +985,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:501:20",
+      "id": "decision:step:RouteTool:510:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "not (call.name == 'write_todos') and call.name == 'durable_wait' and not (duration_seconds \u003c= 0)",
       "phase": "execute",
       "span": {
-        "startLine": 501,
+        "startLine": 510,
         "startColumn": 20,
-        "endLine": 501,
+        "endLine": 510,
         "endColumn": 62
       },
       "decision": {
@@ -1002,16 +1002,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:526:28",
+      "id": "decision:step:RouteTool:535:28",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "not (call.name == 'write_todos') and not (call.name == 'durable_wait') and call.name == 'request_user_input' and validation_error is not None and self.flow.has_next_tool_call(context)",
       "phase": "execute",
       "span": {
-        "startLine": 526,
+        "startLine": 535,
         "startColumn": 28,
-        "endLine": 526,
+        "endLine": 535,
         "endColumn": 68
       },
       "decision": {
@@ -1019,16 +1019,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:528:24",
+      "id": "decision:step:RouteTool:537:24",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "not (call.name == 'write_todos') and not (call.name == 'durable_wait') and call.name == 'request_user_input' and validation_error is not None and not (self.flow.has_next_tool_call(context))",
       "phase": "execute",
       "span": {
-        "startLine": 528,
+        "startLine": 537,
         "startColumn": 24,
-        "endLine": 528,
+        "endLine": 537,
         "endColumn": 69
       },
       "decision": {
@@ -1036,16 +1036,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:553:20",
+      "id": "decision:step:RouteTool:562:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "not (call.name == 'write_todos') and not (call.name == 'durable_wait') and call.name == 'request_user_input' and not (validation_error is not None)",
       "phase": "execute",
       "span": {
-        "startLine": 553,
+        "startLine": 562,
         "startColumn": 20,
-        "endLine": 553,
+        "endLine": 562,
         "endColumn": 42
       },
       "decision": {
@@ -1053,16 +1053,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:560:20",
+      "id": "decision:step:RouteTool:569:20",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "not (call.name == 'write_todos') and not (call.name == 'durable_wait') and not (call.name == 'request_user_input') and definition.requires_approval",
       "phase": "execute",
       "span": {
-        "startLine": 560,
+        "startLine": 569,
         "startColumn": 20,
-        "endLine": 560,
+        "endLine": 569,
         "endColumn": 69
       },
       "decision": {
@@ -1070,16 +1070,16 @@
       }
     },
     {
-      "id": "decision:step:RouteTool:561:16",
+      "id": "decision:step:RouteTool:570:16",
       "kind": "decision",
       "name": "goTo",
       "parentId": "step:RouteTool",
       "condition": "not (call.name == 'write_todos') and not (call.name == 'durable_wait') and not (call.name == 'request_user_input') and not (definition.requires_approval)",
       "phase": "execute",
       "span": {
-        "startLine": 561,
+        "startLine": 570,
         "startColumn": 16,
-        "endLine": 561,
+        "endLine": 570,
         "endColumn": 58
       },
       "decision": {
@@ -1091,9 +1091,9 @@
       "kind": "attribute",
       "name": "AgentConfig",
       "span": {
-        "startLine": 723,
+        "startLine": 732,
         "startColumn": 5,
-        "endLine": 723,
+        "endLine": 732,
         "endColumn": 51
       },
       "resource": {
@@ -1105,9 +1105,9 @@
       "kind": "attribute",
       "name": "AgentMessages",
       "span": {
-        "startLine": 726,
+        "startLine": 735,
         "startColumn": 5,
-        "endLine": 726,
+        "endLine": 735,
         "endColumn": 59
       },
       "resource": {
@@ -1120,9 +1120,9 @@
       "kind": "attribute",
       "name": "PendingApproval",
       "span": {
-        "startLine": 728,
+        "startLine": 737,
         "startColumn": 5,
-        "endLine": 728,
+        "endLine": 737,
         "endColumn": 69
       },
       "resource": {
@@ -1134,9 +1134,9 @@
       "kind": "attribute",
       "name": "PendingTimer",
       "span": {
-        "startLine": 729,
+        "startLine": 738,
         "startColumn": 5,
-        "endLine": 729,
+        "endLine": 738,
         "endColumn": 60
       },
       "resource": {
@@ -1148,9 +1148,9 @@
       "kind": "attribute",
       "name": "PendingUserInput",
       "span": {
-        "startLine": 730,
+        "startLine": 739,
         "startColumn": 5,
-        "endLine": 730,
+        "endLine": 739,
         "endColumn": 73
       },
       "resource": {
@@ -1162,9 +1162,9 @@
       "kind": "attribute",
       "name": "AgentPlan",
       "span": {
-        "startLine": 727,
+        "startLine": 736,
         "startColumn": 5,
-        "endLine": 727,
+        "endLine": 736,
         "endColumn": 45
       },
       "resource": {
@@ -1176,9 +1176,9 @@
       "kind": "attribute",
       "name": "AgentState",
       "span": {
-        "startLine": 724,
+        "startLine": 733,
         "startColumn": 5,
-        "endLine": 724,
+        "endLine": 733,
         "endColumn": 48
       },
       "resource": {
@@ -1190,9 +1190,9 @@
       "kind": "attribute",
       "name": "ContextSummary",
       "span": {
-        "startLine": 725,
+        "startLine": 734,
         "startColumn": 5,
-        "endLine": 725,
+        "endLine": 734,
         "endColumn": 58
       },
       "resource": {
@@ -1204,9 +1204,9 @@
       "kind": "channel",
       "name": "PlanExecutions",
       "span": {
-        "startLine": 734,
+        "startLine": 743,
         "startColumn": 5,
-        "endLine": 734,
+        "endLine": 743,
         "endColumn": 73
       },
       "resource": {
@@ -1219,9 +1219,9 @@
       "kind": "channel",
       "name": "QueuedUserMessages",
       "span": {
-        "startLine": 731,
+        "startLine": 740,
         "startColumn": 5,
-        "endLine": 731,
+        "endLine": 740,
         "endColumn": 70
       },
       "resource": {
@@ -1233,9 +1233,9 @@
       "kind": "channel",
       "name": "SteeredUserMessages",
       "span": {
-        "startLine": 732,
+        "startLine": 741,
         "startColumn": 5,
-        "endLine": 732,
+        "endLine": 741,
         "endColumn": 72
       },
       "resource": {
@@ -1247,9 +1247,9 @@
       "kind": "channel",
       "name": "ToolApprovals",
       "span": {
-        "startLine": 733,
+        "startLine": 742,
         "startColumn": 5,
-        "endLine": 733,
+        "endLine": 742,
         "endColumn": 63
       },
       "resource": {
@@ -1262,9 +1262,9 @@
       "kind": "stream",
       "name": "AgentActivity",
       "span": {
-        "startLine": 737,
+        "startLine": 746,
         "startColumn": 5,
-        "endLine": 737,
+        "endLine": 746,
         "endColumn": 75
       },
       "resource": {
@@ -1276,9 +1276,9 @@
       "kind": "stream",
       "name": "AssistantText",
       "span": {
-        "startLine": 736,
+        "startLine": 745,
         "startColumn": 5,
-        "endLine": 736,
+        "endLine": 745,
         "endColumn": 68
       },
       "resource": {
@@ -1290,9 +1290,9 @@
       "kind": "stream",
       "name": "ReasoningSummary",
       "span": {
-        "startLine": 735,
+        "startLine": 744,
         "startColumn": 5,
-        "endLine": 735,
+        "endLine": 744,
         "endColumn": 74
       },
       "resource": {
@@ -1304,9 +1304,9 @@
       "kind": "rpc",
       "name": "approve_tool",
       "span": {
-        "startLine": 1251,
+        "startLine": 1260,
         "startColumn": 5,
-        "endLine": 1267,
+        "endLine": 1276,
         "endColumn": 31
       }
     },
@@ -1315,9 +1315,9 @@
       "kind": "rpc",
       "name": "describe",
       "span": {
-        "startLine": 1319,
+        "startLine": 1328,
         "startColumn": 5,
-        "endLine": 1320,
+        "endLine": 1329,
         "endColumn": 53
       }
     },
@@ -1326,9 +1326,9 @@
       "kind": "rpc",
       "name": "execute_plan",
       "span": {
-        "startLine": 1270,
+        "startLine": 1279,
         "startColumn": 5,
-        "endLine": 1298,
+        "endLine": 1307,
         "endColumn": 31
       }
     },
@@ -1337,9 +1337,9 @@
       "kind": "rpc",
       "name": "history",
       "span": {
-        "startLine": 1301,
+        "startLine": 1310,
         "startColumn": 5,
-        "endLine": 1316,
+        "endLine": 1325,
         "endColumn": 61
       }
     },
@@ -1348,9 +1348,9 @@
       "kind": "rpc",
       "name": "send_message",
       "span": {
-        "startLine": 1224,
+        "startLine": 1233,
         "startColumn": 5,
-        "endLine": 1228,
+        "endLine": 1237,
         "endColumn": 31
       }
     },
@@ -1359,9 +1359,9 @@
       "kind": "rpc",
       "name": "snapshot",
       "span": {
-        "startLine": 1326,
+        "startLine": 1335,
         "startColumn": 5,
-        "endLine": 1352,
+        "endLine": 1361,
         "endColumn": 10
       }
     },
@@ -1370,9 +1370,9 @@
       "kind": "rpc",
       "name": "steer_message",
       "span": {
-        "startLine": 1234,
+        "startLine": 1243,
         "startColumn": 5,
-        "endLine": 1248,
+        "endLine": 1257,
         "endColumn": 31
       }
     },
@@ -1382,9 +1382,9 @@
       "name": "AwaitToolApproval",
       "phase": "wait_for+execute",
       "span": {
-        "startLine": 763,
+        "startLine": 772,
         "startColumn": 13,
-        "endLine": 763,
+        "endLine": 772,
         "endColumn": 37
       }
     },
@@ -1394,9 +1394,9 @@
       "name": "AwaitUser",
       "phase": "wait_for+execute",
       "span": {
-        "startLine": 758,
+        "startLine": 767,
         "startColumn": 13,
-        "endLine": 758,
+        "endLine": 767,
         "endColumn": 28
       }
     },
@@ -1406,9 +1406,9 @@
       "name": "CallModel",
       "phase": "execute",
       "span": {
-        "startLine": 760,
+        "startLine": 769,
         "startColumn": 13,
-        "endLine": 760,
+        "endLine": 769,
         "endColumn": 28
       }
     },
@@ -1418,9 +1418,9 @@
       "name": "CheckSteered",
       "phase": "wait_for+execute",
       "span": {
-        "startLine": 761,
+        "startLine": 770,
         "startColumn": 13,
-        "endLine": 761,
+        "endLine": 770,
         "endColumn": 31
       }
     },
@@ -1430,9 +1430,9 @@
       "name": "CompactContext",
       "phase": "execute",
       "span": {
-        "startLine": 759,
+        "startLine": 768,
         "startColumn": 13,
-        "endLine": 759,
+        "endLine": 768,
         "endColumn": 33
       }
     },
@@ -1442,9 +1442,9 @@
       "name": "DurableWait",
       "phase": "wait_for+execute",
       "span": {
-        "startLine": 765,
+        "startLine": 774,
         "startColumn": 13,
-        "endLine": 765,
+        "endLine": 774,
         "endColumn": 30
       }
     },
@@ -1454,9 +1454,9 @@
       "name": "ExecuteTool",
       "phase": "execute",
       "span": {
-        "startLine": 764,
+        "startLine": 773,
         "startColumn": 13,
-        "endLine": 764,
+        "endLine": 773,
         "endColumn": 30
       }
     },
@@ -1467,9 +1467,9 @@
       "phase": "execute",
       "start": true,
       "span": {
-        "startLine": 757,
+        "startLine": 766,
         "startColumn": 36,
-        "endLine": 757,
+        "endLine": 766,
         "endColumn": 45
       }
     },
@@ -1479,9 +1479,9 @@
       "name": "RouteTool",
       "phase": "execute",
       "span": {
-        "startLine": 762,
+        "startLine": 771,
         "startColumn": 13,
-        "endLine": 762,
+        "endLine": 771,
         "endColumn": 28
       }
     },
@@ -1499,15 +1499,15 @@
       }
     },
     {
-      "id": "wait:AwaitToolApproval:571:16:0",
+      "id": "wait:AwaitToolApproval:580:16:0",
       "kind": "wait",
       "name": "anyOf",
       "parentId": "step:AwaitToolApproval",
       "phase": "wait_for",
       "span": {
-        "startLine": 571,
+        "startLine": 580,
         "startColumn": 16,
-        "endLine": 577,
+        "endLine": 586,
         "endColumn": 10
       },
       "wait": {
@@ -1519,9 +1519,9 @@
             "resourceId": "resource:channel:AIAgentFlow.steered_user_messages",
             "expression": "at_least=1, at_most=MAX_STEERING_MESSAGES",
             "span": {
-              "startLine": 572,
+              "startLine": 581,
               "startColumn": 13,
-              "endLine": 575,
+              "endLine": 584,
               "endColumn": 14
             }
           },
@@ -1531,9 +1531,9 @@
             "resourceId": "resource:channel:AIAgentFlow.tool_approvals",
             "expression": "call.id",
             "span": {
-              "startLine": 576,
+              "startLine": 585,
               "startColumn": 13,
-              "endLine": 576,
+              "endLine": 585,
               "endColumn": 54
             }
           }
@@ -1637,15 +1637,15 @@
       }
     },
     {
-      "id": "wait:CheckSteered:357:16:0",
+      "id": "wait:CheckSteered:366:16:0",
       "kind": "wait",
       "name": "until",
       "parentId": "step:CheckSteered",
       "phase": "wait_for",
       "span": {
-        "startLine": 357,
+        "startLine": 366,
         "startColumn": 16,
-        "endLine": 359,
+        "endLine": 368,
         "endColumn": 10
       },
       "wait": {
@@ -1657,9 +1657,9 @@
             "resourceId": "resource:channel:AIAgentFlow.steered_user_messages",
             "expression": "MAX_STEERING_MESSAGES",
             "span": {
-              "startLine": 358,
+              "startLine": 367,
               "startColumn": 13,
-              "endLine": 358,
+              "endLine": 367,
               "endColumn": 75
             }
           }
@@ -1667,15 +1667,15 @@
       }
     },
     {
-      "id": "wait:DurableWait:672:16:0",
+      "id": "wait:DurableWait:681:16:0",
       "kind": "wait",
       "name": "anyOf",
       "parentId": "step:DurableWait",
       "phase": "wait_for",
       "span": {
-        "startLine": 672,
+        "startLine": 681,
         "startColumn": 16,
-        "endLine": 678,
+        "endLine": 687,
         "endColumn": 10
       },
       "wait": {
@@ -1686,9 +1686,9 @@
             "label": "timedelta(seconds=timer.duration_seconds) timer",
             "expression": "timedelta(seconds=timer.duration_seconds)",
             "span": {
-              "startLine": 673,
+              "startLine": 682,
               "startColumn": 13,
-              "endLine": 673,
+              "endLine": 682,
               "endColumn": 73
             }
           },
@@ -1698,9 +1698,9 @@
             "resourceId": "resource:channel:AIAgentFlow.steered_user_messages",
             "expression": "at_least=1, at_most=MAX_STEERING_MESSAGES",
             "span": {
-              "startLine": 674,
+              "startLine": 683,
               "startColumn": 13,
-              "endLine": 677,
+              "endLine": 686,
               "endColumn": 14
             }
           }
@@ -1712,52 +1712,52 @@
     {
       "id": "edge:0001",
       "kind": "transition",
-      "from": "decision:step:AwaitToolApproval:583:20",
+      "from": "decision:step:AwaitToolApproval:592:20",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 583,
+        "startLine": 592,
         "startColumn": 20,
-        "endLine": 583,
+        "endLine": 592,
         "endColumn": 65
       }
     },
     {
       "id": "edge:0002",
       "kind": "transition",
-      "from": "decision:step:AwaitToolApproval:590:20",
+      "from": "decision:step:AwaitToolApproval:599:20",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 590,
+        "startLine": 599,
         "startColumn": 20,
-        "endLine": 590,
+        "endLine": 599,
         "endColumn": 62
       }
     },
     {
       "id": "edge:0003",
       "kind": "transition",
-      "from": "decision:step:AwaitToolApproval:598:20",
+      "from": "decision:step:AwaitToolApproval:607:20",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 598,
+        "startLine": 607,
         "startColumn": 20,
-        "endLine": 598,
+        "endLine": 607,
         "endColumn": 60
       }
     },
     {
       "id": "edge:0004",
       "kind": "transition",
-      "from": "decision:step:AwaitToolApproval:600:16",
+      "from": "decision:step:AwaitToolApproval:609:16",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 600,
+        "startLine": 609,
         "startColumn": 16,
-        "endLine": 600,
+        "endLine": 609,
         "endColumn": 61
       }
     },
@@ -1816,208 +1816,208 @@
     {
       "id": "edge:0009",
       "kind": "transition",
-      "from": "decision:step:CallModel:339:20",
+      "from": "decision:step:CallModel:345:20",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 339,
+        "startLine": 345,
         "startColumn": 20,
-        "endLine": 339,
+        "endLine": 345,
         "endColumn": 60
       }
     },
     {
       "id": "edge:0010",
       "kind": "transition",
-      "from": "decision:step:CallModel:349:16",
+      "from": "decision:step:CallModel:355:16",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 349,
+        "startLine": 355,
         "startColumn": 16,
-        "endLine": 349,
+        "endLine": 355,
         "endColumn": 56
       }
     },
     {
       "id": "edge:0011",
       "kind": "transition",
-      "from": "decision:step:CheckSteered:369:24",
+      "from": "decision:step:CheckSteered:378:24",
       "to": "step:CompactContext",
       "label": "go_to",
       "span": {
-        "startLine": 369,
+        "startLine": 378,
         "startColumn": 24,
-        "endLine": 369,
+        "endLine": 378,
         "endColumn": 53
       }
     },
     {
       "id": "edge:0012",
       "kind": "transition",
-      "from": "decision:step:CheckSteered:370:20",
+      "from": "decision:step:CheckSteered:379:20",
       "to": "step:CallModel",
       "label": "go_to",
       "span": {
-        "startLine": 370,
+        "startLine": 379,
         "startColumn": 20,
-        "endLine": 370,
+        "endLine": 379,
         "endColumn": 42
       }
     },
     {
       "id": "edge:0013",
       "kind": "transition",
-      "from": "decision:step:CheckSteered:372:20",
+      "from": "decision:step:CheckSteered:381:20",
       "to": "step:AwaitUser",
       "label": "go_to",
       "span": {
-        "startLine": 372,
+        "startLine": 381,
         "startColumn": 20,
-        "endLine": 372,
+        "endLine": 381,
         "endColumn": 42
       }
     },
     {
       "id": "edge:0014",
       "kind": "transition",
-      "from": "decision:step:CheckSteered:374:20",
+      "from": "decision:step:CheckSteered:383:20",
       "to": "step:CallModel",
       "label": "go_to",
       "span": {
-        "startLine": 374,
+        "startLine": 383,
         "startColumn": 20,
-        "endLine": 374,
+        "endLine": 383,
         "endColumn": 42
       }
     },
     {
       "id": "edge:0015",
       "kind": "transition",
-      "from": "decision:step:CheckSteered:376:20",
+      "from": "decision:step:CheckSteered:385:20",
       "to": "step:RouteTool",
       "label": "go_to",
       "span": {
-        "startLine": 376,
+        "startLine": 385,
         "startColumn": 20,
-        "endLine": 376,
+        "endLine": 385,
         "endColumn": 42
       }
     },
     {
       "id": "edge:0016",
       "kind": "transition",
-      "from": "decision:step:CheckSteered:378:20",
+      "from": "decision:step:CheckSteered:387:20",
       "to": "step:AwaitToolApproval",
       "label": "go_to",
       "span": {
-        "startLine": 378,
+        "startLine": 387,
         "startColumn": 20,
-        "endLine": 378,
+        "endLine": 387,
         "endColumn": 50
       }
     },
     {
       "id": "edge:0017",
       "kind": "transition",
-      "from": "decision:step:CheckSteered:380:20",
+      "from": "decision:step:CheckSteered:389:20",
       "to": "step:ExecuteTool",
       "label": "go_to",
       "span": {
-        "startLine": 380,
+        "startLine": 389,
         "startColumn": 20,
-        "endLine": 380,
+        "endLine": 389,
         "endColumn": 44
       }
     },
     {
       "id": "edge:0018",
       "kind": "transition",
-      "from": "decision:step:CheckSteered:382:20",
+      "from": "decision:step:CheckSteered:391:20",
       "to": "step:DurableWait",
       "label": "go_to",
       "span": {
-        "startLine": 382,
+        "startLine": 391,
         "startColumn": 20,
-        "endLine": 382,
+        "endLine": 391,
         "endColumn": 44
       }
     },
     {
       "id": "edge:0019",
       "kind": "transition",
-      "from": "decision:step:CompactContext:257:16",
+      "from": "decision:step:CompactContext:260:16",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 257,
+        "startLine": 260,
         "startColumn": 16,
-        "endLine": 257,
+        "endLine": 260,
         "endColumn": 56
       }
     },
     {
       "id": "edge:0020",
       "kind": "transition",
-      "from": "decision:step:DurableWait:699:20",
+      "from": "decision:step:DurableWait:708:20",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 699,
+        "startLine": 708,
         "startColumn": 20,
-        "endLine": 699,
+        "endLine": 708,
         "endColumn": 65
       }
     },
     {
       "id": "edge:0021",
       "kind": "transition",
-      "from": "decision:step:DurableWait:717:20",
+      "from": "decision:step:DurableWait:726:20",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 717,
+        "startLine": 726,
         "startColumn": 20,
-        "endLine": 717,
+        "endLine": 726,
         "endColumn": 60
       }
     },
     {
       "id": "edge:0022",
       "kind": "transition",
-      "from": "decision:step:DurableWait:719:16",
+      "from": "decision:step:DurableWait:728:16",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 719,
+        "startLine": 728,
         "startColumn": 16,
-        "endLine": 719,
+        "endLine": 728,
         "endColumn": 61
       }
     },
     {
       "id": "edge:0023",
       "kind": "transition",
-      "from": "decision:step:ExecuteTool:660:20",
+      "from": "decision:step:ExecuteTool:669:20",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 660,
+        "startLine": 669,
         "startColumn": 20,
-        "endLine": 660,
+        "endLine": 669,
         "endColumn": 60
       }
     },
     {
       "id": "edge:0024",
       "kind": "transition",
-      "from": "decision:step:ExecuteTool:662:16",
+      "from": "decision:step:ExecuteTool:671:16",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 662,
+        "startLine": 671,
         "startColumn": 16,
-        "endLine": 662,
+        "endLine": 671,
         "endColumn": 61
       }
     },
@@ -2037,208 +2037,208 @@
     {
       "id": "edge:0026",
       "kind": "transition",
-      "from": "decision:step:RouteTool:415:24",
+      "from": "decision:step:RouteTool:424:24",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 415,
+        "startLine": 424,
         "startColumn": 24,
-        "endLine": 415,
+        "endLine": 424,
         "endColumn": 64
       }
     },
     {
       "id": "edge:0027",
       "kind": "transition",
-      "from": "decision:step:RouteTool:417:20",
+      "from": "decision:step:RouteTool:426:20",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 417,
+        "startLine": 426,
         "startColumn": 20,
-        "endLine": 417,
+        "endLine": 426,
         "endColumn": 65
       }
     },
     {
       "id": "edge:0028",
       "kind": "transition",
-      "from": "decision:step:RouteTool:433:28",
+      "from": "decision:step:RouteTool:442:28",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 433,
+        "startLine": 442,
         "startColumn": 28,
-        "endLine": 433,
+        "endLine": 442,
         "endColumn": 68
       }
     },
     {
       "id": "edge:0029",
       "kind": "transition",
-      "from": "decision:step:RouteTool:435:24",
+      "from": "decision:step:RouteTool:444:24",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 435,
+        "startLine": 444,
         "startColumn": 24,
-        "endLine": 435,
+        "endLine": 444,
         "endColumn": 69
       }
     },
     {
       "id": "edge:0030",
       "kind": "transition",
-      "from": "decision:step:RouteTool:456:28",
+      "from": "decision:step:RouteTool:465:28",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 456,
+        "startLine": 465,
         "startColumn": 28,
-        "endLine": 456,
+        "endLine": 465,
         "endColumn": 68
       }
     },
     {
       "id": "edge:0031",
       "kind": "transition",
-      "from": "decision:step:RouteTool:458:24",
+      "from": "decision:step:RouteTool:467:24",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 458,
+        "startLine": 467,
         "startColumn": 24,
-        "endLine": 458,
+        "endLine": 467,
         "endColumn": 69
       }
     },
     {
       "id": "edge:0032",
       "kind": "transition",
-      "from": "decision:step:RouteTool:476:24",
+      "from": "decision:step:RouteTool:485:24",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 476,
+        "startLine": 485,
         "startColumn": 24,
-        "endLine": 476,
+        "endLine": 485,
         "endColumn": 64
       }
     },
     {
       "id": "edge:0033",
       "kind": "transition",
-      "from": "decision:step:RouteTool:478:20",
+      "from": "decision:step:RouteTool:487:20",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 478,
+        "startLine": 487,
         "startColumn": 20,
-        "endLine": 478,
+        "endLine": 487,
         "endColumn": 65
       }
     },
     {
       "id": "edge:0034",
       "kind": "transition",
-      "from": "decision:step:RouteTool:494:28",
+      "from": "decision:step:RouteTool:503:28",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 494,
+        "startLine": 503,
         "startColumn": 28,
-        "endLine": 494,
+        "endLine": 503,
         "endColumn": 68
       }
     },
     {
       "id": "edge:0035",
       "kind": "transition",
-      "from": "decision:step:RouteTool:496:24",
+      "from": "decision:step:RouteTool:505:24",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 496,
+        "startLine": 505,
         "startColumn": 24,
-        "endLine": 496,
+        "endLine": 505,
         "endColumn": 69
       }
     },
     {
       "id": "edge:0036",
       "kind": "transition",
-      "from": "decision:step:RouteTool:501:20",
+      "from": "decision:step:RouteTool:510:20",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 501,
+        "startLine": 510,
         "startColumn": 20,
-        "endLine": 501,
+        "endLine": 510,
         "endColumn": 62
       }
     },
     {
       "id": "edge:0037",
       "kind": "transition",
-      "from": "decision:step:RouteTool:526:28",
+      "from": "decision:step:RouteTool:535:28",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 526,
+        "startLine": 535,
         "startColumn": 28,
-        "endLine": 526,
+        "endLine": 535,
         "endColumn": 68
       }
     },
     {
       "id": "edge:0038",
       "kind": "transition",
-      "from": "decision:step:RouteTool:528:24",
+      "from": "decision:step:RouteTool:537:24",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 528,
+        "startLine": 537,
         "startColumn": 24,
-        "endLine": 528,
+        "endLine": 537,
         "endColumn": 69
       }
     },
     {
       "id": "edge:0039",
       "kind": "transition",
-      "from": "decision:step:RouteTool:553:20",
+      "from": "decision:step:RouteTool:562:20",
       "to": "step:AwaitUser",
       "label": "go_to",
       "span": {
-        "startLine": 553,
+        "startLine": 562,
         "startColumn": 20,
-        "endLine": 553,
+        "endLine": 562,
         "endColumn": 42
       }
     },
     {
       "id": "edge:0040",
       "kind": "transition",
-      "from": "decision:step:RouteTool:560:20",
+      "from": "decision:step:RouteTool:569:20",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 560,
+        "startLine": 569,
         "startColumn": 20,
-        "endLine": 560,
+        "endLine": 569,
         "endColumn": 69
       }
     },
     {
       "id": "edge:0041",
       "kind": "transition",
-      "from": "decision:step:RouteTool:561:16",
+      "from": "decision:step:RouteTool:570:16",
       "to": "step:CheckSteered",
       "label": "go_to",
       "span": {
-        "startLine": 561,
+        "startLine": 570,
         "startColumn": 16,
-        "endLine": 561,
+        "endLine": 570,
         "endColumn": 58
       }
     },
@@ -2249,9 +2249,9 @@
       "to": "step:CallModel",
       "label": "get",
       "span": {
-        "startLine": 273,
+        "startLine": 279,
         "startColumn": 18,
-        "endLine": 273,
+        "endLine": 279,
         "endColumn": 47
       },
       "metadata": {
@@ -2265,9 +2265,9 @@
       "to": "step:CompactContext",
       "label": "get",
       "span": {
-        "startLine": 216,
+        "startLine": 219,
         "startColumn": 18,
-        "endLine": 216,
+        "endLine": 219,
         "endColumn": 47
       },
       "metadata": {
@@ -2281,9 +2281,9 @@
       "to": "step:ExecuteTool",
       "label": "get",
       "span": {
-        "startLine": 617,
+        "startLine": 626,
         "startColumn": 18,
-        "endLine": 617,
+        "endLine": 626,
         "endColumn": 47
       },
       "metadata": {
@@ -2297,9 +2297,9 @@
       "to": "step:RouteTool",
       "label": "get",
       "span": {
-        "startLine": 393,
+        "startLine": 402,
         "startColumn": 18,
-        "endLine": 393,
+        "endLine": 402,
         "endColumn": 47
       },
       "metadata": {
@@ -2313,9 +2313,9 @@
       "to": "rpc:history",
       "label": "get",
       "span": {
-        "startLine": 1313,
+        "startLine": 1322,
         "startColumn": 23,
-        "endLine": 1313,
+        "endLine": 1322,
         "endColumn": 74
       },
       "metadata": {
@@ -2329,9 +2329,9 @@
       "to": "rpc:snapshot",
       "label": "get",
       "span": {
-        "startLine": 1334,
+        "startLine": 1343,
         "startColumn": 27,
-        "endLine": 1334,
+        "endLine": 1343,
         "endColumn": 78
       },
       "metadata": {
@@ -2345,9 +2345,9 @@
       "to": "rpc:approve_tool",
       "label": "get",
       "span": {
-        "startLine": 1257,
+        "startLine": 1266,
         "startColumn": 23,
-        "endLine": 1257,
+        "endLine": 1266,
         "endColumn": 57
       },
       "metadata": {
@@ -2361,9 +2361,9 @@
       "to": "step:DurableWait",
       "label": "get",
       "span": {
-        "startLine": 682,
+        "startLine": 691,
         "startColumn": 17,
-        "endLine": 682,
+        "endLine": 691,
         "endColumn": 53
       },
       "metadata": {
@@ -2377,9 +2377,9 @@
       "to": "step:DurableWait",
       "label": "get",
       "span": {
-        "startLine": 670,
+        "startLine": 679,
         "startColumn": 17,
-        "endLine": 670,
+        "endLine": 679,
         "endColumn": 53
       },
       "metadata": {
@@ -2393,9 +2393,9 @@
       "to": "rpc:execute_plan",
       "label": "get",
       "span": {
-        "startLine": 1275,
+        "startLine": 1284,
         "startColumn": 17,
-        "endLine": 1275,
+        "endLine": 1284,
         "endColumn": 40
       },
       "metadata": {
@@ -2409,9 +2409,9 @@
       "to": "rpc:history",
       "label": "get",
       "span": {
-        "startLine": 1302,
+        "startLine": 1311,
         "startColumn": 17,
-        "endLine": 1302,
+        "endLine": 1311,
         "endColumn": 40
       },
       "metadata": {
@@ -2425,9 +2425,9 @@
       "to": "rpc:snapshot",
       "label": "get",
       "span": {
-        "startLine": 1327,
+        "startLine": 1336,
         "startColumn": 17,
-        "endLine": 1327,
+        "endLine": 1336,
         "endColumn": 40
       },
       "metadata": {
@@ -2457,9 +2457,9 @@
       "to": "step:CallModel",
       "label": "get",
       "span": {
-        "startLine": 274,
+        "startLine": 280,
         "startColumn": 17,
-        "endLine": 274,
+        "endLine": 280,
         "endColumn": 45
       },
       "metadata": {
@@ -2473,9 +2473,9 @@
       "to": "step:CompactContext",
       "label": "get",
       "span": {
-        "startLine": 217,
+        "startLine": 220,
         "startColumn": 17,
-        "endLine": 217,
+        "endLine": 220,
         "endColumn": 45
       },
       "metadata": {
@@ -2489,9 +2489,9 @@
       "to": "step:RouteTool",
       "label": "get",
       "span": {
-        "startLine": 394,
+        "startLine": 403,
         "startColumn": 17,
-        "endLine": 394,
+        "endLine": 403,
         "endColumn": 45
       },
       "metadata": {
@@ -2534,9 +2534,9 @@
       "to": "rpc:execute_plan",
       "label": "size",
       "span": {
-        "startLine": 1283,
+        "startLine": 1292,
         "startColumn": 16,
-        "endLine": 1283,
+        "endLine": 1292,
         "endColumn": 55
       },
       "metadata": {
@@ -2550,9 +2550,9 @@
       "to": "rpc:snapshot",
       "label": "pending_messages",
       "span": {
-        "startLine": 1345,
+        "startLine": 1354,
         "startColumn": 36,
-        "endLine": 1345,
+        "endLine": 1354,
         "endColumn": 87
       },
       "metadata": {
@@ -2566,9 +2566,9 @@
       "to": "rpc:steer_message",
       "label": "find_pending_message",
       "span": {
-        "startLine": 1241,
+        "startLine": 1250,
         "startColumn": 19,
-        "endLine": 1244,
+        "endLine": 1253,
         "endColumn": 10
       },
       "metadata": {
@@ -2624,9 +2624,9 @@
       "to": "rpc:execute_plan",
       "label": "size",
       "span": {
-        "startLine": 1284,
+        "startLine": 1293,
         "startColumn": 16,
-        "endLine": 1284,
+        "endLine": 1293,
         "endColumn": 56
       },
       "metadata": {
@@ -2640,9 +2640,9 @@
       "to": "rpc:snapshot",
       "label": "pending_messages",
       "span": {
-        "startLine": 1349,
+        "startLine": 1358,
         "startColumn": 36,
-        "endLine": 1349,
+        "endLine": 1358,
         "endColumn": 88
       },
       "metadata": {
@@ -2656,9 +2656,9 @@
       "to": "step:AwaitToolApproval",
       "label": "results",
       "span": {
-        "startLine": 580,
+        "startLine": 589,
         "startColumn": 28,
-        "endLine": 580,
+        "endLine": 589,
         "endColumn": 76
       },
       "metadata": {
@@ -2688,9 +2688,9 @@
       "to": "step:CheckSteered",
       "label": "results",
       "span": {
-        "startLine": 362,
+        "startLine": 371,
         "startColumn": 20,
-        "endLine": 362,
+        "endLine": 371,
         "endColumn": 68
       },
       "metadata": {
@@ -2704,9 +2704,9 @@
       "to": "step:DurableWait",
       "label": "results",
       "span": {
-        "startLine": 683,
+        "startLine": 692,
         "startColumn": 28,
-        "endLine": 683,
+        "endLine": 692,
         "endColumn": 76
       },
       "metadata": {
@@ -2717,12 +2717,12 @@
       "id": "edge:0072",
       "kind": "wait_condition",
       "from": "resource:channel:AIAgentFlow.steered_user_messages",
-      "to": "wait:AwaitToolApproval:571:16:0",
+      "to": "wait:AwaitToolApproval:580:16:0",
       "label": "SteeredUserMessages.for 1…MAX_STEERING_MESSAGES",
       "span": {
-        "startLine": 572,
+        "startLine": 581,
         "startColumn": 13,
-        "endLine": 575,
+        "endLine": 584,
         "endColumn": 14
       }
     },
@@ -2756,12 +2756,12 @@
       "id": "edge:0075",
       "kind": "wait_condition",
       "from": "resource:channel:AIAgentFlow.steered_user_messages",
-      "to": "wait:CheckSteered:357:16:0",
+      "to": "wait:CheckSteered:366:16:0",
       "label": "SteeredUserMessages.at most MAX_STEERING_MESSAGES",
       "span": {
-        "startLine": 358,
+        "startLine": 367,
         "startColumn": 13,
-        "endLine": 358,
+        "endLine": 367,
         "endColumn": 75
       }
     },
@@ -2769,12 +2769,12 @@
       "id": "edge:0076",
       "kind": "wait_condition",
       "from": "resource:channel:AIAgentFlow.steered_user_messages",
-      "to": "wait:DurableWait:672:16:0",
+      "to": "wait:DurableWait:681:16:0",
       "label": "SteeredUserMessages.for 1…MAX_STEERING_MESSAGES",
       "span": {
-        "startLine": 674,
+        "startLine": 683,
         "startColumn": 13,
-        "endLine": 677,
+        "endLine": 686,
         "endColumn": 14
       }
     },
@@ -2785,9 +2785,9 @@
       "to": "step:AwaitToolApproval",
       "label": "results",
       "span": {
-        "startLine": 585,
+        "startLine": 594,
         "startColumn": 21,
-        "endLine": 585,
+        "endLine": 594,
         "endColumn": 71
       },
       "metadata": {
@@ -2798,12 +2798,12 @@
       "id": "edge:0078",
       "kind": "wait_condition",
       "from": "resource:channel:AIAgentFlow.tool_approvals",
-      "to": "wait:AwaitToolApproval:571:16:0",
+      "to": "wait:AwaitToolApproval:580:16:0",
       "label": "ToolApprovals[call.id].for 1",
       "span": {
-        "startLine": 576,
+        "startLine": 585,
         "startColumn": 13,
-        "endLine": 576,
+        "endLine": 585,
         "endColumn": 54
       }
     },
@@ -2814,9 +2814,9 @@
       "to": "resource:channel:AIAgentFlow.tool_approvals",
       "label": "publish",
       "span": {
-        "startLine": 1262,
+        "startLine": 1271,
         "startColumn": 9,
-        "endLine": 1266,
+        "endLine": 1275,
         "endColumn": 10
       },
       "metadata": {
@@ -2830,9 +2830,9 @@
       "to": "resource:attribute:AIAgentFlow.state",
       "label": "set",
       "span": {
-        "startLine": 1289,
+        "startLine": 1298,
         "startColumn": 9,
-        "endLine": 1292,
+        "endLine": 1301,
         "endColumn": 10
       },
       "metadata": {
@@ -2846,9 +2846,9 @@
       "to": "resource:channel:AIAgentFlow.plan_executions",
       "label": "publish",
       "span": {
-        "startLine": 1293,
+        "startLine": 1302,
         "startColumn": 9,
-        "endLine": 1297,
+        "endLine": 1306,
         "endColumn": 10
       },
       "metadata": {
@@ -2862,9 +2862,9 @@
       "to": "resource:channel:AIAgentFlow.queued_user_messages",
       "label": "publish",
       "span": {
-        "startLine": 1227,
+        "startLine": 1236,
         "startColumn": 9,
-        "endLine": 1227,
+        "endLine": 1236,
         "endColumn": 58
       },
       "metadata": {
@@ -2878,9 +2878,9 @@
       "to": "resource:channel:AIAgentFlow.queued_user_messages",
       "label": "delete",
       "span": {
-        "startLine": 1245,
+        "startLine": 1254,
         "startColumn": 9,
-        "endLine": 1245,
+        "endLine": 1254,
         "endColumn": 68
       },
       "metadata": {
@@ -2894,9 +2894,9 @@
       "to": "resource:channel:AIAgentFlow.steered_user_messages",
       "label": "publish",
       "span": {
-        "startLine": 1247,
+        "startLine": 1256,
         "startColumn": 13,
-        "endLine": 1247,
+        "endLine": 1256,
         "endColumn": 71
       },
       "metadata": {
@@ -2910,9 +2910,9 @@
       "to": "resource:attribute:AIAgentFlow.pending_approval",
       "label": "delete",
       "span": {
-        "startLine": 588,
+        "startLine": 597,
         "startColumn": 9,
-        "endLine": 588,
+        "endLine": 597,
         "endColumn": 51
       },
       "metadata": {
@@ -2977,9 +2977,9 @@
       "to": "resource:attribute:AIAgentFlow.state",
       "label": "set",
       "span": {
-        "startLine": 340,
+        "startLine": 346,
         "startColumn": 9,
-        "endLine": 348,
+        "endLine": 354,
         "endColumn": 10
       },
       "metadata": {
@@ -2993,9 +2993,9 @@
       "to": "resource:stream:AIAgentFlow.agent_activity",
       "label": "write",
       "span": {
-        "startLine": 285,
+        "startLine": 291,
         "startColumn": 9,
-        "endLine": 288,
+        "endLine": 294,
         "endColumn": 10
       },
       "metadata": {
@@ -3012,9 +3012,9 @@
       "to": "resource:stream:AIAgentFlow.assistant_text",
       "label": "write",
       "span": {
-        "startLine": 295,
+        "startLine": 301,
         "startColumn": 17,
-        "endLine": 295,
+        "endLine": 301,
         "endColumn": 37
       },
       "metadata": {
@@ -3031,9 +3031,9 @@
       "to": "resource:stream:AIAgentFlow.reasoning_summary",
       "label": "write",
       "span": {
-        "startLine": 296,
+        "startLine": 302,
         "startColumn": 17,
-        "endLine": 296,
+        "endLine": 302,
         "endColumn": 40
       },
       "metadata": {
@@ -3050,9 +3050,9 @@
       "to": "resource:attribute:AIAgentFlow.state",
       "label": "set",
       "span": {
-        "startLine": 248,
+        "startLine": 251,
         "startColumn": 9,
-        "endLine": 248,
+        "endLine": 251,
         "endColumn": 44
       },
       "metadata": {
@@ -3066,9 +3066,9 @@
       "to": "resource:attribute:AIAgentFlow.summary",
       "label": "set",
       "span": {
-        "startLine": 239,
+        "startLine": 242,
         "startColumn": 9,
-        "endLine": 242,
+        "endLine": 245,
         "endColumn": 10
       },
       "metadata": {
@@ -3082,9 +3082,9 @@
       "to": "resource:stream:AIAgentFlow.agent_activity",
       "label": "write",
       "span": {
-        "startLine": 250,
+        "startLine": 253,
         "startColumn": 9,
-        "endLine": 256,
+        "endLine": 259,
         "endColumn": 10
       },
       "metadata": {
@@ -3101,9 +3101,9 @@
       "to": "resource:attribute:AIAgentFlow.pending_timer",
       "label": "delete",
       "span": {
-        "startLine": 684,
+        "startLine": 693,
         "startColumn": 9,
-        "endLine": 684,
+        "endLine": 693,
         "endColumn": 48
       },
       "metadata": {
@@ -3117,9 +3117,9 @@
       "to": "resource:stream:AIAgentFlow.agent_activity",
       "label": "write",
       "span": {
-        "startLine": 654,
+        "startLine": 663,
         "startColumn": 9,
-        "endLine": 657,
+        "endLine": 666,
         "endColumn": 10
       },
       "metadata": {
@@ -3168,9 +3168,9 @@
       "to": "resource:attribute:AIAgentFlow.pending_approval",
       "label": "set",
       "span": {
-        "startLine": 556,
+        "startLine": 565,
         "startColumn": 13,
-        "endLine": 559,
+        "endLine": 568,
         "endColumn": 14
       },
       "metadata": {
@@ -3184,9 +3184,9 @@
       "to": "resource:attribute:AIAgentFlow.pending_timer",
       "label": "set",
       "span": {
-        "startLine": 497,
+        "startLine": 506,
         "startColumn": 13,
-        "endLine": 500,
+        "endLine": 509,
         "endColumn": 14
       },
       "metadata": {
@@ -3200,9 +3200,9 @@
       "to": "resource:attribute:AIAgentFlow.pending_user_input",
       "label": "set",
       "span": {
-        "startLine": 529,
+        "startLine": 538,
         "startColumn": 13,
-        "endLine": 532,
+        "endLine": 541,
         "endColumn": 14
       },
       "metadata": {
@@ -3216,9 +3216,9 @@
       "to": "resource:stream:AIAgentFlow.agent_activity",
       "label": "write",
       "span": {
-        "startLine": 549,
+        "startLine": 558,
         "startColumn": 13,
-        "endLine": 552,
+        "endLine": 561,
         "endColumn": 14
       },
       "metadata": {

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/stretchr/testify v1.11.1
 	github.com/superdurable/dex/blob-cache-go v0.1.0
-	github.com/superdurable/dex/sdk-go v0.2.11
+	github.com/superdurable/dex/sdk-go v0.3.2
 )
 
 require (

--- a/examples/go/go.sum
+++ b/examples/go/go.sum
@@ -90,8 +90,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/superdurable/dex/blob-cache-go v0.1.0 h1:+c3H5YBWG3DlICOHbgT9IUM5vTlfLYGP5Vd5sWr7WTY=
 github.com/superdurable/dex/blob-cache-go v0.1.0/go.mod h1:Atepb7+sztvDCztVKmlvEKCSKFCkHKtDhoFYjaFmtEw=
-github.com/superdurable/dex/sdk-go v0.2.11 h1:d8G8u0z1bzI2kH/LnRip7v58PNWRmFfDUsz3Vzn6XJs=
-github.com/superdurable/dex/sdk-go v0.2.11/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
+github.com/superdurable/dex/sdk-go v0.3.2 h1:TbFYFiIz7PR5HCIyOPPstyCY3HmzGosyDDskha5pUfE=
+github.com/superdurable/dex/sdk-go v0.3.2/go.mod h1:8Wj5wPf9dyb7hDnA40j8xISR/zjhX57NrUDVcXgf5x8=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=

--- a/examples/go/patterns/timeout/controller.go
+++ b/examples/go/patterns/timeout/controller.go
@@ -47,6 +47,12 @@ func patternStartOptions() sdk.StartFlowOptions {
 	return sdk.StartFlowOptions{
 		Timeout:       &timeout,
 		TimeoutPolicy: sdk.TimeoutHandler,
+		TimeoutHandlerOptions: &sdk.FlowTimeoutHandlerOptions{
+			MethodTimeout: 30 * time.Second,
+			Retry: &sdk.RetryPolicy{
+				MaximumAttempts: 3,
+			},
+		},
 	}
 }
 

--- a/examples/go/primitives/channel/README.md
+++ b/examples/go/primitives/channel/README.md
@@ -2,6 +2,7 @@
 
 Minimal Flow that waits on a Channel, lists pending messages by ID, deletes them,
 and transactionally moves one message between Channels.
+The Step explicitly loads pending messages for Execute and deletes the first queued message with its decision.
 
 HTTP:
 

--- a/examples/go/primitives/channel/workflow.go
+++ b/examples/go/primitives/channel/workflow.go
@@ -58,6 +58,12 @@ type channelWaitStep struct {
 	dex.StepDefaults
 }
 
+func (channelWaitStep) GetStepOptions() *dex.StepOptions {
+	return &dex.StepOptions{
+		ExecuteLoadChannels: []dex.ChannelDef{Queued},
+	}
+}
+
 func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 	return dex.AnyOf(
 		Approval.ForOne(),
@@ -66,6 +72,16 @@ func (channelWaitStep) WaitFor(_ dex.Context, input int) (*dex.Wait, error) {
 }
 
 func (channelWaitStep) Execute(ctx dex.Context, _ int) (*dex.StepDecision, error) {
+	pending, err := Queued.PendingMessages(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(pending) > 0 {
+		if err := Queued.Delete(ctx, pending[0].MessageID); err != nil {
+			return nil, err
+		}
+		return dex.GracefulComplete(pending[0].Value), nil
+	}
 	if ctx.HasTimerFired() {
 		return dex.GracefulComplete("approval timed out"), nil
 	}

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "io.superdurable:dex-sdk:0.2.10"
+    implementation "io.superdurable:dex-sdk:0.3.1"
 
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/timeout/README.md
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/timeout/README.md
@@ -1,27 +1,18 @@
 # FlowGracefulTimeout
 
-## Overview
+This Flow uses a one-minute soft timeout. Its handler has a 30-second attempt
+limit and retries invocation failures for up to three attempts.
 
-The `FlowGracefulTimeout` serves as an example of managing tasks using a timeout mechanism. This workflow ensures that tasks are completed within a designated time frame. If a task exceeds this duration, the workflow can forcibly terminate to prevent endless execution or a log can be emitted and the state can return `StateDecision.deadEnd()`.
+## Usage
 
-## Workflow Details
+Start the fast path:
 
-![Handling Timeout Workflow](./assets/Dex-Design-Patterns_HandlingTimeoutWorkflow.png)
-<br>([diagram link](https://drive.google.com/file/d/1MZXEXlF3WbzwFAaove0cySbbC798KPlV/view?usp=drive_link))
-
-### Workflow States
-
-- **InitState**: Accepts a `Boolean` indicating whether the workflow should simulate a successful or long-running task that exceeds the timeout. Transitions to both `TimeoutState` and `TaskState` simultaneously, allowing them to run in parallel.
-- **TimeoutState**: Waits for a timer to complete, set to 1 minute. If the timer completes before the task, it forcefully fails the workflow, indicating that the task did not finish in time.
-- **TaskState**: Represents the main task execution within the workflow. Accepts a `Boolean` to determine if the task should complete successfully or exceed the timeout. If simulating a delay, waits for a timer longer than the timeout (65 seconds) fails the workflow. If the task completes successfully, it forcefully completes the workflow, closing the timeout state thread.
-
-### Usage
-
-1. Start a workflow using an endpoint. Example:
 ```http request
 http://localhost:8080/patterns/timeout/start?workflowId=handleTimeoutWorkflow
 ```
-2. If you want the timeout state to be triggered add the parameter `successfulWorkflow=false`
+
+Trigger the timeout handler:
+
 ```http request
 http://localhost:8080/patterns/timeout/start?workflowId=handleTimeoutWorkflow&successfulWorkflow=false
 ```

--- a/examples/java/src/main/java/io/superdurable/dex/patterns/timeout/TimeoutController.java
+++ b/examples/java/src/main/java/io/superdurable/dex/patterns/timeout/TimeoutController.java
@@ -18,6 +18,8 @@ package io.superdurable.dex.patterns.timeout;
 
 import io.superdurable.dex.Client;
 import io.superdurable.dex.FlowTimeoutPolicy;
+import io.superdurable.dex.FlowTimeoutHandlerOptions;
+import io.superdurable.dex.RetryPolicy;
 import io.superdurable.dex.StartFlowOptions;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -51,6 +53,10 @@ public class TimeoutController {
                 StartFlowOptions.newBuilder()
                         .timeout(Duration.ofMinutes(1))
                         .timeoutPolicy(FlowTimeoutPolicy.HANDLER)
+                        .timeoutHandlerOptions(FlowTimeoutHandlerOptions.newBuilder()
+                                .methodTimeout(Duration.ofSeconds(30))
+                                .retry(RetryPolicy.newBuilder().maximumAttempts(3).build())
+                                .build())
                         .build());
         return ResponseEntity.ok(String.format("success for workflow %s", workflowId));
     }

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/channel/ChannelFlow.java
@@ -25,6 +25,7 @@ import io.superdurable.dex.RPC;
 import io.superdurable.dex.Step;
 import io.superdurable.dex.StepDecision;
 import io.superdurable.dex.StepList;
+import io.superdurable.dex.StepOptions;
 import io.superdurable.dex.Timer;
 import io.superdurable.dex.Wait;
 import org.springframework.stereotype.Component;
@@ -82,6 +83,13 @@ public class ChannelFlow implements Flow<Integer> {
         }
 
         @Override
+        public StepOptions getStepOptions() {
+            return StepOptions.newBuilder()
+                    .addExecuteLoadChannel(queued)
+                    .build();
+        }
+
+        @Override
         public Wait waitFor(final Context context, final Integer input) {
             return Wait.anyOf(
                     approval.forOne(),
@@ -90,6 +98,11 @@ public class ChannelFlow implements Flow<Integer> {
 
         @Override
         public StepDecision execute(final Context context, final Integer input) {
+            final List<ChannelMessage<String>> pending = queued.pendingMessages(context);
+            if (!pending.isEmpty()) {
+                queued.delete(context, pending.get(0).getMessageId());
+                return StepDecision.gracefulComplete(pending.get(0).getValue());
+            }
             if (context.hasTimerFired()) {
                 return StepDecision.gracefulComplete("approval timed out");
             }

--- a/examples/java/src/main/java/io/superdurable/dex/primitives/channel/README.md
+++ b/examples/java/src/main/java/io/superdurable/dex/primitives/channel/README.md
@@ -2,6 +2,7 @@
 
 Minimal Flow that waits on a Channel, lists pending messages by ID, deletes them,
 and transactionally moves one message between Channels.
+The Step explicitly loads pending messages for Execute and deletes the first queued message with its decision.
 
 HTTP:
 

--- a/examples/python/dex_examples/patterns/timeout/README.md
+++ b/examples/python/dex_examples/patterns/timeout/README.md
@@ -1,26 +1,8 @@
 # Flow Graceful Timeout
 
-A flow-level timeout that fails the flow deliberately instead of letting the
-platform kill it. The flow's configured timeout terminates it abruptly, with no
-chance to record why it stopped; a parallel timeout branch gives you that
-chance, and it is where any cleanup would go.
+This Flow uses a one-minute soft timeout. Its handler has a 30-second attempt
+limit and retries invocation failures for up to three attempts.
 
-## Steps
-
-1. `Init` — starts `Task` and `Timeout` in parallel, passing its own boolean
-   input through to `Task`.
-2. `Task` — skips the wait entirely when the input is `True` (the fast path);
-   otherwise it waits 65 seconds to simulate slow work, then force-completes the
-   flow.
-3. `Timeout` — waits 1 minute on a timer, then force-fails the flow with an
-   explanatory message.
-
-Whichever branch finishes first decides the outcome. With input `True` the task
-wins and the flow completes; with `False` the 65-second task loses to the
-1-minute timer and the flow fails on purpose.
-
-## Guidance
-
-Set the timer shorter than the flow's own timeout so the graceful path always
-wins the race. Keep any work in `Timeout` cheap and idempotent — it may run
-concurrently with the tail of the task branch.
+With a true input, the start Step completes immediately. With a false input, it
+waits 65 seconds, so the Flow timeout handler runs first and deliberately fails
+the Flow with an application message.

--- a/examples/python/dex_examples/patterns/timeout/controller.py
+++ b/examples/python/dex_examples/patterns/timeout/controller.py
@@ -18,7 +18,12 @@ from datetime import timedelta
 
 from quart import Blueprint
 
-from dex import FlowTimeoutPolicy, StartFlowOptions
+from dex import (
+    FlowTimeoutHandlerOptions,
+    FlowTimeoutPolicy,
+    RetryPolicy,
+    StartFlowOptions,
+)
 
 from dex_examples.app import ExampleApp
 from dex_examples.shared.query import optional_query, required_query
@@ -37,6 +42,10 @@ def create_timeout_blueprint(app_state: ExampleApp) -> Blueprint:
             StartFlowOptions(
                 timeout=timedelta(minutes=1),
                 timeout_policy=FlowTimeoutPolicy.HANDLER,
+                timeout_handler_options=FlowTimeoutHandlerOptions(
+                    method_timeout=timedelta(seconds=30),
+                    retry=RetryPolicy(maximum_attempts=3),
+                ),
             ),
         )
         return f"success for workflow {flow_id}"

--- a/examples/python/dex_examples/primitives/channel/README.md
+++ b/examples/python/dex_examples/primitives/channel/README.md
@@ -2,6 +2,7 @@
 
 Minimal Flow that waits on a Channel, lists pending messages by ID, deletes them,
 and transactionally moves one message between Channels.
+The Step explicitly loads pending messages for Execute and deletes the first queued message with its decision.
 
 HTTP:
 

--- a/examples/python/dex_examples/primitives/channel/channel_flow.py
+++ b/examples/python/dex_examples/primitives/channel/channel_flow.py
@@ -27,6 +27,7 @@ from dex import (
     Step,
     StepDecision,
     StepList,
+    StepOptions,
     Timer,
     Wait,
     go_to,
@@ -41,8 +42,12 @@ class MoveMessage:
 
 
 class ChannelWaitStep(Step[int]):
-    def __init__(self, approval: Channel[str]) -> None:
+    def __init__(self, approval: Channel[str], queued: Channel[str]) -> None:
         self.approval = approval
+        self.queued = queued
+
+    def get_step_options(self) -> StepOptions:
+        return StepOptions(execute_load_channels=(self.queued,))
 
     def wait_for(self, context: Context, input: int) -> Wait:
         return Wait.any_of(
@@ -51,6 +56,10 @@ class ChannelWaitStep(Step[int]):
         )
 
     def execute(self, context: Context, input: int) -> StepDecision:
+        pending = self.queued.pending_messages(context)
+        if pending:
+            self.queued.delete(context, pending[0].message_id)
+            return graceful_complete(pending[0].value)
         if context.has_timer_fired():
             return graceful_complete("approval timed out")
         approvals = self.approval.results(context)
@@ -63,7 +72,7 @@ class ChannelFlow(Flow[int]):
     moved = Channel("Moved", str)
 
     def __init__(self) -> None:
-        self.wait_for_approval = ChannelWaitStep(self.approval)
+        self.wait_for_approval = ChannelWaitStep(self.approval, self.queued)
 
     def get_steps(self) -> StepList[int]:
         return StepList.start_step(self.wait_for_approval)

--- a/examples/python/dex_examples/products/ai-agent/ai_agent_flow.py
+++ b/examples/python/dex_examples/products/ai-agent/ai_agent_flow.py
@@ -205,7 +205,10 @@ class CompactContext(Step[int]):
         self.flow = flow
 
     def get_step_options(self) -> StepOptions:
-        return MODEL_OPTIONS
+        return replace(
+            MODEL_OPTIONS,
+            execute_load_attribute_maps=(self.flow.messages,),
+        )
 
     async def execute(  # type: ignore[override]
         self,
@@ -262,7 +265,10 @@ class CallModel(Step[None]):
         self.flow = flow
 
     def get_step_options(self) -> StepOptions:
-        return MODEL_OPTIONS
+        return replace(
+            MODEL_OPTIONS,
+            execute_load_attribute_maps=(self.flow.messages,),
+        )
 
     async def execute(  # type: ignore[override]
         self,
@@ -352,6 +358,9 @@ class CallModel(Step[None]):
 class CheckSteered(Step[str]):
     def __init__(self, flow: AIAgentFlow) -> None:
         self.flow = flow
+
+    def get_step_options(self) -> StepOptions:
+        return StepOptions(execute_load_attribute_maps=(self.flow.messages,))
 
     def wait_for(self, context: Context, input: str) -> Wait:
         return Wait.until(

--- a/examples/python/pyproject.toml
+++ b/examples/python/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "dex-python-sdk==0.2.10",
+    "dex-python-sdk==0.3.2",
     "flask>=3.0,<4",
     "litellm>=1.75,<2",
     "mcp>=2.1,<3",

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -628,7 +628,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dex-python-sdk", specifier = "==0.2.10" },
+    { name = "dex-python-sdk", specifier = "==0.3.2" },
     { name = "flask", specifier = ">=3.0,<4" },
     { name = "litellm", specifier = ">=1.75,<2" },
     { name = "mcp", specifier = ">=2.1,<3" },
@@ -649,20 +649,20 @@ dev = [
 
 [[package]]
 name = "dex-python-sdk"
-version = "0.2.10"
+version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "grpcio-status" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/15/bf759dd30322dfb02e3b7b6910b1c318d985454a25aa37baab23db812b67/dex_python_sdk-0.2.10.tar.gz", hash = "sha256:4c30893ace2bdf6f193696f87617423097986916ce7e241aab5bb078767b9d34", size = 174777, upload-time = "2026-09-03T18:37:40.915Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/19/1b3765b1697f7e05e70cd38d9bdee9f94b27d42e9b501133ce5fbc7713f1/dex_python_sdk-0.3.2.tar.gz", hash = "sha256:a0b08869c749dff028c63e6ec4e5e8f5cb4bf5507fc3bbd6b7314786275f2dd6", size = 178317, upload-time = "2026-09-04T18:26:06.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/4c/97420ea6697564cf87c7247be7a1c67a351de1342d79733c8d60af027613/dex_python_sdk-0.2.10-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ccb22bff92d4721988d943bc785711f00b28d0e10e7564e1605f67def22c3aac", size = 650638, upload-time = "2026-09-03T18:37:34.34Z" },
-    { url = "https://files.pythonhosted.org/packages/25/f9/48f55c0fba826f70ff2b8270ecb858948c9f71f16e8d5a5e67d5ffe620cc/dex_python_sdk-0.2.10-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:1d9f3c72a7fb7aa34200108c0cd40ec103f0f8e869a6e9d6701fbdfa1ac36656", size = 629110, upload-time = "2026-09-03T18:37:35.558Z" },
-    { url = "https://files.pythonhosted.org/packages/57/7f/8d481399e630323854e491ef849277cfd8f60eb945cd3e2fa26655471b95/dex_python_sdk-0.2.10-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69696b3f45f1a7cab88fe29e5bc41e199ccae97248043a1a36f5282467671ad2", size = 692056, upload-time = "2026-09-03T18:37:36.764Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/59/76b7a90790443a427908d648b31331e85a4338aa78deeeefeb25a0175039/dex_python_sdk-0.2.10-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c21ad5666242308b9f4c991fec49e30686761e8fa35003acc463ea175b0925c8", size = 694376, upload-time = "2026-09-03T18:37:38.343Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/8f/67e642bac8af0903ee3c9e3ddd25f8a383b2b0c3c2c7c2cf3cebccdadb44/dex_python_sdk-0.2.10-cp311-abi3-win_amd64.whl", hash = "sha256:ab22d557252072858776dec891b15ac663a266dd50a626ae0008a2f98ceb2dba", size = 538370, upload-time = "2026-09-03T18:37:39.842Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/42/9bedd8ca5074f0fec7ba2dc27bd6b274722ff98d70bb63052d43b767e68b/dex_python_sdk-0.3.2-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c40e0d880af6f8b0a2fda58bed714825a89fbf054b16102d1f5d9ae8ac97e625", size = 654409, upload-time = "2026-09-04T18:26:00.215Z" },
+    { url = "https://files.pythonhosted.org/packages/88/99/84a39194517cea8f62d7b577fafb966c18dade539fa01586d201002eb12a/dex_python_sdk-0.3.2-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b02894a0b5ce72eb922334cb288e871bee5d32a81fe1b102ccb0459d699baa70", size = 632883, upload-time = "2026-09-04T18:26:01.582Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/94/22d2b75128e7c4a0e1bf54c8164fe66083d3e61f5cd1c73b2989b430bcff/dex_python_sdk-0.3.2-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5d575549bbf80d64a11bf2ed52912ff198699618fec9ab7780110ffaf120ca2", size = 695827, upload-time = "2026-09-04T18:26:02.817Z" },
+    { url = "https://files.pythonhosted.org/packages/99/14/2528e755757b86eb8e8287e318cf4b38cf6759346913a11cae1b6cf82c2b/dex_python_sdk-0.3.2-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7714e6d64932ac8dee8dda9c3d9d654fddd3cfb694e845870af60fe84e8a82db", size = 698146, upload-time = "2026-09-04T18:26:03.941Z" },
+    { url = "https://files.pythonhosted.org/packages/94/61/338694a6aa34d53f3dd8f2198c5ed6340718e45dc7b7cdef3fbaac318e91/dex_python_sdk-0.3.2-cp311-abi3-win_amd64.whl", hash = "sha256:72b0ba80f8d50ff83280756f3878c1e1377a804a246da9abd57d9f6652de69a4", size = 542179, upload-time = "2026-09-04T18:26:05.021Z" },
 ]
 
 [[package]]

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "dex-blob-cache"
-version = "0.2.9"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9239ff69867ad30891b0144690e3d1bd223bdd0755e04c88102821585f1018"
+checksum = "8045abef8afcf825eeaaed929753f55ad5a9573f5380245d8d9735e00d1cc1a7"
 dependencies = [
  "crc32c",
  "sha2",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "dex-protocol"
-version = "0.2.9"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7fedec07f4325d2ca5032c5212b933fcf021b1eca67f11ef26d28bb384f732"
+checksum = "1da3b97b574733ed7cf700a4c8b2610738753950074bf47bc7d55db7685b33bf"
 dependencies = [
  "prost",
  "prost-types",
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "dex-sdk"
-version = "0.2.9"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4899d97003f72c6f31668664dadef5fe2e2a7e518dbcd683d79aba2863bb57c8"
+checksum = "b46b0b3e71061675db4aac5972da85b9570e0fd901e1cce52b0d3f720abc9d24"
 dependencies = [
  "dex-blob-cache",
  "dex-protocol",

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 rust-version = "1.97"
 
 [dependencies]
-dex-sdk = "=0.2.9"
+dex-sdk = "=0.3.1"
 fastrand = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/rust/src/patterns/timeout/README.md
+++ b/examples/rust/src/patterns/timeout/README.md
@@ -3,7 +3,6 @@
 This Flow uses a one-minute soft timeout. Its handler has a 30-second attempt
 limit and retries invocation failures for up to three attempts.
 
-## Endpoints
+## Endpoint
 
 - `GET /patterns/timeout/start?workflowId={workflowId}`
-- `GET /patterns/timeout/start?workflowId={workflowId}&successfulWorkflow=false`

--- a/examples/rust/src/patterns/timeout/controller.rs
+++ b/examples/rust/src/patterns/timeout/controller.rs
@@ -52,6 +52,7 @@ async fn start(
     match run_blocking(move || {
         let flow = FlowGracefulTimeout::default();
         let input = true;
+        let timeout_handler_options = flow.timeout_handler_options();
         client
             .start_flow_with_options(
                 &flow,
@@ -59,7 +60,8 @@ async fn start(
                 input,
                 StartFlowOptions::new()
                     .timeout(Duration::from_secs(60))
-                    .timeout_policy(FlowTimeoutPolicy::Handler),
+                    .timeout_policy(FlowTimeoutPolicy::Handler)
+                    .timeout_handler_options(timeout_handler_options),
             )
             .map(|run_id| StartResponse { flow_id, run_id })
     }) {

--- a/examples/rust/src/patterns/timeout/flow.rs
+++ b/examples/rust/src/patterns/timeout/flow.rs
@@ -31,7 +31,8 @@
 use std::time::Duration;
 
 use dex_sdk::{
-    Context, Flow, FlowTimeoutHandler, HandlerResult, Step, StepDecision, StepList, Timer, Wait,
+    Context, Flow, FlowTimeoutHandler, FlowTimeoutHandlerOptions, HandlerResult, RetryPolicy, Step,
+    StepDecision, StepList, Timer, Wait,
 };
 
 #[derive(Default)]
@@ -70,6 +71,12 @@ impl Step for LongWaitStep {
 }
 
 impl FlowGracefulTimeout {
+    pub(crate) fn timeout_handler_options(&self) -> FlowTimeoutHandlerOptions {
+        FlowTimeoutHandlerOptions::new()
+            .method_timeout(Duration::from_secs(30))
+            .retry(RetryPolicy::new().maximum_attempts(3))
+    }
+
     fn handle_timeout(&self, _context: &mut Context) -> HandlerResult<StepDecision> {
         Ok(StepDecision::force_fail("task exceeded graceful timeout"))
     }

--- a/examples/rust/src/primitives/channel/README.md
+++ b/examples/rust/src/primitives/channel/README.md
@@ -1,7 +1,8 @@
 # Channel primitive
 
 This Flow can list and delete pending messages by ID. Its move RPC atomically
-deletes from one Channel and publishes to another on Temporal.
+deletes from one Channel and publishes to another. The Step explicitly loads
+pending messages for Execute and deletes the first queued message with its decision.
 
 HTTP:
 

--- a/examples/rust/src/primitives/channel/flow.rs
+++ b/examples/rust/src/primitives/channel/flow.rs
@@ -18,7 +18,7 @@ use std::sync::LazyLock;
 
 use dex_sdk::{
     Channel, Context, Flow, HandlerResult, PersistenceSchema, Rpc, RpcList, Step, StepDecision,
-    StepList, Timer, Wait,
+    StepList, StepOptions, Timer, Wait,
 };
 use serde::{Deserialize, Serialize};
 
@@ -84,6 +84,10 @@ struct ChannelWait;
 impl Step for ChannelWait {
     type Input = i32;
 
+    fn options(&self) -> StepOptions<Self::Input> {
+        StepOptions::new().execute_load_channel(&QUEUED)
+    }
+
     fn wait_for(&self, _context: &mut Context, input: Self::Input) -> HandlerResult<Wait> {
         Ok(Wait::any_of([
             APPROVAL.for_one(),
@@ -92,6 +96,11 @@ impl Step for ChannelWait {
     }
 
     fn execute(&self, context: &mut Context, _input: Self::Input) -> HandlerResult<StepDecision> {
+        let pending = QUEUED.pending_messages(context)?;
+        if let Some(message) = pending.first() {
+            QUEUED.delete(context, &message.message_id)?;
+            return Ok(StepDecision::graceful_complete(message.value.clone()));
+        }
         if context.has_any_timer_fired() {
             return Ok(StepDecision::graceful_complete(
                 "approval timed out".to_owned(),

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@superdurable/dex-examples-typescript",
       "version": "0.0.0",
       "dependencies": {
-        "@superdurable/dex": "0.2.9",
+        "@superdurable/dex": "0.3.2",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -125,9 +125,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@superdurable/dex": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.2.9.tgz",
-      "integrity": "sha512-lGLZW6GsTovrkE2EwuI4D18pnS6iSt+qHLiDF0SP53h8wHtbv2B1dRzQkQLG9UJwiLnAYJTGOy4KehrY16724Q==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@superdurable/dex/-/dex-0.3.2.tgz",
+      "integrity": "sha512-dLq9egH3STs+K82LYlGL/JtL+Fi9JBipk2PfLIcKdG8J8EoTS7Y46BotBs+9EJkrNuRK3ZT4wg1FDB2IGyE9Ig==",
       "license": "LicenseRef-Super-Durable-1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.13.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -16,7 +16,7 @@
     "smoke": "npm run build && node --test --experimental-test-isolation=none --test-force-exit --test-concurrency=1 'dist/test/e2e/flow-smoke.test.js'"
   },
   "dependencies": {
-    "@superdurable/dex": "0.2.9",
+    "@superdurable/dex": "0.3.2",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/examples/typescript/src/patterns/timeout/README.md
+++ b/examples/typescript/src/patterns/timeout/README.md
@@ -1,27 +1,18 @@
 # FlowGracefulTimeout
 
-## Overview
+This Flow uses a one-minute soft timeout. Its handler has a 30-second attempt
+limit and retries invocation failures for up to three attempts.
 
-The `FlowGracefulTimeout` serves as an example of managing tasks using a timeout mechanism. This workflow ensures that tasks are completed within a designated time frame. If a task exceeds this duration, the workflow can forcibly terminate to prevent endless execution or a log can be emitted and the state can return `StateDecision.deadEnd()`.
+## Usage
 
-## Workflow Details
+Start the fast path:
 
-![Handling Timeout Workflow](./assets/Dex-Design-Patterns_HandlingTimeoutWorkflow.png)
-<br>([diagram link](https://drive.google.com/file/d/1MZXEXlF3WbzwFAaove0cySbbC798KPlV/view?usp=drive_link))
-
-### Workflow States
-
-- **InitState**: Accepts a `Boolean` indicating whether the workflow should simulate a successful or long-running task that exceeds the timeout. Transitions to both `TimeoutState` and `TaskState` simultaneously, allowing them to run in parallel.
-- **TimeoutState**: Waits for a timer to complete, set to 1 minute. If the timer completes before the task, it forcefully fails the workflow, indicating that the task did not finish in time.
-- **TaskState**: Represents the main task execution within the workflow. Accepts a `Boolean` to determine if the task should complete successfully or exceed the timeout. If simulating a delay, waits for a timer longer than the timeout (65 seconds) fails the workflow. If the task completes successfully, it forcefully completes the workflow, closing the timeout state thread.
-
-### Usage
-
-1. Start a workflow using an endpoint. Example:
 ```http request
 http://localhost:8080/patterns/timeout/start?workflowId=handleTimeoutWorkflow
 ```
-2. If you want the timeout state to be triggered add the parameter `successfulWorkflow=false`
+
+Trigger the timeout handler:
+
 ```http request
 http://localhost:8080/patterns/timeout/start?workflowId=handleTimeoutWorkflow&successfulWorkflow=false
 ```

--- a/examples/typescript/src/patterns/timeout/controller.ts
+++ b/examples/typescript/src/patterns/timeout/controller.ts
@@ -16,7 +16,10 @@
 
 import { Router } from "express";
 
-import { FlowTimeoutPolicy, type Client } from "@superdurable/dex";
+import {
+  FlowTimeoutPolicy,
+  type Client,
+} from "@superdurable/dex";
 
 import { startOptions } from "../../config/env.js";
 import { flowGracefulTimeout } from "./flow-graceful-timeout.js";
@@ -35,6 +38,10 @@ export function createTimeoutRouter(client: Client): Router {
         ...startOptions(),
         timeoutMs: 60_000,
         timeoutPolicy: FlowTimeoutPolicy.HANDLER,
+        timeoutHandlerOptions: {
+          methodTimeoutMs: 30_000,
+          retry: { maximumAttempts: 3 },
+        },
       },
     );
     response.send(`success for workflow ${workflowId}`);

--- a/examples/typescript/src/primitives/channel/README.md
+++ b/examples/typescript/src/primitives/channel/README.md
@@ -2,6 +2,7 @@
 
 Minimal Flow that waits on a Channel, lists pending messages by ID, deletes them,
 and transactionally moves one message between Channels.
+The Step explicitly loads pending messages for Execute and deletes the first queued message with its decision.
 
 HTTP:
 

--- a/examples/typescript/src/primitives/channel/channel-flow.ts
+++ b/examples/typescript/src/primitives/channel/channel-flow.ts
@@ -30,6 +30,7 @@ import {
   type PersistenceSchema,
   type Step,
   type StepDecision,
+  type StepOptions,
 } from "@superdurable/dex";
 
 const approval = new Channel("Approval", stringCodec);
@@ -49,6 +50,10 @@ class ChannelWait implements Step<number> {
     return "ChannelWait";
   }
 
+  public getStepOptions(): StepOptions {
+    return { executeLoadChannels: [queued] };
+  }
+
   public waitFor(_context: Context, input: number): Wait {
     return Wait.anyOf(
       approval.forOne(),
@@ -57,6 +62,11 @@ class ChannelWait implements Step<number> {
   }
 
   public execute(context: Context, _input: number): StepDecision {
+    const pending = queued.pendingMessages(context);
+    if (pending.length > 0) {
+      queued.delete(context, pending[0]!.messageId);
+      return gracefulComplete(pending[0]!.value);
+    }
     if (context.hasTimerFired()) {
       return gracefulComplete("approval timed out");
     }

--- a/protos/README.md
+++ b/protos/README.md
@@ -58,6 +58,25 @@ execution makes staged effects atomic and validates Channel deletions. It does
 not isolate handler reads from concurrent writers. When that isolation matters,
 all cooperating Steps and RPCs must use the same Attribute lock.
 
+`StepOptions` stores separate selection lists for WaitFor and Execute.
+`FlowTimeoutHandlerOptions` stores the same lists for the synthetic timeout
+Step. Each method still receives ordinary Attributes and every Channel's size
+metadata. WaitFor and Execute use independent snapshots; Execute loads after the
+winning Wait consumes messages. Retries reuse the first request snapshot for
+that logical method execution.
+
+WaitFor, Execute, timeout-handler, and RPC responses carry
+`ChannelMessageDeletion` side effects outside `StepDecision`. The interpreter
+commits successful responses in this order: Attribute writes, best-effort
+Channel deletions, Channel publications, then the Step decision. A missing
+message is a no-op for these handler responses.
+
+Timeout-handler options are accepted only with a positive Flow timeout and a
+resolved `HANDLER` policy. The options become Execute settings for the synthetic
+timeout Step and survive start history, continue-as-new, SubFlow start, and Flow
+retry. A no-input recovery movement carries `Context.recovery_error` after the
+handler exhausts its retry policy.
+
 ## Worker targets
 
 `WorkerTarget.address` is a plaintext gRPC target. Set `is_headless_address` for a

--- a/sdk-java/README.md
+++ b/sdk-java/README.md
@@ -41,6 +41,20 @@ atomic commit and Channel deletion validation. Attribute locks add isolation
 only among cooperating Steps and RPCs using the same lock. Write-only publish
 and delete operations do not require loading.
 
+## Step and timeout-handler state loading
+
+`StepOptions` provides the same five selections independently for `waitFor` and
+`execute`: all AttributeMap instances, exact AttributeMap instances, Channels,
+all ChannelMap instances, and exact ChannelMap instances. The methods receive
+independent snapshots. Execute reads after the winning Wait consumes messages;
+retries of one logical method call reuse its first snapshot.
+
+`FlowTimeoutHandlerOptions` provides Execute-style timeouts, heartbeat detection,
+retry, durability, Attribute locks, and the same state selections. Set it on
+`StartFlowOptions` or `SubFlowOptions` only for a positive timeout using `HANDLER`.
+Exhausted retries may proceed to a registered `Step<Void>`; read the final
+failure with `Context.getRecoveryError()`.
+
 Java SDK for [Dex workflow engine](https://github.com/superdurable/dex)
 
 See [samples](../examples/java) for how to use this SDK to build your workflow.

--- a/sdk-java/src/main/java/io/superdurable/dex/FlowTimeoutPolicy.java
+++ b/sdk-java/src/main/java/io/superdurable/dex/FlowTimeoutPolicy.java
@@ -21,6 +21,6 @@ public enum FlowTimeoutPolicy {
     /** Cancels the Flow without retrying it. */
     CANCEL,
 
-    /** Invokes {@link Flow#handleTimeout} once after the durable timer completes or is skipped. */
+    /** Starts one logical {@link Flow#handleTimeout} execution after the durable timer completes or is skipped. */
     HANDLER
 }

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -40,6 +40,20 @@ atomic commit and Channel deletion validation. Attribute locks add isolation
 only among cooperating Steps and RPCs using the same lock. Write-only publish
 and delete operations do not require loading.
 
+## Step and timeout-handler state loading
+
+`StepOptions` provides the same five selections independently for `wait_for` and
+`execute`: all AttributeMap instances, exact AttributeMap instances, Channels,
+all ChannelMap instances, and exact ChannelMap instances. The methods receive
+independent snapshots. Execute reads after the winning Wait consumes messages;
+retries of one logical method call reuse its first snapshot.
+
+`FlowTimeoutHandlerOptions` provides Execute-style timeouts, heartbeat detection,
+retry, durability, Attribute locks, and the same state selections. Set it on
+`StartFlowOptions` or `SubFlowOptions` only for a positive timeout using
+`FlowTimeoutPolicy::Handler`. Exhausted retries may proceed to a registered
+`Step<Input = ()>`; read the final failure with `Context::recovery_error`.
+
 [![Rust SDK CI](https://github.com/superdurable/dex/actions/workflows/sdk-rust-ci.yml/badge.svg?branch=main)](https://github.com/superdurable/dex/actions/workflows/sdk-rust-ci.yml)
 
 This workspace contains the synchronous Rust SDK, the shared DXBC BlobCache,

--- a/skills/dex-developer/SKILL.md
+++ b/skills/dex-developer/SKILL.md
@@ -79,7 +79,7 @@ Read [large-attributes-and-locality.md](references/large-attributes-and-locality
 
 Read [ai-agents.md](references/ai-agents.md) when an Agent owns model context, calls MCP or other tools, waits for approval, compacts conversation history, or exposes a durable wait tool.
 
-For queued-message inspection, deletion, editing, steering, or an application snapshot RPC, also read [primitives.md](references/primitives.md) and [operations.md](references/operations.md). These operations apply only to pending Channel messages, not conversation history.
+For selective Step or timeout-handler state loading, Flow timeout recovery, queued-message inspection, deletion, editing, steering, or an application snapshot RPC, also read [primitives.md](references/primitives.md) and [operations.md](references/operations.md). These operations apply only to pending Channel messages, not conversation history.
 
 ## Choose proven Flow shapes
 
@@ -117,7 +117,7 @@ Before handing off application code:
 - build or type-check succeeds
 - the relevant integration scenario passes
 - every used durable primitive is registered
-- retry, timeout, duplicate request, and terminal behavior are intentional
+- retry, timeout-handler execution and recovery, duplicate request, and terminal behavior are intentional
 - heartbeat cadence, checkpoint recovery, and best-effort progress behavior are intentional
 - Worker and Client share compatible registry and payload/blob configuration
 - user-facing instructions mention only Dex components and commands

--- a/skills/dex-developer/references/primitives.md
+++ b/skills/dex-developer/references/primitives.md
@@ -18,6 +18,8 @@ Use multiple next Steps for parallel work. Use cancellation deliberately when a 
 
 Step durability resolves in this order: a method override, FlowConfig, then **SYNC**. The default retry total duration is four hours. Regular attempts default to a two-hour method timeout and one-minute heartbeat timeout.
 
+Every **WaitFor** and **Execute** call receives ordinary Attributes and Channel size metadata. AttributeMap values and pending Channel messages require method-specific selections in StepOptions. Select the whole map only when the method must enumerate instances; otherwise select exact instances. WaitFor and Execute use independent snapshots. Execute loads after Wait consumption, and retries reuse the first snapshot for that logical method call. Attribute locks do not load state.
+
 A long-running regular attempt must emit an explicit heartbeat or Stream message before its heartbeat timeout. A heartbeat value is a retry checkpoint. An explicit valueless heartbeat clears the checkpoint; a Stream message preserves its current state. The local phase of **ASYNC** durability ignores heartbeats but still emits Stream messages.
 
 For an LLM call that may remain healthy without output for more than one minute, tell the application developer to raise **HeartbeatTimeout** above its one-minute default. Size it to the longest acceptable silent interval, and use the method timeout to cap the whole attempt. Do not add periodic heartbeats solely to mask provider silence; they prove only that application code is running, not that the upstream request is progressing.
@@ -30,7 +32,7 @@ Use an Attribute for durable state inside one Flow execution. Register every Att
 
 Use one Attribute when the value is cohesive and should be replaced as a unit. Use an AttributeMap when runtime-keyed instances change independently; each instance is stored separately, avoiding a rewrite of the whole collection. Use stable domain keys and delete instances that are no longer needed.
 
-RPCs receive regular Attribute values automatically. They must explicitly load AttributeMap entries. Load the whole map for broad snapshots or exact instances for known keys. AttributeMap size does not make its entries available. An explicit load controls data transfer only; it does not enable transactional execution or isolation.
+Steps, timeout handlers, and RPCs receive regular Attribute values automatically. They must explicitly load AttributeMap entries. Load the whole map for broad snapshots or exact instances for known keys. AttributeMap size does not make its entries available. An explicit load controls data transfer only; it does not enable transactional execution or isolation.
 
 Lock the exact AttributeMap instance when Steps or RPCs can race on it. Do not treat an AttributeMap index as an index over its instances: all instances share one Flow search field, later writes replace that field, and instance keys are not searchable. AttributeMap enumeration is not server-side pagination.
 
@@ -46,7 +48,9 @@ Use a ChannelMap when the same message contract is partitioned by a dynamic key.
 
 Every pending Channel message has a server-assigned message ID. List pending messages when an application needs a durable queue UI. Listing preserves FIFO order and does not consume messages. Only a pending message can be deleted; deletion after consumption returns the Channel-message-not-found error.
 
-RPCs always receive ChannelInfo sizes, so Channel size and ChannelMap keys and sizes do not require a load. Reading pending message envelopes requires an explicit Channel or ChannelMap load. Load the whole ChannelMap or exact instances according to what the handler reads. A loaded empty queue is empty; reading an unloaded queue is a usage error.
+Steps, timeout handlers, and RPCs always receive ChannelInfo sizes, so Channel size and ChannelMap keys and sizes do not require a load. Reading pending message envelopes requires an explicit Channel or ChannelMap load. Load the whole ChannelMap or exact instances according to what the handler reads. A loaded empty queue is empty; reading an unloaded queue is a usage error.
+
+Steps and timeout handlers may delete a pending message in the same response as Attribute writes, Channel publications, and a decision. A known message ID can be deleted without loading its envelope. Deletion is a response side effect, not part of the Step decision. If the message is already absent, deletion is best effort and the remaining effects still apply.
 
 A Channel queue is not conversation history. Keep consumed user and assistant messages in Attributes when the application must display or reconstruct them.
 
@@ -89,6 +93,10 @@ Docs: https://docs.superdurable.io/primitives/stream
 ## Timer
 
 Use a Timer Condition for a durable delay, reminder, deadline branch, or scheduling loop. Decide what happens if a timer is skipped and whether the business deadline should complete, cancel, fail, or route to a handler.
+
+A Flow timeout handler has Execute semantics. Configure its per-attempt timeout, heartbeat timeout, retry, failure route, durability, locks, and selective state loads through FlowTimeoutHandlerOptions on StartFlowOptions or SubFlowOptions. These options require a positive Flow timeout and the Handler policy. Handler timing starts after the soft timeout fires and may extend beyond the original deadline.
+
+Route exhausted handler retries only to a registered no-input Step. The SDK supplies null or unit input, and the recovery Step reads the final failure from Context. Without a failure target, exhausted retries fail the Flow. Continue-as-new and Flow retry preserve timeout-handler options; Flow retry starts a new soft-timeout budget.
 
 Docs: https://docs.superdurable.io/primitives/timer
 


### PR DESCRIPTION
## Summary

- document method-specific Step and timeout-handler state loading in English and Simplified Chinese
- update Channel and graceful-timeout runnable examples across Go, Java, Python, Rust, and TypeScript
- demonstrate handler-side Channel deletion and timeout-handler retry recovery through Context recovery errors
- update the Dex developer skill, protocol and SDK docs, generated Flow definition, and example dependencies to published SDK releases

## Validation

- Go examples unit tests and primitives compile
- Java examples compile and pure unit test passes against dex-sdk 0.3.1
- Python examples: 25 unit tests pass against dex-python-sdk 0.3.2
- TypeScript examples: typecheck and 7 tests pass against @superdurable/dex 0.3.2
- Rust examples: check, clippy, fmt-check, and tests pass against dex-sdk 0.3.1
- docs prose check, bilingual production build, and site smoke tests pass
- Flow definitions regenerated
- Dex developer skill validation passes
- copyright check passes